### PR TITLE
[NotificationManager/AN-1651] - NPE NotificationSyncService

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/notification/NotificationSyncService.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/notification/NotificationSyncService.java
@@ -30,18 +30,21 @@ public class NotificationSyncService extends Service {
   }
 
   @Override public int onStartCommand(Intent intent, int flags, int startId) {
-    switch (intent.getAction()) {
-      case PUSH_NOTIFICATIONS_CAMPAIGN_ACTION:
-        notificationSync.syncCampaigns()
-            .doOnTerminate(() -> stopSelf(startId))
-            .subscribe(() -> {
-            }, throwable -> throwable.printStackTrace());
-        break;
-      case PUSH_NOTIFICATIONS_SOCIAL_ACTION:
-        notificationSync.syncSocial()
-            .doOnTerminate(() -> stopSelf(startId))
-            .subscribe(() -> {
-            }, throwable -> throwable.printStackTrace());
+
+    if (intent.getAction() != null) {
+      switch (intent.getAction()) {
+        case PUSH_NOTIFICATIONS_CAMPAIGN_ACTION:
+          notificationSync.syncCampaigns()
+              .doOnTerminate(() -> stopSelf(startId))
+              .subscribe(() -> {
+              }, throwable -> throwable.printStackTrace());
+          break;
+        case PUSH_NOTIFICATIONS_SOCIAL_ACTION:
+          notificationSync.syncSocial()
+              .doOnTerminate(() -> stopSelf(startId))
+              .subscribe(() -> {
+              }, throwable -> throwable.printStackTrace());
+      }
     }
 
     return Service.START_NOT_STICKY;


### PR DESCRIPTION
Corrected a bug where the application was crashing when trying to get the intent action.
https://fabric.io/aptoide2/android/apps/cm.aptoide.pt/issues/592c6278be077a4dcc662952?time=last-ninety-days