### PR TITLE
[AN-2218] Fixed misplaced CreateStoreDisplayble on MyStoresFragment

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/view/recycler/displayable/DisplayablesFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/view/recycler/displayable/DisplayablesFactory.java
@@ -147,7 +147,8 @@ public class DisplayablesFactory {
 
         case MY_STORE_META:
           return Observable.from(
-              createMyStoreDisplayables(widget.getViewObject(), storeAnalytics, storeContext));
+              createMyStoreDisplayables(widget.getViewObject(), storeAnalytics, storeContext,
+                  accountManager));
 
         case STORES_RECOMMENDED:
           return Observable.just(
@@ -377,14 +378,15 @@ public class DisplayablesFactory {
   }
 
   private static List<Displayable> createMyStoreDisplayables(Object viewObject,
-      StoreAnalytics storeAnalytics, StoreContext storeContext) {
+      StoreAnalytics storeAnalytics, StoreContext storeContext,
+      AptoideAccountManager accountManager) {
     LinkedList<Displayable> displayables = new LinkedList<>();
 
     if (viewObject instanceof MyStore) {
       MyStore store = (MyStore) viewObject;
       if (!store.isCreateStore()) {
         displayables.add(new MyStoreDisplayable(store, storeContext));
-      } else if (store.isLogged()) {
+      } else if (accountManager.isLoggedIn()) {
         displayables.add(new CreateStoreDisplayable(storeAnalytics, store.getTimelineStats()));
       } else {
         displayables.add(new LoginDisplayable());

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/MyStore.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/MyStore.java
@@ -29,8 +29,4 @@ public class MyStore {
   public boolean isCreateStore() {
     return getHomeMeta == null;
   }
-
-  public boolean isLogged() {
-    return timelineStats != null;
-  }
 }


### PR DESCRIPTION
The problem:
1. Logout if you're logged in;
2. Go to MyStoreFragment tab;
- problem: displays a create store widget;
- expected: displays a login widget;

The fix:
When the user is logged out, the MyStoresFragment should have a LoginDisplayable.
The current scenario was adding a CreateStoreWidget, because the MyStore viewObject was the one giving information if the user is or is not logged in.
This responsibility is from the AptoideAccountManager, so now the DisplayablesFactory adds the right displayable according to the user's log in state.