### PR TITLE
[AN-1893] Fixed a bug where aggregated card sharing was always return…

### DIFF
--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/data/MinimalCardViewFactory.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/data/MinimalCardViewFactory.java
@@ -138,7 +138,7 @@ public class MinimalCardViewFactory {
     commentButton.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
         new SocialCardTouchEvent(post, CardTouchEvent.Type.COMMENT, position)));
     shareButton.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
-        new CardTouchEvent(originalPost, CardTouchEvent.Type.SHARE)));
+        new MinimalPostTouchEvent(originalPost, post, CardTouchEvent.Type.SHARE)));
     this.likePreviewContainer.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
         new LikesPreviewCardTouchEvent(post, post.getLikesNumber(),
             CardTouchEvent.Type.LIKES_PREVIEW)));

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/data/MinimalPostTouchEvent.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/data/MinimalPostTouchEvent.java
@@ -1,0 +1,18 @@
+package cm.aptoide.pt.v8engine.social.data;
+
+/**
+ * Created by jdandrade on 11/08/2017.
+ */
+
+public class MinimalPostTouchEvent extends CardTouchEvent {
+  private final Post originalPost;
+
+  public MinimalPostTouchEvent(Post originalPost, MinimalPost post, Type share) {
+    super(post, share);
+    this.originalPost = originalPost;
+  }
+
+  public Post getOriginalPost() {
+    return originalPost;
+  }
+}

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/data/share/BaseShareDialog.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/data/share/BaseShareDialog.java
@@ -49,6 +49,11 @@ abstract class BaseShareDialog<T extends Post> implements ShareDialogInterface<T
     setupEvents(post);
   }
 
+  @Override @CallSuper public void setupMinimalPost(T originalPost, T minimalPost) {
+    setupView(dialog.getDialogView(), originalPost);
+    setupEvents(minimalPost);
+  }
+
   private ShareEvent updateEventWithPrivacyCheckbox(ShareEvent shareEvent) {
     CheckBox makeMyProfilePrivate = (CheckBox) dialog.getDialogView()
         .findViewById(R.id.social_preview_checkbox);

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/data/share/ShareDialogInterface.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/data/share/ShareDialogInterface.java
@@ -11,4 +11,6 @@ public interface ShareDialogInterface<T> extends DialogInterface {
   void show();
 
   void setup(T post);
+
+  void setupMinimalPost(T originalPost, T minimalPost);
 }

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/view/TimelineFragment.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/view/TimelineFragment.java
@@ -437,16 +437,14 @@ public class TimelineFragment extends FragmentView implements TimelineView {
     shareDialog = shareDialogFactory.createDialogFor(post, account);
     shareDialog.setup(post);
 
-    shareDialog.cancels()
-        .doOnNext(__ -> shareDialog.dismiss())
-        .compose(bindUntilEvent(LifecycleEvent.PAUSE))
-        .subscribe();
+    handleSharePreviewAnswer();
+  }
 
-    shareDialog.shares()
-        .doOnNext(event -> sharePostPublishSubject.onNext(event))
-        .compose(bindUntilEvent(LifecycleEvent.PAUSE))
-        .subscribe();
-    shareDialog.show();
+  @Override public void showSharePreview(Post originalPost, Post card, Account account) {
+    shareDialog = shareDialogFactory.createDialogFor(originalPost, account);
+    shareDialog.setupMinimalPost(originalPost, card);
+
+    handleSharePreviewAnswer();
   }
 
   @Override public void showShareSuccessMessage() {
@@ -498,6 +496,19 @@ public class TimelineFragment extends FragmentView implements TimelineView {
   @Override public void hidePostProgressIndicator() {
     postIndicator = false;
     hideProgressIndicator();
+  }
+
+  private void handleSharePreviewAnswer() {
+    shareDialog.cancels()
+        .doOnNext(__ -> shareDialog.dismiss())
+        .compose(bindUntilEvent(LifecycleEvent.PAUSE))
+        .subscribe();
+
+    shareDialog.shares()
+        .doOnNext(event -> sharePostPublishSubject.onNext(event))
+        .compose(bindUntilEvent(LifecycleEvent.PAUSE))
+        .subscribe();
+    shareDialog.show();
   }
 
   private void hideProgressIndicator() {

--- a/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/view/TimelineView.java
+++ b/v8engine/src/main/java/cm/aptoide/pt/v8engine/social/view/TimelineView.java
@@ -66,6 +66,8 @@ public interface TimelineView extends View {
 
   void showSharePreview(Post post, Account account);
 
+  void showSharePreview(Post originalPost, Post card, Account account);
+
   void showShareSuccessMessage();
 
   void showCommentDialog(SocialCardTouchEvent touchEvent);


### PR DESCRIPTION
What does this PR do?

   This pull-request fixes the error that was being returned when user shares aggregated cards.

Where should the reviewer start?

- [ ] TimelineFragment

How should this be manually tested?

  Open Aptoide v8 > Timeline > test shares on aggregated and non-aggregated cards

What are the relevant tickets?

Tickets related to this pull-request: [AN-1893](https://aptoide.atlassian.net/browse/AN-1893)

Screenshots (if appropriate):
N/A

Questions:

   Is there a blog post? N/A
   Does this add new dependencies which need to be added? No
