### PR TITLE
[AN-1486] - Copied two old events and added facebook analytics user p…

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/analytics/Analytics.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/analytics/Analytics.java
@@ -728,26 +728,15 @@ public class Analytics {
 
     public static void website(String uri) {
       Logger.d(TAG, "website: " + uri);
-      Map<String, String> facebookMap = new HashMap<>();
-      facebookMap.put(SOURCE, WEBSITE);
+      HashMap<String, String> map = new HashMap<>();
+      map.put(SOURCE, WEBSITE);
 
       if (uri != null) {
-        facebookMap.put(URI, uri.substring(0, uri.indexOf(":")));
+        map.put(URI, uri.substring(0, uri.indexOf(":")));
       }
 
-      logFacebookEvents(FACEBOOK_APP_LAUNCH, facebookMap);
-      try {
-        HashMap<String, String> map = new HashMap<>();
-        map.put(SOURCE, WEBSITE);
-
-        if (uri != null) {
-          map.put(URI, uri.substring(0, uri.indexOf(":")));
-        }
-
-        track(EVENT_NAME, map, ALL);
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
+      track(EVENT_NAME, map, ALL);
+      logFacebookEvents(FACEBOOK_APP_LAUNCH, map);
     }
 
     public static void newUpdatesNotification() {


### PR DESCRIPTION
Copied two events (App Install and App Launches) from localytics to facebook.
The first of these was partially implemented, the only thing missing was the facebook logger call.
Added facebooks userProperties. This is the facebook equivalent to localytics custom dimensions. There are some dimensions that won't migrated to facebook.