### PR TITLE
[AN-1921] Fixed markAsRead in landscape (in reality in small screens,…

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/social/view/TimelineFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/social/view/TimelineFragment.java
@@ -517,7 +517,7 @@ public class TimelineFragment extends FragmentView implements TimelineView {
   @Override public Observable<Post> getVisibleItems() {
     return RxRecyclerView.scrollEvents(list)
         .subscribeOn(AndroidSchedulers.mainThread())
-        .map(recyclerViewScrollEvent -> layoutManager.findFirstCompletelyVisibleItemPosition())
+        .map(recyclerViewScrollEvent -> layoutManager.findFirstVisibleItemPosition())
         .filter(position -> position != RecyclerView.NO_POSITION)
         .distinctUntilChanged()
         .map(visibleItem -> adapter.getPost(visibleItem));


### PR DESCRIPTION
… because we were only sending the request when item was fully visible)