### PR TITLE
Bugfix/asv 346 app card layout breaking

### DIFF
--- a/app/src/main/res/layout/app_home_item.xml
+++ b/app/src/main/res/layout/app_home_item.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="107dp"
-    android:layout_height="156dp"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
     android:clickable="true"
     android:focusable="true"
     android:foreground="?selectableItemBackground"
@@ -27,9 +27,10 @@
         />
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_width="107dp"
+        android:layout_height="wrap_content"
         android:layout_below="@+id/icon"
+        android:layout_marginBottom="5dp"
         android:layout_marginEnd="8dp"
         android:layout_marginLeft="8dp"
         android:layout_marginRight="8dp"

--- a/app/src/main/res/layout/displayable_grid_ad.xml
+++ b/app/src/main/res/layout/displayable_grid_ad.xml
@@ -2,8 +2,8 @@
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="107dp"
-    android:layout_height="156dp"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
     android:clickable="true"
     android:foreground="?selectableItemBackground"
     >
@@ -27,9 +27,10 @@
         />
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_width="107dp"
+        android:layout_height="wrap_content"
         android:layout_below="@+id/icon"
+        android:layout_marginBottom="5dp"
         android:layout_marginEnd="8dp"
         android:layout_marginLeft="8dp"
         android:layout_marginRight="8dp"

--- a/app/src/main/res/layout/displayable_grid_app.xml
+++ b/app/src/main/res/layout/displayable_grid_app.xml
@@ -1,15 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:clickable="true"
+    android:focusable="true"
     android:foreground="?selectableItemBackground"
     >
-  <include
-      layout="@layout/app_home_item"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      />
 
-</FrameLayout>
+  <RelativeLayout
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:orientation="vertical"
+      android:paddingBottom="5dp"
+      android:paddingTop="8dp"
+      style="?attr/backgroundCard"
+      >
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="88dp"
+        android:layout_height="88dp"
+        android:layout_centerHorizontal="true"
+        android:adjustViewBounds="true"
+        android:contentDescription="@null"
+        />
+
+    <LinearLayout
+        android:layout_width="107dp"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/icon"
+        android:layout_marginBottom="5dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="4dp"
+        android:orientation="vertical"
+        >
+
+      <TextView
+          android:id="@+id/name"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:ellipsize="end"
+          android:lines="2"
+          style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
+          />
+
+      <include
+          layout="@layout/rating_label"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginLeft="1dp"
+          android:layout_marginStart="1dp"
+          />
+
+    </LinearLayout>
+
+  </RelativeLayout>
+
+</android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/displayable_grid_app.xml
+++ b/app/src/main/res/layout/displayable_grid_app.xml
@@ -1,84 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="107dp"
-    android:layout_height="156dp"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
     android:clickable="true"
     android:foreground="?selectableItemBackground"
     >
+  <include
+      layout="@layout/app_home_item"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      />
 
-  <RelativeLayout
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:orientation="vertical"
-      android:paddingBottom="5dp"
-      android:paddingTop="8dp"
-      style="?attr/backgroundCard"
-      >
-
-    <ImageView
-        android:id="@+id/icon"
-        android:layout_width="88dp"
-        android:layout_height="88dp"
-        android:layout_centerHorizontal="true"
-        android:adjustViewBounds="true"
-        android:contentDescription="@null"
-        />
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@+id/icon"
-        android:layout_marginEnd="8dp"
-        android:layout_marginLeft="8dp"
-        android:layout_marginRight="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="4dp"
-        android:orientation="vertical"
-        >
-
-      <TextView
-          android:id="@+id/name"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:ellipsize="end"
-          android:lines="2"
-          style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
-          />
-
-      <LinearLayout
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginLeft="1dp"
-          android:layout_marginStart="1dp"
-          android:layout_marginTop="2dp"
-          android:orientation="horizontal"
-          >
-
-        <ImageView
-            android:layout_width="10dp"
-            android:layout_height="10dp"
-            android:layout_gravity="center_vertical"
-            android:src="@drawable/ic_star_black"
-            />
-        <TextView
-            android:id="@+id/rating_label"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="1dp"
-            android:layout_marginLeft="5dp"
-            android:layout_marginStart="5dp"
-            android:textSize="10sp"
-            tools:ignore="SmallSp"
-            tools:text="2.3"
-            style="@style/Aptoide.TextView.Regular.XXS.Black"
-            />
-
-      </LinearLayout>
-
-    </LinearLayout>
-
-  </RelativeLayout>
-
-</android.support.v7.widget.CardView>
+</FrameLayout>


### PR DESCRIPTION
**What does this PR do?**

   This PR aims to fix a bug with the new app cards. On certain devices the bottom of the card would be cut off, hiding the app rating. There was also a bug where the cards would have to much spacing between them inside certain bundles on high dpi devices.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] app_home_item.xml
- [ ] displayable_grid_app.xml

**How should this be manually tested?**

Check on a high dpi device and that the described bugs are no longer happening.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-346](<https://aptoide.atlassian.net/browse/ASV-346>)

**Code Review Checklist**

- [x] Architecture
- [x] Documentation on public interfaces
- [x] Database changed?
- [ ] If yes - Database migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [ ] Partners build
- [x] Unit tests pass
- [x] Functional QA tests pass