### PR TITLE
Wizard Presenter is throwing a null pointer on page selection

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/view/wizard/WizardFragment.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/view/wizard/WizardFragment.java
@@ -137,7 +137,6 @@ public class WizardFragment extends UIComponentFragment implements WizardView {
   }
 
   @Override public void goToNextPage() {
-    // safety check. should not be needed
     if (viewPager.getCurrentItem() < viewPagerAdapter.getCount() - 1) {
       viewPager.setCurrentItem(viewPager.getCurrentItem() + 1);
     }
@@ -155,8 +154,14 @@ public class WizardFragment extends UIComponentFragment implements WizardView {
    * @param selectedPage Position index of the new selected page.
    */
   @Override public void handleSelectedPage(int selectedPage) {
-    wizardButtons.get(selectedPage)
-        .setChecked(true);
+    if (wizardButtons == null || selectedPage >= wizardButtons.size()) {
+      return;
+    }
+
+    RadioButton radioButton = wizardButtons.get(selectedPage);
+    if (radioButton != null) {
+      radioButton.setChecked(true);
+    }
   }
 
   @Override public int getWizardButtonsCount() {


### PR DESCRIPTION
What does this pull request do?

This pull request is an attemp to fix this [issue](https://www.fabric.io/aptoide2/android/apps/cm.aptoide.pt/issues/596f626dbe077a4dcccd145f?time=last-seven-days).


How should this be manually tested?

Navigate in the wizard pages and try pressing the round icons to check if app crashes


Tickets related to this pull-request: 

- [ ] [AN-1833](https://aptoide.atlassian.net/browse/AN-1833)