### PR TITLE
[AN-1866] Fixing Post in Timeline navigation.

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/presenter/TimelinePresenter.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/presenter/TimelinePresenter.java
@@ -163,13 +163,13 @@ public class TimelinePresenter implements Presenter {
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
         .flatMap(created -> timelineNavigation.postNavigation()
             .observeOn(AndroidSchedulers.mainThread())
-            .doOnNext(__ -> view.showProgressIndicator())
+            .doOnNext(__ -> view.showPostProgressIndicator())
             .flatMapSingle(cardId -> Single.zip(
                 accountManager.isLoggedIn() || userId != null ? timeline.getTimelineStats()
                     : timeline.getTimelineLoginPost(), timeline.getFreshCards(cardId),
                 (post, posts) -> mergeStatsPostWithPosts(post, posts)))
             .observeOn(AndroidSchedulers.mainThread())
-            .doOnNext(cards -> showCardsAndHideProgress(cards))
+            .doOnNext(cards -> showCardsAndHidePostProgress(cards))
             .retry())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(cards -> {
@@ -817,6 +817,11 @@ public class TimelinePresenter implements Presenter {
 
   private void showCardsAndHideProgress(List<Post> cards) {
     view.hideProgressIndicator();
+    view.showCards(cards);
+  }
+
+  private void showCardsAndHidePostProgress(List<Post> cards) {
+    view.hidePostProgressIndicator();
     view.showCards(cards);
   }
 

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/presenter/TimelinePresenter.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/presenter/TimelinePresenter.java
@@ -218,7 +218,7 @@ public class TimelinePresenter implements Presenter {
   private void onCreateShowPosts() {
     view.getLifecycle()
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
-        .doOnNext(__ -> view.showProgressIndicator())
+        .doOnNext(__ -> view.showGeneralProgressIndicator())
         .flatMapSingle(__ -> accountManager.accountStatus()
             .first()
             .toSingle())
@@ -293,7 +293,7 @@ public class TimelinePresenter implements Presenter {
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
         .observeOn(AndroidSchedulers.mainThread())
         .flatMap(__ -> view.retry()
-            .doOnNext(__2 -> view.showProgressIndicator())
+            .doOnNext(__2 -> view.showGeneralProgressIndicator())
             .flatMapSingle(__3 -> accountManager.accountStatus()
                 .first()
                 .toSingle())
@@ -816,7 +816,7 @@ public class TimelinePresenter implements Presenter {
   }
 
   private void showCardsAndHideProgress(List<Post> cards) {
-    view.hideProgressIndicator();
+    view.hideGeneralProgressIndicator();
     view.showCards(cards);
   }
 

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/view/TimelineFragment.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/view/TimelineFragment.java
@@ -287,26 +287,18 @@ public class TimelineFragment extends FragmentView implements TimelineView {
           .onRestoreInstanceState(listState);
       listState = null;
     }
-    //genericError.setVisibility(View.GONE);
-    //progressBar.setVisibility(View.GONE);
-    //list.setVisibility(View.VISIBLE);
   }
 
-  @Override public void showProgressIndicator() {
+  @Override public void showGeneralProgressIndicator() {
     progressIndicator = true;
     list.setVisibility(View.GONE);
     genericError.setVisibility(View.GONE);
     progressBar.setVisibility(View.VISIBLE);
   }
 
-  @Override public void hideProgressIndicator() {
+  @Override public void hideGeneralProgressIndicator() {
     progressIndicator = false;
-    if (!postIndicator) {
-      list.setVisibility(View.VISIBLE);
-      swipeRefreshLayout.setVisibility(View.VISIBLE);
-      coordinatorLayout.setVisibility(View.VISIBLE);
-      progressBar.setVisibility(View.GONE);
-    }
+    hideProgressIndicator();
   }
 
   @Override public void hideRefresh() {
@@ -505,7 +497,11 @@ public class TimelineFragment extends FragmentView implements TimelineView {
 
   @Override public void hidePostProgressIndicator() {
     postIndicator = false;
-    if (!progressIndicator) {
+    hideProgressIndicator();
+  }
+
+  private void hideProgressIndicator() {
+    if (!postIndicator && !progressIndicator) {
       list.setVisibility(View.VISIBLE);
       swipeRefreshLayout.setVisibility(View.VISIBLE);
       coordinatorLayout.setVisibility(View.VISIBLE);

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/view/TimelineFragment.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/view/TimelineFragment.java
@@ -37,7 +37,6 @@ import cm.aptoide.pt.v8engine.analytics.Analytics;
 import cm.aptoide.pt.v8engine.crashreports.CrashReport;
 import cm.aptoide.pt.v8engine.database.AccessorFactory;
 import cm.aptoide.pt.v8engine.download.DownloadFactory;
-import cm.aptoide.pt.v8engine.install.InstalledRepository;
 import cm.aptoide.pt.v8engine.install.InstallerFactory;
 import cm.aptoide.pt.v8engine.repository.RepositoryFactory;
 import cm.aptoide.pt.v8engine.social.data.CardTouchEvent;
@@ -48,7 +47,6 @@ import cm.aptoide.pt.v8engine.social.data.PostComment;
 import cm.aptoide.pt.v8engine.social.data.SocialAction;
 import cm.aptoide.pt.v8engine.social.data.SocialCardTouchEvent;
 import cm.aptoide.pt.v8engine.social.data.Timeline;
-import cm.aptoide.pt.v8engine.social.data.TimelineCardFilter;
 import cm.aptoide.pt.v8engine.social.data.TimelinePostsRepository;
 import cm.aptoide.pt.v8engine.social.data.TimelineResponseCardMapper;
 import cm.aptoide.pt.v8engine.social.data.TimelineService;
@@ -73,7 +71,6 @@ import com.jakewharton.rxbinding.support.v7.widget.RxRecyclerView;
 import com.jakewharton.rxbinding.view.RxView;
 import com.jakewharton.rxrelay.PublishRelay;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import rx.Completable;
 import rx.Observable;
@@ -123,6 +120,8 @@ public class TimelineFragment extends FragmentView implements TimelineView {
   private TimelineService timelineService;
   private TimelinePostsRepository timelinePostsRepository;
   private DateCalculator dateCalculator;
+  private boolean postIndicator;
+  private boolean progressIndicator;
 
   public static Fragment newInstance(String action, Long userId, Long storeId,
       StoreContext storeContext) {
@@ -174,7 +173,6 @@ public class TimelineFragment extends FragmentView implements TimelineView {
     timelinePostsRepository =
         ((V8Engine) getContext().getApplicationContext()).getTimelineRepository(
             getArguments().getString(ACTION_KEY));
-
 
     timelineService = new TimelineService(userId,
         ((V8Engine) getContext().getApplicationContext()).getBaseBodyInterceptorV7(),
@@ -289,22 +287,26 @@ public class TimelineFragment extends FragmentView implements TimelineView {
           .onRestoreInstanceState(listState);
       listState = null;
     }
-    genericError.setVisibility(View.GONE);
-    progressBar.setVisibility(View.GONE);
-    list.setVisibility(View.VISIBLE);
+    //genericError.setVisibility(View.GONE);
+    //progressBar.setVisibility(View.GONE);
+    //list.setVisibility(View.VISIBLE);
   }
 
   @Override public void showProgressIndicator() {
+    progressIndicator = true;
     list.setVisibility(View.GONE);
     genericError.setVisibility(View.GONE);
     progressBar.setVisibility(View.VISIBLE);
   }
 
   @Override public void hideProgressIndicator() {
-    list.setVisibility(View.VISIBLE);
-    swipeRefreshLayout.setVisibility(View.VISIBLE);
-    coordinatorLayout.setVisibility(View.VISIBLE);
-    progressBar.setVisibility(View.GONE);
+    progressIndicator = false;
+    if (!postIndicator) {
+      list.setVisibility(View.VISIBLE);
+      swipeRefreshLayout.setVisibility(View.VISIBLE);
+      coordinatorLayout.setVisibility(View.VISIBLE);
+      progressBar.setVisibility(View.GONE);
+    }
   }
 
   @Override public void hideRefresh() {
@@ -492,6 +494,23 @@ public class TimelineFragment extends FragmentView implements TimelineView {
         R.string.timeline_message_error_you_need_to_create_store_with_social_action,
         Snackbar.LENGTH_LONG)
         .show();
+  }
+
+  @Override public void showPostProgressIndicator() {
+    postIndicator = true;
+    list.setVisibility(View.GONE);
+    genericError.setVisibility(View.GONE);
+    progressBar.setVisibility(View.VISIBLE);
+  }
+
+  @Override public void hidePostProgressIndicator() {
+    postIndicator = false;
+    if (!progressIndicator) {
+      list.setVisibility(View.VISIBLE);
+      swipeRefreshLayout.setVisibility(View.VISIBLE);
+      coordinatorLayout.setVisibility(View.VISIBLE);
+      progressBar.setVisibility(View.GONE);
+    }
   }
 
   // TODO: 07/07/2017 migrate this behaviour to mvp

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/view/TimelineView.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/view/TimelineView.java
@@ -77,4 +77,8 @@ public interface TimelineView extends View {
   Observable<Void> loginActionClick();
 
   void showCreateStoreMessage(SocialAction socialAction);
+
+  void showPostProgressIndicator();
+
+  void hidePostProgressIndicator();
 }

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/view/TimelineView.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/view/TimelineView.java
@@ -20,9 +20,9 @@ public interface TimelineView extends View {
 
   void showCards(List<Post> cards);
 
-  void showProgressIndicator();
+  void showGeneralProgressIndicator();
 
-  void hideProgressIndicator();
+  void hideGeneralProgressIndicator();
 
   void hideRefresh();
 


### PR DESCRIPTION
What does this PR do?

   This pull-request fixes the UX when a Post in Timeline is submitted. The loading spinner stays until getUserTimeline with cardId response arrives.

Where should the reviewer start?

- [ ] TimelineFragment

How should this be manually tested?

  Open Aptoide v8 > Timeline > click on FAB > make a Post > check if spinner stays until Timeline with cardId response gets to client.

What are the relevant tickets?

Tickets related to this pull-request: [AN-1866](https://aptoide.atlassian.net/browse/AN-1866)

Screenshots (if appropriate):
N/A

Questions:

   Is there a blog post? N/A
   Does this add new dependencies which need to be added? No
