### PR TITLE
[AO-219] otherversionsfragment collapsingtoolbar title changes on scr…

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/fragment/implementations/OtherVersionsFragment.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/fragment/implementations/OtherVersionsFragment.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.AppBarLayout;
+import android.support.design.widget.CollapsingToolbarLayout;
 import android.text.SpannableString;
 import android.text.style.StyleSpan;
 import android.view.Menu;
@@ -50,6 +51,7 @@ public class OtherVersionsFragment extends AptoideBaseFragment<BaseAdapter> {
   private String appName;
   private String appImgUrl;
   private String appPackge;
+  private CollapsingToolbarLayout collapsingToolbarLayout;
   // views
   private ViewHeader header;
   //private TextView emptyData;
@@ -94,6 +96,7 @@ public class OtherVersionsFragment extends AptoideBaseFragment<BaseAdapter> {
     super.bindViews(view);
     final Context context = getContext();
     header = new ViewHeader(context, view);
+    collapsingToolbarLayout = (CollapsingToolbarLayout) view.findViewById(R.id.collapsing_toolbar);
     //emptyData = (TextView) view.findViewById(R.id.empty_data);
     setHasOptionsMenu(true);
   }
@@ -146,6 +149,7 @@ public class OtherVersionsFragment extends AptoideBaseFragment<BaseAdapter> {
   private void setTitle(String title) {
     if (hasToolbar()) {
       getToolbar().setTitle(title);
+      collapsingToolbarLayout.setTitle(title);
     }
   }
 


### PR DESCRIPTION
the title should be applied to the collapsingToolbarLayout.
Otherwise, on screen rotation, the title applied to the collapsingToolbarLayout will be the baseToolbar title, aka, App Name.

(cherry picked from commit 49ab859)