### PR TITLE
AN-1250 Add Apk Tags Beta/Alpha

### DIFF
--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/BaseBodyWithAlphaBetaKey.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/BaseBodyWithAlphaBetaKey.java
@@ -1,0 +1,21 @@
+package cm.aptoide.pt.dataprovider.ws.v7;
+
+import cm.aptoide.pt.preferences.managed.ManagerPreferences;
+import lombok.Getter;
+
+/**
+ * Created by diogoloureiro on 17/02/2017.
+ *
+ * Requests with this body will check the key to show alpha and beta versions of apps
+ * when the options is set on settings, the ws response will not contain any alpha or beta versions
+ */
+
+public class BaseBodyWithAlphaBetaKey extends BaseBody {
+  @Getter private String notApkTags;
+
+  protected BaseBodyWithAlphaBetaKey() {
+    if (ManagerPreferences.getUpdatesFilterAlphaBetaKey()) {
+      this.notApkTags = "alpha,beta";
+    }
+  }
+}

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/BaseBodyWithApp.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/BaseBodyWithApp.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 /**
  * Created by diogoloureiro on 12/09/16.
  */
-@EqualsAndHashCode(callSuper = true) public class BaseBodyWithApp extends BaseBody {
+@EqualsAndHashCode(callSuper = true) public class BaseBodyWithApp extends BaseBodyWithAlphaBetaKey {
   @Getter @Setter private String storeUser;
   @Getter @Setter private String storePassSha1;
 }

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/GetUserTimelineRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/GetUserTimelineRequest.java
@@ -49,7 +49,7 @@ public class GetUserTimelineRequest extends V7<GetUserTimeline, GetUserTimelineR
     return interfaces.getUserTimeline(url, body, bypassCache);
   }
 
-  @EqualsAndHashCode(callSuper = true) public static class Body extends BaseBody
+  @EqualsAndHashCode(callSuper = true) public static class Body extends BaseBodyWithAlphaBetaKey
       implements Endless {
 
     @Getter private Integer limit;

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/ListAppsRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/ListAppsRequest.java
@@ -8,6 +8,7 @@ package cm.aptoide.pt.dataprovider.ws.v7;
 import cm.aptoide.pt.dataprovider.ws.BaseBodyDecorator;
 import cm.aptoide.pt.model.v7.ListApps;
 import cm.aptoide.pt.model.v7.Type;
+import cm.aptoide.pt.preferences.managed.ManagerPreferences;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -62,18 +63,31 @@ import rx.Observable;
     @Getter private Integer limit;
     @Getter @Setter private int offset;
     @Getter @Setter private Integer groupId;
+    @Getter private String notApkTags;
 
     public Body(StoreCredentials storeCredentials) {
       super(storeCredentials);
+      setNotApkTags();
     }
 
     public Body(StoreCredentials storeCredentials, int limit) {
       super(storeCredentials);
       this.limit = limit;
+      setNotApkTags();
     }
 
     public Body(int groupId) {
       this.groupId = groupId;
+      setNotApkTags();
+    }
+
+    /**
+     * Method to check not Apk Tags on this particular request
+     */
+    private void setNotApkTags() {
+      if (ManagerPreferences.getUpdatesFilterAlphaBetaKey()) {
+        this.notApkTags = "alpha,beta";
+      }
     }
   }
 }

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/ListSearchAppsRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/ListSearchAppsRequest.java
@@ -90,7 +90,7 @@ public class ListSearchAppsRequest extends V7<ListSearchApps, ListSearchAppsRequ
     return interfaces.listSearchApps(body, bypassCache);
   }
 
-  @EqualsAndHashCode(callSuper = true) public static class Body extends BaseBody
+  @EqualsAndHashCode(callSuper = true) public static class Body extends BaseBodyWithAlphaBetaKey
       implements Endless {
 
     @Getter private Integer limit;

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/listapps/ListAppsUpdatesRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/listapps/ListAppsUpdatesRequest.java
@@ -7,7 +7,7 @@ package cm.aptoide.pt.dataprovider.ws.v7.listapps;
 
 import android.content.pm.PackageInfo;
 import cm.aptoide.pt.dataprovider.ws.BaseBodyDecorator;
-import cm.aptoide.pt.dataprovider.ws.v7.BaseBody;
+import cm.aptoide.pt.dataprovider.ws.v7.BaseBodyWithAlphaBetaKey;
 import cm.aptoide.pt.dataprovider.ws.v7.V7;
 import cm.aptoide.pt.model.v7.listapp.ListAppsUpdates;
 import cm.aptoide.pt.preferences.managed.ManagerPreferences;
@@ -126,26 +126,18 @@ import rx.schedulers.Schedulers;
         n + SPLIT_SIZE > apksData.size() ? n + apksData.size() % SPLIT_SIZE : n + SPLIT_SIZE));
   }
 
-  @EqualsAndHashCode(callSuper = true) public static class Body extends BaseBody {
+  @EqualsAndHashCode(callSuper = true) public static class Body extends BaseBodyWithAlphaBetaKey {
 
     @Accessors(chain = true) @Getter @Setter private List<ApksData> apksData;
     @Getter private List<Long> storeIds;
     @Setter @Getter private String aaid;
-    @Getter private String notApkTags;
     @Getter private String notPackageTags;
 
     public Body(List<ApksData> apksData, List<Long> storeIds, String aaid) {
       this.apksData = apksData;
       this.storeIds = storeIds;
       this.aaid = aaid;
-      setNotApkTags();
       setSystemAppsUpdates();
-    }
-
-    private void setNotApkTags() {
-      if (ManagerPreferences.getUpdatesFilterAlphaBetaKey()) {
-        this.notApkTags = "alpha,beta";
-      }
     }
 
     private void setSystemAppsUpdates() {
@@ -162,7 +154,6 @@ import rx.schedulers.Schedulers;
       this.setAptoideVercode(body.getAptoideVercode());
       this.aaid = body.getAaid();
       this.setAptoideId(body.getAptoideId());
-      this.notApkTags = body.getNotApkTags();
       this.notPackageTags = body.getNotPackageTags();
     }
   }


### PR DESCRIPTION
Added the not_apk_tags argument has "alpha,beta" to the following requests:
http://ws75.aptoide.com/api/7/getApp/info=1
http://ws75.aptoide.com/api/7/listApps/info=1
http://ws75.aptoide.com/api/7/listAppVersions/info=1
http://ws75.aptoide.com/api/7/listAppsUpdates/info=1
http://ws75.aptoide.com/api/7/listSearchApps/info=1
http://ws75.aptoide.com/api/7/getUserTimeline/info=1

Please take special attention to the dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/**ListAppsRequest.java**
Maybe you can find a better way to do that 👍 