### PR TITLE
[bugfix/ASV-265] Correctly Fill Apps Fragment

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
@@ -158,10 +158,8 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
       adapter.addUpdateAppsList(list);
     }
     showUpdates = true;
-    if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
-      recyclerView.scrollToPosition(0);
-      hideLoadingProgressBar();
-      recyclerView.setVisibility(View.VISIBLE);
+    if (shouldShowAppsList()) {
+      showAppsList();
     }
   }
 
@@ -170,10 +168,8 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
       adapter.addInstalledAppsList(installedApps);
     }
     showInstalled = true;
-    if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
-      recyclerView.scrollToPosition(0);
-      hideLoadingProgressBar();
-      recyclerView.setVisibility(View.VISIBLE);
+    if (shouldShowAppsList()) {
+      showAppsList();
     }
   }
 
@@ -182,10 +178,8 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
       adapter.addDownloadAppsList(list);
     }
     showDownloads = true;
-    if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
-      recyclerView.scrollToPosition(0);
-      hideLoadingProgressBar();
-      recyclerView.setVisibility(View.VISIBLE);
+    if (shouldShowAppsList()) {
+      showAppsList();
     }
   }
 
@@ -256,12 +250,12 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
   }
 
   @Override public void showUpdatesDownloadList(List<App> updatesDownloadList) {
-    adapter.addUpdateAppsList(updatesDownloadList);
+    if (updatesDownloadList != null && !updatesDownloadList.isEmpty()) {
+      adapter.addUpdateAppsList(updatesDownloadList);
+    }
     showUpdates = true;
-    if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
-      recyclerView.scrollToPosition(0);
-      hideLoadingProgressBar();
-      recyclerView.setVisibility(View.VISIBLE);
+    if (shouldShowAppsList()) {
+      showAppsList();
     }
   }
 
@@ -340,8 +334,17 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     }
   }
 
-  private boolean canShowListOfApps() {
-    return showDownloads && showUpdates && showInstalled;
+  private void showAppsList() {
+    recyclerView.scrollToPosition(0);
+    hideLoadingProgressBar();
+    recyclerView.setVisibility(View.VISIBLE);
+  }
+
+  private boolean shouldShowAppsList() {
+    return showDownloads
+        && showUpdates
+        && showInstalled
+        && recyclerView.getVisibility() != View.VISIBLE;
   }
 
   private void hideLoadingProgressBar() {

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
@@ -13,6 +13,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+import android.widget.ProgressBar;
 import cm.aptoide.accountmanager.AptoideAccountManager;
 import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
@@ -62,6 +63,7 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
   private PublishSubject<Void> updateAll;
   private RxAlertDialog ignoreUpdateDialog;
   private ImageView userAvatar;
+  private ProgressBar progressBar;
   private BottomNavigationActivity bottomNavigationActivity;
   private SwipeRefreshLayout swipeRefreshLayout;
   private boolean showDownloads;
@@ -90,6 +92,8 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     swipeRefreshLayout = (SwipeRefreshLayout) view.findViewById(R.id.fragment_apps_swipe_container);
     swipeRefreshLayout.setColorSchemeResources(R.color.default_progress_bar_color,
         R.color.default_color, R.color.default_progress_bar_color, R.color.default_color);
+    progressBar = (ProgressBar) view.findViewById(R.id.progress_bar);
+    progressBar.setVisibility(View.VISIBLE);
     setupRecyclerView();
     buildIgnoreUpdatesDialog();
     userAvatar = (ImageView) view.findViewById(R.id.user_actionbar_icon);
@@ -155,6 +159,7 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     }
     showUpdates = true;
     if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
+      hideLoadingProgressBar();
       recyclerView.setVisibility(View.VISIBLE);
       recyclerView.smoothScrollToPosition(0);
     }
@@ -166,6 +171,7 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     }
     showInstalled = true;
     if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
+      hideLoadingProgressBar();
       recyclerView.setVisibility(View.VISIBLE);
       recyclerView.smoothScrollToPosition(0);
     }
@@ -177,6 +183,7 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     }
     showDownloads = true;
     if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
+      hideLoadingProgressBar();
       recyclerView.setVisibility(View.VISIBLE);
       recyclerView.smoothScrollToPosition(0);
     }
@@ -252,7 +259,9 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     adapter.addUpdateAppsList(updatesDownloadList);
     showUpdates = true;
     if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
+      hideLoadingProgressBar();
       recyclerView.setVisibility(View.VISIBLE);
+      recyclerView.smoothScrollToPosition(0);
     }
   }
 
@@ -335,8 +344,13 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     return showDownloads && showUpdates && showInstalled;
   }
 
+  private void hideLoadingProgressBar() {
+    progressBar.setVisibility(View.GONE);
+  }
+
   @Override public void onDestroyView() {
     super.onDestroyView();
+    progressBar = null;
     swipeRefreshLayout = null;
     ignoreUpdateDialog = null;
     recyclerView = null;

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
@@ -9,7 +9,6 @@ import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.SimpleItemAnimator;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -65,6 +64,9 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
   private ImageView userAvatar;
   private BottomNavigationActivity bottomNavigationActivity;
   private SwipeRefreshLayout swipeRefreshLayout;
+  private boolean showDownloads;
+  private boolean showUpdates;
+  private boolean showInstalled;
 
   public static AppsFragment newInstance() {
     return new AppsFragment();
@@ -148,15 +150,36 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
   }
 
   @Override public void showUpdatesList(List<App> list) {
-    adapter.addUpdateAppsList(list);
+    if (list != null && !list.isEmpty()) {
+      adapter.addUpdateAppsList(list);
+    }
+    showUpdates = true;
+    if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
+      recyclerView.setVisibility(View.VISIBLE);
+      recyclerView.smoothScrollToPosition(0);
+    }
   }
 
   @Override public void showInstalledApps(List<App> installedApps) {
-    adapter.addInstalledAppsList(installedApps);
+    if (installedApps != null && !installedApps.isEmpty()) {
+      adapter.addInstalledAppsList(installedApps);
+    }
+    showInstalled = true;
+    if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
+      recyclerView.setVisibility(View.VISIBLE);
+      recyclerView.smoothScrollToPosition(0);
+    }
   }
 
   @Override public void showDownloadsList(List<App> list) {
-    adapter.addDownloadAppsList(list);
+    if (list != null && !list.isEmpty()) {
+      adapter.addDownloadAppsList(list);
+    }
+    showDownloads = true;
+    if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
+      recyclerView.setVisibility(View.VISIBLE);
+      recyclerView.smoothScrollToPosition(0);
+    }
   }
 
   @Override public Observable<App> retryDownload() {
@@ -227,6 +250,10 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
 
   @Override public void showUpdatesDownloadList(List<App> updatesDownloadList) {
     adapter.addUpdateAppsList(updatesDownloadList);
+    showUpdates = true;
+    if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
+      recyclerView.setVisibility(View.VISIBLE);
+    }
   }
 
   @Override public Observable<Void> updateAll() {
@@ -302,6 +329,10 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     if (swipeRefreshLayout.isRefreshing()) {
       swipeRefreshLayout.setRefreshing(false);
     }
+  }
+
+  private boolean canShowListOfApps() {
+    return showDownloads && showUpdates && showInstalled;
   }
 
   @Override public void onDestroyView() {

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
@@ -159,9 +159,9 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     }
     showUpdates = true;
     if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
+      recyclerView.scrollToPosition(0);
       hideLoadingProgressBar();
       recyclerView.setVisibility(View.VISIBLE);
-      recyclerView.smoothScrollToPosition(0);
     }
   }
 
@@ -171,9 +171,9 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     }
     showInstalled = true;
     if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
+      recyclerView.scrollToPosition(0);
       hideLoadingProgressBar();
       recyclerView.setVisibility(View.VISIBLE);
-      recyclerView.smoothScrollToPosition(0);
     }
   }
 
@@ -183,9 +183,9 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     }
     showDownloads = true;
     if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
+      recyclerView.scrollToPosition(0);
       hideLoadingProgressBar();
       recyclerView.setVisibility(View.VISIBLE);
-      recyclerView.smoothScrollToPosition(0);
     }
   }
 
@@ -259,9 +259,9 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     adapter.addUpdateAppsList(updatesDownloadList);
     showUpdates = true;
     if (canShowListOfApps() && recyclerView.getVisibility() != View.VISIBLE) {
+      recyclerView.scrollToPosition(0);
       hideLoadingProgressBar();
       recyclerView.setVisibility(View.VISIBLE);
-      recyclerView.smoothScrollToPosition(0);
     }
   }
 

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
@@ -15,6 +15,7 @@ import cm.aptoide.pt.install.InstallAnalytics;
 import cm.aptoide.pt.install.InstallManager;
 import cm.aptoide.pt.updates.UpdatesAnalytics;
 import cm.aptoide.pt.utils.AptoideUtils;
+import java.util.Collections;
 import java.util.List;
 import rx.Completable;
 import rx.Observable;
@@ -83,7 +84,7 @@ public class AppsManager {
     return installManager.getInstallations()
         .flatMap(installations -> {
           if (installations == null || installations.isEmpty()) {
-            return Observable.empty();
+            return Observable.just(Collections.emptyList());
           }
           return Observable.just(installations)
               .flatMapIterable(installs -> installs)

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
@@ -339,7 +339,6 @@ public class AppsPresenter implements Presenter {
         .observeOn(computation)
         .flatMap(__ -> appsManager.getInstalledApps())
         .observeOn(viewScheduler)
-        .filter(list -> !list.isEmpty())
         .doOnNext(installedApps -> view.showInstalledApps(installedApps))
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {
@@ -352,7 +351,6 @@ public class AppsPresenter implements Presenter {
         .observeOn(viewScheduler)
         .flatMap(__ -> appsManager.getUpdatesList(false))
         .observeOn(viewScheduler)
-        .filter(list -> !list.isEmpty())
         .doOnNext(list -> view.showUpdatesList(list))
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
@@ -327,7 +327,6 @@ public class AppsPresenter implements Presenter {
         .observeOn(computation)
         .flatMap(__ -> appsManager.getDownloadApps())
         .observeOn(viewScheduler)
-        .filter(list -> !list.isEmpty())
         .doOnNext(list -> view.showDownloadsList(list))
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {

--- a/app/src/main/res/layout/apps_active_download_app_item.xml
+++ b/app/src/main/res/layout/apps_active_download_app_item.xml
@@ -32,7 +32,6 @@
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:layout_gravity="center_vertical"
-        android:layout_marginBottom="12dp"
         android:layout_marginTop="8dp"
         android:layout_toEndOf="@id/apps_downloads_icon"
         android:layout_toLeftOf="@+id/apps_download_pause_button"

--- a/app/src/main/res/layout/apps_completed_download_app_item.xml
+++ b/app/src/main/res/layout/apps_completed_download_app_item.xml
@@ -33,7 +33,6 @@
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:layout_gravity="center_vertical"
-        android:layout_marginBottom="16dp"
         android:layout_marginTop="12dp"
         android:layout_toEndOf="@id/apps_downloads_icon"
         android:layout_toRightOf="@id/apps_downloads_icon"

--- a/app/src/main/res/layout/apps_error_download_app_item.xml
+++ b/app/src/main/res/layout/apps_error_download_app_item.xml
@@ -32,7 +32,6 @@
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:layout_gravity="center_vertical"
-        android:layout_marginBottom="12dp"
         android:layout_marginTop="8dp"
         android:layout_toEndOf="@id/apps_downloads_icon"
         android:layout_toLeftOf="@+id/apps_download_retry_button"

--- a/app/src/main/res/layout/apps_error_update_app_item.xml
+++ b/app/src/main/res/layout/apps_error_update_app_item.xml
@@ -32,7 +32,6 @@
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:layout_gravity="center_vertical"
-        android:layout_marginBottom="12dp"
         android:layout_marginTop="8dp"
         android:layout_toEndOf="@id/apps_updates_app_icon"
         android:layout_toLeftOf="@+id/apps_updates_retry_button"

--- a/app/src/main/res/layout/apps_header_item.xml
+++ b/app/src/main/res/layout/apps_header_item.xml
@@ -13,6 +13,8 @@
       android:layout_marginBottom="8dp"
       android:layout_marginLeft="8dp"
       android:layout_marginTop="16dp"
+      android:ellipsize="end"
+      android:maxLines="1"
       tools:text="Downloads"
       style="@style/Aptoide.TextView.Regular.L.BlackAlpha"
       />

--- a/app/src/main/res/layout/apps_header_updates_item.xml
+++ b/app/src/main/res/layout/apps_header_updates_item.xml
@@ -17,6 +17,8 @@
       android:layout_marginLeft="8dp"
       android:layout_marginStart="8dp"
       android:layout_marginTop="10dp"
+      android:ellipsize="end"
+      android:maxLines="1"
       tools:text="Updates"
       style="@style/Aptoide.TextView.Regular.L.BlackAlpha"
       />
@@ -30,6 +32,8 @@
       android:layout_centerVertical="true"
       android:layout_marginEnd="16dp"
       android:layout_marginRight="16dp"
+      android:ellipsize="end"
+      android:maxLines="1"
       android:text="@string/apps_button_update_all"
       android:textAllCaps="true"
       android:textColor="@color/orange"

--- a/app/src/main/res/layout/apps_header_updates_item.xml
+++ b/app/src/main/res/layout/apps_header_updates_item.xml
@@ -17,7 +17,7 @@
       android:layout_marginLeft="8dp"
       android:layout_marginStart="8dp"
       android:layout_marginTop="10dp"
-      tools:text="Downloads"
+      tools:text="Updates"
       style="@style/Aptoide.TextView.Regular.L.BlackAlpha"
       />
 
@@ -28,10 +28,8 @@
       android:layout_alignParentEnd="true"
       android:layout_alignParentRight="true"
       android:layout_centerVertical="true"
-      android:layout_marginBottom="16dp"
       android:layout_marginEnd="16dp"
       android:layout_marginRight="16dp"
-      android:layout_marginTop="16dp"
       android:text="@string/apps_button_update_all"
       android:textAllCaps="true"
       android:textColor="@color/orange"

--- a/app/src/main/res/layout/apps_installed_app_item.xml
+++ b/app/src/main/res/layout/apps_installed_app_item.xml
@@ -32,7 +32,6 @@
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:layout_gravity="center_vertical"
-        android:layout_marginBottom="16dp"
         android:layout_marginTop="12dp"
         android:layout_toEndOf="@id/apps_installed_icon"
         android:layout_toRightOf="@id/apps_installed_icon"

--- a/app/src/main/res/layout/apps_installed_app_item.xml
+++ b/app/src/main/res/layout/apps_installed_app_item.xml
@@ -43,6 +43,8 @@
           android:id="@+id/apps_installed_app_name"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          android:ellipsize="end"
+          android:maxLines="1"
           tools:text="Aptoide"
           style="@style/Aptoide.TextView.Regular.M.BlackAlpha"
           />
@@ -51,6 +53,8 @@
           android:id="@+id/apps_installed_app_version"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          android:ellipsize="end"
+          android:maxLines="1"
           tools:text="1994"
           style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
           />

--- a/app/src/main/res/layout/apps_standby_download_app_item.xml
+++ b/app/src/main/res/layout/apps_standby_download_app_item.xml
@@ -31,13 +31,11 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:layout_marginBottom="12dp"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
         android:layout_marginTop="8dp"
         android:layout_weight="2"
         android:orientation="vertical"
-
         >
 
       <TextView

--- a/app/src/main/res/layout/apps_standby_download_app_item.xml
+++ b/app/src/main/res/layout/apps_standby_download_app_item.xml
@@ -15,6 +15,7 @@
       android:layout_alignParentLeft="true"
       android:layout_alignParentStart="true"
       android:orientation="horizontal"
+      android:weightSum="3"
       >
 
     <ImageView
@@ -29,8 +30,7 @@
 
     <LinearLayout
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
+        android:layout_height="match_parent"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
         android:layout_marginTop="8dp"
@@ -40,7 +40,7 @@
 
       <TextView
           android:id="@+id/apps_downloads_app_name"
-          android:layout_width="match_parent"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginBottom="4dp"
           android:ellipsize="end"

--- a/app/src/main/res/layout/apps_standby_update_app_item.xml
+++ b/app/src/main/res/layout/apps_standby_update_app_item.xml
@@ -31,13 +31,11 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:layout_marginBottom="12dp"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
         android:layout_marginTop="8dp"
         android:layout_weight="2"
         android:orientation="vertical"
-
         >
 
       <TextView

--- a/app/src/main/res/layout/apps_standby_update_app_item.xml
+++ b/app/src/main/res/layout/apps_standby_update_app_item.xml
@@ -15,6 +15,7 @@
       android:layout_alignParentLeft="true"
       android:layout_alignParentStart="true"
       android:orientation="horizontal"
+      android:weightSum="3"
       >
 
     <ImageView
@@ -29,8 +30,7 @@
 
     <LinearLayout
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
+        android:layout_height="match_parent"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
         android:layout_marginTop="8dp"
@@ -40,7 +40,7 @@
 
       <TextView
           android:id="@+id/apps_updates_app_name"
-          android:layout_width="match_parent"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginBottom="4dp"
           android:ellipsize="end"

--- a/app/src/main/res/layout/apps_update_app_item.xml
+++ b/app/src/main/res/layout/apps_update_app_item.xml
@@ -73,6 +73,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
+            android:ellipsize="end"
+            android:maxLines="1"
             tools:text="1239123ojd"
             style="@style/Aptoide.TextView.Medium.XS.Grey"
             />

--- a/app/src/main/res/layout/apps_update_app_item.xml
+++ b/app/src/main/res/layout/apps_update_app_item.xml
@@ -32,7 +32,6 @@
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:layout_gravity="center_vertical"
-        android:layout_marginBottom="16dp"
         android:layout_marginTop="12dp"
         android:layout_toEndOf="@id/apps_updates_app_icon"
         android:layout_toLeftOf="@+id/apps_updates_update_button"

--- a/app/src/main/res/layout/apps_updating_app_item.xml
+++ b/app/src/main/res/layout/apps_updating_app_item.xml
@@ -32,7 +32,6 @@
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:layout_gravity="center_vertical"
-        android:layout_marginBottom="12dp"
         android:layout_marginTop="8dp"
         android:layout_toEndOf="@id/apps_updates_app_icon"
         android:layout_toLeftOf="@+id/apps_updates_pause_button"

--- a/app/src/main/res/layout/fragment_apps.xml
+++ b/app/src/main/res/layout/fragment_apps.xml
@@ -7,18 +7,24 @@
     >
 
   <include layout="@layout/action_bar"/>
-  <android.support.v4.widget.SwipeRefreshLayout
-      android:id="@+id/fragment_apps_swipe_container"
+  <FrameLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       >
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/fragment_apps_recycler_view"
+    <include layout="@layout/partial_view_progress_bar"/>
+
+    <android.support.v4.widget.SwipeRefreshLayout
+        android:id="@+id/fragment_apps_swipe_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:scrollbars="vertical"
-        android:visibility="gone"
-        />
-
-  </android.support.v4.widget.SwipeRefreshLayout>
+        >
+      <android.support.v7.widget.RecyclerView
+          android:id="@+id/fragment_apps_recycler_view"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
+          android:scrollbars="vertical"
+          android:visibility="gone"
+          />
+    </android.support.v4.widget.SwipeRefreshLayout>
+  </FrameLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_apps.xml
+++ b/app/src/main/res/layout/fragment_apps.xml
@@ -17,6 +17,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical"
+        android:visibility="gone"
         />
 
   </android.support.v4.widget.SwipeRefreshLayout>


### PR DESCRIPTION
**What does this PR do?**

   Fix the filling of the AppsFragment. Before, the installed would come first and then, when the updates and the downloads (if existent) were added to the view, the view would be still be focused on the installed apps.
Now it only shows the list when all apps are ready.

**Database changed?**

    No

**Where should the reviewer start?**

- AppsFragment

**How should this be manually tested?**

Open AppsFragment and the view should be focused on the Downloads or the updates (if there are any at the moment).

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-265](https://aptoide.atlassian.net/browse/ASV-265)

**Questions:**





**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass