### PR TITLE
[AN-2212] SpotAndShareActivityView now extends Vanilla's ActivityView

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/spotandshare/view/SpotAndShareActivityView.java
+++ b/app/src/main/java/cm/aptoide/pt/spotandshare/view/SpotAndShareActivityView.java
@@ -1,8 +1,8 @@
 package cm.aptoide.pt.spotandshare.view;
 
-import cm.aptoide.pt.analytics.view.AnalyticsActivity;
+import cm.aptoide.pt.view.ActivityView;
 
-public abstract class SpotAndShareActivityView extends AnalyticsActivity {
+public abstract class SpotAndShareActivityView extends ActivityView {
 
   private Presenter presenter;
 


### PR DESCRIPTION
Spot and share was crashing after pressing start button.
It was not using vanilla's ActivityView interface so it was crashing while trying to cast to ActivityView on BaseActivity.