### PR TITLE
[AN-1614] Fix to the cardId field that was being sent null in the Agg…

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialArticleWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialArticleWidget.java
@@ -248,8 +248,7 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
 
       compositeSubscription.add(RxView.clicks(comment)
           .flatMap(aVoid -> Observable.fromCallable(() -> {
-            final String elementId = displayable.getTimelineCard()
-                .getCardId();
+            final String elementId = minimalCard.getCardId();
             Fragment fragment = V8Engine.getFragmentProvider()
                 .newCommentGridRecyclerFragmentWithCommentDialogOpen(CommentType.TIMELINE,
                     elementId);

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
@@ -19,9 +19,9 @@ import cm.aptoide.pt.v8engine.R;
 import cm.aptoide.pt.v8engine.V8Engine;
 import cm.aptoide.pt.v8engine.analytics.Analytics;
 import cm.aptoide.pt.v8engine.crashreports.CrashReport;
-import cm.aptoide.pt.v8engine.view.dialog.SharePreviewDialog;
 import cm.aptoide.pt.v8engine.timeline.view.LikeButtonView;
 import cm.aptoide.pt.v8engine.timeline.view.displayable.AggregatedSocialInstallDisplayable;
+import cm.aptoide.pt.v8engine.view.dialog.SharePreviewDialog;
 import com.jakewharton.rxbinding.view.RxView;
 import rx.Observable;
 import rx.android.schedulers.AndroidSchedulers;
@@ -196,8 +196,7 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
 
       compositeSubscription.add(RxView.clicks(comment)
           .flatMap(aVoid -> Observable.fromCallable(() -> {
-            final String elementId = displayable.getTimelineCard()
-                .getCardId();
+            final String elementId = minimalCard.getCardId();
             Fragment fragment = V8Engine.getFragmentProvider()
                 .newCommentGridRecyclerFragmentWithCommentDialogOpen(CommentType.TIMELINE,
                     elementId);

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialStoreLatestAppsWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialStoreLatestAppsWidget.java
@@ -318,8 +318,7 @@ public class AggregatedSocialStoreLatestAppsWidget
 
       compositeSubscription.add(RxView.clicks(comment)
           .flatMap(aVoid -> Observable.fromCallable(() -> {
-            final String elementId = displayable.getTimelineCard()
-                .getCardId();
+            final String elementId = minimalCard.getCardId();
             Fragment fragment = V8Engine.getFragmentProvider()
                 .newCommentGridRecyclerFragmentWithCommentDialogOpen(CommentType.TIMELINE,
                     elementId);

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
@@ -225,8 +225,7 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
 
       compositeSubscription.add(RxView.clicks(comment)
           .flatMap(aVoid -> Observable.fromCallable(() -> {
-            final String elementId = displayable.getTimelineCard()
-                .getCardId();
+            final String elementId = minimalCard.getCardId();
             Fragment fragment = V8Engine.getFragmentProvider()
                 .newCommentGridRecyclerFragmentWithCommentDialogOpen(CommentType.TIMELINE,
                     elementId);


### PR DESCRIPTION
What does this PR do?

   This pull-request fixes the commentID(cardId) field that was being sent null in the Aggregated cards.

Where should the reviewer start?

- [x] Aggregated Video
- [x] Aggregated Article
- [x] Aggregated Install
- [x] Aggregated Store Latest

How should this be manually tested?

  Open Aptoide v8 > Apps Timeline > Comment each type of aggregated card in a sub-card.

What are the relevant tickets?

Tickets related to this pull-request: [Aggregated Comments](https://aptoide.atlassian.net/browse/AN-1614).

Screenshots (if appropriate)

N/A
Questions:

   Is there a blog post? N/A
   Does this add new dependencies which need to be added? No
