### PR TITLE
[Hotfix/ASV-141] Appview error analytics NPE

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -45,6 +45,7 @@ import cm.aptoide.pt.analytics.FirstLaunchAnalytics;
 import cm.aptoide.pt.analytics.NavigationTracker;
 import cm.aptoide.pt.analytics.TrackerFilter;
 import cm.aptoide.pt.analytics.analytics.AnalyticsManager;
+import cm.aptoide.pt.analytics.analytics.AnalyticsNormalizer;
 import cm.aptoide.pt.analytics.analytics.AptoideBiAnalytics;
 import cm.aptoide.pt.analytics.analytics.AptoideBiEventLogger;
 import cm.aptoide.pt.analytics.analytics.AptoideBiEventService;
@@ -993,7 +994,8 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
       @Named("facebookEvents") Collection<String> facebookEvents,
       @Named("fabricEvents") Collection<String> fabricEvents,
       @Named("flurryEvents") Collection<String> flurryEvents,
-      @Named("flurrySession") SessionLogger flurrySessionLogger) {
+      @Named("flurrySession") SessionLogger flurrySessionLogger,
+      @Named("normalizer") AnalyticsNormalizer analyticsNormalizer) {
 
     return new AnalyticsManager.Builder().addLogger(aptoideBiEventLogger, aptoideEvents)
         .addLogger(facebookEventLogger, facebookEvents)
@@ -1001,7 +1003,12 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
         .addLogger(flurryEventLogger, flurryEvents)
         .addSessionLogger(flurrySessionLogger)
         .setKnockLogger(knockEventLogger)
+        .setAnalyticsNormalizer(analyticsNormalizer)
         .build();
+  }
+
+  @Singleton @Provides @Named("normalizer") AnalyticsNormalizer providesAnalyticsNormalizer() {
+    return new AnalyticsNormalizer();
   }
 
   @Singleton @Provides AppShortcutsAnalytics providesAppShortcutsAnalytics(

--- a/app/src/main/java/cm/aptoide/pt/analytics/ScreenTagHistory.java
+++ b/app/src/main/java/cm/aptoide/pt/analytics/ScreenTagHistory.java
@@ -19,11 +19,11 @@ public class ScreenTagHistory {
   }
 
   public String getStore() {
-    return store;
+    return store != null ? store : "";
   }
 
   public String getFragment() {
-    return fragment;
+    return fragment != null ? fragment : "";
   }
 
   public void setFragment(String fragment) {
@@ -31,7 +31,7 @@ public class ScreenTagHistory {
   }
 
   public String getTag() {
-    return tag;
+    return tag != null ? tag : "";
   }
 
   public void setTag(String tag) {

--- a/app/src/main/java/cm/aptoide/pt/analytics/analytics/AnalyticsManager.java
+++ b/app/src/main/java/cm/aptoide/pt/analytics/analytics/AnalyticsManager.java
@@ -12,14 +12,17 @@ public class AnalyticsManager {
   private static final String TAG = AnalyticsManager.class.getSimpleName();
   private final HttpKnockEventLogger knockEventLogger;
   private final SessionLogger sessionLogger;
+  private final AnalyticsNormalizer analyticsNormalizer;
 
   private Map<EventLogger, Collection<String>> eventLoggers;
 
   private AnalyticsManager(HttpKnockEventLogger knockLogger,
-      Map<EventLogger, Collection<String>> eventLoggers, SessionLogger sessionLogger) {
+      Map<EventLogger, Collection<String>> eventLoggers, SessionLogger sessionLogger,
+      AnalyticsNormalizer analyticsNormalizer) {
     this.knockEventLogger = knockLogger;
     this.eventLoggers = eventLoggers;
     this.sessionLogger = sessionLogger;
+    this.analyticsNormalizer = analyticsNormalizer;
   }
 
   /**
@@ -48,6 +51,7 @@ public class AnalyticsManager {
     for (Map.Entry<EventLogger, Collection<String>> loggerEntry : eventLoggers.entrySet()) {
       if (loggerEntry.getValue()
           .contains(eventName)) {
+        data = analyticsNormalizer.normalize(data);
         loggerEntry.getKey()
             .log(eventName, data, action, context);
         eventsSent++;
@@ -107,6 +111,7 @@ public class AnalyticsManager {
     private final Map<EventLogger, Collection<String>> eventLoggers;
     private HttpKnockEventLogger httpKnockEventLogger;
     private SessionLogger sessionLogger;
+    private AnalyticsNormalizer analyticsNormalizer;
 
     /**
      * <p>Start the builder.</p>
@@ -174,6 +179,19 @@ public class AnalyticsManager {
     }
 
     /**
+     * <p>Sets a {@link AnalyticsNormalizer} that will allow to normalize event attributes
+     * according to the normalizer implementation.</p>
+     *
+     * @param analyticsNormalizer The {@code analyticsNormalizer} to normalize the events data.
+     *
+     * @return A builder with the updated {@link AnalyticsNormalizer}
+     */
+    public Builder setAnalyticsNormalizer(AnalyticsNormalizer analyticsNormalizer) {
+      this.analyticsNormalizer = analyticsNormalizer;
+      return this;
+    }
+
+    /**
      * <p>Builds an AnalyticsManager object.</p>
      *
      * <p> An AnalyticsManager needs an {@link HttpKnockEventLogger} and at least one {@link
@@ -200,7 +218,8 @@ public class AnalyticsManager {
       if (eventLoggers.size() < 1) {
         throw new IllegalArgumentException("Analytics manager need at least one logger");
       }
-      return new AnalyticsManager(httpKnockEventLogger, eventLoggers, sessionLogger);
+      return new AnalyticsManager(httpKnockEventLogger, eventLoggers, sessionLogger,
+          analyticsNormalizer);
     }
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/analytics/analytics/AnalyticsManager.java
+++ b/app/src/main/java/cm/aptoide/pt/analytics/analytics/AnalyticsManager.java
@@ -48,10 +48,10 @@ public class AnalyticsManager {
         + context
         + "]");
     int eventsSent = 0;
+    data = analyticsNormalizer.normalize(data);
     for (Map.Entry<EventLogger, Collection<String>> loggerEntry : eventLoggers.entrySet()) {
       if (loggerEntry.getValue()
           .contains(eventName)) {
-        data = analyticsNormalizer.normalize(data);
         loggerEntry.getKey()
             .log(eventName, data, action, context);
         eventsSent++;

--- a/app/src/main/java/cm/aptoide/pt/analytics/analytics/AnalyticsNormalizer.java
+++ b/app/src/main/java/cm/aptoide/pt/analytics/analytics/AnalyticsNormalizer.java
@@ -1,0 +1,21 @@
+package cm.aptoide.pt.analytics.analytics;
+
+import java.util.Map;
+
+/**
+ * Created by jdandrade on 27/02/2018.
+ */
+
+public class AnalyticsNormalizer {
+  Map<String, Object> normalize(Map<String, Object> data) {
+    if (data == null) {
+      return null;
+    }
+    for (Map.Entry<String, Object> entry : data.entrySet()) {
+      if (entry.getValue() == null) {
+        entry.setValue("");
+      }
+    }
+    return data;
+  }
+}

--- a/app/src/test/java/cm/aptoide/pt/analytics/ScreenTagHistoryTest.java
+++ b/app/src/test/java/cm/aptoide/pt/analytics/ScreenTagHistoryTest.java
@@ -1,0 +1,45 @@
+package cm.aptoide.pt.analytics;
+
+import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ScreenTagHistoryTest {
+
+  @Test public void checkIfNullFragmentReturnEmptyStringFragment() {
+    //Given a ScreenTagHistory with null fragment
+    ScreenTagHistory screenTagHistory =
+        ScreenTagHistory.Builder.build(null, "tag", StoreContext.home);
+
+    //When fragment getter is requested
+    //Then it should return an empty string
+    assertFalse(screenTagHistory.getFragment() == null);
+    assertTrue(screenTagHistory.getFragment()
+        .equals(""));
+  }
+
+  @Test public void checkIfNullTagReturnEmptyStringTag() {
+    //Given a ScreenTagHistory with null tag
+    ScreenTagHistory screenTagHistory =
+        ScreenTagHistory.Builder.build("fragment", null, StoreContext.home);
+
+    //When tag getter is requested
+    //Then it should return an empty string
+    assertFalse(screenTagHistory.getTag() == null);
+    assertTrue(screenTagHistory.getTag()
+        .equals(""));
+  }
+
+  @Test public void checkIfNullStoreReturnEmptyStringStore() {
+    //Given a ScreenTagHistory with null storeContext
+    ScreenTagHistory screenTagHistory = ScreenTagHistory.Builder.build("fragment", "tag", null);
+
+    //When store getter is requested
+    //Then it should return an empty string
+    assertFalse(screenTagHistory.getStore() == null);
+    assertTrue(screenTagHistory.getStore()
+        .equals(""));
+  }
+}

--- a/app/src/test/java/cm/aptoide/pt/analytics/analytics/AnalyticsManagerTest.java
+++ b/app/src/test/java/cm/aptoide/pt/analytics/analytics/AnalyticsManagerTest.java
@@ -14,10 +14,12 @@ public class AnalyticsManagerTest {
     String eventName = "TestEvent";
     EventLogger eventLogger = mock(EventLogger.class);
     HttpKnockEventLogger knockEventLogger = mock(HttpKnockEventLogger.class);
+    AnalyticsNormalizer analyticsNormalizer = mock(AnalyticsNormalizer.class);
 
     AnalyticsManager analyticsManager =
         new AnalyticsManager.Builder().addLogger(eventLogger, Arrays.asList(eventName))
             .setKnockLogger(knockEventLogger)
+            .setAnalyticsNormalizer(analyticsNormalizer)
             .build();
 
     Map<String, Object> data = new HashMap<>();
@@ -31,10 +33,12 @@ public class AnalyticsManagerTest {
     String eventName = "TestEvent";
     EventLogger eventLogger = mock(EventLogger.class);
     HttpKnockEventLogger knockEventLogger = mock(HttpKnockEventLogger.class);
+    AnalyticsNormalizer analyticsNormalizer = mock(AnalyticsNormalizer.class);
 
     AnalyticsManager analyticsManager =
         new AnalyticsManager.Builder().addLogger(eventLogger, Arrays.asList(eventName))
             .setKnockLogger(knockEventLogger)
+            .setAnalyticsNormalizer(analyticsNormalizer)
             .build();
 
     Map<String, Object> data = new HashMap<>();

--- a/app/src/test/java/cm/aptoide/pt/analytics/analytics/AnalyticsNormalizerTest.java
+++ b/app/src/test/java/cm/aptoide/pt/analytics/analytics/AnalyticsNormalizerTest.java
@@ -1,0 +1,49 @@
+package cm.aptoide.pt.analytics.analytics;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by jdandrade on 27/02/2018.
+ */
+
+public class AnalyticsNormalizerTest {
+
+  private AnalyticsNormalizer analyticsNormalizer;
+
+  @Before public void setupAnalyticsNormalizer() {
+    analyticsNormalizer = new AnalyticsNormalizer();
+  }
+
+  @Test public void normalizeNullEventAttributeValuesToEmptyString() {
+    String key1 = "key1";
+    String key3 = "key3";
+    String key2 = "key2";
+
+    //Given a event data Map with non null key attribute
+    Map<String, Object> data = new HashMap<>();
+    data.put(key1, "value1");
+    data.put(key2, 2);
+
+    //And null value attribute
+    data.put(key3, null);
+
+    //When the attributes get normalized by the AnalyticsNormalized
+    data = analyticsNormalizer.normalize(data);
+
+    //Then data with all key-values is returned
+    assertTrue(data.containsKey(key1));
+    assertTrue(data.containsKey(key2));
+    assertTrue(data.containsKey(key3));
+
+    //And null values are set to empty strings
+    assertFalse(data.containsValue(null));
+    assertTrue(data.get(key3)
+        .equals(""));
+  }
+}

--- a/app/src/test/java/cm/aptoide/pt/analytics/analytics/AnalyticsNormalizerTest.java
+++ b/app/src/test/java/cm/aptoide/pt/analytics/analytics/AnalyticsNormalizerTest.java
@@ -22,8 +22,8 @@ public class AnalyticsNormalizerTest {
 
   @Test public void normalizeNullEventAttributeValuesToEmptyString() {
     String key1 = "key1";
-    String key3 = "key3";
     String key2 = "key2";
+    String key3 = "key3";
 
     //Given a event data Map with non null key attribute
     Map<String, Object> data = new HashMap<>();


### PR DESCRIPTION
**What does this PR do?**

  This pull request deploys a fix to the Analytics lib that was throwing a NullPointerException when a certain key-value pair attribute in the Event body had a null value. 
  Now every value in that situation will be set to an empty string: ""
  The ScreenTagHistory class was also affected by this PR changes. 
  The getters now don't return null when requested, they return "" otherwise.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AnalyticsManager.java
- [ ] ScreenTagHistory.java

**How should this be tested?**

  Unit tests: AnalyticsNormalizerTest ; ScreenTagHistoryTest.java

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-141](https://aptoide.atlassian.net/browse/ASV-141)

**Code Review Checklist**

- [x] Architecture
- [x] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] Partners build
- [x] Unit tests pass
- [x] Functional QA tests pass