### PR TITLE
[AN-1646] Add social info bar to the aggregated minimal cards.

### DIFF
--- a/model/src/main/java/cm/aptoide/pt/model/v7/timeline/MinimalCard.java
+++ b/model/src/main/java/cm/aptoide/pt/model/v7/timeline/MinimalCard.java
@@ -17,19 +17,39 @@ public class MinimalCard {
   private SocialCardStats stats;
   private UserSharerTimeline owner;
   private List<UserSharerTimeline> sharers;
+  private List<UserTimeline> usersLikes;
+  private List<SocialCard.CardComment> comments;
   private My my;
 
   public MinimalCard(@JsonProperty("card_id") String cardId,
       @JsonFormat(pattern = "yyyy-MM-dd", timezone = "UTC") @JsonProperty("date") Date date,
       @JsonProperty("owner") UserSharerTimeline owner,
       @JsonProperty("sharers") List<UserSharerTimeline> sharers,
-      @JsonProperty("stats") SocialCardStats stats, @JsonProperty("my") My my) {
+      @JsonProperty("stats") SocialCardStats stats, @JsonProperty("my") My my,
+      @JsonProperty("likes") List<UserTimeline> usersLikes) {
+    this.usersLikes = usersLikes;
     this.cardId = cardId;
     this.my = my;
     this.date = date;
     this.owner = owner;
     this.sharers = sharers;
     this.stats = stats;
+  }
+
+  public List<SocialCard.CardComment> getComments() {
+    return comments;
+  }
+
+  public void setComments(List<SocialCard.CardComment> comments) {
+    this.comments = comments;
+  }
+
+  public List<UserTimeline> getUsersLikes() {
+    return usersLikes;
+  }
+
+  public void setUsersLikes(List<UserTimeline> usersLikes) {
+    this.usersLikes = usersLikes;
   }
 
   public SocialCardStats getStats() {

--- a/model/src/main/java/cm/aptoide/pt/model/v7/timeline/SocialCardStats.java
+++ b/model/src/main/java/cm/aptoide/pt/model/v7/timeline/SocialCardStats.java
@@ -1,6 +1,5 @@
 package cm.aptoide.pt.model.v7.timeline;
 
-import java.util.List;
 import lombok.Data;
 
 /**
@@ -9,5 +8,4 @@ import lombok.Data;
 @Data public class SocialCardStats {
   private long likes;
   private long comments;
-  private List<UserTimeline> usersLikes;
 }

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/CardToDisplayableConverter.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/CardToDisplayableConverter.java
@@ -235,7 +235,8 @@ public class CardToDisplayableConverter implements CardToDisplayable {
     //
     converters.put(AggregatedSocialInstall.class,
         (card, dateCalculator, spannableFactory, downloadFactory, linksHandlerFactory) -> AggregatedSocialInstallDisplayable.from(
-            (AggregatedSocialInstall) card, timelineAnalytics, socialRepository, dateCalculator));
+            (AggregatedSocialInstall) card, timelineAnalytics, socialRepository, dateCalculator,
+            spannableFactory));
 
     //
     // AggregatedSocialArticle

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialArticleDisplayable.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialArticleDisplayable.java
@@ -12,12 +12,14 @@ import cm.aptoide.pt.model.v7.timeline.AggregatedSocialArticle;
 import cm.aptoide.pt.model.v7.timeline.MinimalCard;
 import cm.aptoide.pt.model.v7.timeline.UserSharerTimeline;
 import cm.aptoide.pt.v8engine.R;
+import cm.aptoide.pt.v8engine.V8Engine;
 import cm.aptoide.pt.v8engine.link.Link;
 import cm.aptoide.pt.v8engine.link.LinksHandlerFactory;
 import cm.aptoide.pt.v8engine.timeline.SocialRepository;
 import cm.aptoide.pt.v8engine.timeline.TimelineAnalytics;
 import cm.aptoide.pt.v8engine.timeline.view.ShareCardCallback;
 import cm.aptoide.pt.v8engine.util.DateCalculator;
+import cm.aptoide.pt.v8engine.view.navigator.FragmentNavigator;
 import cm.aptoide.pt.v8engine.view.recycler.displayable.Displayable;
 import cm.aptoide.pt.v8engine.view.recycler.displayable.SpannableFactory;
 import java.util.ArrayList;
@@ -218,8 +220,18 @@ public class AggregatedSocialArticleDisplayable extends CardDisplayable {
     return headerNamesStringBuilder.toString();
   }
 
+  public Spannable getBlackHighlightedLike(Context context, String string) {
+    return spannableFactory.createColorSpan(context.getString(R.string.x_liked_it, string),
+        ContextCompat.getColor(context, R.color.black_87_alpha), string);
+  }
+
   public String getTimeSinceLastUpdate(Context context) {
     return dateCalculator.getTimeSinceDate(context, date);
+  }
+
+  public void likesPreviewClick(FragmentNavigator navigator, long numberOfLikes, String cardId) {
+    navigator.navigateTo(V8Engine.getFragmentProvider()
+        .newTimeLineLikesFragment(cardId, numberOfLikes, "default"));
   }
 
   public String getTimeSinceLastUpdate(Context context, Date date) {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialInstallDisplayable.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialInstallDisplayable.java
@@ -1,15 +1,20 @@
 package cm.aptoide.pt.v8engine.timeline.view.displayable;
 
 import android.content.Context;
+import android.support.v4.content.ContextCompat;
+import android.text.Spannable;
 import cm.aptoide.pt.model.v7.timeline.AggregatedSocialInstall;
 import cm.aptoide.pt.model.v7.timeline.MinimalCard;
 import cm.aptoide.pt.model.v7.timeline.UserSharerTimeline;
 import cm.aptoide.pt.v8engine.R;
+import cm.aptoide.pt.v8engine.V8Engine;
 import cm.aptoide.pt.v8engine.timeline.SocialRepository;
 import cm.aptoide.pt.v8engine.timeline.TimelineAnalytics;
 import cm.aptoide.pt.v8engine.timeline.view.ShareCardCallback;
 import cm.aptoide.pt.v8engine.util.DateCalculator;
+import cm.aptoide.pt.v8engine.view.navigator.FragmentNavigator;
 import cm.aptoide.pt.v8engine.view.recycler.displayable.Displayable;
+import cm.aptoide.pt.v8engine.view.recycler.displayable.SpannableFactory;
 import java.util.Date;
 import java.util.List;
 
@@ -35,6 +40,7 @@ public class AggregatedSocialInstallDisplayable extends CardDisplayable {
   private Date date;
   private String abTestingURL;
   private TimelineAnalytics timelineAnalytics;
+  private SpannableFactory spannableFactory;
 
   public AggregatedSocialInstallDisplayable() {
   }
@@ -42,11 +48,12 @@ public class AggregatedSocialInstallDisplayable extends CardDisplayable {
   public AggregatedSocialInstallDisplayable(AggregatedSocialInstall card, long appId,
       String packageName, String appName, String appIcon, String abTestingURL, Date date,
       TimelineAnalytics timelineAnalytics, SocialRepository socialRepository,
-      DateCalculator dateCalculator) {
+      DateCalculator dateCalculator, SpannableFactory spannableFactory) {
     super(card, timelineAnalytics);
     this.minimalCardList = card.getMinimalCardList();
     this.sharers = card.getSharers();
     this.socialRepository = socialRepository;
+    this.spannableFactory = spannableFactory;
     this.timelineAnalytics = timelineAnalytics;
     this.appStoreId = card.getApp()
         .getStore()
@@ -66,7 +73,7 @@ public class AggregatedSocialInstallDisplayable extends CardDisplayable {
 
   public static Displayable from(AggregatedSocialInstall aggregatedSocialInstall,
       TimelineAnalytics timelineAnalytics, SocialRepository socialRepository,
-      DateCalculator dateCalculator) {
+      DateCalculator dateCalculator, SpannableFactory spannableFactory) {
 
     String abTestingURL = null;
 
@@ -87,7 +94,7 @@ public class AggregatedSocialInstallDisplayable extends CardDisplayable {
         .getPackageName(), aggregatedSocialInstall.getApp()
         .getName(), aggregatedSocialInstall.getApp()
         .getIcon(), abTestingURL, aggregatedSocialInstall.getDate(), timelineAnalytics,
-        socialRepository, dateCalculator);
+        socialRepository, dateCalculator, spannableFactory);
   }
 
   @Override
@@ -165,6 +172,16 @@ public class AggregatedSocialInstallDisplayable extends CardDisplayable {
 
   public long getAppStoreId() {
     return appStoreId;
+  }
+
+  public void likesPreviewClick(FragmentNavigator navigator, long numberOfLikes, String cardId) {
+    navigator.navigateTo(V8Engine.getFragmentProvider()
+        .newTimeLineLikesFragment(cardId, numberOfLikes, "default"));
+  }
+
+  public Spannable getBlackHighlightedLike(Context context, String string) {
+    return spannableFactory.createColorSpan(context.getString(R.string.x_liked_it, string),
+        ContextCompat.getColor(context, R.color.black_87_alpha), string);
   }
 
   public String getCardHeaderNames() {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialStoreLatestAppsDisplayable.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialStoreLatestAppsDisplayable.java
@@ -1,21 +1,26 @@
 package cm.aptoide.pt.v8engine.timeline.view.displayable;
 
 import android.content.Context;
+import android.support.v4.content.ContextCompat;
+import android.text.Spannable;
 import cm.aptoide.pt.model.v7.listapp.App;
 import cm.aptoide.pt.model.v7.store.Store;
 import cm.aptoide.pt.model.v7.timeline.AggregatedSocialStoreLatestApps;
 import cm.aptoide.pt.model.v7.timeline.MinimalCard;
 import cm.aptoide.pt.model.v7.timeline.UserSharerTimeline;
 import cm.aptoide.pt.v8engine.R;
+import cm.aptoide.pt.v8engine.V8Engine;
 import cm.aptoide.pt.v8engine.store.StoreCredentialsProvider;
 import cm.aptoide.pt.v8engine.timeline.SocialRepository;
 import cm.aptoide.pt.v8engine.timeline.TimelineAnalytics;
 import cm.aptoide.pt.v8engine.timeline.view.ShareCardCallback;
 import cm.aptoide.pt.v8engine.util.DateCalculator;
+import cm.aptoide.pt.v8engine.view.navigator.FragmentNavigator;
 import cm.aptoide.pt.v8engine.view.recycler.displayable.Displayable;
 import cm.aptoide.pt.v8engine.view.recycler.displayable.SpannableFactory;
 import java.util.Date;
 import java.util.List;
+import java.util.Stack;
 
 import static cm.aptoide.pt.v8engine.analytics.Analytics.AppsTimeline.BLANK;
 
@@ -25,6 +30,7 @@ import static cm.aptoide.pt.v8engine.analytics.Analytics.AppsTimeline.BLANK;
 
 public class AggregatedSocialStoreLatestAppsDisplayable extends CardDisplayable {
   public static final String CARD_TYPE_NAME = "AGGREGATED_SOCIAL_LATEST_APPS";
+  private SpannableFactory spannableFactory;
   private List<App> latestApps;
   private String abTestingUrl;
   private Store ownerStore;
@@ -54,6 +60,7 @@ public class AggregatedSocialStoreLatestAppsDisplayable extends CardDisplayable 
     this.dateCalculator = dateCalculator;
     this.timelineAnalytics = timelineAnalytics;
     this.socialRepository = socialRepository;
+    this.spannableFactory = spannableFactory;
     this.storeCredentialsProvider = storeCredentialsProvider;
     this.minimalCards = minimalCards;
     this.sharers = sharers;
@@ -156,6 +163,16 @@ public class AggregatedSocialStoreLatestAppsDisplayable extends CardDisplayable 
 
   @Override public int getViewLayout() {
     return R.layout.displayable_social_timeline_aggregated_social_store;
+  }
+
+  public void likesPreviewClick(FragmentNavigator navigator, long numberOfLikes, String cardId) {
+    navigator.navigateTo(V8Engine.getFragmentProvider()
+        .newTimeLineLikesFragment(cardId, numberOfLikes, "default"));
+  }
+
+  public Spannable getBlackHighlightedLike(Context context, String string) {
+    return spannableFactory.createColorSpan(context.getString(R.string.x_liked_it, string),
+        ContextCompat.getColor(context, R.color.black_87_alpha), string);
   }
 
   @Override

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialVideoDisplayable.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialVideoDisplayable.java
@@ -12,12 +12,14 @@ import cm.aptoide.pt.model.v7.timeline.AggregatedSocialVideo;
 import cm.aptoide.pt.model.v7.timeline.MinimalCard;
 import cm.aptoide.pt.model.v7.timeline.UserSharerTimeline;
 import cm.aptoide.pt.v8engine.R;
+import cm.aptoide.pt.v8engine.V8Engine;
 import cm.aptoide.pt.v8engine.link.Link;
 import cm.aptoide.pt.v8engine.link.LinksHandlerFactory;
 import cm.aptoide.pt.v8engine.timeline.SocialRepository;
 import cm.aptoide.pt.v8engine.timeline.TimelineAnalytics;
 import cm.aptoide.pt.v8engine.timeline.view.ShareCardCallback;
 import cm.aptoide.pt.v8engine.util.DateCalculator;
+import cm.aptoide.pt.v8engine.view.navigator.FragmentNavigator;
 import cm.aptoide.pt.v8engine.view.recycler.displayable.Displayable;
 import cm.aptoide.pt.v8engine.view.recycler.displayable.SpannableFactory;
 import java.util.ArrayList;
@@ -241,6 +243,16 @@ public class AggregatedSocialVideoDisplayable extends CardDisplayable {
     socialRepository.like(cardId, cardType, "", rating,
         getTimelineSocialActionObject(CARD_TYPE_NAME, BLANK, LIKE, BLANK, getPublisherName(),
             BLANK));
+  }
+
+  public Spannable getBlackHighlightedLike(Context context, String string) {
+    return spannableFactory.createColorSpan(context.getString(R.string.x_liked_it, string),
+        ContextCompat.getColor(context, R.color.black_87_alpha), string);
+  }
+
+  public void likesPreviewClick(FragmentNavigator navigator, long numberOfLikes, String cardId) {
+    navigator.navigateTo(V8Engine.getFragmentProvider()
+        .newTimeLineLikesFragment(cardId, numberOfLikes, "default"));
   }
 
   @Override public int getViewLayout() {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialArticleWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialArticleWidget.java
@@ -372,6 +372,18 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
           }, throwable -> CrashReport.getInstance()
               .log(throwable)));
 
+      compositeSubscription.add(RxView.clicks(numberComments)
+          .flatMap(aVoid -> {
+            final String elementId = minimalCard.getCardId();
+            Fragment fragment = V8Engine.getFragmentProvider()
+                .newCommentGridRecyclerFragment(CommentType.TIMELINE, elementId);
+            getFragmentNavigator().navigateTo(fragment);
+            return null;
+          })
+          .subscribe(aVoid -> knockWithSixpackCredentials(displayable.getAbTestingURL()),
+              throwable -> CrashReport.getInstance()
+                  .log(throwable)));
+
       compositeSubscription.add(RxView.clicks(comment)
           .flatMap(aVoid -> Observable.fromCallable(() -> {
             final String elementId = minimalCard.getCardId();

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialArticleWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialArticleWidget.java
@@ -1,19 +1,24 @@
 package cm.aptoide.pt.v8engine.timeline.view.widget;
 
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
 import android.support.v7.widget.CardView;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RatingBar;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import cm.aptoide.accountmanager.AptoideAccountManager;
 import cm.aptoide.pt.dataprovider.util.CommentType;
 import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
 import cm.aptoide.pt.dataprovider.ws.v7.BaseBody;
 import cm.aptoide.pt.imageloader.ImageLoader;
+import cm.aptoide.pt.model.v7.store.Store;
 import cm.aptoide.pt.model.v7.timeline.MinimalCard;
+import cm.aptoide.pt.model.v7.timeline.UserTimeline;
 import cm.aptoide.pt.v8engine.R;
 import cm.aptoide.pt.v8engine.V8Engine;
 import cm.aptoide.pt.v8engine.analytics.Analytics;
@@ -164,6 +169,22 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
       LikeButtonView likeSubCardButton =
           (LikeButtonView) subCardView.findViewById(R.id.social_like_button);
       LinearLayout likeLayout = (LinearLayout) subCardView.findViewById(R.id.social_like);
+      LinearLayout socialInfoBar = (LinearLayout) subCardView.findViewById(R.id.social_info_bar);
+      RelativeLayout likePreviewContainer = (RelativeLayout) subCardView.findViewById(
+          R.id.displayable_social_timeline_likes_preview_container);
+      TextView numberLikes = (TextView) subCardView.findViewById(R.id.social_number_of_likes);
+      TextView numberLikesOneLike = (TextView) subCardView.findViewById(R.id.social_one_like);
+      TextView numberComments = (TextView) subCardView.findViewById(R.id.social_number_of_comments);
+      LinearLayout socialCommentBar =
+          (LinearLayout) subCardView.findViewById(R.id.social_latest_comment_bar);
+      TextView socialCommentUsername =
+          (TextView) subCardView.findViewById(R.id.social_latest_comment_user_name);
+      TextView socialCommentBody =
+          (TextView) subCardView.findViewById(R.id.social_latest_comment_body);
+      ImageView latestCommentMainAvatar =
+          (ImageView) subCardView.findViewById(R.id.card_last_comment_main_icon);
+
+      int marginOfTheNextLikePreview = 0;
 
       ImageLoader.with(getContext())
           .loadWithShadowCircleTransform(minimalCard.getSharers()
@@ -189,6 +210,61 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
 
       cardHeaderTimestamp.setText(
           displayable.getTimeSinceLastUpdate(getContext(), minimalCard.getDate()));
+
+      likePreviewContainer.removeAllViews();
+      showLikesPreview(marginOfTheNextLikePreview, likePreviewContainer, minimalCard);
+
+      if ((minimalCard.getUsersLikes() != null
+          && minimalCard.getUsersLikes()
+          .size() != 0)
+          || minimalCard.getStats()
+          .getComments() > 0) {
+        socialInfoBar.setVisibility(View.VISIBLE);
+      } else {
+        socialInfoBar.setVisibility(View.GONE);
+      }
+
+      final long numberOfLikes = minimalCard.getStats()
+          .getLikes();
+      if (numberOfLikes > 0) {
+        if (numberOfLikes > 1) {
+          showNumberOfLikes(numberOfLikes, numberLikes, numberLikesOneLike);
+        } else if (minimalCard.getUsersLikes() != null
+            && minimalCard.getUsersLikes()
+            .size() != 0) {
+          if (minimalCard.getUsersLikes()
+              .get(0)
+              .getName() != null) {
+            numberLikesOneLike.setText(displayable.getBlackHighlightedLike(getContext(),
+                minimalCard.getUsersLikes()
+                    .get(0)
+                    .getName()));
+            numberLikes.setVisibility(View.INVISIBLE);
+            numberLikesOneLike.setVisibility(View.VISIBLE);
+          } else {
+            if (minimalCard.getUsersLikes()
+                .get(0)
+                .getStore() != null
+                && minimalCard.getUsersLikes()
+                .get(0)
+                .getStore()
+                .getName() != null) {
+              numberLikesOneLike.setText(displayable.getBlackHighlightedLike(getContext(),
+                  minimalCard.getUsersLikes()
+                      .get(0)
+                      .getStore()
+                      .getName()));
+              numberLikes.setVisibility(View.INVISIBLE);
+              numberLikesOneLike.setVisibility(View.VISIBLE);
+            } else {
+              showNumberOfLikes(numberOfLikes, numberLikes, numberLikesOneLike);
+            }
+          }
+        }
+      } else {
+        numberLikes.setVisibility(View.INVISIBLE);
+        numberLikesOneLike.setVisibility(View.INVISIBLE);
+      }
 
       compositeSubscription.add(displayable.getRelatedToApplication()
           .observeOn(AndroidSchedulers.mainThread())
@@ -219,6 +295,30 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
         likeSubCardButton.setHeartState(false);
       }
 
+      if (minimalCard.getStats()
+          .getComments() > 0
+          && minimalCard.getComments()
+          .size() > 0) {
+        numberComments.setVisibility(View.VISIBLE);
+        numberComments.setText(String.format("%s %s", String.valueOf(minimalCard.getStats()
+            .getComments()), getContext().getString(R.string.comments)
+            .toLowerCase()));
+        socialCommentBar.setVisibility(View.VISIBLE);
+        ImageLoader.with(getContext())
+            .loadWithShadowCircleTransform(minimalCard.getComments()
+                .get(0)
+                .getAvatar(), latestCommentMainAvatar);
+        socialCommentUsername.setText(minimalCard.getComments()
+            .get(0)
+            .getName());
+        socialCommentBody.setText(minimalCard.getComments()
+            .get(0)
+            .getBody());
+      } else {
+        numberComments.setVisibility(View.INVISIBLE);
+        socialCommentBar.setVisibility(View.GONE);
+      }
+
       compositeSubscription.add(RxView.clicks(likeLayout)
           .subscribe(click -> {
             if (!hasSocialPermissions(Analytics.Account.AccountOrigins.LIKE_CARD)) return;
@@ -232,9 +332,28 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
               .toSingle()
               .toObservable())
           .observeOn(AndroidSchedulers.mainThread())
-          .subscribe(account -> likeCard(displayable, minimalCard.getCardId(), 1),
-              err -> CrashReport.getInstance()
-                  .log(err)));
+          .subscribe(account -> {
+            if (likeCard(displayable, minimalCard.getCardId(), 1)) {
+              numberLikes.setText(String.valueOf(minimalCard.getStats()
+                  .getLikes() + 1));
+              numberLikes.setVisibility(View.VISIBLE);
+              if (likePreviewContainer.getChildCount() < 4) {
+                if (!minimalCard.getMy()
+                    .isLiked()) {
+                  knockWithSixpackCredentials(displayable.getAbTestingURL());
+                  UserTimeline user = new UserTimeline();
+                  Store store = new Store();
+                  store.setAvatar(account.getStoreAvatar());
+                  user.setAvatar(account.getAvatar());
+                  user.setStore(store);
+                  addUserToPreview(marginOfTheNextLikePreview, user, likePreviewContainer,
+                      marginOfTheNextLikePreview);
+                  likePreviewContainer.invalidate();
+                }
+              }
+            }
+          }, err -> CrashReport.getInstance()
+              .log(err)));
 
       compositeSubscription.add(RxView.clicks(shareSubCardButton)
           .subscribe(click -> shareCard(displayable, minimalCard.getCardId(), null,
@@ -266,6 +385,12 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
               err -> CrashReport.getInstance()
                   .log(err)));
 
+      compositeSubscription.add(RxView.clicks(likePreviewContainer)
+          .subscribe(click -> displayable.likesPreviewClick(getFragmentNavigator(),
+              minimalCard.getStats()
+                  .getLikes(), minimalCard.getCardId()), err -> CrashReport.getInstance()
+              .log(err)));
+
       subCardsContainer.addView(subCardView);
       i++;
     }
@@ -287,5 +412,66 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
     } else {
       seeMore.setVisibility(View.GONE);
     }
+  }
+
+  private int addUserToPreview(int i, UserTimeline user, ViewGroup likePreviewContainer,
+      int marginOfTheNextLikePreview) {
+    View likeUserPreviewView;
+    ImageView likeUserPreviewIcon;
+    likeUserPreviewView =
+        inflater.inflate(R.layout.social_timeline_like_user_preview, likePreviewContainer, false);
+    likeUserPreviewIcon =
+        (ImageView) likeUserPreviewView.findViewById(R.id.social_timeline_like_user_preview);
+    ViewGroup.MarginLayoutParams p =
+        (ViewGroup.MarginLayoutParams) likeUserPreviewView.getLayoutParams();
+    p.setMargins(i, 0, 0, 0);
+    likeUserPreviewView.requestLayout();
+
+    if (user != null) {
+      final FragmentActivity context = getContext();
+      if (user.getAvatar() != null) {
+        ImageLoader.with(context)
+            .loadWithShadowCircleTransform(user.getAvatar(), likeUserPreviewIcon);
+      } else if (user.getStore()
+          .getAvatar() != null) {
+        ImageLoader.with(context)
+            .loadWithShadowCircleTransform(user.getStore()
+                .getAvatar(), likeUserPreviewIcon);
+      }
+      likePreviewContainer.addView(likeUserPreviewView);
+      return marginOfTheNextLikePreview - 20;
+    } else {
+      return marginOfTheNextLikePreview;
+    }
+  }
+
+  private void showLikesPreview(int marginOfTheNextLikePreview, ViewGroup likePreviewContainer,
+      MinimalCard minimalCard) {
+    marginOfTheNextLikePreview = 60;
+    for (int j = 0; j < minimalCard.getStats()
+        .getLikes(); j++) {
+
+      UserTimeline user = null;
+      if (minimalCard.getUsersLikes() != null && j < minimalCard.getUsersLikes()
+          .size()) {
+        user = minimalCard.getUsersLikes()
+            .get(j);
+      }
+      marginOfTheNextLikePreview =
+          addUserToPreview(marginOfTheNextLikePreview, user, likePreviewContainer,
+              marginOfTheNextLikePreview);
+      if (marginOfTheNextLikePreview < 0) {
+        break;
+      }
+    }
+  }
+
+  private void showNumberOfLikes(long numberOfLikes, TextView numberLikes,
+      TextView numberLikesOneLike) {
+    numberLikes.setVisibility(View.VISIBLE);
+    numberLikes.setText(String.format("%s %s", String.valueOf(numberOfLikes),
+        getContext().getString(R.string.likes)
+            .toLowerCase()));
+    numberLikesOneLike.setVisibility(View.INVISIBLE);
   }
 }

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialArticleWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialArticleWidget.java
@@ -373,12 +373,11 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
               .log(throwable)));
 
       compositeSubscription.add(RxView.clicks(numberComments)
-          .flatMap(aVoid -> {
+          .doOnNext(click -> {
             final String elementId = minimalCard.getCardId();
             Fragment fragment = V8Engine.getFragmentProvider()
                 .newCommentGridRecyclerFragment(CommentType.TIMELINE, elementId);
             getFragmentNavigator().navigateTo(fragment);
-            return null;
           })
           .subscribe(aVoid -> knockWithSixpackCredentials(displayable.getAbTestingURL()),
               throwable -> CrashReport.getInstance()

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialArticleWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialArticleWidget.java
@@ -334,13 +334,13 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
           .observeOn(AndroidSchedulers.mainThread())
           .subscribe(account -> {
             if (likeCard(displayable, minimalCard.getCardId(), 1)) {
+              knockWithSixpackCredentials(displayable.getAbTestingURL());
               numberLikes.setText(String.valueOf(minimalCard.getStats()
                   .getLikes() + 1));
               numberLikes.setVisibility(View.VISIBLE);
               if (likePreviewContainer.getChildCount() < 4) {
                 if (!minimalCard.getMy()
                     .isLiked()) {
-                  knockWithSixpackCredentials(displayable.getAbTestingURL());
                   UserTimeline user = new UserTimeline();
                   Store store = new Store();
                   store.setAvatar(account.getStoreAvatar());
@@ -426,7 +426,7 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
     }
   }
 
-  private int addUserToPreview(int i, UserTimeline user, ViewGroup likePreviewContainer,
+  private int addUserToPreview(int marginLeft, UserTimeline user, ViewGroup likePreviewContainer,
       int marginOfTheNextLikePreview) {
     View likeUserPreviewView;
     ImageView likeUserPreviewIcon;
@@ -436,7 +436,7 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
         (ImageView) likeUserPreviewView.findViewById(R.id.social_timeline_like_user_preview);
     ViewGroup.MarginLayoutParams p =
         (ViewGroup.MarginLayoutParams) likeUserPreviewView.getLayoutParams();
-    p.setMargins(i, 0, 0, 0);
+    p.setMargins(marginLeft, 0, 0, 0);
     likeUserPreviewView.requestLayout();
 
     if (user != null) {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialArticleWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialArticleWidget.java
@@ -212,7 +212,7 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
           displayable.getTimeSinceLastUpdate(getContext(), minimalCard.getDate()));
 
       likePreviewContainer.removeAllViews();
-      showLikesPreview(marginOfTheNextLikePreview, likePreviewContainer, minimalCard);
+      showLikesPreview(likePreviewContainer, minimalCard);
 
       if ((minimalCard.getUsersLikes() != null
           && minimalCard.getUsersLikes()
@@ -457,9 +457,8 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
     }
   }
 
-  private void showLikesPreview(int marginOfTheNextLikePreview, ViewGroup likePreviewContainer,
-      MinimalCard minimalCard) {
-    marginOfTheNextLikePreview = 60;
+  private void showLikesPreview(ViewGroup likePreviewContainer, MinimalCard minimalCard) {
+    int marginOfTheNextLikePreview = 60;
     for (int j = 0; j < minimalCard.getStats()
         .getLikes(); j++) {
 

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
@@ -216,7 +216,7 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
       }
 
       likePreviewContainer.removeAllViews();
-      showLikesPreview(marginOfTheNextLikePreview, likePreviewContainer, minimalCard);
+      showLikesPreview(likePreviewContainer, minimalCard);
 
       if ((minimalCard.getUsersLikes() != null
           && minimalCard.getUsersLikes()
@@ -423,9 +423,8 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
     }
   }
 
-  private void showLikesPreview(int marginOfTheNextLikePreview, ViewGroup likePreviewContainer,
-      MinimalCard minimalCard) {
-    marginOfTheNextLikePreview = 60;
+  private void showLikesPreview(ViewGroup likePreviewContainer, MinimalCard minimalCard) {
+    int marginOfTheNextLikePreview = 60;
     for (int j = 0; j < minimalCard.getStats()
         .getLikes(); j++) {
 

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
@@ -347,6 +347,18 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
       likeLayout.setVisibility(View.VISIBLE);
       comment.setVisibility(View.VISIBLE);
 
+      compositeSubscription.add(RxView.clicks(numberComments)
+          .flatMap(aVoid -> {
+            final String elementId = minimalCard.getCardId();
+            Fragment fragment = V8Engine.getFragmentProvider()
+                .newCommentGridRecyclerFragment(CommentType.TIMELINE, elementId);
+            getFragmentNavigator().navigateTo(fragment);
+            return null;
+          })
+          .subscribe(aVoid -> knockWithSixpackCredentials(displayable.getAbTestingURL()),
+              throwable -> CrashReport.getInstance()
+                  .log(throwable)));
+
       compositeSubscription.add(RxView.clicks(comment)
           .flatMap(aVoid -> Observable.fromCallable(() -> {
             final String elementId = minimalCard.getCardId();

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
@@ -321,13 +321,13 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
           .observeOn(AndroidSchedulers.mainThread())
           .subscribe(account -> {
             if (likeCard(displayable, minimalCard.getCardId(), 1)) {
+              knockWithSixpackCredentials(displayable.getAbTestingURL());
               numberLikes.setText(String.valueOf(minimalCard.getStats()
                   .getLikes() + 1));
               numberLikes.setVisibility(View.VISIBLE);
               if (likePreviewContainer.getChildCount() < 4) {
                 if (!minimalCard.getMy()
                     .isLiked()) {
-                  knockWithSixpackCredentials(displayable.getAbTestingURL());
                   UserTimeline user = new UserTimeline();
                   Store store = new Store();
                   store.setAvatar(account.getStoreAvatar());
@@ -392,7 +392,7 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
     }
   }
 
-  private int addUserToPreview(int i, UserTimeline user, ViewGroup likePreviewContainer,
+  private int addUserToPreview(int marginLeft, UserTimeline user, ViewGroup likePreviewContainer,
       int marginOfTheNextLikePreview) {
     View likeUserPreviewView;
     ImageView likeUserPreviewIcon;
@@ -402,7 +402,7 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
         (ImageView) likeUserPreviewView.findViewById(R.id.social_timeline_like_user_preview);
     ViewGroup.MarginLayoutParams p =
         (ViewGroup.MarginLayoutParams) likeUserPreviewView.getLayoutParams();
-    p.setMargins(i, 0, 0, 0);
+    p.setMargins(marginLeft, 0, 0, 0);
     likeUserPreviewView.requestLayout();
 
     if (user != null) {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
@@ -1,20 +1,25 @@
 package cm.aptoide.pt.v8engine.timeline.view.widget;
 
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
 import android.support.v7.widget.CardView;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RatingBar;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import cm.aptoide.accountmanager.AptoideAccountManager;
 import cm.aptoide.pt.dataprovider.util.CommentType;
 import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
 import cm.aptoide.pt.dataprovider.ws.v7.BaseBody;
 import cm.aptoide.pt.imageloader.ImageLoader;
+import cm.aptoide.pt.model.v7.store.Store;
 import cm.aptoide.pt.model.v7.timeline.MinimalCard;
+import cm.aptoide.pt.model.v7.timeline.UserTimeline;
 import cm.aptoide.pt.v8engine.R;
 import cm.aptoide.pt.v8engine.V8Engine;
 import cm.aptoide.pt.v8engine.analytics.Analytics;
@@ -161,6 +166,23 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
       TextView shareSubCardButton = (TextView) subCardView.findViewById(R.id.social_share);
       LinearLayout likeLayout = (LinearLayout) subCardView.findViewById(R.id.social_like);
       TextView comment = (TextView) subCardView.findViewById(R.id.social_comment);
+      LinearLayout socialInfoBar = (LinearLayout) subCardView.findViewById(R.id.social_info_bar);
+      RelativeLayout likePreviewContainer = (RelativeLayout) subCardView.findViewById(
+          R.id.displayable_social_timeline_likes_preview_container);
+      TextView numberLikes = (TextView) subCardView.findViewById(R.id.social_number_of_likes);
+      TextView numberLikesOneLike = (TextView) subCardView.findViewById(R.id.social_one_like);
+      TextView numberComments = (TextView) subCardView.findViewById(R.id.social_number_of_comments);
+      LinearLayout socialCommentBar =
+          (LinearLayout) subCardView.findViewById(R.id.social_latest_comment_bar);
+      TextView socialCommentUsername =
+          (TextView) subCardView.findViewById(R.id.social_latest_comment_user_name);
+      TextView socialCommentBody =
+          (TextView) subCardView.findViewById(R.id.social_latest_comment_body);
+      ImageView latestCommentMainAvatar =
+          (ImageView) subCardView.findViewById(R.id.card_last_comment_main_icon);
+
+      int marginOfTheNextLikePreview = 0;
+
       ImageLoader.with(getContext())
           .loadWithShadowCircleTransform(minimalCard.getSharers()
               .get(0)
@@ -193,6 +215,85 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
         likeSubCardButton.setHeartState(false);
       }
 
+      likePreviewContainer.removeAllViews();
+      showLikesPreview(marginOfTheNextLikePreview, likePreviewContainer, minimalCard);
+
+      if ((minimalCard.getUsersLikes() != null
+          && minimalCard.getUsersLikes()
+          .size() != 0)
+          || minimalCard.getStats()
+          .getComments() > 0) {
+        socialInfoBar.setVisibility(View.VISIBLE);
+      } else {
+        socialInfoBar.setVisibility(View.GONE);
+      }
+
+      final long numberOfLikes = minimalCard.getStats()
+          .getLikes();
+      if (numberOfLikes > 0) {
+        if (numberOfLikes > 1) {
+          showNumberOfLikes(numberOfLikes, numberLikes, numberLikesOneLike);
+        } else if (minimalCard.getUsersLikes() != null
+            && minimalCard.getUsersLikes()
+            .size() != 0) {
+          if (minimalCard.getUsersLikes()
+              .get(0)
+              .getName() != null) {
+            numberLikesOneLike.setText(displayable.getBlackHighlightedLike(getContext(),
+                minimalCard.getUsersLikes()
+                    .get(0)
+                    .getName()));
+            numberLikes.setVisibility(View.INVISIBLE);
+            numberLikesOneLike.setVisibility(View.VISIBLE);
+          } else {
+            if (minimalCard.getUsersLikes()
+                .get(0)
+                .getStore() != null
+                && minimalCard.getUsersLikes()
+                .get(0)
+                .getStore()
+                .getName() != null) {
+              numberLikesOneLike.setText(displayable.getBlackHighlightedLike(getContext(),
+                  minimalCard.getUsersLikes()
+                      .get(0)
+                      .getStore()
+                      .getName()));
+              numberLikes.setVisibility(View.INVISIBLE);
+              numberLikesOneLike.setVisibility(View.VISIBLE);
+            } else {
+              showNumberOfLikes(numberOfLikes, numberLikes, numberLikesOneLike);
+            }
+          }
+        }
+      } else {
+        numberLikes.setVisibility(View.INVISIBLE);
+        numberLikesOneLike.setVisibility(View.INVISIBLE);
+      }
+
+      if (minimalCard.getStats()
+          .getComments() > 0
+          && minimalCard.getComments()
+          .size() > 0) {
+        numberComments.setVisibility(View.VISIBLE);
+        numberComments.setText(String.format("%s %s", String.valueOf(minimalCard.getStats()
+            .getComments()), getContext().getString(R.string.comments)
+            .toLowerCase()));
+        socialCommentBar.setVisibility(View.VISIBLE);
+        ImageLoader.with(getContext())
+            .loadWithShadowCircleTransform(minimalCard.getComments()
+                .get(0)
+                .getAvatar(), latestCommentMainAvatar);
+        socialCommentUsername.setText(minimalCard.getComments()
+            .get(0)
+            .getName());
+        socialCommentBody.setText(minimalCard.getComments()
+            .get(0)
+            .getBody());
+      } else {
+        numberComments.setVisibility(View.INVISIBLE);
+        socialCommentBar.setVisibility(View.GONE);
+      }
+
       compositeSubscription.add(RxView.clicks(shareSubCardButton)
           .subscribe(click -> shareCard(displayable, minimalCard.getCardId(), null,
               SharePreviewDialog.SharePreviewOpenMode.SHARE), err -> CrashReport.getInstance()
@@ -218,9 +319,28 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
               .toSingle()
               .toObservable())
           .observeOn(AndroidSchedulers.mainThread())
-          .subscribe(account -> likeCard(displayable, minimalCard.getCardId(), 1),
-              err -> CrashReport.getInstance()
-                  .log(err)));
+          .subscribe(account -> {
+            if (likeCard(displayable, minimalCard.getCardId(), 1)) {
+              numberLikes.setText(String.valueOf(minimalCard.getStats()
+                  .getLikes() + 1));
+              numberLikes.setVisibility(View.VISIBLE);
+              if (likePreviewContainer.getChildCount() < 4) {
+                if (!minimalCard.getMy()
+                    .isLiked()) {
+                  knockWithSixpackCredentials(displayable.getAbTestingURL());
+                  UserTimeline user = new UserTimeline();
+                  Store store = new Store();
+                  store.setAvatar(account.getStoreAvatar());
+                  user.setAvatar(account.getAvatar());
+                  user.setStore(store);
+                  addUserToPreview(marginOfTheNextLikePreview, user, likePreviewContainer,
+                      marginOfTheNextLikePreview);
+                  likePreviewContainer.invalidate();
+                }
+              }
+            }
+          }, err -> CrashReport.getInstance()
+              .log(err)));
 
       compositeSubscription.add(accountManager.accountStatus()
           .subscribe());
@@ -240,6 +360,12 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
               err -> CrashReport.getInstance()
                   .log(err)));
 
+      compositeSubscription.add(RxView.clicks(likePreviewContainer)
+          .subscribe(click -> displayable.likesPreviewClick(getFragmentNavigator(),
+              minimalCard.getStats()
+                  .getLikes(), minimalCard.getCardId()), err -> CrashReport.getInstance()
+              .log(err)));
+
       subCardsContainer.addView(subCardView);
       i++;
     }
@@ -252,5 +378,66 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
     } else {
       seeMore.setVisibility(View.GONE);
     }
+  }
+
+  private int addUserToPreview(int i, UserTimeline user, ViewGroup likePreviewContainer,
+      int marginOfTheNextLikePreview) {
+    View likeUserPreviewView;
+    ImageView likeUserPreviewIcon;
+    likeUserPreviewView =
+        inflater.inflate(R.layout.social_timeline_like_user_preview, likePreviewContainer, false);
+    likeUserPreviewIcon =
+        (ImageView) likeUserPreviewView.findViewById(R.id.social_timeline_like_user_preview);
+    ViewGroup.MarginLayoutParams p =
+        (ViewGroup.MarginLayoutParams) likeUserPreviewView.getLayoutParams();
+    p.setMargins(i, 0, 0, 0);
+    likeUserPreviewView.requestLayout();
+
+    if (user != null) {
+      final FragmentActivity context = getContext();
+      if (user.getAvatar() != null) {
+        ImageLoader.with(context)
+            .loadWithShadowCircleTransform(user.getAvatar(), likeUserPreviewIcon);
+      } else if (user.getStore()
+          .getAvatar() != null) {
+        ImageLoader.with(context)
+            .loadWithShadowCircleTransform(user.getStore()
+                .getAvatar(), likeUserPreviewIcon);
+      }
+      likePreviewContainer.addView(likeUserPreviewView);
+      return marginOfTheNextLikePreview - 20;
+    } else {
+      return marginOfTheNextLikePreview;
+    }
+  }
+
+  private void showLikesPreview(int marginOfTheNextLikePreview, ViewGroup likePreviewContainer,
+      MinimalCard minimalCard) {
+    marginOfTheNextLikePreview = 60;
+    for (int j = 0; j < minimalCard.getStats()
+        .getLikes(); j++) {
+
+      UserTimeline user = null;
+      if (minimalCard.getUsersLikes() != null && j < minimalCard.getUsersLikes()
+          .size()) {
+        user = minimalCard.getUsersLikes()
+            .get(j);
+      }
+      marginOfTheNextLikePreview =
+          addUserToPreview(marginOfTheNextLikePreview, user, likePreviewContainer,
+              marginOfTheNextLikePreview);
+      if (marginOfTheNextLikePreview < 0) {
+        break;
+      }
+    }
+  }
+
+  private void showNumberOfLikes(long numberOfLikes, TextView numberLikes,
+      TextView numberLikesOneLike) {
+    numberLikes.setVisibility(View.VISIBLE);
+    numberLikes.setText(String.format("%s %s", String.valueOf(numberOfLikes),
+        getContext().getString(R.string.likes)
+            .toLowerCase()));
+    numberLikesOneLike.setVisibility(View.INVISIBLE);
   }
 }

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
@@ -348,12 +348,11 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
       comment.setVisibility(View.VISIBLE);
 
       compositeSubscription.add(RxView.clicks(numberComments)
-          .flatMap(aVoid -> {
+          .doOnNext(click -> {
             final String elementId = minimalCard.getCardId();
             Fragment fragment = V8Engine.getFragmentProvider()
                 .newCommentGridRecyclerFragment(CommentType.TIMELINE, elementId);
             getFragmentNavigator().navigateTo(fragment);
-            return null;
           })
           .subscribe(aVoid -> knockWithSixpackCredentials(displayable.getAbTestingURL()),
               throwable -> CrashReport.getInstance()

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialStoreLatestAppsWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialStoreLatestAppsWidget.java
@@ -337,7 +337,7 @@ public class AggregatedSocialStoreLatestAppsWidget
       }
 
       likePreviewContainer.removeAllViews();
-      showLikesPreview(marginOfTheNextLikePreview, likePreviewContainer, minimalCard);
+      showLikesPreview(likePreviewContainer, minimalCard);
 
       if ((minimalCard.getUsersLikes() != null
           && minimalCard.getUsersLikes()
@@ -546,9 +546,8 @@ public class AggregatedSocialStoreLatestAppsWidget
     }
   }
 
-  private void showLikesPreview(int marginOfTheNextLikePreview, ViewGroup likePreviewContainer,
-      MinimalCard minimalCard) {
-    marginOfTheNextLikePreview = 60;
+  private void showLikesPreview(ViewGroup likePreviewContainer, MinimalCard minimalCard) {
+    int marginOfTheNextLikePreview = 60;
     for (int j = 0; j < minimalCard.getStats()
         .getLikes(); j++) {
 

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialStoreLatestAppsWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialStoreLatestAppsWidget.java
@@ -2,12 +2,15 @@ package cm.aptoide.pt.v8engine.timeline.view.widget;
 
 import android.os.Build;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
 import android.support.v7.widget.CardView;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import cm.aptoide.accountmanager.AptoideAccountManager;
 import cm.aptoide.pt.database.accessors.AccessorFactory;
@@ -18,6 +21,7 @@ import cm.aptoide.pt.dataprovider.ws.v7.BaseBody;
 import cm.aptoide.pt.imageloader.ImageLoader;
 import cm.aptoide.pt.model.v7.listapp.App;
 import cm.aptoide.pt.model.v7.timeline.MinimalCard;
+import cm.aptoide.pt.model.v7.timeline.UserTimeline;
 import cm.aptoide.pt.networkclient.WebService;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.design.ShowMessage;
@@ -283,6 +287,23 @@ public class AggregatedSocialStoreLatestAppsWidget
       TextView shareSubCardButton = (TextView) subCardView.findViewById(R.id.social_share);
       LinearLayout likeLayout = (LinearLayout) subCardView.findViewById(R.id.social_like);
       TextView comment = (TextView) subCardView.findViewById(R.id.social_comment);
+      LinearLayout socialInfoBar = (LinearLayout) subCardView.findViewById(R.id.social_info_bar);
+      RelativeLayout likePreviewContainer = (RelativeLayout) subCardView.findViewById(
+          R.id.displayable_social_timeline_likes_preview_container);
+      TextView numberLikes = (TextView) subCardView.findViewById(R.id.social_number_of_likes);
+      TextView numberLikesOneLike = (TextView) subCardView.findViewById(R.id.social_one_like);
+      TextView numberComments = (TextView) subCardView.findViewById(R.id.social_number_of_comments);
+      LinearLayout socialCommentBar =
+          (LinearLayout) subCardView.findViewById(R.id.social_latest_comment_bar);
+      TextView socialCommentUsername =
+          (TextView) subCardView.findViewById(R.id.social_latest_comment_user_name);
+      TextView socialCommentBody =
+          (TextView) subCardView.findViewById(R.id.social_latest_comment_body);
+      ImageView latestCommentMainAvatar =
+          (ImageView) subCardView.findViewById(R.id.card_last_comment_main_icon);
+
+      int marginOfTheNextLikePreview = 0;
+
       ImageLoader.with(getContext())
           .loadWithShadowCircleTransform(minimalCard.getSharers()
               .get(0)
@@ -315,6 +336,85 @@ public class AggregatedSocialStoreLatestAppsWidget
         likeSubCardButton.setHeartState(false);
       }
 
+      likePreviewContainer.removeAllViews();
+      showLikesPreview(marginOfTheNextLikePreview, likePreviewContainer, minimalCard);
+
+      if ((minimalCard.getUsersLikes() != null
+          && minimalCard.getUsersLikes()
+          .size() != 0)
+          || minimalCard.getStats()
+          .getComments() > 0) {
+        socialInfoBar.setVisibility(View.VISIBLE);
+      } else {
+        socialInfoBar.setVisibility(View.GONE);
+      }
+
+      final long numberOfLikes = minimalCard.getStats()
+          .getLikes();
+      if (numberOfLikes > 0) {
+        if (numberOfLikes > 1) {
+          showNumberOfLikes(numberOfLikes, numberLikes, numberLikesOneLike);
+        } else if (minimalCard.getUsersLikes() != null
+            && minimalCard.getUsersLikes()
+            .size() != 0) {
+          if (minimalCard.getUsersLikes()
+              .get(0)
+              .getName() != null) {
+            numberLikesOneLike.setText(displayable.getBlackHighlightedLike(getContext(),
+                minimalCard.getUsersLikes()
+                    .get(0)
+                    .getName()));
+            numberLikes.setVisibility(View.INVISIBLE);
+            numberLikesOneLike.setVisibility(View.VISIBLE);
+          } else {
+            if (minimalCard.getUsersLikes()
+                .get(0)
+                .getStore() != null
+                && minimalCard.getUsersLikes()
+                .get(0)
+                .getStore()
+                .getName() != null) {
+              numberLikesOneLike.setText(displayable.getBlackHighlightedLike(getContext(),
+                  minimalCard.getUsersLikes()
+                      .get(0)
+                      .getStore()
+                      .getName()));
+              numberLikes.setVisibility(View.INVISIBLE);
+              numberLikesOneLike.setVisibility(View.VISIBLE);
+            } else {
+              showNumberOfLikes(numberOfLikes, numberLikes, numberLikesOneLike);
+            }
+          }
+        }
+      } else {
+        numberLikes.setVisibility(View.INVISIBLE);
+        numberLikesOneLike.setVisibility(View.INVISIBLE);
+      }
+
+      if (minimalCard.getStats()
+          .getComments() > 0
+          && minimalCard.getComments()
+          .size() > 0) {
+        numberComments.setVisibility(View.VISIBLE);
+        numberComments.setText(String.format("%s %s", String.valueOf(minimalCard.getStats()
+            .getComments()), getContext().getString(R.string.comments)
+            .toLowerCase()));
+        socialCommentBar.setVisibility(View.VISIBLE);
+        ImageLoader.with(getContext())
+            .loadWithShadowCircleTransform(minimalCard.getComments()
+                .get(0)
+                .getAvatar(), latestCommentMainAvatar);
+        socialCommentUsername.setText(minimalCard.getComments()
+            .get(0)
+            .getName());
+        socialCommentBody.setText(minimalCard.getComments()
+            .get(0)
+            .getBody());
+      } else {
+        numberComments.setVisibility(View.INVISIBLE);
+        socialCommentBar.setVisibility(View.GONE);
+      }
+
       compositeSubscription.add(RxView.clicks(shareSubCardButton)
           .subscribe(click -> shareCard(displayable, minimalCard.getCardId(), null,
               SharePreviewDialog.SharePreviewOpenMode.SHARE), err -> CrashReport.getInstance()
@@ -333,9 +433,29 @@ public class AggregatedSocialStoreLatestAppsWidget
               .toSingle()
               .toObservable())
           .observeOn(AndroidSchedulers.mainThread())
-          .subscribe(account -> likeCard(displayable, minimalCard.getCardId(), 1),
-              err -> CrashReport.getInstance()
-                  .log(err)));
+          .subscribe(account -> {
+            if (likeCard(displayable, minimalCard.getCardId(), 1)) {
+              numberLikes.setText(String.valueOf(minimalCard.getStats()
+                  .getLikes() + 1));
+              numberLikes.setVisibility(View.VISIBLE);
+              if (likePreviewContainer.getChildCount() < 4) {
+                if (!minimalCard.getMy()
+                    .isLiked()) {
+                  knockWithSixpackCredentials(displayable.getAbTestingURL());
+                  UserTimeline user = new UserTimeline();
+                  cm.aptoide.pt.model.v7.store.Store store =
+                      new cm.aptoide.pt.model.v7.store.Store();
+                  store.setAvatar(account.getStoreAvatar());
+                  user.setAvatar(account.getAvatar());
+                  user.setStore(store);
+                  addUserToPreview(marginOfTheNextLikePreview, user, likePreviewContainer,
+                      marginOfTheNextLikePreview);
+                  likePreviewContainer.invalidate();
+                }
+              }
+            }
+          }, err -> CrashReport.getInstance()
+              .log(err)));
 
       compositeSubscription.add(RxView.clicks(seeMore)
           .subscribe(click -> {
@@ -363,6 +483,12 @@ public class AggregatedSocialStoreLatestAppsWidget
               err -> CrashReport.getInstance()
                   .log(err)));
 
+      compositeSubscription.add(RxView.clicks(likePreviewContainer)
+          .subscribe(click -> displayable.likesPreviewClick(getFragmentNavigator(),
+              minimalCard.getStats()
+                  .getLikes(), minimalCard.getCardId()), err -> CrashReport.getInstance()
+              .log(err)));
+
       subCardsContainer.addView(subCardView);
       i++;
     }
@@ -375,5 +501,66 @@ public class AggregatedSocialStoreLatestAppsWidget
     } else {
       seeMore.setVisibility(View.GONE);
     }
+  }
+
+  private int addUserToPreview(int i, UserTimeline user, ViewGroup likePreviewContainer,
+      int marginOfTheNextLikePreview) {
+    View likeUserPreviewView;
+    ImageView likeUserPreviewIcon;
+    likeUserPreviewView =
+        inflater.inflate(R.layout.social_timeline_like_user_preview, likePreviewContainer, false);
+    likeUserPreviewIcon =
+        (ImageView) likeUserPreviewView.findViewById(R.id.social_timeline_like_user_preview);
+    ViewGroup.MarginLayoutParams p =
+        (ViewGroup.MarginLayoutParams) likeUserPreviewView.getLayoutParams();
+    p.setMargins(i, 0, 0, 0);
+    likeUserPreviewView.requestLayout();
+
+    if (user != null) {
+      final FragmentActivity context = getContext();
+      if (user.getAvatar() != null) {
+        ImageLoader.with(context)
+            .loadWithShadowCircleTransform(user.getAvatar(), likeUserPreviewIcon);
+      } else if (user.getStore()
+          .getAvatar() != null) {
+        ImageLoader.with(context)
+            .loadWithShadowCircleTransform(user.getStore()
+                .getAvatar(), likeUserPreviewIcon);
+      }
+      likePreviewContainer.addView(likeUserPreviewView);
+      return marginOfTheNextLikePreview - 20;
+    } else {
+      return marginOfTheNextLikePreview;
+    }
+  }
+
+  private void showLikesPreview(int marginOfTheNextLikePreview, ViewGroup likePreviewContainer,
+      MinimalCard minimalCard) {
+    marginOfTheNextLikePreview = 60;
+    for (int j = 0; j < minimalCard.getStats()
+        .getLikes(); j++) {
+
+      UserTimeline user = null;
+      if (minimalCard.getUsersLikes() != null && j < minimalCard.getUsersLikes()
+          .size()) {
+        user = minimalCard.getUsersLikes()
+            .get(j);
+      }
+      marginOfTheNextLikePreview =
+          addUserToPreview(marginOfTheNextLikePreview, user, likePreviewContainer,
+              marginOfTheNextLikePreview);
+      if (marginOfTheNextLikePreview < 0) {
+        break;
+      }
+    }
+  }
+
+  private void showNumberOfLikes(long numberOfLikes, TextView numberLikes,
+      TextView numberLikesOneLike) {
+    numberLikes.setVisibility(View.VISIBLE);
+    numberLikes.setText(String.format("%s %s", String.valueOf(numberOfLikes),
+        getContext().getString(R.string.likes)
+            .toLowerCase()));
+    numberLikesOneLike.setVisibility(View.INVISIBLE);
   }
 }

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialStoreLatestAppsWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialStoreLatestAppsWidget.java
@@ -435,13 +435,13 @@ public class AggregatedSocialStoreLatestAppsWidget
           .observeOn(AndroidSchedulers.mainThread())
           .subscribe(account -> {
             if (likeCard(displayable, minimalCard.getCardId(), 1)) {
+              knockWithSixpackCredentials(displayable.getAbTestingURL());
               numberLikes.setText(String.valueOf(minimalCard.getStats()
                   .getLikes() + 1));
               numberLikes.setVisibility(View.VISIBLE);
               if (likePreviewContainer.getChildCount() < 4) {
                 if (!minimalCard.getMy()
                     .isLiked()) {
-                  knockWithSixpackCredentials(displayable.getAbTestingURL());
                   UserTimeline user = new UserTimeline();
                   cm.aptoide.pt.model.v7.store.Store store =
                       new cm.aptoide.pt.model.v7.store.Store();
@@ -515,7 +515,7 @@ public class AggregatedSocialStoreLatestAppsWidget
     }
   }
 
-  private int addUserToPreview(int i, UserTimeline user, ViewGroup likePreviewContainer,
+  private int addUserToPreview(int marginLeft, UserTimeline user, ViewGroup likePreviewContainer,
       int marginOfTheNextLikePreview) {
     View likeUserPreviewView;
     ImageView likeUserPreviewIcon;
@@ -525,7 +525,7 @@ public class AggregatedSocialStoreLatestAppsWidget
         (ImageView) likeUserPreviewView.findViewById(R.id.social_timeline_like_user_preview);
     ViewGroup.MarginLayoutParams p =
         (ViewGroup.MarginLayoutParams) likeUserPreviewView.getLayoutParams();
-    p.setMargins(i, 0, 0, 0);
+    p.setMargins(marginLeft, 0, 0, 0);
     likeUserPreviewView.requestLayout();
 
     if (user != null) {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialStoreLatestAppsWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialStoreLatestAppsWidget.java
@@ -470,6 +470,18 @@ public class AggregatedSocialStoreLatestAppsWidget
       likeLayout.setVisibility(View.VISIBLE);
       comment.setVisibility(View.VISIBLE);
 
+      compositeSubscription.add(RxView.clicks(numberComments)
+          .flatMap(aVoid -> {
+            final String elementId = minimalCard.getCardId();
+            Fragment fragment = V8Engine.getFragmentProvider()
+                .newCommentGridRecyclerFragment(CommentType.TIMELINE, elementId);
+            getFragmentNavigator().navigateTo(fragment);
+            return null;
+          })
+          .subscribe(aVoid -> knockWithSixpackCredentials(displayable.getAbTestingURL()),
+              throwable -> CrashReport.getInstance()
+                  .log(throwable)));
+
       compositeSubscription.add(RxView.clicks(comment)
           .flatMap(aVoid -> Observable.fromCallable(() -> {
             final String elementId = minimalCard.getCardId();

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialStoreLatestAppsWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialStoreLatestAppsWidget.java
@@ -471,12 +471,11 @@ public class AggregatedSocialStoreLatestAppsWidget
       comment.setVisibility(View.VISIBLE);
 
       compositeSubscription.add(RxView.clicks(numberComments)
-          .flatMap(aVoid -> {
+          .doOnNext(click -> {
             final String elementId = minimalCard.getCardId();
             Fragment fragment = V8Engine.getFragmentProvider()
                 .newCommentGridRecyclerFragment(CommentType.TIMELINE, elementId);
             getFragmentNavigator().navigateTo(fragment);
-            return null;
           })
           .subscribe(aVoid -> knockWithSixpackCredentials(displayable.getAbTestingURL()),
               throwable -> CrashReport.getInstance()

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
@@ -376,12 +376,11 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
       comment.setVisibility(View.VISIBLE);
 
       compositeSubscription.add(RxView.clicks(numberComments)
-          .flatMap(aVoid -> {
+          .doOnNext(click -> {
             final String elementId = minimalCard.getCardId();
             Fragment fragment = V8Engine.getFragmentProvider()
                 .newCommentGridRecyclerFragment(CommentType.TIMELINE, elementId);
             getFragmentNavigator().navigateTo(fragment);
-            return null;
           })
           .subscribe(aVoid -> knockWithSixpackCredentials(displayable.getAbTestingURL()),
               throwable -> CrashReport.getInstance()

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
@@ -234,13 +234,13 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
           .observeOn(AndroidSchedulers.mainThread())
           .subscribe(account -> {
             if (likeCard(displayable, minimalCard.getCardId(), 1)) {
+              knockWithSixpackCredentials(displayable.getAbTestingURL());
               numberLikes.setText(String.valueOf(minimalCard.getStats()
                   .getLikes() + 1));
               numberLikes.setVisibility(View.VISIBLE);
               if (likePreviewContainer.getChildCount() < 4) {
                 if (!minimalCard.getMy()
                     .isLiked()) {
-                  knockWithSixpackCredentials(displayable.getAbTestingURL());
                   UserTimeline user = new UserTimeline();
                   Store store = new Store();
                   store.setAvatar(account.getStoreAvatar());
@@ -429,7 +429,7 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
     }
   }
 
-  private int addUserToPreview(int i, UserTimeline user, ViewGroup likePreviewContainer,
+  private int addUserToPreview(int marginLeft, UserTimeline user, ViewGroup likePreviewContainer,
       int marginOfTheNextLikePreview) {
     View likeUserPreviewView;
     ImageView likeUserPreviewIcon;
@@ -439,7 +439,7 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
         (ImageView) likeUserPreviewView.findViewById(R.id.social_timeline_like_user_preview);
     ViewGroup.MarginLayoutParams p =
         (ViewGroup.MarginLayoutParams) likeUserPreviewView.getLayoutParams();
-    p.setMargins(i, 0, 0, 0);
+    p.setMargins(marginLeft, 0, 0, 0);
     likeUserPreviewView.requestLayout();
 
     if (user != null) {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
@@ -1,20 +1,25 @@
 package cm.aptoide.pt.v8engine.timeline.view.widget;
 
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
 import android.support.v7.widget.CardView;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RatingBar;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import cm.aptoide.accountmanager.AptoideAccountManager;
 import cm.aptoide.pt.dataprovider.util.CommentType;
 import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
 import cm.aptoide.pt.dataprovider.ws.v7.BaseBody;
 import cm.aptoide.pt.imageloader.ImageLoader;
+import cm.aptoide.pt.model.v7.store.Store;
 import cm.aptoide.pt.model.v7.timeline.MinimalCard;
+import cm.aptoide.pt.model.v7.timeline.UserTimeline;
 import cm.aptoide.pt.v8engine.R;
 import cm.aptoide.pt.v8engine.V8Engine;
 import cm.aptoide.pt.v8engine.analytics.Analytics;
@@ -167,6 +172,23 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
       TextView shareSubCardButton = (TextView) subCardView.findViewById(R.id.social_share);
       LinearLayout likeLayout = (LinearLayout) subCardView.findViewById(R.id.social_like);
       TextView comment = (TextView) subCardView.findViewById(R.id.social_comment);
+      LinearLayout socialInfoBar = (LinearLayout) subCardView.findViewById(R.id.social_info_bar);
+      RelativeLayout likePreviewContainer = (RelativeLayout) subCardView.findViewById(
+          R.id.displayable_social_timeline_likes_preview_container);
+      TextView numberLikes = (TextView) subCardView.findViewById(R.id.social_number_of_likes);
+      TextView numberLikesOneLike = (TextView) subCardView.findViewById(R.id.social_one_like);
+      TextView numberComments = (TextView) subCardView.findViewById(R.id.social_number_of_comments);
+      LinearLayout socialCommentBar =
+          (LinearLayout) subCardView.findViewById(R.id.social_latest_comment_bar);
+      TextView socialCommentUsername =
+          (TextView) subCardView.findViewById(R.id.social_latest_comment_user_name);
+      TextView socialCommentBody =
+          (TextView) subCardView.findViewById(R.id.social_latest_comment_body);
+      ImageView latestCommentMainAvatar =
+          (ImageView) subCardView.findViewById(R.id.card_last_comment_main_icon);
+
+      int marginOfTheNextLikePreview = 0;
+
       ImageLoader.with(getContext())
           .loadWithShadowCircleTransform(minimalCard.getSharers()
               .get(0)
@@ -210,9 +232,28 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
               .toSingle()
               .toObservable())
           .observeOn(AndroidSchedulers.mainThread())
-          .subscribe(account -> likeCard(displayable, minimalCard.getCardId(), 1),
-              err -> CrashReport.getInstance()
-                  .log(err)));
+          .subscribe(account -> {
+            if (likeCard(displayable, minimalCard.getCardId(), 1)) {
+              numberLikes.setText(String.valueOf(minimalCard.getStats()
+                  .getLikes() + 1));
+              numberLikes.setVisibility(View.VISIBLE);
+              if (likePreviewContainer.getChildCount() < 4) {
+                if (!minimalCard.getMy()
+                    .isLiked()) {
+                  knockWithSixpackCredentials(displayable.getAbTestingURL());
+                  UserTimeline user = new UserTimeline();
+                  Store store = new Store();
+                  store.setAvatar(account.getStoreAvatar());
+                  user.setAvatar(account.getAvatar());
+                  user.setStore(store);
+                  addUserToPreview(marginOfTheNextLikePreview, user, likePreviewContainer,
+                      marginOfTheNextLikePreview);
+                  likePreviewContainer.invalidate();
+                }
+              }
+            }
+          }, err -> CrashReport.getInstance()
+              .log(err)));
 
       compositeSubscription.add(displayable.getRelatedToApplication()
           .observeOn(AndroidSchedulers.mainThread())
@@ -243,6 +284,85 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
         likeSubCardButton.setHeartState(false);
       }
 
+      likePreviewContainer.removeAllViews();
+      showLikesPreview(marginOfTheNextLikePreview, likePreviewContainer, minimalCard);
+
+      if ((minimalCard.getUsersLikes() != null
+          && minimalCard.getUsersLikes()
+          .size() != 0)
+          || minimalCard.getStats()
+          .getComments() > 0) {
+        socialInfoBar.setVisibility(View.VISIBLE);
+      } else {
+        socialInfoBar.setVisibility(View.GONE);
+      }
+
+      final long numberOfLikes = minimalCard.getStats()
+          .getLikes();
+      if (numberOfLikes > 0) {
+        if (numberOfLikes > 1) {
+          showNumberOfLikes(numberOfLikes, numberLikes, numberLikesOneLike);
+        } else if (minimalCard.getUsersLikes() != null
+            && minimalCard.getUsersLikes()
+            .size() != 0) {
+          if (minimalCard.getUsersLikes()
+              .get(0)
+              .getName() != null) {
+            numberLikesOneLike.setText(displayable.getBlackHighlightedLike(getContext(),
+                minimalCard.getUsersLikes()
+                    .get(0)
+                    .getName()));
+            numberLikes.setVisibility(View.INVISIBLE);
+            numberLikesOneLike.setVisibility(View.VISIBLE);
+          } else {
+            if (minimalCard.getUsersLikes()
+                .get(0)
+                .getStore() != null
+                && minimalCard.getUsersLikes()
+                .get(0)
+                .getStore()
+                .getName() != null) {
+              numberLikesOneLike.setText(displayable.getBlackHighlightedLike(getContext(),
+                  minimalCard.getUsersLikes()
+                      .get(0)
+                      .getStore()
+                      .getName()));
+              numberLikes.setVisibility(View.INVISIBLE);
+              numberLikesOneLike.setVisibility(View.VISIBLE);
+            } else {
+              showNumberOfLikes(numberOfLikes, numberLikes, numberLikesOneLike);
+            }
+          }
+        }
+      } else {
+        numberLikes.setVisibility(View.INVISIBLE);
+        numberLikesOneLike.setVisibility(View.INVISIBLE);
+      }
+
+      if (minimalCard.getStats()
+          .getComments() > 0
+          && minimalCard.getComments()
+          .size() > 0) {
+        numberComments.setVisibility(View.VISIBLE);
+        numberComments.setText(String.format("%s %s", String.valueOf(minimalCard.getStats()
+            .getComments()), getContext().getString(R.string.comments)
+            .toLowerCase()));
+        socialCommentBar.setVisibility(View.VISIBLE);
+        ImageLoader.with(getContext())
+            .loadWithShadowCircleTransform(minimalCard.getComments()
+                .get(0)
+                .getAvatar(), latestCommentMainAvatar);
+        socialCommentUsername.setText(minimalCard.getComments()
+            .get(0)
+            .getName());
+        socialCommentBody.setText(minimalCard.getComments()
+            .get(0)
+            .getBody());
+      } else {
+        numberComments.setVisibility(View.INVISIBLE);
+        socialCommentBar.setVisibility(View.GONE);
+      }
+
       compositeSubscription.add(RxView.clicks(seeMore)
           .subscribe(click -> {
             showSubCards(displayable, 10);
@@ -268,6 +388,12 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
               err -> CrashReport.getInstance()
                   .log(err)));
 
+      compositeSubscription.add(RxView.clicks(likePreviewContainer)
+          .subscribe(click -> displayable.likesPreviewClick(getFragmentNavigator(),
+              minimalCard.getStats()
+                  .getLikes(), minimalCard.getCardId()), err -> CrashReport.getInstance()
+              .log(err)));
+
       subCardsContainer.addView(subCardView);
       i++;
     }
@@ -289,5 +415,66 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
     } else {
       seeMore.setVisibility(View.GONE);
     }
+  }
+
+  private int addUserToPreview(int i, UserTimeline user, ViewGroup likePreviewContainer,
+      int marginOfTheNextLikePreview) {
+    View likeUserPreviewView;
+    ImageView likeUserPreviewIcon;
+    likeUserPreviewView =
+        inflater.inflate(R.layout.social_timeline_like_user_preview, likePreviewContainer, false);
+    likeUserPreviewIcon =
+        (ImageView) likeUserPreviewView.findViewById(R.id.social_timeline_like_user_preview);
+    ViewGroup.MarginLayoutParams p =
+        (ViewGroup.MarginLayoutParams) likeUserPreviewView.getLayoutParams();
+    p.setMargins(i, 0, 0, 0);
+    likeUserPreviewView.requestLayout();
+
+    if (user != null) {
+      final FragmentActivity context = getContext();
+      if (user.getAvatar() != null) {
+        ImageLoader.with(context)
+            .loadWithShadowCircleTransform(user.getAvatar(), likeUserPreviewIcon);
+      } else if (user.getStore()
+          .getAvatar() != null) {
+        ImageLoader.with(context)
+            .loadWithShadowCircleTransform(user.getStore()
+                .getAvatar(), likeUserPreviewIcon);
+      }
+      likePreviewContainer.addView(likeUserPreviewView);
+      return marginOfTheNextLikePreview - 20;
+    } else {
+      return marginOfTheNextLikePreview;
+    }
+  }
+
+  private void showLikesPreview(int marginOfTheNextLikePreview, ViewGroup likePreviewContainer,
+      MinimalCard minimalCard) {
+    marginOfTheNextLikePreview = 60;
+    for (int j = 0; j < minimalCard.getStats()
+        .getLikes(); j++) {
+
+      UserTimeline user = null;
+      if (minimalCard.getUsersLikes() != null && j < minimalCard.getUsersLikes()
+          .size()) {
+        user = minimalCard.getUsersLikes()
+            .get(j);
+      }
+      marginOfTheNextLikePreview =
+          addUserToPreview(marginOfTheNextLikePreview, user, likePreviewContainer,
+              marginOfTheNextLikePreview);
+      if (marginOfTheNextLikePreview < 0) {
+        break;
+      }
+    }
+  }
+
+  private void showNumberOfLikes(long numberOfLikes, TextView numberLikes,
+      TextView numberLikesOneLike) {
+    numberLikes.setVisibility(View.VISIBLE);
+    numberLikes.setText(String.format("%s %s", String.valueOf(numberOfLikes),
+        getContext().getString(R.string.likes)
+            .toLowerCase()));
+    numberLikesOneLike.setVisibility(View.INVISIBLE);
   }
 }

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
@@ -375,6 +375,18 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
       likeLayout.setVisibility(View.VISIBLE);
       comment.setVisibility(View.VISIBLE);
 
+      compositeSubscription.add(RxView.clicks(numberComments)
+          .flatMap(aVoid -> {
+            final String elementId = minimalCard.getCardId();
+            Fragment fragment = V8Engine.getFragmentProvider()
+                .newCommentGridRecyclerFragment(CommentType.TIMELINE, elementId);
+            getFragmentNavigator().navigateTo(fragment);
+            return null;
+          })
+          .subscribe(aVoid -> knockWithSixpackCredentials(displayable.getAbTestingURL()),
+              throwable -> CrashReport.getInstance()
+                  .log(throwable)));
+
       compositeSubscription.add(RxView.clicks(comment)
           .flatMap(aVoid -> Observable.fromCallable(() -> {
             final String elementId = minimalCard.getCardId();

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
@@ -285,7 +285,7 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
       }
 
       likePreviewContainer.removeAllViews();
-      showLikesPreview(marginOfTheNextLikePreview, likePreviewContainer, minimalCard);
+      showLikesPreview(likePreviewContainer, minimalCard);
 
       if ((minimalCard.getUsersLikes() != null
           && minimalCard.getUsersLikes()
@@ -460,9 +460,8 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
     }
   }
 
-  private void showLikesPreview(int marginOfTheNextLikePreview, ViewGroup likePreviewContainer,
-      MinimalCard minimalCard) {
-    marginOfTheNextLikePreview = 60;
+  private void showLikesPreview(ViewGroup likePreviewContainer, MinimalCard minimalCard) {
+    int marginOfTheNextLikePreview = 60;
     for (int j = 0; j < minimalCard.getStats()
         .getLikes(); j++) {
 

--- a/v8engine/src/main/res/layout/social_info_bar_timeline.xml
+++ b/v8engine/src/main/res/layout/social_info_bar_timeline.xml
@@ -4,7 +4,6 @@
     android:id="@+id/social_info_bar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/backgroundCardColor"
     android:orientation="vertical"
     >
 

--- a/v8engine/src/main/res/layout/social_last_comment_bar.xml
+++ b/v8engine/src/main/res/layout/social_last_comment_bar.xml
@@ -4,7 +4,6 @@
     android:id="@+id/social_latest_comment_bar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/backgroundCardColor"
     android:orientation="vertical"
     >
 

--- a/v8engine/src/main/res/layout/timeline_sub_minimal_card.xml
+++ b/v8engine/src/main/res/layout/timeline_sub_minimal_card.xml
@@ -21,6 +21,11 @@
 
     <include layout="@layout/apps_timeline_card_header"/>
 
+    <include layout="@layout/social_last_comment_bar"/>
+
+    <include layout="@layout/social_info_bar_timeline"/>
+
+
     <View
         android:id="@+id/card_custom_view_line_separator"
         android:layout_width="match_parent"


### PR DESCRIPTION
What does this PR do?

   This pull-request adds the social info bar (likes preview + number of comments + last comment made) to the Aggregated card shares (sub-cards - minimal cards).

Where should the reviewer start?

- [x] Aggregated Social install card
- [x] Aggregated Social article card
- [ ] Aggregated Social video card
- [x] Aggregated Social store latest card

How should this be manually tested?

  Open Aptoide v8 > Apps Timeline > Find aggregated cards > check if it has likes & comments and if they show up in the social info bar. If not, make a comment/like in it.

What are the relevant tickets?

Tickets related to this pull-request: [AN-1646](https://aptoide.atlassian.net/browse/AN-1646).

Screenshots (if appropriate)

N/A
Questions:

   Is there a blog post? N/A
   Does this add new dependencies which need to be added? No
