### PR TITLE
[Hotfix/AN-2235] ANR suggestions add store

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -28,6 +28,8 @@
 -keepattributes Signature
 -keepattributes Exceptions
 
+-keepnames class rx.Single
+
 -keepclasseswithmembers class * {
     @retrofit2.http.* <methods>;
 }

--- a/app/src/androidTest/java/cm/aptoide/pt/MockApplicationModule.java
+++ b/app/src/androidTest/java/cm/aptoide/pt/MockApplicationModule.java
@@ -246,7 +246,7 @@ public class MockApplicationModule extends ApplicationModule {
 
   @Override StoreManager provideStoreManager(@Named("default") OkHttpClient okHttpClient,
       @Named("multipart") MultipartBodyInterceptor multipartBodyInterceptor,
-      @Named("defaulInterceptorV3")
+      @Named("defaultInterceptorV3")
           BodyInterceptor<cm.aptoide.pt.dataprovider.ws.v3.BaseBody> bodyInterceptorV3,
       @Named("account-settings-pool-v7")
           BodyInterceptor<BaseBody> accountSettingsBodyInterceptorPoolV7,

--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -723,7 +723,7 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
 
   @Singleton @Provides StoreManager provideStoreManager(@Named("default") OkHttpClient okHttpClient,
       @Named("multipart") MultipartBodyInterceptor multipartBodyInterceptor,
-      @Named("defaulInterceptorV3")
+      @Named("defaultInterceptorV3")
           BodyInterceptor<cm.aptoide.pt.dataprovider.ws.v3.BaseBody> bodyInterceptorV3,
       @Named("account-settings-pool-v7")
           BodyInterceptor<cm.aptoide.pt.dataprovider.ws.v7.BaseBody> accountSettingsBodyInterceptorPoolV7,
@@ -758,7 +758,7 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
     return new PackageRepository(application.getPackageManager());
   }
 
-  @Singleton @Provides @Named("defaulInterceptorV3")
+  @Singleton @Provides @Named("defaultInterceptorV3")
   BodyInterceptor<cm.aptoide.pt.dataprovider.ws.v3.BaseBody> providesBodyInterceptorV3(
       IdsRepository idsRepository, QManager qManager,
       @Named("default") SharedPreferences defaultSharedPreferences,
@@ -797,10 +797,10 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
         converterFactory, tokenInvalidator, sharedPreferences);
   }
 
-  @Singleton @Provides @Named("ws-prod-base-url") String providesBaseWebServiceTestsUrl() {
+  @Singleton @Provides @Named("ws-prod-suggestions-base-url") String provideSearchBaseUrl() {
     return "http://"
         + cm.aptoide.pt.dataprovider.BuildConfig.APTOIDE_WEB_SERVICES_SEARCH_HOST
-        + "/api/7/";
+        + "/v1/";
   }
 
   @Singleton @Provides @Named("rx") CallAdapter.Factory providesCallAdapterFactory() {
@@ -813,7 +813,8 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
         Schedulers.io());
   }
 
-  @Singleton @Provides Retrofit providesDefaultRetrofit(@Named("ws-prod-base-url") String baseUrl,
+  @Singleton @Provides Retrofit providesSearchSuggestionsRetrofit(
+      @Named("ws-prod-suggestions-base-url") String baseUrl,
       @Named("default") OkHttpClient httpClient, Converter.Factory converterFactory,
       @Named("rx") CallAdapter.Factory rxCallAdapterFactory) {
     return new Retrofit.Builder().baseUrl(baseUrl)

--- a/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
+++ b/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
@@ -186,7 +186,7 @@ public abstract class AptoideApplication extends Application {
   @Inject SyncScheduler alarmSyncScheduler;
   @Inject @Named("pool-v7") BodyInterceptor<BaseBody> bodyInterceptorPoolV7;
   @Inject @Named("web-v7") BodyInterceptor<BaseBody> bodyInterceptorWebV7;
-  @Inject @Named("defaulInterceptorV3") BodyInterceptor<cm.aptoide.pt.dataprovider.ws.v3.BaseBody>
+  @Inject @Named("defaultInterceptorV3") BodyInterceptor<cm.aptoide.pt.dataprovider.ws.v3.BaseBody>
       bodyInterceptorV3;
   @Inject L2Cache httpClientCache;
   @Inject QManager qManager;

--- a/app/src/main/java/cm/aptoide/pt/search/suggestions/SearchSuggestionRemoteRepository.java
+++ b/app/src/main/java/cm/aptoide/pt/search/suggestions/SearchSuggestionRemoteRepository.java
@@ -5,9 +5,9 @@ import retrofit2.http.Path;
 import rx.Single;
 
 public interface SearchSuggestionRemoteRepository {
-  @GET("/v1/suggestion/app/{query}") Single<Suggestions> getSuggestionForApp(
+  @GET("suggestion/app/{query}") Single<Suggestions> getSuggestionForApp(
       @Path("query") String query);
 
-  @GET("/v1/suggestion/store/{query}") Single<Suggestions> getSuggestionForStore(
+  @GET("suggestion/store/{query}") Single<Suggestions> getSuggestionForStore(
       @Path("query") String query);
 }


### PR DESCRIPTION
In production variant, calls to the suggestions api would crash (search app & search store).

This was due to the fact Single was being used in the retrofit interface. ref ( https://github.com/square/retrofit/issues/1584)

solution was to add proguard rule.

Also did some name refactoring and moved the suggestions api version to the base url, which is provided by the dagger app module.