### PR TITLE
[AN-1641] Added multiple names support to the minimal card headers

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialArticleDisplayable.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialArticleDisplayable.java
@@ -37,11 +37,9 @@ import static cm.aptoide.pt.v8engine.analytics.Analytics.AppsTimeline.BLANK;
 public class AggregatedSocialArticleDisplayable extends CardDisplayable {
   public static final String CARD_TYPE_NAME = "AGGREGATED_SOCIAL_ARTICLE";
   private Link link;
-  private Link developerLink;
   private String title;
   private String publisherName;
   private String thumbnailUrl;
-  private String avatarUrl;
   private String abTestingURL;
   private String packageName;
   private List<App> relatedToAppsList;
@@ -57,17 +55,14 @@ public class AggregatedSocialArticleDisplayable extends CardDisplayable {
   }
 
   public AggregatedSocialArticleDisplayable(AggregatedSocialArticle card, String title, Link link,
-      Link developerLink, String publisherName, String thumbnailUrl, String avatarUrl,
-      String abTestingURL, List<App> relatedToAppsList, Date date, DateCalculator dateCalculator,
-      SpannableFactory spannableFactory, TimelineAnalytics timelineAnalytics,
-      SocialRepository socialRepository) {
+      String publisherName, String thumbnailUrl, String abTestingURL, List<App> relatedToAppsList,
+      Date date, DateCalculator dateCalculator, SpannableFactory spannableFactory,
+      TimelineAnalytics timelineAnalytics, SocialRepository socialRepository) {
     super(card, timelineAnalytics);
     this.link = link;
-    this.developerLink = developerLink;
     this.title = title;
     this.publisherName = publisherName;
     this.thumbnailUrl = thumbnailUrl;
-    this.avatarUrl = avatarUrl;
     this.abTestingURL = abTestingURL;
     this.relatedToAppsList = relatedToAppsList;
     this.date = date;
@@ -96,11 +91,9 @@ public class AggregatedSocialArticleDisplayable extends CardDisplayable {
     }
     return new AggregatedSocialArticleDisplayable(card, card.getTitle(),
         linksHandlerFactory.get(LinksHandlerFactory.CUSTOM_TABS_LINK_TYPE, card.getUrl()),
-        linksHandlerFactory.get(LinksHandlerFactory.CUSTOM_TABS_LINK_TYPE, card.getPublisher()
-            .getBaseUrl()), card.getPublisher()
-        .getName(), card.getThumbnailUrl(), card.getPublisher()
-        .getLogoUrl(), abTestingURL, card.getApps(), card.getDate(), dateCalculator,
-        spannableFactory, timelineAnalytics, socialRepository);
+        card.getPublisher()
+            .getName(), card.getThumbnailUrl(), abTestingURL, card.getApps(), card.getDate(),
+        dateCalculator, spannableFactory, timelineAnalytics, socialRepository);
   }
 
   public Observable<List<Installed>> getRelatedToApplication() {
@@ -111,6 +104,8 @@ public class AggregatedSocialArticleDisplayable extends CardDisplayable {
       for (int i = 0; i < relatedToAppsList.size(); i++) {
         packageNamesList.add(relatedToAppsList.get(i)
             .getPackageName());
+        packageName = relatedToAppsList.get(i)
+            .getPackageName();
       }
 
       final String[] packageNames = packageNamesList.toArray(new String[packageNamesList.size()]);
@@ -159,16 +154,8 @@ public class AggregatedSocialArticleDisplayable extends CardDisplayable {
     return abTestingURL;
   }
 
-  public String getPackageName() {
-    return packageName;
-  }
-
   public List<App> getRelatedToAppsList() {
     return relatedToAppsList;
-  }
-
-  public Date getDate() {
-    return date;
   }
 
   public List<MinimalCard> getMinimalCardList() {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialInstallDisplayable.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialInstallDisplayable.java
@@ -99,14 +99,14 @@ public class AggregatedSocialInstallDisplayable extends CardDisplayable {
 
   @Override
   public void share(String cardId, boolean privacyResult, ShareCardCallback shareCardCallback) {
-    socialRepository.share(getTimelineCard().getCardId(), getAppStoreId(), privacyResult,
+    socialRepository.share(cardId, getAppStoreId(), privacyResult,
         shareCardCallback,
         getTimelineSocialActionObject(CARD_TYPE_NAME, BLANK, SHARE, getPackageName(), BLANK,
             BLANK));
   }
 
   @Override public void share(String cardId, ShareCardCallback shareCardCallback) {
-    socialRepository.share(getTimelineCard().getCardId(), getAppStoreId(), shareCardCallback,
+    socialRepository.share(cardId, getAppStoreId(), shareCardCallback,
         getTimelineSocialActionObject(CARD_TYPE_NAME, BLANK, SHARE, getPackageName(), BLANK,
             BLANK));
   }

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialInstallDisplayable.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialInstallDisplayable.java
@@ -99,8 +99,7 @@ public class AggregatedSocialInstallDisplayable extends CardDisplayable {
 
   @Override
   public void share(String cardId, boolean privacyResult, ShareCardCallback shareCardCallback) {
-    socialRepository.share(cardId, getAppStoreId(), privacyResult,
-        shareCardCallback,
+    socialRepository.share(cardId, getAppStoreId(), privacyResult, shareCardCallback,
         getTimelineSocialActionObject(CARD_TYPE_NAME, BLANK, SHARE, getPackageName(), BLANK,
             BLANK));
   }

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialStoreLatestAppsDisplayable.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialStoreLatestAppsDisplayable.java
@@ -20,7 +20,6 @@ import cm.aptoide.pt.v8engine.view.recycler.displayable.Displayable;
 import cm.aptoide.pt.v8engine.view.recycler.displayable.SpannableFactory;
 import java.util.Date;
 import java.util.List;
-import java.util.Stack;
 
 import static cm.aptoide.pt.v8engine.analytics.Analytics.AppsTimeline.BLANK;
 
@@ -95,10 +94,6 @@ public class AggregatedSocialStoreLatestAppsDisplayable extends CardDisplayable 
     return minimalCards;
   }
 
-  public List<UserSharerTimeline> getSharers() {
-    return sharers;
-  }
-
   public Store getOwnerStore() {
     return ownerStore;
   }
@@ -139,11 +134,6 @@ public class AggregatedSocialStoreLatestAppsDisplayable extends CardDisplayable 
         packageName, ownerStore.getName());
   }
 
-  public void sendOpenStoreEvent() {
-    timelineAnalytics.sendOpenStoreEvent(CARD_TYPE_NAME, TimelineAnalytics.SOURCE_APTOIDE,
-        ownerStore.getName());
-  }
-
   public void sendOpenSharedStoreEvent() {
     timelineAnalytics.sendOpenStoreEvent(CARD_TYPE_NAME, TimelineAnalytics.SOURCE_APTOIDE,
         sharedStore.getName());
@@ -159,6 +149,10 @@ public class AggregatedSocialStoreLatestAppsDisplayable extends CardDisplayable 
     }
     headerNamesStringBuilder.setLength(headerNamesStringBuilder.length() - 2);
     return headerNamesStringBuilder.toString();
+  }
+
+  public List<UserSharerTimeline> getSharers() {
+    return sharers;
   }
 
   @Override public int getViewLayout() {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialStoreLatestAppsDisplayable.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialStoreLatestAppsDisplayable.java
@@ -177,12 +177,12 @@ public class AggregatedSocialStoreLatestAppsDisplayable extends CardDisplayable 
 
   @Override
   public void share(String cardId, boolean privacyResult, ShareCardCallback shareCardCallback) {
-    socialRepository.share(getTimelineCard().getCardId(), privacyResult, shareCardCallback,
+    socialRepository.share(cardId, privacyResult, shareCardCallback,
         getTimelineSocialActionObject(CARD_TYPE_NAME, BLANK, SHARE, BLANK, BLANK, BLANK));
   }
 
   @Override public void share(String cardId, ShareCardCallback shareCardCallback) {
-    socialRepository.share(getTimelineCard().getCardId(), shareCardCallback,
+    socialRepository.share(cardId, shareCardCallback,
         getTimelineSocialActionObject(CARD_TYPE_NAME, BLANK, SHARE, BLANK, BLANK, BLANK));
   }
 

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialVideoDisplayable.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialVideoDisplayable.java
@@ -40,10 +40,8 @@ public class AggregatedSocialVideoDisplayable extends CardDisplayable {
   private List<MinimalCard> minimalCards;
   private String title;
   private Link link;
-  private Link developerLink;
   private String publisherName;
   private String thumbnailUrl;
-  private String channelLogoUrl;
   private long appId;
   private String packageName;
   private String abTestingURL;
@@ -58,17 +56,15 @@ public class AggregatedSocialVideoDisplayable extends CardDisplayable {
   }
 
   public AggregatedSocialVideoDisplayable(AggregatedSocialVideo card, String title, Link link,
-      Link developerLink, String publisherName, String thumbnailUrl, String channelLogoUrl,
-      long appId, String abTestingURL, List<App> relatedToApps, Date date,
-      DateCalculator dateCalculator, SpannableFactory spannableFactory,
-      TimelineAnalytics timelineAnalytics, SocialRepository socialRepository) {
+      String publisherName, String thumbnailUrl, long appId, String abTestingURL,
+      List<App> relatedToApps, Date date, DateCalculator dateCalculator,
+      SpannableFactory spannableFactory, TimelineAnalytics timelineAnalytics,
+      SocialRepository socialRepository) {
     super(card, timelineAnalytics);
     this.title = title;
     this.link = link;
-    this.developerLink = developerLink;
     this.publisherName = publisherName;
     this.thumbnailUrl = thumbnailUrl;
-    this.channelLogoUrl = channelLogoUrl;
     this.appId = appId;
     this.abTestingURL = abTestingURL;
     this.relatedToApps = relatedToApps;
@@ -100,11 +96,9 @@ public class AggregatedSocialVideoDisplayable extends CardDisplayable {
     }
     return new AggregatedSocialVideoDisplayable(card, card.getTitle(),
         linksHandlerFactory.get(LinksHandlerFactory.CUSTOM_TABS_LINK_TYPE, card.getUrl()),
-        linksHandlerFactory.get(LinksHandlerFactory.CUSTOM_TABS_LINK_TYPE, card.getPublisher()
-            .getBaseUrl()), card.getPublisher()
-        .getName(), card.getThumbnailUrl(), card.getPublisher()
-        .getLogoUrl(), appId, abTestingURL, card.getApps(), card.getDate(), dateCalculator,
-        spannableFactory, timelineAnalytics, socialRepository);
+        card.getPublisher()
+            .getName(), card.getThumbnailUrl(), appId, abTestingURL, card.getApps(), card.getDate(),
+        dateCalculator, spannableFactory, timelineAnalytics, socialRepository);
   }
 
   public Observable<List<Installed>> getRelatedToApplication() {
@@ -115,6 +109,8 @@ public class AggregatedSocialVideoDisplayable extends CardDisplayable {
       for (int i = 0; i < relatedToApps.size(); i++) {
         packageNamesList.add(relatedToApps.get(i)
             .getPackageName());
+        packageName = relatedToApps.get(i)
+            .getPackageName();
       }
 
       final String[] packageNames = packageNamesList.toArray(new String[packageNamesList.size()]);
@@ -142,14 +138,17 @@ public class AggregatedSocialVideoDisplayable extends CardDisplayable {
         ContextCompat.getColor(context, R.color.black_87_alpha), title);
   }
 
-  public void sendOpenChannelEvent() {
-    timelineAnalytics.sendOpenBlogEvent(CARD_TYPE_NAME, getTitle(), getDeveloperLink().getUrl(),
-        packageName);
-  }
-
   public void sendOpenVideoEvent() {
     timelineAnalytics.sendOpenArticleEvent(CARD_TYPE_NAME, getTitle(), getLink().getUrl(),
         packageName);
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public Link getLink() {
+    return link;
   }
 
   public String getCardHeaderNames() {
@@ -164,6 +163,10 @@ public class AggregatedSocialVideoDisplayable extends CardDisplayable {
     return headerNamesStringBuilder.toString();
   }
 
+  public List<UserSharerTimeline> getSharers() {
+    return sharers;
+  }
+
   public String getTimeSinceLastUpdate(Context context) {
     return dateCalculator.getTimeSinceDate(context, date);
   }
@@ -172,36 +175,12 @@ public class AggregatedSocialVideoDisplayable extends CardDisplayable {
     return dateCalculator.getTimeSinceDate(context, date);
   }
 
-  public List<UserSharerTimeline> getSharers() {
-    return sharers;
-  }
-
   public List<MinimalCard> getMinimalCards() {
     return minimalCards;
   }
 
-  public String getTitle() {
-    return title;
-  }
-
-  public Link getLink() {
-    return link;
-  }
-
-  public Link getDeveloperLink() {
-    return developerLink;
-  }
-
-  public String getPublisherName() {
-    return publisherName;
-  }
-
   public String getThumbnailUrl() {
     return thumbnailUrl;
-  }
-
-  public String getChannelLogoUrl() {
-    return channelLogoUrl;
   }
 
   public long getAppId() {
@@ -214,10 +193,6 @@ public class AggregatedSocialVideoDisplayable extends CardDisplayable {
 
   public List<App> getRelatedToApps() {
     return relatedToApps;
-  }
-
-  public Date getDate() {
-    return date;
   }
 
   @Override
@@ -243,6 +218,10 @@ public class AggregatedSocialVideoDisplayable extends CardDisplayable {
     socialRepository.like(cardId, cardType, "", rating,
         getTimelineSocialActionObject(CARD_TYPE_NAME, BLANK, LIKE, BLANK, getPublisherName(),
             BLANK));
+  }
+
+  public String getPublisherName() {
+    return publisherName;
   }
 
   public Spannable getBlackHighlightedLike(Context context, String string) {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialVideoDisplayable.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/displayable/AggregatedSocialVideoDisplayable.java
@@ -222,13 +222,13 @@ public class AggregatedSocialVideoDisplayable extends CardDisplayable {
 
   @Override
   public void share(String cardId, boolean privacyResult, ShareCardCallback shareCardCallback) {
-    socialRepository.share(getTimelineCard().getCardId(), privacyResult, shareCardCallback,
+    socialRepository.share(cardId, privacyResult, shareCardCallback,
         getTimelineSocialActionObject(CARD_TYPE_NAME, BLANK, SHARE, BLANK, getPublisherName(),
             BLANK));
   }
 
   @Override public void share(String cardId, ShareCardCallback shareCardCallback) {
-    socialRepository.share(getTimelineCard().getCardId(), shareCardCallback,
+    socialRepository.share(cardId, shareCardCallback,
         getTimelineSocialActionObject(CARD_TYPE_NAME, BLANK, SHARE, BLANK, getPublisherName(),
             BLANK));
   }

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialArticleWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialArticleWidget.java
@@ -6,6 +6,7 @@ import android.support.v7.widget.CardView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RatingBar;
@@ -19,6 +20,7 @@ import cm.aptoide.pt.imageloader.ImageLoader;
 import cm.aptoide.pt.model.v7.store.Store;
 import cm.aptoide.pt.model.v7.timeline.MinimalCard;
 import cm.aptoide.pt.model.v7.timeline.UserTimeline;
+import cm.aptoide.pt.model.v7.timeline.UserSharerTimeline;
 import cm.aptoide.pt.v8engine.R;
 import cm.aptoide.pt.v8engine.V8Engine;
 import cm.aptoide.pt.v8engine.analytics.Analytics;
@@ -28,6 +30,7 @@ import cm.aptoide.pt.v8engine.timeline.view.displayable.AggregatedSocialArticleD
 import cm.aptoide.pt.v8engine.timeline.view.displayable.SocialArticleDisplayable;
 import cm.aptoide.pt.v8engine.view.dialog.SharePreviewDialog;
 import com.jakewharton.rxbinding.view.RxView;
+import java.util.List;
 import rx.Observable;
 import rx.android.schedulers.AndroidSchedulers;
 
@@ -119,7 +122,9 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
 
     setCardViewMargin(displayable, cardView);
 
-    setAdditionalNumberOfSharersLabel(displayable);
+    setAdditionalNumberOfSharersLabel(additionalNumberOfSharesLabel,
+        additionalNumberOfSharesCircularMask, displayable.getSharers()
+            .size());
     showSeeMoreAction(displayable);
     showSubCards(displayable, 2);
   }
@@ -128,9 +133,8 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
     return AggregatedSocialArticleDisplayable.CARD_TYPE_NAME;
   }
 
-  private void setAdditionalNumberOfSharersLabel(AggregatedSocialArticleDisplayable displayable) {
-    int numberOfSharers = displayable.getSharers()
-        .size();
+  private void setAdditionalNumberOfSharersLabel(TextView additionalNumberOfSharesLabel,
+      ImageView additionalNumberOfSharesCircularMask, int numberOfSharers) {
 
     if (numberOfSharers <= 2) {
       additionalNumberOfSharesLabel.setVisibility(View.INVISIBLE);
@@ -157,18 +161,22 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
       }
       View subCardView =
           inflater.inflate(R.layout.timeline_sub_minimal_card, subCardsContainer, false);
-      ImageView minimalCardHeaderMainAvatar = (ImageView) subCardView.findViewById(R.id.card_image);
       TextView minimalCardHeaderMainName = (TextView) subCardView.findViewById(R.id.card_title);
-      ImageView minimalCardHeaderSecondaryAvatar =
-          (ImageView) subCardView.findViewById(R.id.card_user_avatar);
-      TextView minimalCardHeaderSecondaryName =
-          (TextView) subCardView.findViewById(R.id.card_subtitle);
+      ImageView minimalCardHeaderMainAvatar =
+          (ImageView) subCardView.findViewById(R.id.card_header_avatar_1);
+      ImageView minimalCardHeaderMainAvatar2 =
+          (ImageView) subCardView.findViewById(R.id.card_header_avatar_2);
       TextView cardHeaderTimestamp = (TextView) subCardView.findViewById(R.id.card_date);
       TextView comment = (TextView) subCardView.findViewById(R.id.social_comment);
       TextView shareSubCardButton = (TextView) subCardView.findViewById(R.id.social_share);
       LikeButtonView likeSubCardButton =
           (LikeButtonView) subCardView.findViewById(R.id.social_like_button);
       LinearLayout likeLayout = (LinearLayout) subCardView.findViewById(R.id.social_like);
+      FrameLayout plusFrame = (FrameLayout) subCardView.findViewById(R.id.card_header_plus_frame);
+      TextView additionalNumberOfSharesLabel = (TextView) subCardView.findViewById(
+          R.id.timeline_header_aditional_number_of_shares_circular);
+      ImageView additionalNumberOfSharesCircularMask =
+          (ImageView) subCardView.findViewById(R.id.card_header_avatar_plus);
       LinearLayout socialInfoBar = (LinearLayout) subCardView.findViewById(R.id.social_info_bar);
       RelativeLayout likePreviewContainer = (RelativeLayout) subCardView.findViewById(
           R.id.displayable_social_timeline_likes_preview_container);
@@ -192,21 +200,19 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
               .getUser()
               .getAvatar(), minimalCardHeaderMainAvatar);
 
-      minimalCardHeaderMainName.setText(minimalCard.getSharers()
-          .get(0)
-          .getUser()
-          .getName());
+      if (minimalCard.getSharers()
+          .size() > 1) {
+        ImageLoader.with(getContext())
+            .loadWithShadowCircleTransform(minimalCard.getSharers()
+                .get(1)
+                .getUser()
+                .getAvatar(), minimalCardHeaderMainAvatar2);
+      } else {
+        plusFrame.setVisibility(View.GONE);
+        minimalCardHeaderMainAvatar2.setVisibility(View.GONE);
+      }
 
-      ImageLoader.with(getContext())
-          .loadWithShadowCircleTransform(minimalCard.getSharers()
-              .get(0)
-              .getStore()
-              .getAvatar(), minimalCardHeaderSecondaryAvatar);
-
-      minimalCardHeaderSecondaryName.setText(minimalCard.getSharers()
-          .get(0)
-          .getStore()
-          .getName());
+      minimalCardHeaderMainName.setText(getCardHeaderNames(minimalCard.getSharers()));
 
       cardHeaderTimestamp.setText(
           displayable.getTimeSinceLastUpdate(getContext(), minimalCard.getDate()));
@@ -265,6 +271,10 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
         numberLikes.setVisibility(View.INVISIBLE);
         numberLikesOneLike.setVisibility(View.INVISIBLE);
       }
+
+      setAdditionalNumberOfSharersLabel(additionalNumberOfSharesLabel,
+          additionalNumberOfSharesCircularMask, minimalCard.getSharers()
+              .size());
 
       compositeSubscription.add(displayable.getRelatedToApplication()
           .observeOn(AndroidSchedulers.mainThread())
@@ -483,5 +493,23 @@ public class AggregatedSocialArticleWidget extends CardWidget<AggregatedSocialAr
         getContext().getString(R.string.likes)
             .toLowerCase()));
     numberLikesOneLike.setVisibility(View.INVISIBLE);
+  }
+
+  public String getCardHeaderNames(List<UserSharerTimeline> sharers) {
+    StringBuilder headerNamesStringBuilder = new StringBuilder();
+    if (sharers.size() == 1) {
+      return headerNamesStringBuilder.append(sharers.get(0)
+          .getStore()
+          .getName())
+          .toString();
+    }
+    List<UserSharerTimeline> firstSharers = sharers.subList(0, 2);
+    for (UserSharerTimeline user : firstSharers) {
+      headerNamesStringBuilder.append(user.getStore()
+          .getName())
+          .append(", ");
+    }
+    headerNamesStringBuilder.setLength(headerNamesStringBuilder.length() - 2);
+    return headerNamesStringBuilder.toString();
   }
 }

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialInstallWidget.java
@@ -7,6 +7,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RatingBar;
@@ -20,6 +21,7 @@ import cm.aptoide.pt.imageloader.ImageLoader;
 import cm.aptoide.pt.model.v7.store.Store;
 import cm.aptoide.pt.model.v7.timeline.MinimalCard;
 import cm.aptoide.pt.model.v7.timeline.UserTimeline;
+import cm.aptoide.pt.model.v7.timeline.UserSharerTimeline;
 import cm.aptoide.pt.v8engine.R;
 import cm.aptoide.pt.v8engine.V8Engine;
 import cm.aptoide.pt.v8engine.analytics.Analytics;
@@ -28,6 +30,7 @@ import cm.aptoide.pt.v8engine.timeline.view.LikeButtonView;
 import cm.aptoide.pt.v8engine.timeline.view.displayable.AggregatedSocialInstallDisplayable;
 import cm.aptoide.pt.v8engine.view.dialog.SharePreviewDialog;
 import com.jakewharton.rxbinding.view.RxView;
+import java.util.List;
 import rx.Observable;
 import rx.android.schedulers.AndroidSchedulers;
 
@@ -102,7 +105,9 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
         .load(displayable.getAppIcon(), appIcon);
     appName.setText(displayable.getAppName());
     ratingBar.setRating(displayable.getAppRatingAverage());
-    setAdditionalNumberOfSharersLabel(displayable);
+    setAdditionalNumberOfSharersLabel(additionalNumberOfSharesLabel,
+        additionalNumberOfSharesCircularMask, displayable.getSharers()
+            .size());
     setCardViewMargin(displayable, cardView);
     showSeeMoreAction(displayable);
     showSubCards(displayable, 2);
@@ -125,9 +130,8 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
     return AggregatedSocialInstallDisplayable.CARD_TYPE_NAME;
   }
 
-  private void setAdditionalNumberOfSharersLabel(AggregatedSocialInstallDisplayable displayable) {
-    int numberOfSharers = displayable.getSharers()
-        .size();
+  private void setAdditionalNumberOfSharersLabel(TextView additionalNumberOfSharesLabel,
+      ImageView additionalNumberOfSharesCircularMask, int numberOfSharers) {
 
     if (numberOfSharers <= 2) {
       additionalNumberOfSharesLabel.setVisibility(View.INVISIBLE);
@@ -154,12 +158,11 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
       }
       View subCardView =
           inflater.inflate(R.layout.timeline_sub_minimal_card, subCardsContainer, false);
-      ImageView minimalCardHeaderMainAvatar = (ImageView) subCardView.findViewById(R.id.card_image);
+      ImageView minimalCardHeaderMainAvatar =
+          (ImageView) subCardView.findViewById(R.id.card_header_avatar_1);
+      ImageView minimalCardHeaderMainAvatar2 =
+          (ImageView) subCardView.findViewById(R.id.card_header_avatar_2);
       TextView minimalCardHeaderMainName = (TextView) subCardView.findViewById(R.id.card_title);
-      ImageView minimalCardHeaderSecondaryAvatar =
-          (ImageView) subCardView.findViewById(R.id.card_user_avatar);
-      TextView minimalCardHeaderSecondaryName =
-          (TextView) subCardView.findViewById(R.id.card_subtitle);
       TextView cardHeaderTimestamp = (TextView) subCardView.findViewById(R.id.card_date);
       LikeButtonView likeSubCardButton =
           (LikeButtonView) subCardView.findViewById(R.id.social_like_button);
@@ -183,27 +186,31 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
 
       int marginOfTheNextLikePreview = 0;
 
+      FrameLayout plusFrame = (FrameLayout) subCardView.findViewById(R.id.card_header_plus_frame);
+      TextView additionalNumberOfSharesLabel = (TextView) subCardView.findViewById(
+          R.id.timeline_header_aditional_number_of_shares_circular);
+      ImageView additionalNumberOfSharesCircularMask =
+          (ImageView) subCardView.findViewById(R.id.card_header_avatar_plus);
+
       ImageLoader.with(getContext())
           .loadWithShadowCircleTransform(minimalCard.getSharers()
               .get(0)
               .getUser()
               .getAvatar(), minimalCardHeaderMainAvatar);
 
-      minimalCardHeaderMainName.setText(minimalCard.getSharers()
-          .get(0)
-          .getUser()
-          .getName());
+      if (minimalCard.getSharers()
+          .size() > 1) {
+        ImageLoader.with(getContext())
+            .loadWithShadowCircleTransform(minimalCard.getSharers()
+                .get(1)
+                .getUser()
+                .getAvatar(), minimalCardHeaderMainAvatar2);
+      } else {
+        plusFrame.setVisibility(View.GONE);
+        minimalCardHeaderMainAvatar2.setVisibility(View.GONE);
+      }
 
-      ImageLoader.with(getContext())
-          .loadWithShadowCircleTransform(minimalCard.getSharers()
-              .get(0)
-              .getStore()
-              .getAvatar(), minimalCardHeaderSecondaryAvatar);
-
-      minimalCardHeaderSecondaryName.setText(minimalCard.getSharers()
-          .get(0)
-          .getStore()
-          .getName());
+      minimalCardHeaderMainName.setText(getCardHeaderNames(minimalCard.getSharers()));
 
       cardHeaderTimestamp.setText(
           displayable.getTimeSinceLastUpdate(getContext(), minimalCard.getDate()));
@@ -293,6 +300,10 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
         numberComments.setVisibility(View.INVISIBLE);
         socialCommentBar.setVisibility(View.GONE);
       }
+
+      setAdditionalNumberOfSharersLabel(additionalNumberOfSharesLabel,
+          additionalNumberOfSharesCircularMask, minimalCard.getSharers()
+              .size());
 
       compositeSubscription.add(RxView.clicks(shareSubCardButton)
           .subscribe(click -> shareCard(displayable, minimalCard.getCardId(), null,
@@ -449,5 +460,23 @@ public class AggregatedSocialInstallWidget extends CardWidget<AggregatedSocialIn
         getContext().getString(R.string.likes)
             .toLowerCase()));
     numberLikesOneLike.setVisibility(View.INVISIBLE);
+  }
+
+  public String getCardHeaderNames(List<UserSharerTimeline> sharers) {
+    StringBuilder headerNamesStringBuilder = new StringBuilder();
+    if (sharers.size() == 1) {
+      return headerNamesStringBuilder.append(sharers.get(0)
+          .getStore()
+          .getName())
+          .toString();
+    }
+    List<UserSharerTimeline> firstSharers = sharers.subList(0, 2);
+    for (UserSharerTimeline user : firstSharers) {
+      headerNamesStringBuilder.append(user.getStore()
+          .getName())
+          .append(", ");
+    }
+    headerNamesStringBuilder.setLength(headerNamesStringBuilder.length() - 2);
+    return headerNamesStringBuilder.toString();
   }
 }

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/view/widget/AggregatedSocialVideoWidget.java
@@ -20,6 +20,7 @@ import cm.aptoide.pt.imageloader.ImageLoader;
 import cm.aptoide.pt.model.v7.store.Store;
 import cm.aptoide.pt.model.v7.timeline.MinimalCard;
 import cm.aptoide.pt.model.v7.timeline.UserTimeline;
+import cm.aptoide.pt.model.v7.timeline.UserSharerTimeline;
 import cm.aptoide.pt.v8engine.R;
 import cm.aptoide.pt.v8engine.V8Engine;
 import cm.aptoide.pt.v8engine.analytics.Analytics;
@@ -28,6 +29,7 @@ import cm.aptoide.pt.v8engine.timeline.view.LikeButtonView;
 import cm.aptoide.pt.v8engine.timeline.view.displayable.AggregatedSocialVideoDisplayable;
 import cm.aptoide.pt.v8engine.view.dialog.SharePreviewDialog;
 import com.jakewharton.rxbinding.view.RxView;
+import java.util.List;
 import rx.Observable;
 import rx.android.schedulers.AndroidSchedulers;
 
@@ -121,7 +123,9 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
           displayable.sendOpenVideoEvent();
         }));
 
-    setAdditionalNumberOfSharersLabel(displayable);
+    setAdditionalNumberOfSharersLabel(additionalNumberOfSharesLabel,
+        additionalNumberOfSharesCircularMask, displayable.getSharers()
+            .size());
     setCardViewMargin(displayable, cardView);
     showSeeMoreAction(displayable);
     showSubCards(displayable, 2);
@@ -131,9 +135,8 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
     return AggregatedSocialVideoDisplayable.CARD_TYPE_NAME;
   }
 
-  private void setAdditionalNumberOfSharersLabel(AggregatedSocialVideoDisplayable displayable) {
-    int numberOfSharers = displayable.getSharers()
-        .size();
+  private void setAdditionalNumberOfSharersLabel(TextView additionalNumberOfSharesLabel,
+      ImageView additionalNumberOfSharesCircularMask, int numberOfSharers) {
 
     if (numberOfSharers <= 2) {
       additionalNumberOfSharesLabel.setVisibility(View.INVISIBLE);
@@ -160,18 +163,23 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
       }
       View subCardView =
           inflater.inflate(R.layout.timeline_sub_minimal_card, subCardsContainer, false);
-      ImageView minimalCardHeaderMainAvatar = (ImageView) subCardView.findViewById(R.id.card_image);
       TextView minimalCardHeaderMainName = (TextView) subCardView.findViewById(R.id.card_title);
-      ImageView minimalCardHeaderSecondaryAvatar =
-          (ImageView) subCardView.findViewById(R.id.card_user_avatar);
-      TextView minimalCardHeaderSecondaryName =
-          (TextView) subCardView.findViewById(R.id.card_subtitle);
+      ImageView minimalCardHeaderMainAvatar =
+          (ImageView) subCardView.findViewById(R.id.card_header_avatar_1);
+      ImageView minimalCardHeaderMainAvatar2 =
+          (ImageView) subCardView.findViewById(R.id.card_header_avatar_2);
       TextView cardHeaderTimestamp = (TextView) subCardView.findViewById(R.id.card_date);
       LikeButtonView likeSubCardButton =
           (LikeButtonView) subCardView.findViewById(R.id.social_like_button);
       TextView shareSubCardButton = (TextView) subCardView.findViewById(R.id.social_share);
       LinearLayout likeLayout = (LinearLayout) subCardView.findViewById(R.id.social_like);
       TextView comment = (TextView) subCardView.findViewById(R.id.social_comment);
+      FrameLayout plusFrame = (FrameLayout) subCardView.findViewById(R.id.card_header_plus_frame);
+      TextView additionalNumberOfSharesLabel = (TextView) subCardView.findViewById(
+          R.id.timeline_header_aditional_number_of_shares_circular);
+      ImageView additionalNumberOfSharesCircularMask =
+          (ImageView) subCardView.findViewById(R.id.card_header_avatar_plus);
+
       LinearLayout socialInfoBar = (LinearLayout) subCardView.findViewById(R.id.social_info_bar);
       RelativeLayout likePreviewContainer = (RelativeLayout) subCardView.findViewById(
           R.id.displayable_social_timeline_likes_preview_container);
@@ -195,21 +203,23 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
               .getUser()
               .getAvatar(), minimalCardHeaderMainAvatar);
 
-      minimalCardHeaderMainName.setText(minimalCard.getSharers()
-          .get(0)
-          .getUser()
-          .getName());
+      if (minimalCard.getSharers()
+          .size() > 1) {
+        ImageLoader.with(getContext())
+            .loadWithShadowCircleTransform(minimalCard.getSharers()
+                .get(1)
+                .getUser()
+                .getAvatar(), minimalCardHeaderMainAvatar2);
+      } else {
+        plusFrame.setVisibility(View.GONE);
+        minimalCardHeaderMainAvatar2.setVisibility(View.GONE);
+      }
 
-      ImageLoader.with(getContext())
-          .loadWithShadowCircleTransform(minimalCard.getSharers()
-              .get(0)
-              .getStore()
-              .getAvatar(), minimalCardHeaderSecondaryAvatar);
+      minimalCardHeaderMainName.setText(getCardHeaderNames(minimalCard.getSharers()));
 
-      minimalCardHeaderSecondaryName.setText(minimalCard.getSharers()
-          .get(0)
-          .getStore()
-          .getName());
+      setAdditionalNumberOfSharersLabel(additionalNumberOfSharesLabel,
+          additionalNumberOfSharesCircularMask, minimalCard.getSharers()
+              .size());
 
       cardHeaderTimestamp.setText(
           displayable.getTimeSinceLastUpdate(getContext(), minimalCard.getDate()));
@@ -486,5 +496,23 @@ public class AggregatedSocialVideoWidget extends CardWidget<AggregatedSocialVide
         getContext().getString(R.string.likes)
             .toLowerCase()));
     numberLikesOneLike.setVisibility(View.INVISIBLE);
+  }
+
+  public String getCardHeaderNames(List<UserSharerTimeline> sharers) {
+    StringBuilder headerNamesStringBuilder = new StringBuilder();
+    if (sharers.size() == 1) {
+      return headerNamesStringBuilder.append(sharers.get(0)
+          .getStore()
+          .getName())
+          .toString();
+    }
+    List<UserSharerTimeline> firstSharers = sharers.subList(0, 2);
+    for (UserSharerTimeline user : firstSharers) {
+      headerNamesStringBuilder.append(user.getStore()
+          .getName())
+          .append(", ");
+    }
+    headerNamesStringBuilder.setLength(headerNamesStringBuilder.length() - 2);
+    return headerNamesStringBuilder.toString();
   }
 }

--- a/v8engine/src/main/res/layout/apps_timeline_multiple_heads_card_header.xml
+++ b/v8engine/src/main/res/layout/apps_timeline_multiple_heads_card_header.xml
@@ -35,6 +35,7 @@
         tools:ignore="contentDescription"
         />
     <FrameLayout
+        android:id="@+id/card_header_plus_frame"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignBottom="@id/card_header_avatar_1"

--- a/v8engine/src/main/res/layout/timeline_sub_minimal_card.xml
+++ b/v8engine/src/main/res/layout/timeline_sub_minimal_card.xml
@@ -19,7 +19,7 @@
       android:orientation="vertical"
       >
 
-    <include layout="@layout/apps_timeline_card_header"/>
+    <include layout="@layout/apps_timeline_multiple_heads_card_header"/>
 
     <include layout="@layout/social_last_comment_bar"/>
 


### PR DESCRIPTION
What does this PR do?

   This pull-request adds the possibility to show multiple people that shared via the same social card and generated an Aggregated social card.
   This will show up multiple heads/names inside minimal cards of the Aggregated cards.

Where should the reviewer start?

- [ ] Aggregated Social install card
- [ ] Aggregated Social article card
- [ ] Aggregated Social video card
- [ ] Aggregated Social store latest card

How should this be manually tested?

  Open Aptoide v8 > Apps Timeline > Find aggregated cards > check if multiple people show up in some of the minimal cards. (if you are following ana2016, nzxt, trinkes15, it should happen, ask me about this).

What are the relevant tickets?

Tickets related to this pull-request: [AN-1641](https://aptoide.atlassian.net/browse/AN-1641).

Screenshots (if appropriate):
[Final result example](https://my.pcloud.com/publink/show?code=XZgYU3ZqlQ7G27pbqQd7jG5STRygVRA3KFk)

Questions:

   Is there a blog post? N/A
   Does this add new dependencies which need to be added? No
