### PR TITLE
stores tab store meta now displays the default following stats inform…

### DIFF
--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/WSWidgetsUtils.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/WSWidgetsUtils.java
@@ -169,7 +169,14 @@ import rx.schedulers.Schedulers;
                     } else {
                       return Observable.error(throwable);
                     }
-                  }), (timelineStats, getHomeMeta) -> new MyStore(timelineStats, getHomeMeta))
+                  }), (timelineStats, getHomeMeta) -> {
+                if (timelineStats.getData() == null) { // this happens when server returns SYS-1
+                  TimelineStats defaultTimelineStats = createErrorTimelineStatus();
+                  return new MyStore(defaultTimelineStats, getHomeMeta);
+                } else {
+                  return new MyStore(timelineStats, getHomeMeta);
+                }
+              })
               .doOnNext(obj -> wsWidget.setViewObject(obj))
               .onErrorResumeNext(throwable -> Observable.empty())
               .map(myStore -> wsWidget);


### PR DESCRIPTION
…ation (0/0) when getTimelineStats returns SYS-1

To test, rewrite getTimelineStats reponse in charles with:

{
	"info": {
		"status": "FAIL",
		"time": {
			"seconds": 0.0012128353118896,
			"human": "1 millisecond"
		}
	},
	"errors": [{
		"code": "SYS-1",
		"description": "Random Error",
		"details": {}
	}]
}

The issue here is that SYS-1 is not parsed as an error in our ws method calls and the rxjava chain doesn't break, making error handling in the onErrorReturn method unreliable for this case.

What was done was null checking the response in the widget mapping and returning the same default TimelineStats object with 0/0 data that was being used for the onErrorReturn handling.