### PR TITLE
Hotfix/an 2053 runtime exception viewpager screenshots

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/view/app/screenshots/ScreenshotsViewerFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/app/screenshots/ScreenshotsViewerFragment.java
@@ -57,18 +57,12 @@ public class ScreenshotsViewerFragment extends UIComponentFragment {
   }
 
   @Override public void setupViews() {
-
+    screenshots.setTrackingEnabled(false);
     if (uris != null && uris.size() > 0) {
       screenshots.setAdapter(new ViewPagerAdapterScreenshots(uris));
       screenshots.setCurrentItem(currentItem);
     }
-
-    btnCloseViewer.setOnClickListener(new View.OnClickListener() {
-      @Override public void onClick(View v) {
-        //getActivity().finish();
-        getActivity().onBackPressed();
-      }
-    });
+    btnCloseViewer.setOnClickListener(v -> getActivity().onBackPressed());
   }
 
   @Override public void onResume() {

--- a/app/src/main/java/cm/aptoide/pt/view/custom/AptoideViewPager.java
+++ b/app/src/main/java/cm/aptoide/pt/view/custom/AptoideViewPager.java
@@ -19,6 +19,7 @@ import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
 @Deprecated public class AptoideViewPager extends ViewPager {
 
   private boolean enabled = true;
+  private boolean trackingEnabled = true;
 
   public AptoideViewPager(Context context) {
     super(context);
@@ -33,26 +34,27 @@ import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
     addOnPageChangeListener(new SimpleOnPageChangeListener() {
       @Override public void onPageSelected(int position) {
         super.onPageSelected(position);
+        if (trackingEnabled) {
+          if (!(getAdapter() instanceof NavigationTrackerPagerAdapterHelper)) {
+            throw new RuntimeException(getAdapter().getClass()
+                .getSimpleName()
+                + " has to implement "
+                + NavigationTrackerPagerAdapterHelper.class.getSimpleName());
+          }
+          if (position != 0) {
+            final NavigationTrackerPagerAdapterHelper adapter =
+                (NavigationTrackerPagerAdapterHelper) getAdapter();
 
-        if (!(getAdapter() instanceof NavigationTrackerPagerAdapterHelper)) {
-          throw new RuntimeException(getAdapter().getClass()
-              .getSimpleName()
-              + " has to implement "
-              + NavigationTrackerPagerAdapterHelper.class.getSimpleName());
-        }
-        if (position != 0) {
-          final NavigationTrackerPagerAdapterHelper adapter =
-              (NavigationTrackerPagerAdapterHelper) getAdapter();
+            String currentView = adapter.getItemName(position);
+            String tag = adapter.getItemTag(position);
+            StoreContext storeContext = adapter.getItemStore();
 
-          String currentView = adapter.getItemName(position);
-          String tag = adapter.getItemTag(position);
-          StoreContext storeContext = adapter.getItemStore();
+            ((AptoideApplication) getContext().getApplicationContext()).getAptoideNavigationTracker()
+                .registerScreen(ScreenTagHistory.Builder.build(currentView, tag, storeContext));
 
-          ((AptoideApplication) getContext().getApplicationContext()).getAptoideNavigationTracker()
-              .registerScreen(ScreenTagHistory.Builder.build(currentView, tag, storeContext));
-
-          ((AptoideApplication) getContext().getApplicationContext()).getPageViewsAnalytics()
-              .sendPageViewedEvent();
+            ((AptoideApplication) getContext().getApplicationContext()).getPageViewsAnalytics()
+                .sendPageViewedEvent();
+          }
         }
       }
     });
@@ -76,5 +78,9 @@ import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
 
   public void setPagingEnabled(boolean enabled) {
     this.enabled = enabled;
+  }
+
+  public void setTrackingEnabled(boolean trackingEnabled) {
+    this.trackingEnabled = trackingEnabled;
   }
 }


### PR DESCRIPTION
Screenshots view pager adapter was not implementing Navigationtracker, resulting in a runtime exception being thrown when the user goes to the screenshots in an appview.

