### PR TITLE
[AN-1987] Timeline ads are not pre-fetched anymore on getUserTimeline…

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
+++ b/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
@@ -157,7 +157,6 @@ import cm.aptoide.pt.repository.RepositoryFactory;
 import cm.aptoide.pt.root.RootAvailabilityManager;
 import cm.aptoide.pt.root.RootValueSaver;
 import cm.aptoide.pt.social.TimelineRepositoryFactory;
-import cm.aptoide.pt.social.data.TimelineAdsRepository;
 import cm.aptoide.pt.social.data.TimelinePostsRepository;
 import cm.aptoide.pt.social.data.TimelineResponseCardMapper;
 import cm.aptoide.pt.spotandshare.AccountGroupNameProvider;
@@ -1323,8 +1322,7 @@ public abstract class AptoideApplication extends Application {
           new TimelineRepositoryFactory(new HashMap<>(), getAccountSettingsBodyInterceptorPoolV7(),
               getDefaultClient(), getDefaultSharedPreferences(), getTokenInvalidator(),
               new LinksHandlerFactory(this), getPackageRepository(),
-              WebService.getDefaultConverter(), new TimelineResponseCardMapper(
-              () -> new TimelineAdsRepository(context, BehaviorRelay.create()), getMarketName()),
+              WebService.getDefaultConverter(), new TimelineResponseCardMapper(getMarketName()),
               RepositoryFactory.getUpdateRepository(context,
                   ((AptoideApplication) context.getApplicationContext()).getDefaultSharedPreferences()));
     }

--- a/app/src/main/java/cm/aptoide/pt/social/data/AdPost.java
+++ b/app/src/main/java/cm/aptoide/pt/social/data/AdPost.java
@@ -1,18 +1,12 @@
 package cm.aptoide.pt.social.data;
 
-import android.os.Handler;
-import android.os.Looper;
-import rx.Single;
-
 /**
  * Created by jdandrade on 14/08/2017.
  */
 
 public class AdPost extends DummyPost {
-  private final TimelineAdsRepository adsRepository;
 
-  public AdPost(TimelineAdsRepository adsRepository) {
-    this.adsRepository = adsRepository;
+  public AdPost() {
   }
 
   @Override public String getCardId() {
@@ -21,14 +15,5 @@ public class AdPost extends DummyPost {
 
   @Override public CardType getType() {
     return CardType.AD;
-  }
-
-  public Single<AdResponse> getAdView() {
-    return adsRepository.getAd();
-  }
-
-  public void init() {
-    Handler handler = new Handler(Looper.getMainLooper());
-    handler.post(() -> adsRepository.fetchAd());
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/social/data/CardViewHolderFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/social/data/CardViewHolderFactory.java
@@ -41,16 +41,19 @@ public class CardViewHolderFactory {
   private final SpannableFactory spannableFactory;
   private final MinimalCardViewFactory minimalCardViewFactory;
   private final String marketName;
+  private final TimelineAdsRepository adsRepository;
   private StoreContext storeContext;
 
   public CardViewHolderFactory(PublishSubject<CardTouchEvent> cardTouchEventPublishSubject,
       DateCalculator dateCalculator, SpannableFactory spannableFactory,
-      MinimalCardViewFactory minimalCardViewFactory, String marketName, StoreContext storeContext) {
+      MinimalCardViewFactory minimalCardViewFactory, String marketName,
+      TimelineAdsRepository adsRepository, StoreContext storeContext) {
     this.minimalCardViewFactory = minimalCardViewFactory;
     this.cardTouchEventPublishSubject = cardTouchEventPublishSubject;
     this.dateCalculator = dateCalculator;
     this.spannableFactory = spannableFactory;
     this.marketName = marketName;
+    this.adsRepository = adsRepository;
     this.storeContext = storeContext;
   }
 
@@ -134,8 +137,8 @@ public class CardViewHolderFactory {
             .inflate(R.layout.timeline_login_item, parent, false), cardTouchEventPublishSubject);
       case AD:
         return new TimelineAdPostViewHolder(LayoutInflater.from(parent.getContext())
-            .inflate(R.layout.timeline_native_ad_item, parent, false),
-            cardTouchEventPublishSubject);
+            .inflate(R.layout.timeline_native_ad_item, parent, false), cardTouchEventPublishSubject,
+            adsRepository);
       case NOTIFICATIONS:
         return new Notifications(LayoutInflater.from(parent.getContext())
             .inflate(R.layout.timeline_notification, parent, false), cardTouchEventPublishSubject,

--- a/app/src/main/java/cm/aptoide/pt/social/data/TimelineAdsRepository.java
+++ b/app/src/main/java/cm/aptoide/pt/social/data/TimelineAdsRepository.java
@@ -19,16 +19,13 @@ import rx.Single;
  */
 
 public class TimelineAdsRepository {
-
-  private final Context context;
   private final BehaviorRelay<AdResponse> ad;
 
-  public TimelineAdsRepository(Context context, BehaviorRelay<AdResponse> ad) {
-    this.context = context;
+  public TimelineAdsRepository(BehaviorRelay<AdResponse> ad) {
     this.ad = ad;
   }
 
-  public void fetchAd() {
+  public void fetchAd(final Context context) {
     MoPubNative moPubNative = new MoPubNative(context, BuildConfig.MOPUB_NATIVE_AD_UNIT_ID,
         new MoPubNative.MoPubNativeNetworkListener() {
           @Override public void onNativeLoad(NativeAd nativeAd) {

--- a/app/src/main/java/cm/aptoide/pt/social/data/TimelineResponseCardMapper.java
+++ b/app/src/main/java/cm/aptoide/pt/social/data/TimelineResponseCardMapper.java
@@ -52,12 +52,9 @@ import java.util.List;
  */
 
 public class TimelineResponseCardMapper {
-  private final AdsRepositoryProvider adsRepositoryProvider;
   private final String marketName;
 
-  public TimelineResponseCardMapper(AdsRepositoryProvider adsRepositoryProvider,
-      String marketName) {
-    this.adsRepositoryProvider = adsRepositoryProvider;
+  public TimelineResponseCardMapper(String marketName) {
     this.marketName = marketName;
   }
 
@@ -505,10 +502,7 @@ public class TimelineResponseCardMapper {
             aggregatedSocialStoreLatestApps.getApps(), abUrl, CardType.AGGREGATED_SOCIAL_STORE,
             getMarkAsReadUrl(aggregatedSocialStoreLatestApps)));
       } else if (item instanceof AdTimelineItem) {
-
-        AdPost adPost = new AdPost(adsRepositoryProvider.getAdsRepository());
-        adPost.init();
-        cards.add(adPost);
+        cards.add(new AdPost());
       }
     }
   }
@@ -516,9 +510,5 @@ public class TimelineResponseCardMapper {
   @Nullable private String getMarkAsReadUrl(TimelineCard card) {
     return card.getUrls() == null ? null : card.getUrls()
         .getRead();
-  }
-
-  public interface AdsRepositoryProvider {
-    TimelineAdsRepository getAdsRepository();
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/social/view/TimelineFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/social/view/TimelineFragment.java
@@ -209,9 +209,7 @@ public class TimelineFragment extends FragmentView implements TimelineView {
 
     timelineService =
         new TimelineService(userId, baseBodyInterceptorV7, defaultClient, defaultConverter,
-            new TimelineResponseCardMapper(
-                () -> new TimelineAdsRepository(getContext(), BehaviorRelay.create()), marketName),
-            tokenInvalidator, sharedPreferences);
+            new TimelineResponseCardMapper(marketName), tokenInvalidator, sharedPreferences);
   }
 
   @Override public void onSaveInstanceState(Bundle outState) {
@@ -253,10 +251,13 @@ public class TimelineFragment extends FragmentView implements TimelineView {
     floatingActionButton = (FloatingActionButton) view.findViewById(R.id.floating_action_button);
 
     SpannableFactory spannableFactory = new SpannableFactory();
+    TimelineAdsRepository timelineAdsRepository = new TimelineAdsRepository(BehaviorRelay.create());
+
     adapter = new PostAdapter(new ArrayList<>(),
         new CardViewHolderFactory(postTouchEventPublishSubject, dateCalculator, spannableFactory,
             new MinimalCardViewFactory(dateCalculator, spannableFactory,
-                postTouchEventPublishSubject), marketName, storeContext), new ProgressCard());
+                postTouchEventPublishSubject), marketName, timelineAdsRepository, storeContext),
+        new ProgressCard());
     list.setAdapter(adapter);
 
     final StoreAccessor storeAccessor = AccessorFactory.getAccessorFor(

--- a/app/src/main/java/cm/aptoide/pt/social/view/viewholder/TimelineAdPostViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/social/view/viewholder/TimelineAdPostViewHolder.java
@@ -2,12 +2,12 @@ package cm.aptoide.pt.social.view.viewholder;
 
 import android.view.View;
 import android.widget.LinearLayout;
-import android.widget.ProgressBar;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.social.data.AdPost;
 import cm.aptoide.pt.social.data.AdResponse;
 import cm.aptoide.pt.social.data.CardTouchEvent;
+import cm.aptoide.pt.social.data.TimelineAdsRepository;
 import rx.subjects.PublishSubject;
 
 /**
@@ -17,29 +17,32 @@ import rx.subjects.PublishSubject;
 public class TimelineAdPostViewHolder extends PostViewHolder<AdPost> {
   private final PublishSubject<CardTouchEvent> cardTouchEventPublishSubject;
   private final LinearLayout cardLayout;
-  private final ProgressBar adLoading;
+  private final TimelineAdsRepository adsRepository;
 
   public TimelineAdPostViewHolder(View view,
-      PublishSubject<CardTouchEvent> cardTouchEventPublishSubject) {
+      PublishSubject<CardTouchEvent> cardTouchEventPublishSubject,
+      TimelineAdsRepository adsRepository) {
     super(view, cardTouchEventPublishSubject);
     this.cardTouchEventPublishSubject = cardTouchEventPublishSubject;
     this.cardLayout = (LinearLayout) view.findViewById(R.id.card_layout);
-    this.adLoading = (ProgressBar) view.findViewById(R.id.timeline_ad_loading);
+    this.adsRepository = adsRepository;
   }
 
   @Override public void setPost(AdPost post, int position) {
     this.cardLayout.setVisibility(View.VISIBLE);
     this.cardLayout.removeAllViews();
-    this.cardLayout.addView(adLoading);
-    this.adLoading.setVisibility(View.VISIBLE);
-    post.getAdView()
+    tryToShowAd(post, position);
+  }
+
+  private void tryToShowAd(AdPost post, int position) {
+    adsRepository.fetchAd(itemView.getContext());
+    adsRepository.getAd()
         .subscribe(adResponse -> {
           if (adResponse.getStatus()
               .equals(AdResponse.Status.ok)) {
             if (adResponse.getView()
                 .getParent() == null) {
               cardLayout.addView(adResponse.getView());
-              adLoading.setVisibility(View.GONE);
             } else {
               handleNativeAdError(post, position);
             }

--- a/app/src/main/res/layout/timeline_native_ad_item.xml
+++ b/app/src/main/res/layout/timeline_native_ad_item.xml
@@ -13,17 +13,6 @@
       android:layout_height="wrap_content"
       android:orientation="vertical"
       >
-
-    <ProgressBar
-        android:id="@+id/timeline_ad_loading"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:layout_marginBottom="10dp"
-        android:layout_marginTop="10dp"
-        android:indeterminate="true"
-        />
-
   </LinearLayout>
 
 </android.support.v7.widget.CardView>


### PR DESCRIPTION
This PR will make the timeline Ads be loaded only when the card adapter item is loaded, not pre-fetched anymore when the getUserTimeline request is made.

This is an improvement we are trying to make because of the fact that Timeline is called whenever user opens the application, and we were going to pre-fetch ads that would be never shown (possibility) .