### PR TITLE
[AN-2007] Fixing click on likes preview (social post cards) & likes text clickable

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/social/data/MinimalCardViewFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/social/data/MinimalCardViewFactory.java
@@ -144,6 +144,12 @@ public class MinimalCardViewFactory {
     this.likePreviewContainer.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
         new LikesPreviewCardTouchEvent(post, post.getLikesNumber(),
             CardTouchEvent.Type.LIKES_PREVIEW)));
+    this.numberLikes.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
+        new LikesPreviewCardTouchEvent(post, post.getLikesNumber(),
+            CardTouchEvent.Type.LIKES_PREVIEW)));
+    this.numberLikesOneLike.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
+        new LikesPreviewCardTouchEvent(post, post.getLikesNumber(),
+            CardTouchEvent.Type.LIKES_PREVIEW)));
     this.numberComments.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
         new CardTouchEvent(post, CardTouchEvent.Type.COMMENT_NUMBER)));
     return subCardView;

--- a/app/src/main/java/cm/aptoide/pt/social/presenter/TimelinePresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/social/presenter/TimelinePresenter.java
@@ -926,11 +926,13 @@ public class TimelinePresenter implements Presenter {
   private void clickOnLikesPreview() {
     view.getLifecycle()
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
-        .flatMap(created -> view.postClicked())
-        .filter(cardTouchEvent -> cardTouchEvent.getActionType()
-            .equals(CardTouchEvent.Type.LIKES_PREVIEW))
-        .doOnNext(cardTouchEvent -> timelineNavigation.navigateToLikesView(cardTouchEvent.getCard()
-            .getCardId(), ((LikesPreviewCardTouchEvent) cardTouchEvent).getLikesNumber()))
+        .flatMap(created -> view.postClicked()
+            .filter(cardTouchEvent -> cardTouchEvent.getActionType()
+                .equals(CardTouchEvent.Type.LIKES_PREVIEW))
+            .doOnNext(cardTouchEvent -> timelineNavigation.navigateToLikesView(
+                cardTouchEvent.getCard()
+                    .getCardId(), ((LikesPreviewCardTouchEvent) cardTouchEvent).getLikesNumber()))
+            .retry())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(cardTouchEvent -> timeline.knockWithSixpackCredentials(cardTouchEvent.getCard()
             .getAbUrl()), throwable -> {

--- a/app/src/main/java/cm/aptoide/pt/social/view/viewholder/SocialMediaViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/social/view/viewholder/SocialMediaViewHolder.java
@@ -177,6 +177,12 @@ public class SocialMediaViewHolder extends SocialPostViewHolder<SocialMedia> {
             CardTouchEvent.Type.LIKES_PREVIEW)));
     this.numberComments.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
         new CardTouchEvent(card, CardTouchEvent.Type.COMMENT_NUMBER)));
+    this.numberLikes.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
+        new LikesPreviewCardTouchEvent(card, card.getLikesNumber(),
+            CardTouchEvent.Type.LIKES_PREVIEW)));
+    this.numberLikesOneLike.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
+        new LikesPreviewCardTouchEvent(card, card.getLikesNumber(),
+            CardTouchEvent.Type.LIKES_PREVIEW)));
   }
 
   public Spannable getStyledTitle(Context context, String title) {

--- a/app/src/main/java/cm/aptoide/pt/social/view/viewholder/SocialPostMediaViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/social/view/viewholder/SocialPostMediaViewHolder.java
@@ -17,7 +17,7 @@ import cm.aptoide.pt.dataprovider.model.v7.timeline.UserTimeline;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.social.data.CardTouchEvent;
 import cm.aptoide.pt.social.data.CardType;
-import cm.aptoide.pt.social.data.LikesCardTouchEvent;
+import cm.aptoide.pt.social.data.LikesPreviewCardTouchEvent;
 import cm.aptoide.pt.social.data.SocialCardTouchEvent;
 import cm.aptoide.pt.social.data.SocialHeaderCardTouchEvent;
 import cm.aptoide.pt.social.data.SocialMedia;
@@ -183,7 +183,14 @@ public class SocialPostMediaViewHolder extends SocialPostViewHolder<SocialMedia>
     this.shareButton.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
         new CardTouchEvent(card, CardTouchEvent.Type.SHARE)));
     this.likePreviewContainer.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
-        new LikesCardTouchEvent(card, card.getLikesNumber(), CardTouchEvent.Type.LIKES_PREVIEW)));
+        new LikesPreviewCardTouchEvent(card, card.getLikesNumber(),
+            CardTouchEvent.Type.LIKES_PREVIEW)));
+    this.numberLikes.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
+        new LikesPreviewCardTouchEvent(card, card.getLikesNumber(),
+            CardTouchEvent.Type.LIKES_PREVIEW)));
+    this.numberLikesOneLike.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
+        new LikesPreviewCardTouchEvent(card, card.getLikesNumber(),
+            CardTouchEvent.Type.LIKES_PREVIEW)));
     this.numberComments.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
         new CardTouchEvent(card, CardTouchEvent.Type.COMMENT_NUMBER)));
   }

--- a/app/src/main/java/cm/aptoide/pt/social/view/viewholder/SocialPostRecommendationViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/social/view/viewholder/SocialPostRecommendationViewHolder.java
@@ -17,7 +17,7 @@ import cm.aptoide.pt.R;
 import cm.aptoide.pt.dataprovider.model.v7.timeline.UserTimeline;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.social.data.CardTouchEvent;
-import cm.aptoide.pt.social.data.LikesCardTouchEvent;
+import cm.aptoide.pt.social.data.LikesPreviewCardTouchEvent;
 import cm.aptoide.pt.social.data.RatedRecommendation;
 import cm.aptoide.pt.social.data.SocialCardTouchEvent;
 import cm.aptoide.pt.social.data.SocialHeaderCardTouchEvent;
@@ -159,7 +159,14 @@ public class SocialPostRecommendationViewHolder extends SocialPostViewHolder<Rat
     this.shareButton.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
         new CardTouchEvent(card, CardTouchEvent.Type.SHARE)));
     this.likePreviewContainer.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
-        new LikesCardTouchEvent(card, card.getLikesNumber(), CardTouchEvent.Type.LIKES_PREVIEW)));
+        new LikesPreviewCardTouchEvent(card, card.getLikesNumber(),
+            CardTouchEvent.Type.LIKES_PREVIEW)));
+    this.numberLikes.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
+        new LikesPreviewCardTouchEvent(card, card.getLikesNumber(),
+            CardTouchEvent.Type.LIKES_PREVIEW)));
+    this.numberLikesOneLike.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
+        new LikesPreviewCardTouchEvent(card, card.getLikesNumber(),
+            CardTouchEvent.Type.LIKES_PREVIEW)));
     this.numberComments.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
         new CardTouchEvent(card, CardTouchEvent.Type.COMMENT_NUMBER)));
   }

--- a/app/src/main/java/cm/aptoide/pt/social/view/viewholder/SocialRecommendationViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/social/view/viewholder/SocialRecommendationViewHolder.java
@@ -170,6 +170,12 @@ public class SocialRecommendationViewHolder extends SocialPostViewHolder<RatedRe
     this.likePreviewContainer.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
         new LikesPreviewCardTouchEvent(card, card.getLikesNumber(),
             CardTouchEvent.Type.LIKES_PREVIEW)));
+    this.numberLikes.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
+        new LikesPreviewCardTouchEvent(card, card.getLikesNumber(),
+            CardTouchEvent.Type.LIKES_PREVIEW)));
+    this.numberLikesOneLike.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
+        new LikesPreviewCardTouchEvent(card, card.getLikesNumber(),
+            CardTouchEvent.Type.LIKES_PREVIEW)));
     this.numberComments.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
         new CardTouchEvent(card, CardTouchEvent.Type.COMMENT_NUMBER)));
   }

--- a/app/src/main/java/cm/aptoide/pt/social/view/viewholder/SocialStoreViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/social/view/viewholder/SocialStoreViewHolder.java
@@ -185,6 +185,12 @@ public class SocialStoreViewHolder extends SocialPostViewHolder<SocialStore> {
     this.likePreviewContainer.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
         new LikesPreviewCardTouchEvent(card, card.getLikesNumber(),
             CardTouchEvent.Type.LIKES_PREVIEW)));
+    this.numberLikes.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
+        new LikesPreviewCardTouchEvent(card, card.getLikesNumber(),
+            CardTouchEvent.Type.LIKES_PREVIEW)));
+    this.numberLikesOneLike.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
+        new LikesPreviewCardTouchEvent(card, card.getLikesNumber(),
+            CardTouchEvent.Type.LIKES_PREVIEW)));
     this.numberComments.setOnClickListener(click -> this.cardTouchEventPublishSubject.onNext(
         new CardTouchEvent(card, CardTouchEvent.Type.COMMENT_NUMBER)));
   }


### PR DESCRIPTION
This PR fixes the click on likes preview (user/store images that liked a card) on social Social Post cards (we were dealing with a cast exception).

This PR also adds the option to click on likes text (8 likes / User X Liked) text to go to the likes list. (in the future we should change User X Liked to jump directly to the user's store/timeline.)