### PR TITLE
AO-216 fix feedbackfragment crash on trying to send feedback after sc…

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/fragment/implementations/SendFeedbackFragment.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/fragment/implementations/SendFeedbackFragment.java
@@ -84,7 +84,7 @@ public class SendFeedbackFragment extends BaseToolbarFragment {
   @Override public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
     if (savedInstanceState != null) {
-      savedInstanceState.getString(KEY_SCREENSHOT_PATH);
+      screenShotPath = savedInstanceState.getString(KEY_SCREENSHOT_PATH);
     }
   }
 


### PR DESCRIPTION
on screen rotation in the sendfeedbackfragment the app will crash on send feeback if the checkbox is checked, because you are not saving the screenshoot path onsaveinstancestate.
this pull request fixes that.

**You should consider request the external storage** permission as well!
I haven't add that on this pull request because that should follow with a dialog and that requires new strings...
you are assuming you have this permission on this state, and if you don't have, the app will not crash but no attaches will be present on the email as well!