### PR TITLE
[Bugfix/ASV-223] bug fix: Home menu - loading more

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/AptoideBottomNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/home/AptoideBottomNavigator.java
@@ -25,7 +25,7 @@ public interface AptoideBottomNavigator {
   /**
    * Hides or shows the BottomNavigation depending on the fragment
    */
-  void toogleBottomNavigation();
+  void toggleBottomNavigation();
 
   /**
    * Puts the focus on the button of the BottomNavigation request by the fragment that calls this

--- a/app/src/main/java/cm/aptoide/pt/home/BottomHomeFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/BottomHomeFragment.java
@@ -194,8 +194,9 @@ public class BottomHomeFragment extends NavigationTrackFragment implements HomeV
 
   @Override public Observable<Object> reachesBottom() {
     return RxRecyclerView.scrollEvents(bundlesList)
-        .filter(scroll -> isEndReached())
+        .map(scroll -> isEndReached())
         .distinctUntilChanged()
+        .filter(isEnd -> isEnd)
         .cast(Object.class);
   }
 

--- a/app/src/main/java/cm/aptoide/pt/home/BottomNavigationActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/home/BottomNavigationActivity.java
@@ -18,7 +18,6 @@ import cm.aptoide.pt.search.analytics.SearchSource;
 import cm.aptoide.pt.search.view.SearchResultFragment;
 import cm.aptoide.pt.store.view.my.MyStoresFragment;
 import cm.aptoide.pt.view.NotBottomNavigationView;
-import cm.aptoide.pt.view.settings.NewAccountFragment;
 import javax.inject.Inject;
 import rx.Observable;
 import rx.subjects.PublishSubject;
@@ -54,7 +53,7 @@ public abstract class BottomNavigationActivity extends TabNavigatorActivity
     });
     animationup = AnimationUtils.loadAnimation(this, R.anim.slide_up);
     animationdown = AnimationUtils.loadAnimation(this, R.anim.slide_down);
-    toogleBottomNavigation(); //Here because of the SettingsFragment that doesn't extend the BaseFragment
+    toggleBottomNavigation(); //Here because of the SettingsFragment that doesn't extend the BaseFragment
   }
 
   @Override protected void onDestroy() {
@@ -106,7 +105,7 @@ public abstract class BottomNavigationActivity extends TabNavigatorActivity
     }
   }
 
-  @Override public void toogleBottomNavigation() {
+  @Override public void toggleBottomNavigation() {
     Fragment fragment = getFragmentNavigator().getFragment();
     if (fragment instanceof NotBottomNavigationView) {
       if (bottomNavigationView.getVisibility() != View.GONE) {

--- a/app/src/main/java/cm/aptoide/pt/view/BaseFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/BaseFragment.java
@@ -23,7 +23,7 @@ public abstract class BaseFragment extends RxFragment {
   @Override public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
     if (bottomNavigationActivity != null) {
-      bottomNavigationActivity.toogleBottomNavigation();
+      bottomNavigationActivity.toggleBottomNavigation();
     }
   }
 


### PR DESCRIPTION
**What does this PR do?**

  This PR should solve the loading more not being shown correctly issue.
  We were not using distinct until changed correctly since it wasn't filtering out by boolean but by scroll event, which was why it was emitting more than once that it reached bottom, causing race condition problems that would end up hiding the loading more animation right after showing it.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] BottomHomeFragment.java 

**How should this be manually tested?**

  scroll until the end of the list, rotate screen, scroll, go to app view, go back etc

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-223](https://aptoide.atlassian.net/browse/ASV-223)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass