### PR TITLE
[AN-1630] Aggregated cards show additional number of sharers now.

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
@@ -45,6 +45,8 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
   private RatingBar ratingBar;
   private Button getAppButton;
   private CardView cardView;
+  private TextView additionalNumberOfSharesLabel;
+  private ImageView additionalNumberOfSharesCircularMask;
 
   public AggregatedSocialInstallWidget(View itemView) {
     super(itemView);
@@ -70,6 +72,10 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
     getAppButton = (Button) itemView.findViewById(
         R.id.displayable_social_timeline_recommendation_get_app_button);
     cardView = (CardView) itemView.findViewById(R.id.card);
+    additionalNumberOfSharesCircularMask =
+        (ImageView) itemView.findViewById(R.id.card_header_avatar_plus);
+    additionalNumberOfSharesLabel =
+        (TextView) itemView.findViewById(R.id.timeline_header_aditional_number_of_shares_circular);
   }
 
   @Override public void bindView(AggregatedSocialInstallDisplayable displayable) {
@@ -91,6 +97,7 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
         .load(displayable.getAppIcon(), appIcon);
     appName.setText(displayable.getAppName());
     ratingBar.setRating(displayable.getAppRatingAverage());
+    setAdditionalNumberOfSharersLabel(displayable);
     setCardViewMargin(displayable, cardView);
     showSeeMoreAction(displayable);
     showSubCards(displayable, 2);
@@ -111,6 +118,25 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
 
   @Override String getCardTypeName() {
     return AggregatedSocialInstallDisplayable.CARD_TYPE_NAME;
+  }
+
+  private void setAdditionalNumberOfSharersLabel(AggregatedSocialInstallDisplayable displayable) {
+    int numberOfSharers = displayable.getSharers()
+        .size();
+
+    if (numberOfSharers <= 2) {
+      additionalNumberOfSharesLabel.setVisibility(View.INVISIBLE);
+      additionalNumberOfSharesCircularMask.setVisibility(View.INVISIBLE);
+      return;
+    } else {
+      additionalNumberOfSharesLabel.setVisibility(View.VISIBLE);
+      additionalNumberOfSharesCircularMask.setVisibility(View.VISIBLE);
+      numberOfSharers -= 2;
+    }
+
+    additionalNumberOfSharesLabel.setText(
+        String.format(getContext().getString(R.string.timeline_short_plus),
+            String.valueOf(numberOfSharers)));
   }
 
   private void showSubCards(AggregatedSocialInstallDisplayable displayable,

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialStoreLatestAppsWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialStoreLatestAppsWidget.java
@@ -30,10 +30,10 @@ import cm.aptoide.pt.v8engine.repository.StoreRepository;
 import cm.aptoide.pt.v8engine.store.StoreCredentialsProviderImpl;
 import cm.aptoide.pt.v8engine.store.StoreThemeEnum;
 import cm.aptoide.pt.v8engine.store.StoreUtilsProxy;
-import cm.aptoide.pt.v8engine.view.dialog.SharePreviewDialog;
 import cm.aptoide.pt.v8engine.timeline.view.LikeButtonView;
 import cm.aptoide.pt.v8engine.timeline.view.displayable.AggregatedSocialInstallDisplayable;
 import cm.aptoide.pt.v8engine.timeline.view.displayable.AggregatedSocialStoreLatestAppsDisplayable;
+import cm.aptoide.pt.v8engine.view.dialog.SharePreviewDialog;
 import com.jakewharton.rxbinding.view.RxView;
 import java.util.HashMap;
 import java.util.Map;
@@ -69,6 +69,8 @@ public class AggregatedSocialStoreLatestAppsWidget
   private StoreRepository storeRepository;
   private StoreUtilsProxy storeUtilsProxy;
   private TextView sharedStoreNameBodyTitle;
+  private TextView additionalNumberOfSharesLabel;
+  private ImageView additionalNumberOfSharesCircularMask;
 
   public AggregatedSocialStoreLatestAppsWidget(View itemView) {
     super(itemView);
@@ -105,6 +107,10 @@ public class AggregatedSocialStoreLatestAppsWidget
     sharedStoreSubscribersNumber =
         (TextView) itemView.findViewById(R.id.social_number_of_followers_text);
     sharedStoreAppsNumber = (TextView) itemView.findViewById(R.id.social_number_of_apps_text);
+    additionalNumberOfSharesCircularMask =
+        (ImageView) itemView.findViewById(R.id.card_header_avatar_plus);
+    additionalNumberOfSharesLabel =
+        (TextView) itemView.findViewById(R.id.timeline_header_aditional_number_of_shares_circular);
   }
 
   @Override public void bindView(AggregatedSocialStoreLatestAppsDisplayable displayable) {
@@ -225,6 +231,7 @@ public class AggregatedSocialStoreLatestAppsWidget
           }
         }, (throwable) -> throwable.printStackTrace()));
 
+    setAdditionalNumberOfSharersLabel(displayable);
     setCardViewMargin(displayable, cardView);
     showSeeMoreAction(displayable);
     showSubCards(displayable, 2);
@@ -232,6 +239,26 @@ public class AggregatedSocialStoreLatestAppsWidget
 
   @Override String getCardTypeName() {
     return AggregatedSocialInstallDisplayable.CARD_TYPE_NAME;
+  }
+
+  private void setAdditionalNumberOfSharersLabel(
+      AggregatedSocialStoreLatestAppsDisplayable displayable) {
+    int numberOfSharers = displayable.getSharers()
+        .size();
+
+    if (numberOfSharers <= 2) {
+      additionalNumberOfSharesLabel.setVisibility(View.INVISIBLE);
+      additionalNumberOfSharesCircularMask.setVisibility(View.INVISIBLE);
+      return;
+    } else {
+      additionalNumberOfSharesLabel.setVisibility(View.VISIBLE);
+      additionalNumberOfSharesCircularMask.setVisibility(View.VISIBLE);
+      numberOfSharers -= 2;
+    }
+
+    additionalNumberOfSharesLabel.setText(
+        String.format(getContext().getString(R.string.timeline_short_plus),
+            String.valueOf(numberOfSharers)));
   }
 
   private void showSubCards(AggregatedSocialStoreLatestAppsDisplayable displayable,

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
@@ -49,6 +49,8 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
   private TextView relatedTo;
   private String appName;
   private RatingBar ratingBar;
+  private TextView additionalNumberOfSharesLabel;
+  private ImageView additionalNumberOfSharesCircularMask;
 
   public AggregatedSocialVideoWidget(View itemView) {
     super(itemView);
@@ -74,6 +76,10 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
     cardView = (CardView) itemView.findViewById(R.id.card);
     relatedTo = (TextView) itemView.findViewById(R.id.app_name);
     ratingBar = (RatingBar) itemView.findViewById(R.id.ratingbar);
+    additionalNumberOfSharesCircularMask =
+        (ImageView) itemView.findViewById(R.id.card_header_avatar_plus);
+    additionalNumberOfSharesLabel =
+        (TextView) itemView.findViewById(R.id.timeline_header_aditional_number_of_shares_circular);
   }
 
   @Override public void bindView(AggregatedSocialVideoDisplayable displayable) {
@@ -110,14 +116,33 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
           displayable.sendOpenVideoEvent();
         }));
 
+    setAdditionalNumberOfSharersLabel(displayable);
     setCardViewMargin(displayable, cardView);
-
     showSeeMoreAction(displayable);
     showSubCards(displayable, 2);
   }
 
   @Override String getCardTypeName() {
     return AggregatedSocialVideoDisplayable.CARD_TYPE_NAME;
+  }
+
+  private void setAdditionalNumberOfSharersLabel(AggregatedSocialVideoDisplayable displayable) {
+    int numberOfSharers = displayable.getSharers()
+        .size();
+
+    if (numberOfSharers <= 2) {
+      additionalNumberOfSharesLabel.setVisibility(View.INVISIBLE);
+      additionalNumberOfSharesCircularMask.setVisibility(View.INVISIBLE);
+      return;
+    } else {
+      additionalNumberOfSharesLabel.setVisibility(View.VISIBLE);
+      additionalNumberOfSharesCircularMask.setVisibility(View.VISIBLE);
+      numberOfSharers -= 2;
+    }
+
+    additionalNumberOfSharesLabel.setText(
+        String.format(getContext().getString(R.string.timeline_short_plus),
+            String.valueOf(numberOfSharers)));
   }
 
   private void showSubCards(AggregatedSocialVideoDisplayable displayable,


### PR DESCRIPTION
What does this PR do?

   This pull-request shows how many additional shares does an aggregated card have.
   Additional shares is the number of extra shares there are after 2 shares. 

Where should the reviewer start?

- [x] Aggregated Social install card
- [x] Aggregated Social article card
- [x] Aggregated Social video card
- [x] Aggregated Social store latest card

How should this be manually tested?

  Open Aptoide v8 > Apps Timeline > Find aggregated card with >2 shares > check if number of additional sharers is being shown and it is correct.

What are the relevant tickets?

Tickets related to this pull-request: [AN-1630](https://aptoide.atlassian.net/browse/AN-1630).

Screenshots (if appropriate)

N/A
Questions:

   Is there a blog post? N/A
   Does this add new dependencies which need to be added? No
