### PR TITLE
[AN-2157] fix get/user refresh flag that was being overriden false in…

### DIFF
--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/GetUserInfoRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/GetUserInfoRequest.java
@@ -44,7 +44,6 @@ public class GetUserInfoRequest extends V7<GetUserInfo, GetUserInfoRequest.Body>
   public static class Body extends BaseBody {
 
     private List<String> nodes;
-    private boolean refresh;
 
     public Body(List<String> nodes) {
       this.nodes = nodes;
@@ -56,10 +55,6 @@ public class GetUserInfoRequest extends V7<GetUserInfo, GetUserInfoRequest.Body>
 
     public void setNodes(List<String> nodes) {
       this.nodes = nodes;
-    }
-
-    public void setRefresh(boolean refresh) {
-      this.refresh = refresh;
     }
   }
 }


### PR DESCRIPTION
… the GetUserInfoRequest body.

This fix solves the problem with the refresh flag in the get/user request that was always false when the user edits/creates store in the stores tab.