### PR TITLE
Hotfix/an 1892 timeline metrics missing

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/data/TimelineCardFilter.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/data/TimelineCardFilter.java
@@ -35,7 +35,12 @@ public class TimelineCardFilter {
 
   private Observable<TimelineItem<TimelineCard>> filterInstalledRecommendation(
       TimelineItem<TimelineCard> timelineItem) {
-    String packageName = getPackageNameFrom(timelineItem);
+    final TimelineCard card = timelineItem.getData();
+    String packageName = null;
+    if (card instanceof Recommendation) {
+      packageName = ((Recommendation) card).getRecommendedApp()
+          .getPackageName();
+    }
     if (!TextUtils.isEmpty(packageName)) {
       return packageRepository.isPackageInstalled(packageName)
           .flatMapObservable(installed -> {
@@ -48,26 +53,18 @@ public class TimelineCardFilter {
     return Observable.just(timelineItem);
   }
 
-  private String getPackageNameFrom(TimelineItem<TimelineCard> timelineItem) {
-    final TimelineCard card = timelineItem.getData();
-    if (card instanceof Recommendation) {
-      return ((Recommendation) card).getRecommendedApp()
-          .getPackageName();
-    }
-    if (card instanceof AppUpdate) {
-      return ((AppUpdate) card).getPackageName();
-    }
-    return null;
-  }
-
   private Observable<TimelineItem<TimelineCard>> filterAlreadyDoneUpdates(
       TimelineItem<TimelineCard> timelineItem) {
-    String packageName = getPackageNameFrom(timelineItem);
+    final TimelineCard card = timelineItem.getData();
+    String packageName = null;
+    if (card instanceof AppUpdate) {
+      packageName = ((AppUpdate) card).getPackageName();
+    }
     if (!TextUtils.isEmpty(packageName)) {
       return packageRepository.getPackageVersionCode(packageName)
           .onErrorResumeNext(err -> Single.just(null))
           .flatMapObservable(versionCode -> {
-            if (versionCode != null && versionCode == ((AppUpdate) timelineItem).getFile()
+            if (versionCode != null && versionCode == ((AppUpdate) timelineItem.getData()).getFile()
                 .getVercode()) {
               return Observable.empty();
             }

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/presenter/TimelinePresenter.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/presenter/TimelinePresenter.java
@@ -325,7 +325,7 @@ public class TimelinePresenter implements Presenter {
         .flatMap(created -> view.postClicked())
         .filter(cardTouchEvent -> cardTouchEvent.getActionType()
             .equals(CardTouchEvent.Type.HEADER))
-        .doOnNext(cardTouchEvent -> timelineAnalytics.sendClickOnMediaHeaderEvent(cardTouchEvent))
+        .doOnNext(cardTouchEvent -> timelineAnalytics.sendClickOnPostHeaderEvent(cardTouchEvent))
         .doOnNext(cardTouchEvent -> timeline.knockWithSixpackCredentials(cardTouchEvent.getCard()
             .getAbUrl()))
         .doOnNext(cardTouchEvent -> {
@@ -365,7 +365,7 @@ public class TimelinePresenter implements Presenter {
         .flatMap(created -> view.postClicked()
             .filter(cardTouchEvent -> cardTouchEvent.getActionType()
                 .equals(CardTouchEvent.Type.BODY))
-            .doOnNext(cardTouchEvent -> timelineAnalytics.sendClickOnMediaBodyEvent(cardTouchEvent))
+            .doOnNext(cardTouchEvent -> timelineAnalytics.sendClickOnPostBodyEvent(cardTouchEvent))
             .doOnNext(cardTouchEvent -> timeline.knockWithSixpackCredentials(
                 cardTouchEvent.getCard()
                     .getAbUrl()))

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/TimelineAnalytics.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/timeline/TimelineAnalytics.java
@@ -401,7 +401,7 @@ public class TimelineAnalytics {
         createEvent(OPEN_STORE, createStoreAppData(cardType, source, packageName, store)));
   }
 
-  public void sendClickOnMediaHeaderEvent(CardTouchEvent cardTouchEvent) {
+  public void sendClickOnPostHeaderEvent(CardTouchEvent cardTouchEvent) {
     final Post post = cardTouchEvent.getCard();
     final CardType postType = post.getType();
 
@@ -458,7 +458,7 @@ public class TimelineAnalytics {
     }
   }
 
-  public void sendClickOnMediaBodyEvent(CardTouchEvent cardTouchEvent) {
+  public void sendClickOnPostBodyEvent(CardTouchEvent cardTouchEvent) {
     final Post post = cardTouchEvent.getCard();
     final CardType postType = post.getType();
 
@@ -488,7 +488,7 @@ public class TimelineAnalytics {
                 .name(), media.getMediaTitle(), media.getPublisherName(),
             Analytics.AppsTimeline.OPEN_VIDEO, "(blank)");
       }
-    } else if (postType.equals(CardType.RECOMMENDATION)) {
+    } else if (postType.equals(CardType.RECOMMENDATION) || postType.equals(CardType.SIMILAR)) {
       Recommendation card = (Recommendation) post;
       Analytics.AppsTimeline.clickOnCard(card.getType()
               .name(), card.getPackageName(), Analytics.AppsTimeline.BLANK, card.getPublisherName(),
@@ -553,8 +553,10 @@ public class TimelineAnalytics {
       Analytics.AppsTimeline.clickOnCard(postType.name(), card.getPackageName(),
           Analytics.AppsTimeline.BLANK, Analytics.AppsTimeline.BLANK,
           Analytics.AppsTimeline.OPEN_APP_VIEW);
+      sendOpenAppEvent(card.getType()
+          .name(), TimelineAnalytics.SOURCE_APTOIDE, card.getPackageName());
     } else if (postType.equals(CardType.SOCIAL_RECOMMENDATION) || postType.equals(
-        CardType.SOCIAL_INSTALL)) {
+        CardType.SOCIAL_INSTALL) || postType.equals(CardType.SOCIAL_POST_RECOMMENDATION)) {
       RatedRecommendation card = (RatedRecommendation) post;
       Analytics.AppsTimeline.clickOnCard(postType.name(), card.getPackageName(),
           Analytics.AppsTimeline.BLANK, Analytics.AppsTimeline.BLANK,
@@ -563,11 +565,15 @@ public class TimelineAnalytics {
               .name(), Analytics.AppsTimeline.OPEN_APP_VIEW, "(blank)", card.getPackageName(),
           card.getPoster()
               .getPrimaryName());
+      sendOpenAppEvent(card.getType()
+          .name(), TimelineAnalytics.SOURCE_APTOIDE, card.getPackageName());
     } else if (postType.equals(CardType.AGGREGATED_SOCIAL_INSTALL)) {
       AggregatedRecommendation card = (AggregatedRecommendation) post;
       Analytics.AppsTimeline.clickOnCard(postType.name(), card.getPackageName(),
           Analytics.AppsTimeline.BLANK, Analytics.AppsTimeline.BLANK,
           Analytics.AppsTimeline.OPEN_APP_VIEW);
+      sendOpenAppEvent(card.getType()
+          .name(), TimelineAnalytics.SOURCE_APTOIDE, card.getPackageName());
     }
   }
 }


### PR DESCRIPTION
What does this PR do?

   This pull-request fixes a bug and adds OPEN_APP events to the similar/popularapp/social_post_recommendation/social_install/aggregated_install cards.

   The bug was the fact that the Card filters were filtering out all the updates because they were being filtered as Installed recommendations.

Where should the reviewer start?

- [ ] TimelineAnalytics : sendClickOnPostBodyEvent(CardTouchEvent cardTouchEvent)
- [ ] TimelineCardFilter

How should this be manually tested?

- [ ]  Open Aptoide v8 > Go to Timeline > get App on SIMILAR card > check if event is sent.
- [ ]  Open Aptoide v8 > Go to Timeline > get App on POPULAR APP card > check if event is sent.
- [ ]  Open Aptoide v8 > Go to Timeline > get App on AGGREGATED_SOCIAL_INSTALL card > check if event is sent.
- [ ]  Open Aptoide v8 > Go to Timeline > get App on SOCIAL_INSTALL card > check if event is sent.
- [ ]  Open Aptoide v8 > Go to Timeline > get App on SOCIAL_POST_RECOMMENDATION card > check if event is sent.

What are the relevant tickets?

Tickets related to this pull-request: [AN-1892](https://aptoide.atlassian.net/browse/AN-1892)

Screenshots (if appropriate):
N/A

Questions:

   Is there a blog post? N/A
   Does this add new dependencies which need to be added? No
