### PR TITLE
[AN-1734] Fixed a merge bug that would make shareApp events from AppV…

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/view/app/AppViewFragment.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/view/app/AppViewFragment.java
@@ -480,7 +480,9 @@ public class AppViewFragment extends AptoideBaseFragment<BaseAdapter>
               && app.getStats()
               .getRating() != null ? app.getStats()
               .getRating()
-              .getAvg() : 0f), SpotAndShareAnalytics.SPOT_AND_SHARE_START_CLICK_ORIGIN_APPVIEW);
+              .getAvg() : 0f), SpotAndShareAnalytics.SPOT_AND_SHARE_START_CLICK_ORIGIN_APPVIEW,
+          app.getStore()
+              .getId());
       appViewAnalytics.sendAppShareEvent();
       return true;
     } else if (i == R.id.menu_schedule) {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/view/app/AppViewFragment.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/view/app/AppViewFragment.java
@@ -481,8 +481,8 @@ public class AppViewFragment extends AptoideBaseFragment<BaseAdapter>
               .getRating() != null ? app.getStats()
               .getRating()
               .getAvg() : 0f), SpotAndShareAnalytics.SPOT_AND_SHARE_START_CLICK_ORIGIN_APPVIEW,
-          app.getStore()
-              .getId());
+          app != null ? app.getStore()
+              .getId() : null);
       appViewAnalytics.sendAppShareEvent();
       return true;
     } else if (i == R.id.menu_schedule) {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/view/share/ShareAppHelper.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/view/share/ShareAppHelper.java
@@ -56,7 +56,7 @@ public class ShareAppHelper {
   }
 
   public void shareApp(String appName, String packageName, String wUrl, String iconPath,
-      float averageRating, String origin) {
+      float averageRating, String origin, Long storeId) {
 
     String title = activity.getString(R.string.share);
 
@@ -68,7 +68,7 @@ public class ShareAppHelper {
       if (ShareDialogs.ShareResponse.SHARE_EXTERNAL == eResponse) {
         caseDefaultShare(appName, wUrl);
       } else if (ShareDialogs.ShareResponse.SHARE_TIMELINE == eResponse) {
-        caseAppsTimelineShare(appName, packageName, iconPath, averageRating);
+        caseAppsTimelineShare(appName, packageName, iconPath, averageRating, storeId);
       } else if (ShareDialogs.ShareResponse.SHARE_SPOT_AND_SHARE == eResponse) {
         caseSpotAndShareShare(appName, packageName, origin);
       }
@@ -80,7 +80,7 @@ public class ShareAppHelper {
         activity.getString(R.string.share))
         .subscribe(shareResponse -> {
           if (ShareDialogs.ShareResponse.SHARE_TIMELINE == shareResponse) {
-            caseAppsTimelineShare(appName, packageName, iconPath, 0);
+            caseAppsTimelineShare(appName, packageName, iconPath, 0, null);
           } else if (ShareDialogs.ShareResponse.SHARE_SPOT_AND_SHARE == shareResponse) {
             caseSpotAndShareShare(appName, packageName, origin);
           }
@@ -100,7 +100,7 @@ public class ShareAppHelper {
   }
 
   private void caseAppsTimelineShare(String appName, String packageName, String iconPath,
-      float averageRating) {
+      float averageRating, Long storeId) {
     if (!accountManager.isLoggedIn()) {
       ShowMessage.asSnack(activity, R.string.you_need_to_be_logged_in, R.string.login,
           snackView -> accountNavigator.navigateToAccountView(
@@ -117,7 +117,7 @@ public class ShareAppHelper {
       SocialRepository socialRepository =
           RepositoryFactory.getSocialRepository(activity, timelineAnalytics, sharedPreferences);
 
-      sharePreviewDialog.showShareCardPreviewDialog(packageName, null, "app", activity,
+      sharePreviewDialog.showShareCardPreviewDialog(packageName, storeId, "app", activity,
           sharePreviewDialog, alertDialog, socialRepository);
     }
   }


### PR DESCRIPTION
What does this PR do?

   This pull-request fixes a merge bug that was making storeId field in the shareApp in the AppView always be null.

Where should the reviewer start?

- [ ] AppViewFragment

How should this be manually tested?

  Open Aptoide v8 > Open your store > open any app > click share icon > share In apps Timeline... > check if request goes with your storeId. 
  This should generate an app post in the timeline and when you click get app it goes to the app view from your store.

What are the relevant tickets?

Tickets related to this pull-request: [AN-1734](https://aptoide.atlassian.net/browse/AN-1734)

Screenshots (if appropriate):
N/A

Questions:

   Is there a blog post? N/A
   Does this add new dependencies which need to be added? No
