### PR TITLE
[AN-2211] Fixed rollback on updated app

### DIFF
--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/GetAppRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/GetAppRequest.java
@@ -63,7 +63,7 @@ public class GetAppRequest extends V7<GetApp, GetAppRequest.Body> {
       OkHttpClient httpClient, Converter.Factory converterFactory,
       TokenInvalidator tokenInvalidator, SharedPreferences sharedPreferences) {
 
-    return new GetAppRequest(getHost(sharedPreferences), new Body(md5, sharedPreferences),
+    return new GetAppRequest(getHost(sharedPreferences), new Body(sharedPreferences, md5),
         bodyInterceptor, httpClient,
         converterFactory, tokenInvalidator);
   }
@@ -130,15 +130,15 @@ public class GetAppRequest extends V7<GetApp, GetAppRequest.Body> {
       this.nodes = new Node(packageName);
     }
 
-    public Body(Boolean refresh, String md5, SharedPreferences sharedPreferences) {
-      super(sharedPreferences);
-      this.md5 = md5;
-      this.nodes = new Node();
-    }
-
     public Body(String uname, SharedPreferences sharedPreferences) {
       super(sharedPreferences);
       this.uname = uname;
+      this.nodes = new Node();
+    }
+
+    public Body(SharedPreferences sharedPreferences, String md5) {
+      super(sharedPreferences);
+      this.md5 = md5;
       this.nodes = new Node();
     }
 


### PR DESCRIPTION
Change from using the body with uname to the one with md5 on the getAppRequest, on method ofMd5.