### PR TITLE
[ASV-252] Fix: Install on TV and Share buttons in AppViewFragment sto…

### DIFF
--- a/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -165,6 +165,7 @@ public class AppViewFragment extends AptoideBaseFragment<BaseAdapter> implements
   private PublishRelay installAppRelay;
   private NotLoggedInShareAnalytics notLoggedInShareAnalytics;
   private CrashReport crashReport;
+  private Observable<MenuItem> toolbarMenuItemClick;
 
   public static AppViewFragment newInstanceUname(String uname) {
     Bundle bundle = new Bundle();
@@ -440,11 +441,10 @@ public class AppViewFragment extends AptoideBaseFragment<BaseAdapter> implements
         });
 
     final Toolbar toolbar = getToolbar();
-    final Observable<MenuItem> toolbarMenuItemClick = RxToolbar.itemClicks(toolbar)
+    toolbarMenuItemClick = RxToolbar.itemClicks(toolbar)
         .publish()
         .autoConnect();
 
-    handleMenuItemClick(toolbarMenuItemClick);
   }
 
   @Override public void load(boolean create, boolean refresh, Bundle savedInstanceState) {
@@ -514,6 +514,8 @@ public class AppViewFragment extends AptoideBaseFragment<BaseAdapter> implements
   }
 
   @Override public void onResume() {
+    handleMenuItemClick(toolbarMenuItemClick);
+
     super.onResume();
 
     // restore download bar status

--- a/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -85,7 +85,6 @@ import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.notification.NotificationAnalytics;
 import cm.aptoide.pt.preferences.managed.ManagerPreferences;
 import cm.aptoide.pt.repository.RepositoryFactory;
-import cm.aptoide.pt.search.SuggestionCursorAdapter;
 import cm.aptoide.pt.search.model.SearchAdResult;
 import cm.aptoide.pt.share.ShareAppHelper;
 import cm.aptoide.pt.store.StoreAnalytics;
@@ -444,7 +443,6 @@ public class AppViewFragment extends AptoideBaseFragment<BaseAdapter> implements
     toolbarMenuItemClick = RxToolbar.itemClicks(toolbar)
         .publish()
         .autoConnect();
-
   }
 
   @Override public void load(boolean create, boolean refresh, Bundle savedInstanceState) {


### PR DESCRIPTION

**What does this PR do?**
   
   Fix: When in an AppView, when the app comes back to foreground, the "install on tv" and "share" menu items no longer respond to click.

   Solved by moving "handleMenuItemClick" from onViewCreated to onResume

**Database changed?**

    No

**Where should the reviewer start?**

- [ ] AppViewFragment.java

**How should this be manually tested?**

  In an AppView, put the app in background, and then back to foreground and click the menu items.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-252]([](https://aptoide.atlassian.net/browse/ASV-252))


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass