### PR TITLE
[AN-1620] Remove overlay on top of video image.

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
@@ -1,6 +1,5 @@
 package cm.aptoide.pt.v8engine.timeline.view.widget;
 
-import android.os.Build;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.CardView;
 import android.view.LayoutInflater;
@@ -100,14 +99,6 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
         .load(displayable.getThumbnailUrl(), thumbnail);
     thumbnail.setScaleType(ImageView.ScaleType.CENTER_CROP);
     play_button.setVisibility(View.VISIBLE);
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      mediaLayout.setForeground(getContext().getResources()
-          .getDrawable(R.color.overlay_black, getContext().getTheme()));
-    } else {
-      mediaLayout.setForeground(getContext().getResources()
-          .getDrawable(R.color.overlay_black));
-    }
 
     compositeSubscription.add(RxView.clicks(mediaLayout)
         .subscribe(v -> {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/SocialVideoWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/SocialVideoWidget.java
@@ -1,6 +1,5 @@
 package cm.aptoide.pt.v8engine.timeline.view.widget;
 
-import android.os.Build;
 import android.support.v4.app.FragmentActivity;
 import android.support.v7.widget.CardView;
 import android.view.View;
@@ -97,14 +96,6 @@ public class SocialVideoWidget extends SocialCardWidget<SocialVideoDisplayable> 
         .load(displayable.getThumbnailUrl(), thumbnail);
     thumbnail.setScaleType(ImageView.ScaleType.CENTER_CROP);
     play_button.setVisibility(View.VISIBLE);
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      mediaLayout.setForeground(context.getResources()
-          .getDrawable(R.color.overlay_black, context.getTheme()));
-    } else {
-      mediaLayout.setForeground(context.getResources()
-          .getDrawable(R.color.overlay_black));
-    }
 
     compositeSubscription.add(RxView.clicks(mediaLayout)
         .subscribe(v -> {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/VideoWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/VideoWidget.java
@@ -5,7 +5,6 @@
 
 package cm.aptoide.pt.v8engine.timeline.view.widget;
 
-import android.os.Build;
 import android.support.v4.app.FragmentActivity;
 import android.support.v7.widget.CardView;
 import android.view.View;
@@ -73,14 +72,6 @@ public class VideoWidget extends CardWidget<VideoDisplayable> {
         .load(displayable.getThumbnailUrl(), thumbnail);
     thumbnail.setScaleType(ImageView.ScaleType.CENTER_CROP);
     play_button.setVisibility(View.VISIBLE);
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      media_layout.setForeground(context.getResources()
-          .getDrawable(R.color.overlay_black, context.getTheme()));
-    } else {
-      media_layout.setForeground(context.getResources()
-          .getDrawable(R.color.overlay_black));
-    }
 
     media_layout.setOnClickListener(v -> {
       knockWithSixpackCredentials(displayable.getAbUrl());

--- a/v8engine/src/main/res/deprecated/layout/brick_app_item_list.xml
+++ b/v8engine/src/main/res/deprecated/layout/brick_app_item_list.xml
@@ -5,6 +5,7 @@
   -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/brick_app_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -37,7 +38,7 @@
         android:layout_centerVertical="true"
         android:paddingEnd="1.5dp"
         android:paddingRight="1.5dp"
-        android:text="Little Commander worl world II"
+        tools:text="Little Commander worl world II"
         android:textColor="?attr/inverseTextColor"
         />
 


### PR DESCRIPTION
What does this PR do?

   This pull-request fixes the related to text on top of video card images.

Where should the reviewer start?

- [x] Video card (non-social, VideoWidget.java)
- [x] Social video card (social, SocialVideoWidget.java)
- [x] Social video aggregated card (social, AggregatedSocialVideoWidget.java)

How should this be manually tested?

  Video card : Open Aptoide v8 > Apps Timeline > Scroll down until you reach a Video card (play icon on top right corner) -> check card related to
  Social Video card: Share a Video Card -> pull-to-refresh -> find Social Video card (video card with share icon) ->check card related to.
  Aggregated Social Video card: Share a card from a friend's Timeline (it will generate a aggregated social card) -> check Timeline for the aggregated social card -> check card related to.

N/A
What are the relevant tickets?

Tickets related to this pull-request: [RelatedTo](https://aptoide.atlassian.net/browse/AN-1620).

Screenshots (if appropriate)

N/A
Questions:

   Is there a blog post? N/A
   Does this add new dependencies which need to be added? No
