### PR TITLE
[AN-1760] Completable does not emit onNext, thus not running the code…

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/AutoUpdate.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/AutoUpdate.java
@@ -158,6 +158,7 @@ public class AutoUpdate extends AsyncTask<Void, Void, AutoUpdate.AutoUpdateInfo>
                   != Install.InstallationStatus.INSTALLING)
               .first(progress -> progress.getState() != Install.InstallationStatus.INSTALLING)
               .subscribe(install -> {
+                // TODO: 12/07/2017 this code doesn't run
                 if (install.isFailed()) {
                   ShowMessage.asSnack(activity, R.string.error_SYS_1);
                 }


### PR DESCRIPTION
What does this PR do?

   This pull-request fixes a bug that was not showing up the share preview/installing snackbar in the app view when install is clicked.

Where should the reviewer start?

- [ ] AppViewInstallWidget [line 508]

How should this be manually tested?

  Open Aptoide v8 > Login (public account+store) > Open any App View > click install
  This should show an installing snackbar + share preview dialog.

What are the relevant tickets?

Tickets related to this pull-request: [AN-1760](https://aptoide.atlassian.net/browse/AN-1760?src=confmacro)

Screenshots (if appropriate):
N/A

Questions:

   Is there a blog post? N/A
   Does this add new dependencies which need to be added? No
