### PR TITLE
[ASV-266] Remove download after cancelling it

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsAdapter.java
@@ -247,4 +247,12 @@ public class AppsAdapter extends RecyclerView.Adapter<AppsViewHolder> {
     }
     return appsByType;
   }
+
+  public void removeCanceledDownload(App app) {
+    if (listOfApps.contains(app)) {
+      int indexOfCanceledDownload = listOfApps.indexOf(app);
+      listOfApps.remove(app);
+      notifyItemRemoved(indexOfCanceledDownload);
+    }
+  }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsAdapter.java
@@ -1,6 +1,7 @@
 package cm.aptoide.pt.home.apps;
 
 import android.support.v7.widget.RecyclerView;
+import android.text.TextUtils;
 import android.view.ViewGroup;
 import java.util.List;
 
@@ -119,15 +120,23 @@ public class AppsAdapter extends RecyclerView.Adapter<AppsViewHolder> {
 
   private void addApps(List<App> list, int offset) {
     for (int i = 0; i < list.size(); i++) {
-      if (listOfApps.contains(list.get(i))) {
-        //update
-        int itemIndex = listOfApps.indexOf(list.get(i));
-        listOfApps.set(itemIndex, list.get(i));//stores the same item with the new emitted changes
-        notifyItemChanged(itemIndex);
+      if (isValid(list.get(i))) {
+        if (listOfApps.contains(list.get(i))) {
+          //update
+          int itemIndex = listOfApps.indexOf(list.get(i));
+          listOfApps.set(itemIndex, list.get(i));//stores the same item with the new emitted changes
+          notifyItemChanged(itemIndex);
+        } else {
+          //add new element
+          listOfApps.add(offset + 1, list.get(i));
+          notifyItemInserted(offset + 1);
+        }
       } else {
-        //add new element
-        listOfApps.add(offset + 1, list.get(i));
-        notifyItemInserted(offset + 1);
+        if (listOfApps.contains(list.get(i))) {
+          int itemIndex = listOfApps.indexOf(list.get(i));
+          listOfApps.remove(itemIndex);
+          notifyItemRemoved(itemIndex);
+        }
       }
     }
   }
@@ -254,5 +263,30 @@ public class AppsAdapter extends RecyclerView.Adapter<AppsViewHolder> {
       listOfApps.remove(app);
       notifyItemRemoved(indexOfCanceledDownload);
     }
+  }
+
+  private boolean isValid(App app) {
+    boolean isValid;
+    switch (app.getType()) {
+      case HEADER_DOWNLOADS:
+      case HEADER_INSTALLED:
+      case HEADER_UPDATES:
+        isValid = true;
+        break;
+      case DOWNLOAD:
+        isValid = !TextUtils.isEmpty(((DownloadApp) app).getAppName());
+        break;
+      case UPDATE:
+        isValid = !TextUtils.isEmpty(((UpdateApp) app).getName());
+        break;
+      case INSTALLED:
+      case INSTALLING:
+        isValid = !TextUtils.isEmpty(((InstalledApp) app).getAppName());
+        break;
+      default:
+        isValid = false;
+        break;
+    }
+    return isValid;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
@@ -334,6 +334,10 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     }
   }
 
+  @Override public void removeCanceledDownload(App app) {
+    adapter.removeCanceledDownload(app);
+  }
+
   private void showAppsList() {
     recyclerView.scrollToPosition(0);
     hideLoadingProgressBar();

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
@@ -69,6 +69,7 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
   private boolean showDownloads;
   private boolean showUpdates;
   private boolean showInstalled;
+  private List<App> blackListDownloads;
 
   public static AppsFragment newInstance() {
     return new AppsFragment();
@@ -79,6 +80,7 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     getFragmentComponent(savedInstanceState).inject(this);
     appItemClicks = PublishSubject.create();
     updateAll = PublishSubject.create();
+    blackListDownloads = new ArrayList<>();
   }
 
   @Override public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
@@ -125,6 +127,7 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
   @Override public void onDestroy() {
     updateAll = null;
     appItemClicks = null;
+    blackListDownloads = null;
     super.onDestroy();
   }
 
@@ -174,6 +177,7 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
   }
 
   @Override public void showDownloadsList(List<App> list) {
+    list.removeAll(blackListDownloads);
     if (list != null && !list.isEmpty()) {
       adapter.addDownloadAppsList(list);
     }
@@ -198,7 +202,8 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
   @Override public Observable<App> cancelDownload() {
     return appItemClicks.filter(
         appClick -> appClick.getClickType() == AppClick.ClickType.CANCEL_DOWNLOAD)
-        .map(appClick -> appClick.getApp());
+        .map(appClick -> appClick.getApp())
+        .doOnNext(app -> blackListDownloads.add(app));
   }
 
   @Override public Observable<App> resumeDownload() {

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragmentView.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragmentView.java
@@ -69,4 +69,6 @@ public interface AppsFragmentView extends View {
   Observable<Void> refreshApps();
 
   void hidePullToRefresh();
+
+  void removeCanceledDownload(App app);
 }

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
@@ -89,8 +89,6 @@ public class AppsManager {
           return Observable.just(installations)
               .flatMapIterable(installs -> installs)
               .filter(install -> install.getType() != Install.InstallationType.UPDATE)
-              .filter(install -> !install.getState()
-                  .equals(Install.InstallationStatus.UNINSTALLED))
               .flatMap(item -> installManager.filterInstalled(item))
               .toList()
               .map(installedApps -> appMapper.getDownloadApps(installedApps));

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
@@ -291,6 +291,7 @@ public class AppsPresenter implements Presenter {
         .observeOn(viewScheduler)
         .flatMap(created -> view.cancelDownload())
         .doOnNext(app -> appsManager.cancelDownload(app))
+        .doOnNext(app -> view.removeCanceledDownload(app))
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(created -> {
         }, error -> crashReport.log(error));


### PR DESCRIPTION
**What does this PR do?**

 There is a problem regarding the lib we use to manage the downloads (FileDownloader). When a download is cancelled, "the lib" will pause it and remove it. This means that after we cancel a download, we will also get an update with a paused download (a paused download will be drawn on the view).  After that update, there would be also another one with empty information regarding the cancelled download (only with packagename and md5).
The ideal fix for this problem would be to update the lib (current version = 1.4.1, last available version =
1.7.2). This would possibly require to update all the callbacks on the DownloadTask class. Ideally there should be a callback for the removed downloads, if not we should create an issue.

This pull request fixed this issue, but it was not the best solution. The invalid (empty) updates were ignored, removing the correspondent app from the list. A blacklist for the cancelled downloads was also created, preventing them from being added to the apps list.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AppsAdapter.java
- [ ] AppsPresenter.java
- [ ] AppsFragment.java

**How should this be manually tested?**

Download an app, pause the download, press the X (cancel) button and that card should be removed.
The Updates are also treated as downloads, so same situation should happen to the updates.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-266](https://aptoide.atlassian.net/browse/ASV-266)

**Questions:**

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass