### PR TITLE
[storeMeta/AN-2170] - solve a bug where the store data isn't refreshe…

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/account/view/LoginActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/LoginActivity.java
@@ -5,25 +5,28 @@ import android.os.Bundle;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.Nullable;
 import cm.aptoide.pt.R;
+import cm.aptoide.pt.navigator.FragmentNavigator;
+import javax.inject.Inject;
 
 public class LoginActivity extends LoginBottomSheetActivity {
 
   public static final String ACCOUNT_TYPE = "account_type";
   public static final String AUTH_TYPE = "auth_type";
   public static final String IS_ADDING_NEW_ACCOUNT = "is_adding_new_account";
-
+  @Inject FragmentNavigator fragmentNavigator;
   private String accountType;
   private String authType;
   private boolean isNewAccount;
 
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    getActivityComponent().inject(this);
     setContentView(getLayoutId());
 
     loadExtras(getIntent());
 
     if (savedInstanceState == null) {
-      getFragmentNavigator().navigateToWithoutBackSave(
+      fragmentNavigator.navigateToWithoutBackSave(
           LoginSignUpFragment.newInstance(false, true, false, accountType, authType, isNewAccount),
           true);
     }

--- a/app/src/main/java/cm/aptoide/pt/account/view/store/ManageStoreFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/store/ManageStoreFragment.java
@@ -38,7 +38,6 @@ import cm.aptoide.pt.account.view.exception.InvalidImageException;
 import cm.aptoide.pt.analytics.ScreenTagHistory;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.dataprovider.model.v7.store.Store;
-import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.permission.AccountPermissionProvider;
 import cm.aptoide.pt.presenter.CompositePresenter;
@@ -114,7 +113,6 @@ public class ManageStoreFragment extends BackButtonFragment implements ManageSto
   private ImageView twitterEndRowIcon;
   private ImageView youtubeEndRowIcon;
   private List<Store.SocialChannelType> storeDeleteLinksList;
-  private int requestCode;
 
   public static ManageStoreFragment newInstance(ManageStoreViewModel storeModel, boolean goToHome) {
     Bundle args = new Bundle();
@@ -130,7 +128,7 @@ public class ManageStoreFragment extends BackButtonFragment implements ManageSto
     super.onCreate(savedInstanceState);
     currentModel = Parcels.unwrap(getArguments().getParcelable(EXTRA_STORE_MODEL));
     goToHome = getArguments().getBoolean(EXTRA_GO_TO_HOME, true);
-    requestCode = getArguments().getInt(FragmentNavigator.REQUEST_CODE_EXTRA);
+
     dialogFragment =
         new ImagePickerDialog.Builder(getContext()).setViewRes(ImagePickerDialog.LAYOUT)
             .setTitle(R.string.upload_dialog_title)

--- a/app/src/main/java/cm/aptoide/pt/app/view/GridAppDisplayable.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/GridAppDisplayable.java
@@ -11,6 +11,7 @@ import cm.aptoide.pt.analytics.NavigationTracker;
 import cm.aptoide.pt.dataprovider.model.v7.Type;
 import cm.aptoide.pt.dataprovider.model.v7.listapp.App;
 import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.view.recycler.displayable.DisplayablePojo;
 
 /**
@@ -24,17 +25,20 @@ public class GridAppDisplayable extends DisplayablePojo<App> {
   private boolean totalDownloads;
   private NavigationTracker navigationTracker;
   private StoreContext storeContext;
+  private FragmentNavigator fragmentNavigator;
 
   public GridAppDisplayable() {
   }
 
   public GridAppDisplayable(App pojo, String tag, boolean totalDownloads,
-      NavigationTracker navigationTracker, StoreContext storeContext) {
+      NavigationTracker navigationTracker, StoreContext storeContext,
+      FragmentNavigator fragmentNavigator) {
     super(pojo);
     this.tag = tag;
     this.totalDownloads = totalDownloads;
     this.navigationTracker = navigationTracker;
     this.storeContext = storeContext;
+    this.fragmentNavigator = fragmentNavigator;
   }
 
   @Override protected Configs getConfig() {
@@ -60,5 +64,9 @@ public class GridAppDisplayable extends DisplayablePojo<App> {
 
   public boolean isTotalDownloads() {
     return this.totalDownloads;
+  }
+
+  public FragmentNavigator getFragmentNavigator() {
+    return fragmentNavigator;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/app/view/GridAppListWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/GridAppListWidget.java
@@ -14,11 +14,14 @@ import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.dataprovider.model.v7.listapp.App;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.utils.AptoideUtils;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.jakewharton.rxbinding.view.RxView;
 import java.util.Date;
+import javax.inject.Inject;
 
 /**
  * Created by neuro on 29-06-2016.
@@ -27,11 +30,14 @@ public class GridAppListWidget extends Widget<GridAppListDisplayable> {
 
   public TextView name;
   public ImageView icon;
+  @Inject FragmentNavigator fragmentNavigator;
   private TextView tvTimeSinceModified;
   private TextView tvStoreName;
 
   public GridAppListWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -62,7 +68,7 @@ public class GridAppListWidget extends Widget<GridAppListDisplayable> {
     compositeSubscription.add(RxView.clicks(itemView)
         .subscribe(v -> {
           // FIXME
-          getFragmentNavigator().navigateTo(AptoideApplication.getFragmentProvider()
+          fragmentNavigator.navigateTo(AptoideApplication.getFragmentProvider()
               .newAppViewFragment(app.getId(), app.getPackageName(), displayable.getTag()), true);
         }, throwable -> CrashReport.getInstance()
             .log(throwable)));

--- a/app/src/main/java/cm/aptoide/pt/app/view/GridAppWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/GridAppWidget.java
@@ -75,7 +75,8 @@ public class GridAppWidget<T extends GridAppDisplayable> extends Widget<T> {
   @NonNull protected Action1<Void> newOnClickListener(T displayable, App pojo, long appId) {
     return v -> {
       // FIXME
-      getFragmentNavigator().navigateTo(AptoideApplication.getFragmentProvider()
+      displayable.getFragmentNavigator()
+          .navigateTo(AptoideApplication.getFragmentProvider()
           .newAppViewFragment(appId, pojo.getPackageName(), pojo.getStore()
               .getAppearance()
               .getTheme(), tvStoreName.getText()

--- a/app/src/main/java/cm/aptoide/pt/app/view/ListAppsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/ListAppsFragment.java
@@ -1,5 +1,7 @@
 package cm.aptoide.pt.app.view;
 
+import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import cm.aptoide.pt.dataprovider.model.v7.ListApps;
 import cm.aptoide.pt.dataprovider.model.v7.listapp.App;
@@ -7,11 +9,13 @@ import cm.aptoide.pt.dataprovider.model.v7.store.Store;
 import cm.aptoide.pt.dataprovider.ws.v7.Endless;
 import cm.aptoide.pt.dataprovider.ws.v7.V7;
 import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.store.view.GetStoreEndlessFragment;
 import cm.aptoide.pt.store.view.featured.AppBrickListDisplayable;
 import cm.aptoide.pt.view.recycler.displayable.Displayable;
 import java.util.LinkedList;
 import java.util.List;
+import javax.inject.Inject;
 import rx.functions.Action1;
 
 /**
@@ -20,8 +24,15 @@ import rx.functions.Action1;
 
 public class ListAppsFragment extends GetStoreEndlessFragment<ListApps> {
 
+  @Inject FragmentNavigator fragmentNavigator;
+
   public static Fragment newInstance() {
     return new ListAppsFragment();
+  }
+
+  @Override public void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    getFragmentComponent(savedInstanceState).inject(this);
   }
 
   @Override protected V7<ListApps, ? extends Endless> buildRequest(boolean refresh, String url) {
@@ -51,7 +62,7 @@ public class ListAppsFragment extends GetStoreEndlessFragment<ListApps> {
               app.getStore()
                   .setAppearance(new Store.Appearance(storeTheme, null));
               displayables.add(new GridAppDisplayable(app, tag, storeContext == StoreContext.home,
-                  navigationTracker, storeContext));
+                  navigationTracker, storeContext, fragmentNavigator));
             }
             break;
         }
@@ -61,7 +72,7 @@ public class ListAppsFragment extends GetStoreEndlessFragment<ListApps> {
               .setAppearance(new Store.Appearance(storeTheme, null));
           displayables.add(
               new GridAppDisplayable(app, tag, storeContext == StoreContext.home, navigationTracker,
-                  storeContext));
+                  storeContext, fragmentNavigator));
         }
       }
 

--- a/app/src/main/java/cm/aptoide/pt/app/view/OfficialAppWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/OfficialAppWidget.java
@@ -21,17 +21,21 @@ import cm.aptoide.pt.R;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.dataprovider.model.v7.GetAppMeta;
 import cm.aptoide.pt.install.InstalledRepository;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.repository.RepositoryFactory;
 import cm.aptoide.pt.utils.AptoideUtils;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.Translator;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 
 public class OfficialAppWidget extends Widget<OfficialAppDisplayable> {
 
   private static final String TAG = OfficialAppWidget.class.getName();
 
+  @Inject FragmentNavigator fragmentNavigator;
   private ImageView appImage;
   private Button installButton;
   private TextView installMessage;
@@ -44,6 +48,8 @@ public class OfficialAppWidget extends Widget<OfficialAppDisplayable> {
 
   public OfficialAppWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -145,7 +151,7 @@ public class OfficialAppWidget extends Widget<OfficialAppDisplayable> {
             Fragment appView = AptoideApplication.getFragmentProvider()
                 .newAppViewFragment(appData.getPackageName(),
                     AppViewFragment.OpenType.OPEN_AND_INSTALL);
-            getFragmentNavigator().navigateTo(appView, true);
+            fragmentNavigator.navigateTo(appView, true);
           }
         }, err -> {
           CrashReport.getInstance()

--- a/app/src/main/java/cm/aptoide/pt/app/view/displayable/AppViewSuggestedAppDisplayable.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/displayable/AppViewSuggestedAppDisplayable.java
@@ -11,6 +11,7 @@ import cm.aptoide.pt.app.AppViewSimilarAppAnalytics;
 import cm.aptoide.pt.app.view.GridAppDisplayable;
 import cm.aptoide.pt.dataprovider.model.v7.listapp.App;
 import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 
 /**
  * Created on 04/05/16.
@@ -24,9 +25,9 @@ public class AppViewSuggestedAppDisplayable extends GridAppDisplayable {
 
   public AppViewSuggestedAppDisplayable(App app,
       AppViewSimilarAppAnalytics appViewSimilarAppAnalytics, NavigationTracker navigationTracker,
-      StoreContext storeContext) {
+      StoreContext storeContext, FragmentNavigator fragmentNavigator) {
     // TODO: 01-08-2017 neuro tags
-    super(app, null, true, navigationTracker, storeContext);
+    super(app, null, true, navigationTracker, storeContext, fragmentNavigator);
 
     this.appViewSimilarAppAnalytics = appViewSimilarAppAnalytics;
   }

--- a/app/src/main/java/cm/aptoide/pt/app/view/widget/AppViewDescriptionWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/widget/AppViewDescriptionWidget.java
@@ -14,15 +14,19 @@ import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.app.view.displayable.AppViewDescriptionDisplayable;
 import cm.aptoide.pt.dataprovider.model.v7.GetAppMeta;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.utils.AptoideUtils;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 
 /**
  * Created on 10/05/16.
  */
 public class AppViewDescriptionWidget extends Widget<AppViewDescriptionDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private TextView descriptionTextView;
   private Button readMoreBtn;
   private String storeName;
@@ -32,6 +36,8 @@ public class AppViewDescriptionWidget extends Widget<AppViewDescriptionDisplayab
 
   public AppViewDescriptionWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -59,7 +65,7 @@ public class AppViewDescriptionWidget extends Widget<AppViewDescriptionDisplayab
                 .sendReadMoreEvent();
             Fragment fragment = AptoideApplication.getFragmentProvider()
                 .newDescriptionFragment(app.getName(), media.getDescription(), storeTheme);
-            getFragmentNavigator().navigateTo(fragment, true);
+            fragmentNavigator.navigateTo(fragment, true);
           }));
     } else {
       // only show "default" description if the app doesn't have one

--- a/app/src/main/java/cm/aptoide/pt/app/view/widget/AppViewFlagThisWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/widget/AppViewFlagThisWidget.java
@@ -23,11 +23,14 @@ import cm.aptoide.pt.dataprovider.ws.v3.AddApkFlagRequest;
 import cm.aptoide.pt.dataprovider.ws.v3.BaseBody;
 import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.navigator.ActivityResultNavigator;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.utils.design.ShowMessage;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import java.math.BigDecimal;
 import java.text.NumberFormat;
 import java.util.Map;
+import javax.inject.Inject;
 import okhttp3.OkHttpClient;
 import rx.android.schedulers.AndroidSchedulers;
 
@@ -39,7 +42,7 @@ public class AppViewFlagThisWidget extends Widget<AppViewFlagThisDisplayable> {
   private static final String TAG = AppViewFlagThisWidget.class.getSimpleName();
 
   private final Map<Integer, GetAppMeta.GetAppMetaFile.Flags.Vote.Type> viewIdTypeMap;
-
+  @Inject FragmentNavigator fragmentNavigator;
   private View goodAppLayoutWrapper;
   private View flagsLayoutWrapper;
 
@@ -64,6 +67,8 @@ public class AppViewFlagThisWidget extends Widget<AppViewFlagThisDisplayable> {
     viewIdTypeMap.put(R.id.needs_licence_layout, GetAppMeta.GetAppMetaFile.Flags.Vote.Type.LICENSE);
     viewIdTypeMap.put(R.id.fake_app_layout, GetAppMeta.GetAppMetaFile.Flags.Vote.Type.FAKE);
     viewIdTypeMap.put(R.id.virus_layout, GetAppMeta.GetAppMetaFile.Flags.Vote.Type.VIRUS);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -225,7 +230,8 @@ public class AppViewFlagThisWidget extends Widget<AppViewFlagThisDisplayable> {
               }
 
               if (voteSubmitted) {
-                ShowMessage.asSnack(getRootView(), R.string.vote_submitted);
+                ShowMessage.asSnack(fragmentNavigator.peekLast()
+                    .getView(), R.string.vote_submitted);
                 return;
               }
             }
@@ -237,12 +243,14 @@ public class AppViewFlagThisWidget extends Widget<AppViewFlagThisDisplayable> {
             }
 
             setAllButtonsUnPressed(v);
-            ShowMessage.asSnack(getRootView(), R.string.unknown_error);
+            ShowMessage.asSnack(fragmentNavigator.peekLast()
+                .getView(), R.string.unknown_error);
           }, error -> {
             CrashReport.getInstance()
                 .log(error);
             setAllButtonsUnPressed(v);
-            ShowMessage.asSnack(getRootView(), R.string.unknown_error);
+            ShowMessage.asSnack(fragmentNavigator.peekLast()
+                .getView(), R.string.unknown_error);
           }));
     };
   }

--- a/app/src/main/java/cm/aptoide/pt/app/view/widget/AppViewInstallWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/widget/AppViewInstallWidget.java
@@ -57,15 +57,18 @@ import cm.aptoide.pt.install.InstallerFactory;
 import cm.aptoide.pt.install.view.InstallWarningDialog;
 import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.navigator.ActivityResultNavigator;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.preferences.managed.ManagerPreferences;
 import cm.aptoide.pt.timeline.SocialRepository;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.utils.SimpleSubscriber;
 import cm.aptoide.pt.utils.design.ShowMessage;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.dialog.SharePreviewDialog;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 import okhttp3.OkHttpClient;
 import retrofit2.Converter;
 import rx.android.schedulers.AndroidSchedulers;
@@ -76,23 +79,20 @@ import rx.android.schedulers.AndroidSchedulers;
 public class AppViewInstallWidget extends Widget<AppViewInstallDisplayable> {
 
   private static final String TAG = AppViewInstallWidget.class.getSimpleName();
-
+  @Inject FragmentNavigator fragmentNavigator;
   private RelativeLayout downloadProgressLayout;
   private RelativeLayout installAndLatestVersionLayout;
-
   private ProgressBar downloadProgress;
   private TextView textProgress;
   private ImageView actionResume;
   private ImageView actionPause;
   private ImageView actionCancel;
   private Button actionButton;
-
   private TextView versionName;
   private View latestAvailableLayout;
   private View latestAvailableTrustedSeal;
   private View notLatestAvailableText;
   private TextView otherVersions;
-
   private App trustedVersion;
   private InstallManager installManager;
   private boolean isUpdate;
@@ -118,6 +118,8 @@ public class AppViewInstallWidget extends Widget<AppViewInstallDisplayable> {
 
   public AppViewInstallWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -725,7 +727,7 @@ public class AppViewInstallWidget extends Widget<AppViewInstallDisplayable> {
   }
 
   private AppViewNavigator getAppViewNavigator() {
-    return new AppViewNavigator(getFragmentNavigator(), getActivityNavigator(), isMultiStoreSearch,
+    return new AppViewNavigator(fragmentNavigator, getActivityNavigator(), isMultiStoreSearch,
         defaultStoreName);
   }
 

--- a/app/src/main/java/cm/aptoide/pt/app/view/widget/AppViewRateAndReviewsWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/widget/AppViewRateAndReviewsWidget.java
@@ -36,10 +36,12 @@ import cm.aptoide.pt.dataprovider.ws.v7.BaseRequestWithStore;
 import cm.aptoide.pt.dataprovider.ws.v7.ListReviewsRequest;
 import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.navigator.ActivityResultNavigator;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.reviews.LanguageFilterHelper;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.GenericDialogs;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.dialog.DialogUtils;
 import cm.aptoide.pt.view.recycler.LinearLayoutManagerWithSmoothScroller;
 import cm.aptoide.pt.view.recycler.widget.Widget;
@@ -49,6 +51,7 @@ import com.jakewharton.rxbinding.view.RxView;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
 import okhttp3.OkHttpClient;
 import retrofit2.Converter;
 import rx.Observable;
@@ -64,23 +67,20 @@ public class AppViewRateAndReviewsWidget extends Widget<AppViewRateAndCommentsDi
   public static final long TIME_BETWEEN_SCROLL = 2 * DateUtils.SECOND_IN_MILLIS;
   private static final String TAG = AppViewRateAndReviewsWidget.class.getSimpleName();
   private static final int MAX_COMMENTS = 3;
+  @Inject FragmentNavigator fragmentNavigator;
   private DialogUtils dialogUtils;
   private AptoideAccountManager accountManager;
   private View emptyReviewsLayout;
   private View ratingLayout;
   private View commentsLayout;
-
   private TextView usersVotedTextView;
   private TextView ratingValue;
   private RatingBar ratingBar;
-
   private Button rateThisButton;
   private Button rateThisButtonLarge;
   private Button readAllButton;
-
   private RecyclerView topReviewsList;
   private ContentLoadingProgressBar topReviewsProgress;
-
   private String appName;
   private String packageName;
   private String storeName;
@@ -93,6 +93,8 @@ public class AppViewRateAndReviewsWidget extends Widget<AppViewRateAndCommentsDi
 
   public AppViewRateAndReviewsWidget(@NonNull View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -179,7 +181,7 @@ public class AppViewRateAndReviewsWidget extends Widget<AppViewRateAndCommentsDi
               .getName(), app.getPackageName(), app.getStore()
               .getAppearance()
               .getTheme());
-      getFragmentNavigator().navigateTo(fragment, true);
+      fragmentNavigator.navigateTo(fragment, true);
     };
 
     compositeSubscription.add(RxView.clicks(readAllButton)

--- a/app/src/main/java/cm/aptoide/pt/app/view/widget/AppViewScreenshotsWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/widget/AppViewScreenshotsWidget.java
@@ -16,19 +16,25 @@ import cm.aptoide.pt.app.view.displayable.AppViewScreenshotsDisplayable;
 import cm.aptoide.pt.app.view.screenshots.ScreenshotsAdapter;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.dataprovider.model.v7.GetAppMeta;
+import cm.aptoide.pt.navigator.FragmentNavigator;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
+import javax.inject.Inject;
 
 /**
  * Created on 11/05/16.
  */
 public class AppViewScreenshotsWidget extends Widget<AppViewScreenshotsDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private RecyclerView mediaList;
   private boolean isMultiStoreSearch;
   private String defaultStoreName;
 
   public AppViewScreenshotsWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -78,7 +84,7 @@ public class AppViewScreenshotsWidget extends Widget<AppViewScreenshotsDisplayab
   }
 
   private AppViewNavigator getAppViewNavigator() {
-    return new AppViewNavigator(getFragmentNavigator(), getActivityNavigator(), isMultiStoreSearch,
+    return new AppViewNavigator(fragmentNavigator, getActivityNavigator(), isMultiStoreSearch,
         defaultStoreName);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/app/view/widget/AppViewSuggestedAppsWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/widget/AppViewSuggestedAppsWidget.java
@@ -12,20 +12,26 @@ import cm.aptoide.pt.app.view.displayable.AppViewSuggestedAppsDisplayable;
 import cm.aptoide.pt.database.realm.MinimalAd;
 import cm.aptoide.pt.dataprovider.model.v7.listapp.App;
 import cm.aptoide.pt.dataprovider.model.v7.store.Store;
+import cm.aptoide.pt.navigator.FragmentNavigator;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.BaseAdapter;
 import cm.aptoide.pt.view.recycler.displayable.Displayable;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import javax.inject.Inject;
 
 public class AppViewSuggestedAppsWidget extends Widget<AppViewSuggestedAppsDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private RecyclerView recyclerView;
   private TextView similarAppsToTextView;
 
   public AppViewSuggestedAppsWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -49,7 +55,8 @@ public class AppViewSuggestedAppsWidget extends Widget<AppViewSuggestedAppsDispl
           .setAppearance(new Store.Appearance());
       displayables.add(
           new AppViewSuggestedAppDisplayable(app, displayable.getAppViewSimilarAppAnalytics(),
-              displayable.getNavigationTracker(), displayable.getStoreContext()));
+              displayable.getNavigationTracker(), displayable.getStoreContext(),
+              fragmentNavigator));
     }
 
     BaseAdapter adapter = new BaseAdapter(displayables) {

--- a/app/src/main/java/cm/aptoide/pt/app/view/widget/OtherVersionWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/widget/OtherVersionWidget.java
@@ -13,17 +13,20 @@ import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.dataprovider.model.v7.Malware;
 import cm.aptoide.pt.dataprovider.model.v7.listapp.App;
 import cm.aptoide.pt.logger.Logger;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.utils.AptoideUtils;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import java.util.Locale;
+import javax.inject.Inject;
 
 public class OtherVersionWidget extends Widget<OtherVersionDisplayable>
     implements View.OnClickListener {
 
   private static final String TAG = OtherVersionWidget.class.getSimpleName();
   private static final Locale DEFAULT_LOCALE = Locale.getDefault();
-
+  @Inject FragmentNavigator fragmentNavigator;
   // left side
   //private ImageView versionBadge;
   private TextView version;
@@ -34,14 +37,14 @@ public class OtherVersionWidget extends Widget<OtherVersionDisplayable>
   private ImageView storeIcon;
   private TextView storeNameView;
   private TextView followers;
-
   private long appId;
   private String packageName;
   private String storeName;
-  private OtherVersionDisplayable displayable;
 
   public OtherVersionWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -62,7 +65,6 @@ public class OtherVersionWidget extends Widget<OtherVersionDisplayable>
   @Override public void bindView(OtherVersionDisplayable displayable) {
     setItemBackgroundColor(itemView);
     try {
-      this.displayable = displayable;
       final App app = displayable.getPojo();
       appId = app.getId();
       storeName = app.getStore()
@@ -154,7 +156,7 @@ public class OtherVersionWidget extends Widget<OtherVersionDisplayable>
 
   @Override public void onClick(View v) {
     Logger.d(TAG, "showing other version for app with id = " + appId);
-    getFragmentNavigator().navigateTo(AptoideApplication.getFragmentProvider()
+    fragmentNavigator.navigateTo(AptoideApplication.getFragmentProvider()
         .newAppViewFragment(appId, packageName, null, storeName, ""), true);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/billing/view/BillingActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/billing/view/BillingActivity.java
@@ -13,7 +13,9 @@ import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.billing.Billing;
 import cm.aptoide.pt.billing.view.payment.PaymentFragment;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.view.BackButtonActivity;
+import javax.inject.Inject;
 
 public class BillingActivity extends BackButtonActivity {
 
@@ -24,7 +26,7 @@ public class BillingActivity extends BackButtonActivity {
       "cm.aptoide.pt.view.payment.intent.extra.MERCHANT_NAME";
   public static final String EXTRA_SERVICE_NAME =
       "cm.aptoide.pt.view.payment.intent.extra.SERVICE_NAME";
-
+  @Inject FragmentNavigator fragmentNavigator;
   private Billing billing;
 
   public static Intent getIntent(Context context, String sku, String merchantName,
@@ -45,11 +47,12 @@ public class BillingActivity extends BackButtonActivity {
 
   protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    getActivityComponent().inject(this);
     setContentView(R.layout.empty_frame);
 
     if (savedInstanceState == null) {
-      getFragmentNavigator().navigateToWithoutBackSave(
-          PaymentFragment.create(getIntent().getExtras()), true);
+      fragmentNavigator.navigateToWithoutBackSave(PaymentFragment.create(getIntent().getExtras()),
+          true);
     }
 
     billing = ((AptoideApplication) getApplication()).getBilling(

--- a/app/src/main/java/cm/aptoide/pt/comments/view/StoreLatestCommentsWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/comments/view/StoreLatestCommentsWidget.java
@@ -25,6 +25,7 @@ import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.preferences.managed.ManagerPreferences;
 import cm.aptoide.pt.store.view.StoreLatestCommentsDisplayable;
 import cm.aptoide.pt.util.CommentOperations;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.FragmentProvider;
 import cm.aptoide.pt.view.custom.HorizontalDividerItemDecoration;
 import cm.aptoide.pt.view.recycler.BaseAdapter;
@@ -33,6 +34,7 @@ import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.trello.rxlifecycle.android.FragmentEvent;
 import java.util.ArrayList;
 import java.util.List;
+import javax.inject.Inject;
 import okhttp3.OkHttpClient;
 import retrofit2.Converter;
 import rx.Completable;
@@ -42,8 +44,8 @@ import rx.schedulers.Schedulers;
 
 public class StoreLatestCommentsWidget extends Widget<StoreLatestCommentsDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private RecyclerView recyclerView;
-
   private long storeId;
   private String storeName;
   private AptoideAccountManager accountManager;
@@ -55,6 +57,8 @@ public class StoreLatestCommentsWidget extends Widget<StoreLatestCommentsDisplay
 
   public StoreLatestCommentsWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -88,7 +92,7 @@ public class StoreLatestCommentsWidget extends Widget<StoreLatestCommentsDisplay
     recyclerView.setAdapter(new CommentListAdapter(storeId, storeName, comments,
         getContext().getSupportFragmentManager(), recyclerView,
         Observable.fromCallable(() -> reloadComments()), accountManager, accountNavigator,
-        getFragmentNavigator(),
+        fragmentNavigator,
         ((AptoideApplication) getContext().getApplicationContext()).getFragmentProvider()));
   }
 

--- a/app/src/main/java/cm/aptoide/pt/navigator/ActivityResultNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/navigator/ActivityResultNavigator.java
@@ -30,8 +30,8 @@ public abstract class ActivityResultNavigator extends ActivityCustomTabsNavigato
     implements ActivityNavigator {
 
   @Inject AccountNavigator accountNavigator;
+  @Inject FragmentNavigator fragmentNavigator;
   private PublishRelay<Result> resultRelay;
-  private FragmentNavigator fragmentNavigator;
   private BehaviorRelay<Map<Integer, Result>> fragmentResultRelay;
   private Map<Integer, Result> fragmentResultMap;
   private BillingNavigator billingNavigator;
@@ -48,10 +48,6 @@ public abstract class ActivityResultNavigator extends ActivityCustomTabsNavigato
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
     fragmentResultRelay = ((AptoideApplication) getApplicationContext()).getFragmentResultRelay();
     fragmentResultMap = ((AptoideApplication) getApplicationContext()).getFragmentResulMap();
-    fragmentNavigator =
-        new FragmentResultNavigator(getSupportFragmentManager(), R.id.fragment_placeholder,
-            android.R.anim.fade_in, android.R.anim.fade_out, fragmentResultMap,
-            fragmentResultRelay);
     // super.onCreate handles fragment creation using FragmentManager.
     // Make sure navigator instances are already created when fragments are created,
     // else getFragmentNavigator and getActivityNavigator will return null.

--- a/app/src/main/java/cm/aptoide/pt/permission/PermissionServiceActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/permission/PermissionServiceActivity.java
@@ -22,12 +22,14 @@ import cm.aptoide.pt.R;
 import cm.aptoide.pt.actions.PermissionService;
 import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.navigator.ActivityResultNavigator;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.preferences.managed.ManagerPreferences;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.utils.SimpleSubscriber;
 import cm.aptoide.pt.utils.design.ShowMessage;
 import com.facebook.FacebookSdk;
+import javax.inject.Inject;
 import rx.functions.Action0;
 
 @Deprecated public abstract class PermissionServiceActivity extends ActivityResultNavigator
@@ -39,19 +41,19 @@ import rx.functions.Action0;
 
   private static final int PERMISSIONS_REQUEST_READ_CONTACTS = 100;
   private static final int PERMISSIONS_REQUEST_ACCESS_CAMERA = 101;
-
+  @Inject FragmentNavigator fragmentNavigator;
   @Nullable private Action0 toRunWhenAccessToFileSystemIsGranted;
   @Nullable private Action0 toRunWhenAccessToFileSystemIsDenied;
   @Nullable private Action0 toRunWhenAccessToAccountsIsGranted;
   @Nullable private Action0 toRunWhenAccessToAccountsIsDenied;
   @Nullable private Action0 toRunWhenAccessToContactsIsGranted;
   @Nullable private Action0 toRunWhenAccessToContactsIsDenied;
-
   private SharedPreferences sharedPreferences;
   private ConnectivityManager connectivityManager;
 
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    getActivityComponent().inject(this);
     connectivityManager = (ConnectivityManager) getSystemService(CONNECTIVITY_SERVICE);
     sharedPreferences =
         ((AptoideApplication) getApplicationContext()).getDefaultSharedPreferences();
@@ -179,7 +181,7 @@ import rx.functions.Action0;
         @Override public void onNext(GenericDialogs.EResponse eResponse) {
           super.onNext(eResponse);
           if (eResponse == GenericDialogs.EResponse.YES) {
-            getFragmentNavigator().navigateTo(AptoideApplication.getFragmentProvider()
+            fragmentNavigator.navigateTo(AptoideApplication.getFragmentProvider()
                 .newSettingsFragment(), true);
           } else {
             if (toRunWhenAccessIsDenied != null) {

--- a/app/src/main/java/cm/aptoide/pt/spotandshare/view/SpotSharePreviewActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/spotandshare/view/SpotSharePreviewActivity.java
@@ -4,15 +4,20 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.view.ActivityView;
+import javax.inject.Inject;
 
 public class SpotSharePreviewActivity extends ActivityView {
 
+  @Inject FragmentNavigator fragmentNavigator;
+
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    getActivityComponent().inject(this);
     setContentView(R.layout.frame_layout);
 
-    getFragmentNavigator().navigateToWithoutBackSave(AptoideApplication.getFragmentProvider()
+    fragmentNavigator.navigateToWithoutBackSave(AptoideApplication.getFragmentProvider()
         .newSpotShareFragment(true), true);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/store/view/AddStoreDialog.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/AddStoreDialog.java
@@ -46,11 +46,12 @@ import cm.aptoide.pt.store.StoreUtilsProxy;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.utils.design.ShowMessage;
-import cm.aptoide.pt.view.MainActivity;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.dialog.BaseDialog;
 import com.facebook.appevents.AppEventsLogger;
 import com.jakewharton.rxbinding.view.RxView;
 import com.trello.rxlifecycle.android.FragmentEvent;
+import javax.inject.Inject;
 import okhttp3.OkHttpClient;
 import retrofit2.Converter;
 
@@ -67,9 +68,8 @@ public class AddStoreDialog extends BaseDialog {
   private static StoreAutoCompleteWebSocket storeAutoCompleteWebSocket;
 
   private final int PRIVATE_STORE_REQUEST_CODE = 20;
-
+  @Inject FragmentNavigator navigator;
   private AptoideAccountManager accountManager;
-  private FragmentNavigator navigator;
   private String storeName;
   private Dialog loadingDialog;
   private SearchView searchView;
@@ -87,18 +87,10 @@ public class AddStoreDialog extends BaseDialog {
   private TokenInvalidator tokenInvalidator;
   private StoreAnalytics storeAnalytics;
 
-  @Override public void onAttach(Activity activity) {
-    super.onAttach(activity);
-    if (activity instanceof MainActivity) {
-      navigator = ((MainActivity) activity).getFragmentNavigator();
-    } else {
-      Logger.e(TAG, "Launched AddStoreDialog from invalid Activity");
-      throw new IllegalStateException();
-    }
-  }
-
   @Override public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    ((BaseActivity) getActivity()).getActivityComponent()
+        .inject(this);
     tokenInvalidator =
         ((AptoideApplication) getContext().getApplicationContext()).getTokenInvalidator();
     converterFactory = WebService.getDefaultConverter();

--- a/app/src/main/java/cm/aptoide/pt/store/view/CreateStoreWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/CreateStoreWidget.java
@@ -8,8 +8,11 @@ import cm.aptoide.pt.account.view.store.ManageStoreFragment;
 import cm.aptoide.pt.account.view.store.ManageStoreViewModel;
 import cm.aptoide.pt.account.view.user.CreateStoreDisplayable;
 import cm.aptoide.pt.crashreports.CrashReport;
+import cm.aptoide.pt.navigator.FragmentNavigator;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 import rx.android.schedulers.AndroidSchedulers;
 
 /**
@@ -19,6 +22,7 @@ import rx.android.schedulers.AndroidSchedulers;
 public class CreateStoreWidget extends Widget<CreateStoreDisplayable> {
 
   private final CrashReport crashReport;
+  @Inject FragmentNavigator fragmentNavigator;
   private Button button;
   private TextView followers;
   private TextView followings;
@@ -26,6 +30,8 @@ public class CreateStoreWidget extends Widget<CreateStoreDisplayable> {
   public CreateStoreWidget(View itemView) {
     super(itemView);
     crashReport = CrashReport.getInstance();
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -44,7 +50,7 @@ public class CreateStoreWidget extends Widget<CreateStoreDisplayable> {
 
     compositeSubscription.add(RxView.clicks(button)
         .observeOn(AndroidSchedulers.mainThread())
-        .doOnNext(click -> getFragmentNavigator().navigateTo(
+        .doOnNext(click -> fragmentNavigator.navigateTo(
             ManageStoreFragment.newInstance(new ManageStoreViewModel(), false), true))
         .doOnNext(__ -> displayable.getStoreAnalytics()
             .sendStoreTabInteractEvent("Login"))

--- a/app/src/main/java/cm/aptoide/pt/store/view/GridStoreMetaWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/GridStoreMetaWidget.java
@@ -31,9 +31,11 @@ import cm.aptoide.pt.store.StoreUtilsProxy;
 import cm.aptoide.pt.timeline.view.follow.TimeLineFollowersFragment;
 import cm.aptoide.pt.timeline.view.follow.TimeLineFollowingFragment;
 import cm.aptoide.pt.utils.AptoideUtils;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.app.ListStoreAppsFragment;
 import cm.aptoide.pt.view.spannable.SpannableFactory;
 import java.util.List;
+import javax.inject.Inject;
 import okhttp3.OkHttpClient;
 import rx.android.schedulers.AndroidSchedulers;
 
@@ -42,6 +44,7 @@ import rx.android.schedulers.AndroidSchedulers;
  */
 public class GridStoreMetaWidget extends MetaStoresBaseWidget<GridStoreMetaDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private AptoideAccountManager accountManager;
   private LinearLayout socialChannelsLayout;
   private ImageView mainIcon;
@@ -65,6 +68,8 @@ public class GridStoreMetaWidget extends MetaStoresBaseWidget<GridStoreMetaDispl
 
   public GridStoreMetaWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -103,7 +108,6 @@ public class GridStoreMetaWidget extends MetaStoresBaseWidget<GridStoreMetaDispl
         ((AptoideApplication) getContext().getApplicationContext()).getDefaultSharedPreferences());
     spannableFactory = new SpannableFactory();
     storeCredentialsProvider = new StoreCredentialsProviderImpl(storeAccessor);
-    FragmentNavigator fragmentNavigator = getFragmentNavigator();
     Resources resources = getContext().getResources();
     followersCountTv.setOnClickListener(v -> {
       navigateToFollowersScreen(displayable, resources, fragmentNavigator);
@@ -243,7 +247,7 @@ public class GridStoreMetaWidget extends MetaStoresBaseWidget<GridStoreMetaDispl
   }
 
   private void navigateToAppsListScreen(long storeName) {
-    getFragmentNavigator().navigateTo(ListStoreAppsFragment.newInstance(storeName), true);
+    fragmentNavigator.navigateTo(ListStoreAppsFragment.newInstance(storeName), true);
   }
 
   private void showSocialChannels(
@@ -336,7 +340,7 @@ public class GridStoreMetaWidget extends MetaStoresBaseWidget<GridStoreMetaDispl
     ManageStoreViewModel viewModel =
         new ManageStoreViewModel(storeId, StoreTheme.fromName(storeThemeName), storeName,
             storeDescription, storeImagePath, socialChannels);
-    getFragmentNavigator().navigateForResult(ManageStoreFragment.newInstance(viewModel, false),
+    fragmentNavigator.navigateForResult(ManageStoreFragment.newInstance(viewModel, false),
         requestCode, true);
   }
 

--- a/app/src/main/java/cm/aptoide/pt/store/view/GridStoreWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/GridStoreWidget.java
@@ -15,20 +15,26 @@ import android.widget.TextView;
 import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.dataprovider.model.v7.store.Store;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.store.StoreTheme;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 import rx.functions.Action1;
 
 public class GridStoreWidget extends Widget<GridStoreDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private ImageView storeAvatar;
   private TextView storeName;
   private LinearLayout storeLayout;
 
   public GridStoreWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -54,7 +60,7 @@ public class GridStoreWidget extends Widget<GridStoreDisplayable> {
             .sendStoreOpenEvent(origin, gridStoreDisplayable.getPojo()
                 .getName());
       }
-      getFragmentNavigator().navigateTo(AptoideApplication.getFragmentProvider()
+      fragmentNavigator.navigateTo(AptoideApplication.getFragmentProvider()
           .newStoreFragment(gridStoreDisplayable.getPojo()
               .getName(), store.getAppearance()
               .getTheme()), true);

--- a/app/src/main/java/cm/aptoide/pt/store/view/StoreTabWidgetsGridRecyclerFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/StoreTabWidgetsGridRecyclerFragment.java
@@ -20,7 +20,7 @@ import cm.aptoide.pt.dataprovider.model.v7.GetStoreWidgets;
 import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
 import cm.aptoide.pt.dataprovider.ws.v7.BaseBody;
 import cm.aptoide.pt.install.InstalledRepository;
-import cm.aptoide.pt.navigator.ActivityResultNavigator;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.repository.RepositoryFactory;
 import cm.aptoide.pt.store.StoreAnalytics;
 import cm.aptoide.pt.store.StoreCredentialsProvider;
@@ -30,6 +30,7 @@ import cm.aptoide.pt.view.recycler.displayable.Displayable;
 import cm.aptoide.pt.view.recycler.displayable.DisplayablesFactory;
 import com.facebook.appevents.AppEventsLogger;
 import java.util.List;
+import javax.inject.Inject;
 import okhttp3.OkHttpClient;
 import rx.Observable;
 
@@ -42,10 +43,12 @@ public abstract class StoreTabWidgetsGridRecyclerFragment extends StoreTabGridRe
   protected StoreUtilsProxy storeUtilsProxy;
   protected InstalledRepository installedRepository;
   protected StoreAnalytics storeAnalytics;
+  @Inject FragmentNavigator fragmentNavigator;
   private StoreTabNavigator storeTabNavigator;
 
   @Override public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    getFragmentComponent(savedInstanceState).inject(this);
     final StoreCredentialsProvider storeCredentialsProvider = new StoreCredentialsProviderImpl(
         AccessorFactory.getAccessorFor(((AptoideApplication) getContext().getApplicationContext()
             .getApplicationContext()).getDatabase(), Store.class));
@@ -80,8 +83,7 @@ public abstract class StoreTabWidgetsGridRecyclerFragment extends StoreTabGridRe
               getContext(), accountManager, storeUtilsProxy,
               (WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE),
               getContext().getResources(), installedRepository, storeAnalytics, storeTabNavigator,
-              navigationTracker, new BadgeDialogFactory(getContext()),
-              ((ActivityResultNavigator) getContext()).getFragmentNavigator(),
+              navigationTracker, new BadgeDialogFactory(getContext()), fragmentNavigator,
               AccessorFactory.getAccessorFor(application.getDatabase(), Store.class),
               application.getBodyInterceptorPoolV7(), application.getDefaultClient(),
               WebService.getDefaultConverter(), application.getTokenInvalidator(),

--- a/app/src/main/java/cm/aptoide/pt/store/view/featured/AppBrickListWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/featured/AppBrickListWidget.java
@@ -13,21 +13,27 @@ import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.dataprovider.model.v7.listapp.App;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 
 /**
  * Created by neuro on 09-05-2016.
  */
 public class AppBrickListWidget extends Widget<AppBrickListDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private TextView name;
   private ImageView graphic;
   private RatingBar ratingBar;
 
   public AppBrickListWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -47,7 +53,7 @@ public class AppBrickListWidget extends Widget<AppBrickListDisplayable> {
         .getAvg());
     compositeSubscription.add(RxView.clicks(itemView)
         .subscribe(v -> {
-          getFragmentNavigator().navigateTo(AptoideApplication.getFragmentProvider()
+          fragmentNavigator.navigateTo(AptoideApplication.getFragmentProvider()
               .newAppViewFragment(app.getId(), app.getPackageName(), app.getStore()
                   .getAppearance()
                   .getTheme(), app.getStore()

--- a/app/src/main/java/cm/aptoide/pt/store/view/featured/AppBrickWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/featured/AppBrickWidget.java
@@ -11,19 +11,25 @@ import android.widget.ImageView;
 import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.crashreports.CrashReport;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 
 /**
  * Created by neuro on 09-05-2016.
  */
 public class AppBrickWidget extends Widget<AppBrickDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private ImageView graphic;
 
   public AppBrickWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -38,7 +44,7 @@ public class AppBrickWidget extends Widget<AppBrickDisplayable> {
 
     compositeSubscription.add(RxView.clicks(itemView)
         .subscribe(v -> {
-          getFragmentNavigator().navigateTo(AptoideApplication.getFragmentProvider()
+          fragmentNavigator.navigateTo(AptoideApplication.getFragmentProvider()
               .newAppViewFragment(displayable.getPojo()
                   .getId(), displayable.getPojo()
                   .getPackageName(), displayable.getPojo()

--- a/app/src/main/java/cm/aptoide/pt/store/view/my/MyStoreWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/my/MyStoreWidget.java
@@ -15,15 +15,18 @@ import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.analytics.Analytics;
 import cm.aptoide.pt.dataprovider.model.v7.store.Store;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.store.StoreAnalytics;
 import cm.aptoide.pt.store.view.MetaStoresBaseWidget;
 import cm.aptoide.pt.timeline.view.follow.TimeLineFollowersFragment;
 import cm.aptoide.pt.timeline.view.follow.TimeLineFollowingFragment;
 import cm.aptoide.pt.utils.AptoideUtils;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.spannable.SpannableFactory;
 import com.facebook.appevents.AppEventsLogger;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 
 /**
  * Created by trinkes on 05/12/2016.
@@ -31,6 +34,7 @@ import com.jakewharton.rxbinding.view.RxView;
 
 public class MyStoreWidget extends MetaStoresBaseWidget<MyStoreDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private ImageView storeIcon;
   private TextView storeName;
   private Button exploreButton;
@@ -43,6 +47,8 @@ public class MyStoreWidget extends MetaStoresBaseWidget<MyStoreDisplayable> {
     super(itemView);
     storeAnalytics =
         new StoreAnalytics(AppEventsLogger.newLogger(getContext()), Analytics.getInstance());
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -70,7 +76,7 @@ public class MyStoreWidget extends MetaStoresBaseWidget<MyStoreDisplayable> {
     storeName.setText(store.getName());
     compositeSubscription.add(RxView.clicks(exploreButton)
         .subscribe(click -> {
-          getFragmentNavigator().navigateTo(AptoideApplication.getFragmentProvider()
+          fragmentNavigator.navigateTo(AptoideApplication.getFragmentProvider()
               .newStoreFragment(store.getName(), storeTheme), true);
           storeAnalytics.sendStoreTabInteractEvent("View Store");
           storeAnalytics.sendStoreOpenEvent("View Own Store", store.getName());
@@ -92,14 +98,14 @@ public class MyStoreWidget extends MetaStoresBaseWidget<MyStoreDisplayable> {
         String.valueOf(displayable.getFollowings())));
 
     compositeSubscription.add(RxView.clicks(followers)
-        .subscribe(click -> getFragmentNavigator().navigateTo(
+        .subscribe(click -> fragmentNavigator.navigateTo(
             TimeLineFollowersFragment.newInstanceUsingUser(storeTheme,
                 AptoideUtils.StringU.getFormattedString(
                     R.string.social_timeline_followers_fragment_title, getContext().getResources(),
                     displayable.getFollowers()), displayable.getStoreContext()), true)));
 
     compositeSubscription.add(RxView.clicks(following)
-        .subscribe(click -> getFragmentNavigator().navigateTo(
+        .subscribe(click -> fragmentNavigator.navigateTo(
             TimeLineFollowingFragment.newInstanceUsingUser(storeTheme,
                 AptoideUtils.StringU.getFormattedString(
                     R.string.social_timeline_following_fragment_title, getContext().getResources(),

--- a/app/src/main/java/cm/aptoide/pt/store/view/recommended/RecommendedStoreWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/recommended/RecommendedStoreWidget.java
@@ -9,14 +9,17 @@ import cm.aptoide.pt.R;
 import cm.aptoide.pt.analytics.Analytics;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.dataprovider.model.v7.store.Store;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.store.StoreAnalytics;
 import cm.aptoide.pt.store.StoreTheme;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.design.ShowMessage;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.facebook.appevents.AppEventsLogger;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;
 
@@ -26,6 +29,7 @@ import rx.schedulers.Schedulers;
 
 public class RecommendedStoreWidget extends Widget<RecommendedStoreDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private TextView storeName;
   private TextView followingUsers;
   private TextView numberStoreApps;
@@ -38,6 +42,8 @@ public class RecommendedStoreWidget extends Widget<RecommendedStoreDisplayable> 
     storeAnalytics =
         new StoreAnalytics(AppEventsLogger.newLogger(getContext().getApplicationContext()),
             Analytics.getInstance());
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -63,7 +69,7 @@ public class RecommendedStoreWidget extends Widget<RecommendedStoreDisplayable> 
     setButtonText(displayable);
     compositeSubscription.add(RxView.clicks(itemView)
         .subscribe(click -> {
-          displayable.openStoreFragment(getFragmentNavigator());
+          displayable.openStoreFragment(fragmentNavigator);
           if (!displayable.getOrigin()
               .isEmpty()) {
             storeAnalytics.sendStoreOpenEvent(displayable.getOrigin(), store.getName());

--- a/app/src/main/java/cm/aptoide/pt/store/view/subscribed/SubscribedStoreWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/subscribed/SubscribedStoreWidget.java
@@ -11,22 +11,28 @@ import android.widget.TextView;
 import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.database.realm.Store;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.store.StoreTheme;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 
 /**
  * Created by neuro on 11-05-2016. //todo: código duplicado, se cair a reflexão, deixa de o ser.
  */
 public class SubscribedStoreWidget extends Widget<SubscribedStoreDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private ImageView storeAvatar;
   private TextView storeName;
   private LinearLayout storeLayout;
 
   public SubscribedStoreWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -48,7 +54,7 @@ public class SubscribedStoreWidget extends Widget<SubscribedStoreDisplayable> {
               .newStoreFragment(displayable.getPojo()
                   .getStoreName(), displayable.getPojo()
                   .getTheme());
-          getFragmentNavigator().navigateTo(fragment, true);
+          fragmentNavigator.navigateTo(fragment, true);
         }));
 
     final Context context = getContext();

--- a/app/src/main/java/cm/aptoide/pt/timeline/post/PostActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/timeline/post/PostActivity.java
@@ -7,20 +7,25 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.account.view.LoginBottomSheet;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.navigator.TabNavigation;
 import cm.aptoide.pt.navigator.TabNavigator;
 import cm.aptoide.pt.view.BackButtonActivity;
+import javax.inject.Inject;
 import rx.Observable;
 
 public class PostActivity extends BackButtonActivity
     implements PostUrlProvider, TabNavigator, LoginBottomSheet {
 
+  @Inject FragmentNavigator fragmentNavigator;
+
   @Override public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    getActivityComponent().inject(this);
     setContentView(getLayoutId());
     if (savedInstanceState == null) {
       final Fragment fragment = PostFragment.newInstanceFromExternalSource();
-      getFragmentNavigator().navigateToWithoutBackSave(fragment, true);
+      fragmentNavigator.navigateToWithoutBackSave(fragment, true);
     }
   }
 

--- a/app/src/main/java/cm/aptoide/pt/timeline/view/displayable/TimeLineStatsWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/timeline/view/displayable/TimeLineStatsWidget.java
@@ -5,8 +5,11 @@ import android.view.View;
 import android.widget.Button;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.crashreports.CrashReport;
+import cm.aptoide.pt.navigator.FragmentNavigator;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 import rx.Observable;
 
 /**
@@ -15,6 +18,7 @@ import rx.Observable;
 
 public class TimeLineStatsWidget extends Widget<TimeLineStatsDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private Button followers;
   private Button following;
   private Button followFriends;
@@ -22,6 +26,8 @@ public class TimeLineStatsWidget extends Widget<TimeLineStatsDisplayable> {
 
   public TimeLineStatsWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @UiThread @Override protected void assignViews(View itemView) {
@@ -36,13 +42,13 @@ public class TimeLineStatsWidget extends Widget<TimeLineStatsDisplayable> {
     following.setText(displayable.getFollowingText(getContext()));
 
     Observable<Void> followersClick = RxView.clicks(followers)
-        .doOnNext(__ -> displayable.followersClick(getFragmentNavigator()));
+        .doOnNext(__ -> displayable.followersClick(fragmentNavigator));
 
     Observable<Void> followingClick = RxView.clicks(following)
-        .doOnNext(__ -> displayable.followingClick(getFragmentNavigator()));
+        .doOnNext(__ -> displayable.followingClick(fragmentNavigator));
 
     Observable<Void> followFriendsClick = RxView.clicks(followFriends)
-        .doOnNext(__ -> displayable.followFriendsClick(getFragmentNavigator()));
+        .doOnNext(__ -> displayable.followFriendsClick(fragmentNavigator));
 
     compositeSubscription.add(Observable.merge(followersClick, followingClick, followFriendsClick)
         .doOnError((throwable) -> CrashReport.getInstance()

--- a/app/src/main/java/cm/aptoide/pt/timeline/view/follow/FollowUserWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/timeline/view/follow/FollowUserWidget.java
@@ -19,6 +19,7 @@ import cm.aptoide.pt.database.realm.Store;
 import cm.aptoide.pt.dataprovider.WebService;
 import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
 import cm.aptoide.pt.dataprovider.ws.v7.BaseBody;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.repository.RepositoryFactory;
 import cm.aptoide.pt.repository.StoreRepository;
@@ -26,8 +27,10 @@ import cm.aptoide.pt.store.StoreCredentialsProviderImpl;
 import cm.aptoide.pt.store.StoreUtilsProxy;
 import cm.aptoide.pt.timeline.view.displayable.FollowUserDisplayable;
 import cm.aptoide.pt.utils.AptoideUtils;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 import okhttp3.OkHttpClient;
 import rx.android.schedulers.AndroidSchedulers;
 
@@ -37,6 +40,7 @@ import rx.android.schedulers.AndroidSchedulers;
 
 public class FollowUserWidget extends Widget<FollowUserDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private TextView userNameTv;
   private TextView storeNameTv;
   private TextView followingNumber;
@@ -53,6 +57,8 @@ public class FollowUserWidget extends Widget<FollowUserDisplayable> {
 
   public FollowUserWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -181,7 +187,7 @@ public class FollowUserWidget extends Widget<FollowUserDisplayable> {
     followingTv.setTextColor(displayable.getStoreColor(getContext().getApplicationContext()));
 
     compositeSubscription.add(RxView.clicks(itemView)
-        .subscribe(click -> displayable.viewClicked(getFragmentNavigator()),
+        .subscribe(click -> displayable.viewClicked(fragmentNavigator),
             err -> CrashReport.getInstance()
                 .log(err)));
   }

--- a/app/src/main/java/cm/aptoide/pt/updates/view/UpdateWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/updates/view/UpdateWidget.java
@@ -25,14 +25,17 @@ import cm.aptoide.pt.analytics.Analytics;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.install.InstalledRepository;
 import cm.aptoide.pt.logger.Logger;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.repository.RepositoryFactory;
 import cm.aptoide.pt.updates.UpdateRepository;
 import cm.aptoide.pt.updates.UpdatesAnalytics;
 import cm.aptoide.pt.utils.design.ShowMessage;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.facebook.appevents.AppEventsLogger;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 import rx.Observable;
 import rx.android.schedulers.AndroidSchedulers;
 
@@ -43,6 +46,7 @@ public class UpdateWidget extends Widget<UpdateDisplayable> {
 
   private static final String TAG = UpdateWidget.class.getSimpleName();
 
+  @Inject FragmentNavigator fragmentNavigator;
   private View updateRowLayout;
   private TextView labelTextView;
   private ImageView icon;
@@ -60,6 +64,8 @@ public class UpdateWidget extends Widget<UpdateDisplayable> {
     super(itemView);
     updatesAnalytics = new UpdatesAnalytics(Analytics.getInstance(),
         AppEventsLogger.newLogger(getContext().getApplicationContext()));
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -148,7 +154,7 @@ public class UpdateWidget extends Widget<UpdateDisplayable> {
           final Fragment fragment = AptoideApplication.getFragmentProvider()
               .newAppViewFragment(updateDisplayable.getAppId(), updateDisplayable.getPackageName(),
                   "");
-          getFragmentNavigator().navigateTo(fragment, true);
+          fragmentNavigator.navigateTo(fragment, true);
         });
   }
 

--- a/app/src/main/java/cm/aptoide/pt/updates/view/rollback/RollbackWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/updates/view/rollback/RollbackWidget.java
@@ -9,11 +9,14 @@ import cm.aptoide.pt.actions.PermissionService;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.database.realm.Rollback;
 import cm.aptoide.pt.logger.Logger;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.utils.design.ShowMessage;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.jakewharton.rxbinding.view.RxView;
 import java.text.DateFormat;
+import javax.inject.Inject;
 
 import static android.text.format.DateFormat.getTimeFormat;
 
@@ -21,6 +24,7 @@ public class RollbackWidget extends Widget<RollbackDisplayable> {
 
   private static final String TAG = RollbackWidget.class.getSimpleName();
 
+  @Inject FragmentNavigator fragmentNavigator;
   private ImageView appIcon;
   private TextView appName;
   private TextView appUpdateVersion;
@@ -29,6 +33,8 @@ public class RollbackWidget extends Widget<RollbackDisplayable> {
 
   public RollbackWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -82,7 +88,7 @@ public class RollbackWidget extends Widget<RollbackDisplayable> {
             Rollback.Action action = Rollback.Action.valueOf(pojo.getAction());
             switch (action) {
               case DOWNGRADE:
-                displayable.update(getFragmentNavigator());
+                displayable.update(fragmentNavigator);
                 break;
               case INSTALL:
                 //only if the app is installed
@@ -95,11 +101,11 @@ public class RollbackWidget extends Widget<RollbackDisplayable> {
                 break;
 
               case UNINSTALL:
-                displayable.install(getFragmentNavigator());
+                displayable.install(fragmentNavigator);
                 break;
 
               case UPDATE:
-                displayable.update(getFragmentNavigator());
+                displayable.update(fragmentNavigator);
                 break;
             }
           }, () -> {

--- a/app/src/main/java/cm/aptoide/pt/view/ActivityComponent.java
+++ b/app/src/main/java/cm/aptoide/pt/view/ActivityComponent.java
@@ -1,6 +1,39 @@
 package cm.aptoide.pt.view;
 
+import cm.aptoide.pt.account.view.LoginActivity;
+import cm.aptoide.pt.app.view.GridAppListWidget;
+import cm.aptoide.pt.app.view.OfficialAppWidget;
+import cm.aptoide.pt.app.view.widget.AppViewDescriptionWidget;
+import cm.aptoide.pt.app.view.widget.AppViewFlagThisWidget;
+import cm.aptoide.pt.app.view.widget.AppViewInstallWidget;
+import cm.aptoide.pt.app.view.widget.AppViewRateAndReviewsWidget;
+import cm.aptoide.pt.app.view.widget.AppViewScreenshotsWidget;
+import cm.aptoide.pt.app.view.widget.AppViewStoreWidget;
+import cm.aptoide.pt.app.view.widget.AppViewSuggestedAppsWidget;
+import cm.aptoide.pt.app.view.widget.OtherVersionWidget;
+import cm.aptoide.pt.billing.view.BillingActivity;
+import cm.aptoide.pt.comments.view.StoreLatestCommentsWidget;
 import cm.aptoide.pt.navigator.ActivityResultNavigator;
+import cm.aptoide.pt.permission.PermissionServiceActivity;
+import cm.aptoide.pt.spotandshare.view.SpotSharePreviewActivity;
+import cm.aptoide.pt.store.view.AddStoreDialog;
+import cm.aptoide.pt.store.view.CreateStoreWidget;
+import cm.aptoide.pt.store.view.GridStoreMetaWidget;
+import cm.aptoide.pt.store.view.GridStoreWidget;
+import cm.aptoide.pt.store.view.featured.AppBrickListWidget;
+import cm.aptoide.pt.store.view.featured.AppBrickWidget;
+import cm.aptoide.pt.store.view.my.MyStoreWidget;
+import cm.aptoide.pt.store.view.recommended.RecommendedStoreWidget;
+import cm.aptoide.pt.store.view.subscribed.SubscribedStoreWidget;
+import cm.aptoide.pt.timeline.post.PostActivity;
+import cm.aptoide.pt.timeline.view.displayable.TimeLineStatsWidget;
+import cm.aptoide.pt.timeline.view.follow.FollowUserWidget;
+import cm.aptoide.pt.updates.view.UpdateWidget;
+import cm.aptoide.pt.updates.view.rollback.RollbackWidget;
+import cm.aptoide.pt.view.recycler.widget.FooterWidget;
+import cm.aptoide.pt.view.recycler.widget.GridAdWidget;
+import cm.aptoide.pt.view.recycler.widget.GridDisplayWidget;
+import cm.aptoide.pt.view.recycler.widget.RowReviewWidget;
 import dagger.Subcomponent;
 
 @ActivityScope @Subcomponent(modules = { ActivityModule.class })
@@ -10,5 +43,71 @@ public interface ActivityComponent {
 
   void inject(ActivityResultNavigator activityResultNavigator);
 
+  void inject(PermissionServiceActivity activityResultNavigator);
+
+  void inject(BillingActivity activityResultNavigator);
+
+  void inject(SpotSharePreviewActivity activity);
+
+  void inject(PostActivity activity);
+
+  void inject(LoginActivity activityResultNavigator);
+
   FragmentComponent plus(FragmentModule fragmentModule);
+
+  void inject(AddStoreDialog dialog);
+
+  void inject(StoreLatestCommentsWidget storeLatestCommentsWidget);
+
+  void inject(AppViewInstallWidget appViewInstallWidget);
+
+  void inject(AppViewRateAndReviewsWidget appViewRateAndReviewsWidget);
+
+  void inject(OtherVersionWidget otherVersionWidget);
+
+  void inject(AppViewScreenshotsWidget appViewScreenshotsWidget);
+
+  void inject(OfficialAppWidget officialAppWidget);
+
+  void inject(GridAppListWidget gridAppListWidget);
+
+  void inject(RollbackWidget rollbackWidget);
+
+  void inject(UpdateWidget updateWidget);
+
+  void inject(GridDisplayWidget gridDisplayWidget);
+
+  void inject(RowReviewWidget rowReviewWidget);
+
+  void inject(FooterWidget footerWidget);
+
+  void inject(GridStoreMetaWidget gridStoreMetaWidget);
+
+  void inject(FollowUserWidget followUserWidget);
+
+  void inject(RecommendedStoreWidget recommendedStoreWidget);
+
+  void inject(SubscribedStoreWidget subscribedStoreWidget);
+
+  void inject(GridStoreWidget gridStoreWidget);
+
+  void inject(MyStoreWidget myStoreWidget);
+
+  void inject(AppBrickWidget appBrickWidget);
+
+  void inject(AppViewStoreWidget appViewStoreWidget);
+
+  void inject(AppBrickListWidget appBrickListWidget);
+
+  void inject(CreateStoreWidget createStoreWidget);
+
+  void inject(TimeLineStatsWidget timeLineStatsWidget);
+
+  void inject(AppViewFlagThisWidget appViewFlagThisWidget);
+
+  void inject(AppViewSuggestedAppsWidget appViewSuggestedAppsWidget);
+
+  void inject(AppViewDescriptionWidget appViewDescriptionWidget);
+
+  void inject(GridAdWidget gridAdWidget);
 }

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentComponent.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentComponent.java
@@ -4,7 +4,10 @@ import cm.aptoide.pt.account.view.LoginSignUpCredentialsFragment;
 import cm.aptoide.pt.account.view.store.ManageStoreFragment;
 import cm.aptoide.pt.account.view.user.ManageUserFragment;
 import cm.aptoide.pt.addressbook.view.AddressBookFragment;
+import cm.aptoide.pt.app.view.ListAppsFragment;
+import cm.aptoide.pt.store.view.StoreTabWidgetsGridRecyclerFragment;
 import cm.aptoide.pt.updates.view.rollback.RollbackFragment;
+import cm.aptoide.pt.view.fragment.FragmentView;
 import dagger.Subcomponent;
 
 @FragmentScope @Subcomponent(modules = { FragmentModule.class })
@@ -19,4 +22,10 @@ public interface FragmentComponent {
   void inject(ManageUserFragment manageUserFragment);
 
   void inject(ManageStoreFragment manageStoreFragment);
+
+  void inject(FragmentView fragmentView);
+
+  void inject(StoreTabWidgetsGridRecyclerFragment fragment);
+
+  void inject(ListAppsFragment fragment);
 }

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -26,6 +26,7 @@ import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.permission.AccountPermissionProvider;
 import cm.aptoide.pt.presenter.LoginSignUpCredentialsPresenter;
 import cm.aptoide.pt.presenter.LoginSignUpCredentialsView;
+import cm.aptoide.pt.store.view.GridStoreMetaDisplayable;
 import dagger.Module;
 import dagger.Provides;
 import java.util.Arrays;
@@ -76,7 +77,8 @@ import rx.schedulers.Schedulers;
       ManageStoreErrorMapper manageStoreErrorMapper, AptoideAccountManager accountManager) {
     return new ManageStorePresenter((ManageStoreView) fragment, CrashReport.getInstance(),
         uriToPathResolver, packageName, manageStoreNavigator,
-        arguments.getBoolean("go_to_home", true), manageStoreErrorMapper, accountManager, 394587);
+        arguments.getBoolean("go_to_home", true), manageStoreErrorMapper, accountManager,
+        GridStoreMetaDisplayable.REQUEST_CODE);
   }
 
   @FragmentScope @Provides ManageUserPresenter provideManageUserPresenter(

--- a/app/src/main/java/cm/aptoide/pt/view/fragment/FragmentView.java
+++ b/app/src/main/java/cm/aptoide/pt/view/fragment/FragmentView.java
@@ -26,19 +26,20 @@ import cm.aptoide.pt.view.MainActivity;
 import com.trello.rxlifecycle.LifecycleTransformer;
 import com.trello.rxlifecycle.RxLifecycle;
 import com.trello.rxlifecycle.android.FragmentEvent;
+import javax.inject.Inject;
 import rx.Observable;
 
 public abstract class FragmentView extends BaseFragment implements View {
 
   private static final String TAG = FragmentView.class.getName();
-
+  @Inject FragmentNavigator fragmentNavigator;
   private boolean startActivityForResultCalled;
   private NavigationTracker navigationTracker;
   private ActivityResultNavigator activityResultNavigator;
   private String defaultThemeName;
 
   public FragmentNavigator getFragmentNavigator() {
-    return activityResultNavigator.getFragmentNavigator();
+    return fragmentNavigator;
   }
 
   public ActivityNavigator getActivityNavigator() {
@@ -64,6 +65,7 @@ public abstract class FragmentView extends BaseFragment implements View {
 
   @Override public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    getFragmentComponent(savedInstanceState).inject(this);
     defaultThemeName =
         ((AptoideApplication) getContext().getApplicationContext()).getDefaultThemeName();
     ScreenTrackingUtils.getInstance()

--- a/app/src/main/java/cm/aptoide/pt/view/recycler/displayable/DisplayablesFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/view/recycler/displayable/DisplayablesFactory.java
@@ -96,7 +96,8 @@ public class DisplayablesFactory {
         case APPS_GROUP:
           return Observable.just(getApps(widget, storeTheme, storeContext,
               context.getApplicationContext()
-                  .getResources(), windowManager, storeTabNavigator, navigationTracker));
+                  .getResources(), windowManager, storeTabNavigator, navigationTracker,
+              fragmentNavigator));
 
         case MY_STORES_SUBSCRIBED:
           return getMyStores(widget, storeRepository, storeTheme, storeContext, windowManager,
@@ -171,7 +172,8 @@ public class DisplayablesFactory {
 
   private static Displayable getApps(GetStoreWidgets.WSWidget wsWidget, String storeTheme,
       StoreContext storeContext, Resources resources, WindowManager windowManager,
-      StoreTabNavigator storeTabNavigator, NavigationTracker navigationTracker) {
+      StoreTabNavigator storeTabNavigator, NavigationTracker navigationTracker,
+      FragmentNavigator fragmentNavigator) {
     ListApps listApps = (ListApps) wsWidget.getViewObject();
     if (listApps == null) {
       return new EmptyDisplayable();
@@ -238,7 +240,7 @@ public class DisplayablesFactory {
       for (App app : apps) {
         DisplayablePojo<App> diplayable =
             new GridAppDisplayable(app, wsWidget.getTag(), storeContext == StoreContext.home,
-                navigationTracker, storeContext);
+                navigationTracker, storeContext, fragmentNavigator);
         displayables.add(diplayable);
       }
     }

--- a/app/src/main/java/cm/aptoide/pt/view/recycler/widget/FooterWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/view/recycler/widget/FooterWidget.java
@@ -10,18 +10,23 @@ import android.widget.Button;
 import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.dataprovider.model.v7.Event;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.store.view.StoreTabGridRecyclerFragment;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.Translator;
 import cm.aptoide.pt.view.recycler.displayable.FooterDisplayable;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 import rx.functions.Action1;
 
 public class FooterWidget extends Widget<FooterDisplayable> {
-
+  @Inject FragmentNavigator fragmentNavigator;
   private Button button;
 
   public FooterWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -43,7 +48,7 @@ public class FooterWidget extends Widget<FooterDisplayable> {
           .getActions()
           .get(0)
           .getEvent();
-      getFragmentNavigator().navigateTo(StoreTabGridRecyclerFragment.newInstance(event,
+      fragmentNavigator.navigateTo(StoreTabGridRecyclerFragment.newInstance(event,
           Translator.translate(displayable.getPojo()
               .getTitle(), getContext().getApplicationContext(), marketName), null,
           displayable.getTag(), displayable.getStoreContext(), false), true);

--- a/app/src/main/java/cm/aptoide/pt/view/recycler/widget/GridAdWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/view/recycler/widget/GridAdWidget.java
@@ -9,17 +9,21 @@ import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.database.realm.MinimalAd;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.search.model.SearchAdResult;
 import cm.aptoide.pt.utils.AptoideUtils;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.displayable.GridAdDisplayable;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 
 /**
  * Created by neuro on 20-06-2016.
  */
 public class GridAdWidget extends Widget<GridAdDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private TextView name;
   private ImageView icon;
   private TextView downloadsNumber;
@@ -27,6 +31,8 @@ public class GridAdWidget extends Widget<GridAdDisplayable> {
 
   public GridAdWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -46,7 +52,7 @@ public class GridAdWidget extends Widget<GridAdDisplayable> {
 
     compositeSubscription.add(RxView.clicks(itemView)
         .subscribe(v -> {
-          getFragmentNavigator().navigateTo(AptoideApplication.getFragmentProvider()
+          fragmentNavigator.navigateTo(AptoideApplication.getFragmentProvider()
               .newAppViewFragment(new SearchAdResult(pojo), displayable.getTag()), true);
         }, throwable -> CrashReport.getInstance()
             .log(throwable)));

--- a/app/src/main/java/cm/aptoide/pt/view/recycler/widget/GridDisplayWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/view/recycler/widget/GridDisplayWidget.java
@@ -14,13 +14,16 @@ import cm.aptoide.pt.R;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.dataprovider.model.v7.Event;
 import cm.aptoide.pt.dataprovider.model.v7.store.GetStoreDisplays;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.store.view.GridDisplayDisplayable;
 import cm.aptoide.pt.store.view.StoreTabFragmentChooser;
 import cm.aptoide.pt.store.view.StoreTabGridRecyclerFragment;
 import cm.aptoide.pt.store.view.home.HomeFragment;
 import cm.aptoide.pt.utils.AptoideUtils;
+import cm.aptoide.pt.view.BaseActivity;
 import com.jakewharton.rxbinding.view.RxView;
+import javax.inject.Inject;
 import rx.functions.Action1;
 
 /**
@@ -30,10 +33,13 @@ public class GridDisplayWidget extends Widget<GridDisplayDisplayable> {
 
   private static final String TAG = GridDisplayWidget.class.getName();
 
+  @Inject FragmentNavigator fragmentNavigator;
   private ImageView imageView;
 
   public GridDisplayWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -50,7 +56,7 @@ public class GridDisplayWidget extends Widget<GridDisplayDisplayable> {
       Event event = pojo.getEvent();
       Event.Name name = event.getName();
       if (StoreTabFragmentChooser.validateAcceptedName(name)) {
-        getFragmentNavigator().navigateTo(
+        fragmentNavigator.navigateTo(
             StoreTabGridRecyclerFragment.newInstance(event, pojo.getLabel(),
                 displayable.getStoreTheme(), displayable.getTag(), displayable.getStoreContext(),
                 false), true);

--- a/app/src/main/java/cm/aptoide/pt/view/recycler/widget/RowReviewWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/view/recycler/widget/RowReviewWidget.java
@@ -12,20 +12,25 @@ import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.reviews.RowReviewDisplayable;
 import cm.aptoide.pt.utils.AptoideUtils;
+import cm.aptoide.pt.view.BaseActivity;
 import com.jakewharton.rxbinding.view.RxView;
 import java.util.Locale;
+import javax.inject.Inject;
 
 public class RowReviewWidget extends Widget<RowReviewDisplayable> {
 
   public ImageView appIcon;
   public TextView rating;
   public TextView appName;
+  @Inject FragmentNavigator fragmentNavigator;
   private ImageView avatar;
   private TextView reviewer;
   private TextView reviewBody;
 
   public RowReviewWidget(View itemView) {
     super(itemView);
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -65,7 +70,6 @@ public class RowReviewWidget extends Widget<RowReviewDisplayable> {
         .loadWithCircleTransformAndPlaceHolderAvatarSize(review.getUser()
             .getAvatar(), avatar, R.drawable.layer_1);
 
-    final FragmentNavigator navigator = getFragmentNavigator();
     compositeSubscription.add(RxView.clicks(itemView)
         .subscribe(aVoid -> {
           if (displayable.getStoreAnalytics() != null) {
@@ -76,7 +80,7 @@ public class RowReviewWidget extends Widget<RowReviewDisplayable> {
                     .getStore()
                     .getName());
           }
-          navigator.navigateTo(AptoideApplication.getFragmentProvider()
+          fragmentNavigator.navigateTo(AptoideApplication.getFragmentProvider()
               .newRateAndReviewsFragment(app.getId(), app.getName(), app.getStore()
                   .getName(), app.getPackageName(), review.getId()), true);
         }));

--- a/app/src/main/java/cm/aptoide/pt/view/recycler/widget/Widget.java
+++ b/app/src/main/java/cm/aptoide/pt/view/recycler/widget/Widget.java
@@ -13,7 +13,6 @@ import android.view.View;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.navigator.ActivityNavigator;
 import cm.aptoide.pt.navigator.ActivityResultNavigator;
-import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.view.recycler.displayable.Displayable;
 import rx.subscriptions.CompositeSubscription;
 
@@ -22,13 +21,11 @@ import rx.subscriptions.CompositeSubscription;
  */
 public abstract class Widget<T extends Displayable> extends RecyclerView.ViewHolder {
 
-  private final FragmentNavigator fragmentNavigator;
   protected CompositeSubscription compositeSubscription;
   private ActivityNavigator activityNavigator;
 
   public Widget(@NonNull View itemView) {
     super(itemView);
-    fragmentNavigator = ((ActivityResultNavigator) getContext()).getFragmentNavigator();
     activityNavigator = ((ActivityResultNavigator) getContext()).getActivityNavigator();
 
     try {
@@ -60,15 +57,6 @@ public abstract class Widget<T extends Displayable> extends RecyclerView.ViewHol
   }
 
   public abstract void bindView(T displayable);
-
-  public View getRootView() {
-    return getFragmentNavigator().peekLast()
-        .getView();
-  }
-
-  protected FragmentNavigator getFragmentNavigator() {
-    return fragmentNavigator;
-  }
 
   protected ActivityNavigator getActivityNavigator() {
     return activityNavigator;

--- a/app/src/vanilla/java/cm/aptoide/pt/app/view/widget/AppViewStoreWidget.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/view/widget/AppViewStoreWidget.java
@@ -19,6 +19,7 @@ import cm.aptoide.pt.dataprovider.model.v7.GetAppMeta;
 import cm.aptoide.pt.dataprovider.model.v7.store.Store;
 import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
 import cm.aptoide.pt.dataprovider.ws.v7.BaseBody;
+import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.repository.RepositoryFactory;
 import cm.aptoide.pt.repository.StoreRepository;
@@ -27,15 +28,18 @@ import cm.aptoide.pt.store.StoreTheme;
 import cm.aptoide.pt.store.StoreUtilsProxy;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.design.ShowMessage;
+import cm.aptoide.pt.view.BaseActivity;
 import cm.aptoide.pt.view.recycler.widget.Widget;
 import com.jakewharton.rxbinding.view.RxView;
 import java.util.Locale;
+import javax.inject.Inject;
 import okhttp3.OkHttpClient;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.functions.Action1;
 
 public class AppViewStoreWidget extends Widget<AppViewStoreDisplayable> {
 
+  @Inject FragmentNavigator fragmentNavigator;
   private ImageView storeAvatarView;
   private TextView storeNameView;
   private TextView storeNumberUsersView;
@@ -47,6 +51,8 @@ public class AppViewStoreWidget extends Widget<AppViewStoreDisplayable> {
   public AppViewStoreWidget(View itemView) {
     super(itemView);
     storeRepository = RepositoryFactory.getStoreRepository(getContext().getApplicationContext());
+    ((BaseActivity) getContext()).getActivityComponent()
+        .inject(this);
   }
 
   @Override protected void assignViews(View itemView) {
@@ -118,7 +124,7 @@ public class AppViewStoreWidget extends Widget<AppViewStoreDisplayable> {
           .sendOpenStoreEvent();
       displayable.getStoreAnalytics()
           .sendStoreOpenEvent("App View", storeName);
-      getFragmentNavigator().navigateTo(AptoideApplication.getFragmentProvider()
+      fragmentNavigator.navigateTo(AptoideApplication.getFragmentProvider()
           .newStoreFragment(storeName, storeTheme), true);
     };
 


### PR DESCRIPTION
…d after an update from edit screen

Edit store screen.
Store meta were using different navigator instances, because of that store meta was never notified when edit was successful and never update itself.