### PR TITLE
Feature/an 1672 share in timeline

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/view/dialog/SharePreviewDialog.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/view/dialog/SharePreviewDialog.java
@@ -206,8 +206,7 @@ public class SharePreviewDialog {
           (ImageView) view.findViewById(R.id.displayable_social_timeline_recommendation_icon);
       TextView appName = (TextView) view.findViewById(
           R.id.displayable_social_timeline_recommendation_similar_apps);
-      TextView appSubTitle =
-          (TextView) view.findViewById(R.id.displayable_social_timeline_recommendation_name);
+      RatingBar ratingBar = (RatingBar) view.findViewById(R.id.rating_bar);
       TextView getApp = (TextView) view.findViewById(
           R.id.displayable_social_timeline_recommendation_get_app_button);
       ImageLoader.with(context)
@@ -221,7 +220,13 @@ public class SharePreviewDialog {
           .getMeta()
           .getData()
           .getName());
-      appSubTitle.setText(R.string.social_timeline_share_dialog_installed_and_recommended);
+      ratingBar.setRating(((AppViewInstallDisplayable) displayable).getPojo()
+          .getNodes()
+          .getMeta()
+          .getData()
+          .getStats()
+          .getRating()
+          .getAvg());
 
       SpannableFactory spannableFactory = new SpannableFactory();
 


### PR DESCRIPTION
What does this PR do?

   This pull-request solves the bug that was preventing the SharePreviewDialog from showing up on install button clicked in the appview. 

Where should the reviewer start?

- [ ] AppView share on install

How should this be manually tested?

  Open Clear Data > Aptoide v8 > Login > App View of any app > click on install > share preview popped up > continue (sharE) > check charles for the ws call. 

What are the relevant tickets?

Tickets related to this pull-request: [AN-1672](https://aptoide.atlassian.net/browse/AN-1672).

Screenshots (if appropriate)

[Expected result](https://my.pcloud.com/publink/show?code=XZk1i3Z5njcJzhiSe8RPXKpvqmTNQFVjUrX)

N/A
Questions:

   Is there a blog post? N/A
   Does this add new dependencies which need to be added? No
