### PR TITLE
[ASV-224] Changed every call to tabNavigator in the deeplinkManager c…

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/BottomNavigationActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/home/BottomNavigationActivity.java
@@ -66,7 +66,10 @@ public abstract class BottomNavigationActivity extends TabNavigatorActivity
         break;
     }
     if (selectedFragment != null) {
-      if (selectedFragment.getClass() != currentFragment.getClass()) {
+      if (currentFragment == null) {
+        FragmentNavigator fragmentNavigator = getFragmentNavigator();
+        fragmentNavigator.navigateTo(selectedFragment, true);
+      } else if (selectedFragment.getClass() != currentFragment.getClass()) {
         FragmentNavigator fragmentNavigator = getFragmentNavigator();
         fragmentNavigator.navigateTo(selectedFragment, true);
       }

--- a/app/src/main/java/cm/aptoide/pt/view/DeepLinkManager.java
+++ b/app/src/main/java/cm/aptoide/pt/view/DeepLinkManager.java
@@ -11,6 +11,7 @@ import cm.aptoide.pt.AppShortcutsAnalytics;
 import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.DeepLinkAnalytics;
 import cm.aptoide.pt.DeepLinkIntentReceiver;
+import cm.aptoide.pt.R;
 import cm.aptoide.pt.ads.AdsRepository;
 import cm.aptoide.pt.analytics.NavigationTracker;
 import cm.aptoide.pt.analytics.ScreenTagHistory;
@@ -23,14 +24,12 @@ import cm.aptoide.pt.dataprovider.model.v7.GetStoreWidgets;
 import cm.aptoide.pt.dataprovider.model.v7.Layout;
 import cm.aptoide.pt.dataprovider.ws.v7.V7;
 import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
+import cm.aptoide.pt.home.AptoideBottomNavigator;
 import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.navigator.FragmentNavigator;
-import cm.aptoide.pt.navigator.SimpleTabNavigation;
-import cm.aptoide.pt.navigator.TabNavigation;
 import cm.aptoide.pt.navigator.TabNavigator;
 import cm.aptoide.pt.notification.NotificationAnalytics;
 import cm.aptoide.pt.repository.StoreRepository;
-import cm.aptoide.pt.search.SearchNavigator;
 import cm.aptoide.pt.search.analytics.SearchAnalytics;
 import cm.aptoide.pt.search.analytics.SearchSource;
 import cm.aptoide.pt.store.StoreAnalytics;
@@ -40,7 +39,6 @@ import cm.aptoide.pt.store.view.StoreFragment;
 import cm.aptoide.pt.store.view.StoreTabFragmentChooser;
 import cm.aptoide.pt.timeline.TimelineAnalytics;
 import cm.aptoide.pt.timeline.view.navigation.AppsTimelineTabNavigation;
-import cm.aptoide.pt.timeline.view.navigation.HomeTabNavigation;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -65,7 +63,6 @@ public class DeepLinkManager {
   private final SharedPreferences sharedPreferences;
   private final StoreAccessor storeAccessor;
   private final String defaultTheme;
-  private final SearchNavigator searchNavigator;
   private final NavigationTracker navigationTracker;
   private final NotificationAnalytics notificationAnalytics;
   private final SearchAnalytics searchAnalytics;
@@ -76,16 +73,17 @@ public class DeepLinkManager {
   private final StoreAnalytics storeAnalytics;
   private final AdsRepository adsRepository;
   private final CompositeSubscription subscriptions;
+  private final AptoideBottomNavigator bottomNavigator;
 
   public DeepLinkManager(StoreUtilsProxy storeUtilsProxy, StoreRepository storeRepository,
       FragmentNavigator fragmentNavigator, TabNavigator tabNavigator,
       DeepLinkMessages deepLinkMessages, SharedPreferences sharedPreferences,
       StoreAccessor storeAccessor, String defaultTheme, NotificationAnalytics notificationAnalytics,
-      NavigationTracker navigationTracker, SearchNavigator searchNavigator,
+      NavigationTracker navigationTracker,
       SearchAnalytics searchAnalytics, AppShortcutsAnalytics appShortcutsAnalytics,
       AptoideAccountManager accountManager, DeepLinkAnalytics deepLinkAnalytics,
       TimelineAnalytics timelineAnalytics, StoreAnalytics storeAnalytics,
-      AdsRepository adsRepository) {
+      AdsRepository adsRepository, AptoideBottomNavigator bottomNavigator) {
     this.storeUtilsProxy = storeUtilsProxy;
     this.storeRepository = storeRepository;
     this.fragmentNavigator = fragmentNavigator;
@@ -96,7 +94,6 @@ public class DeepLinkManager {
     this.defaultTheme = defaultTheme;
     this.navigationTracker = navigationTracker;
     this.notificationAnalytics = notificationAnalytics;
-    this.searchNavigator = searchNavigator;
     this.searchAnalytics = searchAnalytics;
     this.appShortcutsAnalytics = appShortcutsAnalytics;
     this.accountManager = accountManager;
@@ -104,6 +101,7 @@ public class DeepLinkManager {
     this.deepLinkAnalytics = deepLinkAnalytics;
     this.storeAnalytics = storeAnalytics;
     this.adsRepository = adsRepository;
+    this.bottomNavigator = bottomNavigator;
     this.subscriptions = new CompositeSubscription();
   }
 
@@ -192,7 +190,7 @@ public class DeepLinkManager {
   }
 
   private void searchDeepLink(String query, boolean shortcutNavigation) {
-    searchNavigator.navigate(query);
+    bottomNavigator.showFragment(R.id.action_search);
     if (query == null || query.isEmpty()) {
       if (shortcutNavigation) {
         searchAnalytics.searchStart(SearchSource.SHORTCUT, false);
@@ -245,8 +243,8 @@ public class DeepLinkManager {
   }
 
   @NonNull private Completable navigateToStores() {
-    return Completable.fromAction(
-        () -> tabNavigator.navigate(new SimpleTabNavigation(TabNavigation.STORES)));
+    return Completable.fromAction(() -> bottomNavigator.showFragment(R.id.action_stores));
+    //tabNavigator.navigate(new SimpleTabNavigation(TabNavigation.STORES
   }
 
   @NonNull private Completable openStore(Store store) {
@@ -257,7 +255,8 @@ public class DeepLinkManager {
 
   private void downloadNotificationDeepLink() {
     deepLinkAnalytics.downloadingUpdates();
-    tabNavigator.navigate(new SimpleTabNavigation(TabNavigation.DOWNLOADS));
+    //tabNavigator.navigate(new SimpleTabNavigation(TabNavigation.DOWNLOADS));
+    bottomNavigator.showFragment(R.id.action_apps);
   }
 
   private void fromTimelineDeepLink(Intent intent) {
@@ -271,14 +270,14 @@ public class DeepLinkManager {
   }
 
   private void fromHomeDeepLink() {
-
-    tabNavigator.navigate(new HomeTabNavigation());
+    bottomNavigator.showFragment(R.id.action_home);
   }
 
   private void newUpdatesDeepLink() {
     notificationAnalytics.sendUpdatesNotificationClickEvent();
     deepLinkAnalytics.newUpdatesNotification();
-    tabNavigator.navigate(new SimpleTabNavigation(TabNavigation.UPDATES));
+    bottomNavigator.showFragment(R.id.action_apps);
+    //tabNavigator.navigate(new SimpleTabNavigation(TabNavigation.UPDATES));
   }
 
   private void genericDeepLink(Uri uri) {
@@ -323,12 +322,14 @@ public class DeepLinkManager {
             appShortcutsAnalytics.shortcutNavigation(ShortcutDestinations.MY_STORE);
             storeAnalytics.sendStoreOpenEvent(APP_SHORTCUT, navigation.getStore()
                 .getName(), false);
-            fragmentNavigator.navigateTo(StoreFragment.newInstance(navigation.getStore()
-                .getName(), navigation.getStore()
-                .getTheme(), StoreFragment.OpenType.GetHome), true);
+            bottomNavigator.showFragment(R.id.action_stores);
+            //fragmentNavigator.navigateTo(StoreFragment.newInstance(navigation.getStore()
+            //    .getName(), navigation.getStore()
+            //    .getTheme(), StoreFragment.OpenType.GetHome), true);
           } else {
             appShortcutsAnalytics.shortcutNavigation(ShortcutDestinations.MY_STORE_NOT_LOGGED_IN);
-            tabNavigator.navigate(new SimpleTabNavigation(TabNavigation.STORES));
+            bottomNavigator.showFragment(R.id.action_stores);
+            //tabNavigator.navigate(new SimpleTabNavigation(TabNavigation.STORES));
           }
         }, throwable -> Logger.e(TAG, "myStoreDeepLink: " + throwable)));
   }

--- a/app/src/vanilla/java/cm/aptoide/pt/view/ActivityModule.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/view/ActivityModule.java
@@ -140,9 +140,9 @@ import static com.facebook.FacebookSdk.getApplicationContext;
       AdsRepository adsRepository) {
     return new DeepLinkManager(storeUtilsProxy, storeRepository, fragmentNavigator,
         (TabNavigator) activity, (DeepLinkManager.DeepLinkMessages) activity, sharedPreferences,
-        storeAccessor, defaultTheme, notificationAnalytics, navigationTracker, searchNavigator,
+        storeAccessor, defaultTheme, notificationAnalytics, navigationTracker,
         searchAnalytics, appShortcutsAnalytics, accountManager, deepLinkAnalytics,
-        timelineAnalytics, storeAnalytics, adsRepository);
+        timelineAnalytics, storeAnalytics, adsRepository, (AptoideBottomNavigator) activity);
   }
 
   @ActivityScope @Provides Presenter provideMainPresenter(


### PR DESCRIPTION
**What does this PR do?**

This PR aims to change all calls from deeplinks from tab navigation to bottom navigation;

NOTE: Stuff related to the timeline was kept at this point. It's just a matter of removing the corresponding methods from DeepLinkManager class. When this is done, the TabNavigator attribute can be removed

**Database changed?**

No

**Where should the reviewer start?**

- [ ] DeepLinkManager.java

**How should this be manually tested?**

Try the different deeplinks (https://aptoide.atlassian.net/wiki/spaces/AN/pages/1749903/Deeplinks) that navigate to the bottom navigation main fragments; 

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-224](<https://aptoide.atlassian.net/browse/ASV-224>)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass