### PR TITLE
[AN-1885] Show userName instead of storeName when there is no store.

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/data/share/SharePostViewSetup.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/data/share/SharePostViewSetup.java
@@ -96,17 +96,19 @@ public class SharePostViewSetup {
     TextView userName = (TextView) view.findViewById(R.id.card_subtitle);
     ImageView storeAvatar = (ImageView) view.findViewById(R.id.card_image);
     ImageView userAvatar = (ImageView) view.findViewById(R.id.card_user_avatar);
+    TextView date = (TextView) view.findViewById(R.id.card_date);
 
-    final String accountStoreName = account.getStore()
-        .getName();
-    final String accountStoreAvatar = account.getStore()
-        .getAvatar();
+    final String accountUserName = account.getNickname();
+    final String accountUserAvatar = account.getAvatar();
 
-    storeName.setText(accountStoreName);
+    storeName.setText(accountUserName);
+    storeName.setTextColor(ContextCompat.getColor(context, R.color.black_87_alpha));
+
+    date.setText(dateCalculator.getTimeSinceDate(context, new Date()));
 
     storeAvatar.setVisibility(View.VISIBLE);
     ImageLoader.with(context)
-        .loadWithShadowCircleTransform(accountStoreAvatar, storeAvatar);
+        .loadWithShadowCircleTransform(accountUserAvatar, storeAvatar);
 
     userAvatar.setVisibility(View.INVISIBLE);
 


### PR DESCRIPTION
What does this PR do?

   This pull-request fixes the share preview behaviour when user does not have store. It now shows userName and default avatar.

Where should the reviewer start?

- [ ] SharePostViewSetup : setupHeaderWithoutStoreName()

How should this be manually tested?

  Open Aptoide v8 > create account  with username without store > go to timeline > share any card > check if card preview shows default avatar + username on the header.

What are the relevant tickets?

Tickets related to this pull-request: [AN-1885](https://aptoide.atlassian.net/browse/AN-1885)

Screenshots (if appropriate):
N/A

Questions:

   Is there a blog post? N/A
   Does this add new dependencies which need to be added? No
