### PR TITLE
[ASV-285] Fixed mature not being sent in the listSearchApps request;

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -886,10 +886,11 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
       BodyInterceptor<cm.aptoide.pt.dataprovider.ws.v7.BaseBody> baseBodyBodyInterceptor,
       @Named("default") SharedPreferences sharedPreferences, TokenInvalidator tokenInvalidator,
       @Named("default") OkHttpClient okHttpClient, Converter.Factory converterFactory,
-      Database database, AdsRepository adsRepository) {
+      Database database, AdsRepository adsRepository, AptoideAccountManager accountManager) {
     return new SearchManager(sharedPreferences, tokenInvalidator, baseBodyBodyInterceptor,
         okHttpClient, converterFactory, StoreUtils.getSubscribedStoresAuthMap(
-        AccessorFactory.getAccessorFor(database, Store.class)), adsRepository, database);
+        AccessorFactory.getAccessorFor(database, Store.class)), adsRepository, database,
+        accountManager);
   }
 
   @Singleton @Provides SearchSuggestionManager providesSearchSuggestionManager(

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/ListSearchAppsRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/ListSearchAppsRequest.java
@@ -74,16 +74,16 @@ public class ListSearchAppsRequest extends V7<ListSearchApps, ListSearchAppsRequ
       boolean trustedOnly, List<Long> subscribedStoresIds,
       BodyInterceptor<BaseBody> bodyInterceptor, OkHttpClient httpClient,
       Converter.Factory converterFactory, TokenInvalidator tokenInvalidator,
-      SharedPreferences sharedPreferences) {
+      SharedPreferences sharedPreferences, Boolean isMature) {
 
     if (addSubscribedStores) {
       return new ListSearchAppsRequest(
           new Body(Endless.DEFAULT_LIMIT, offset, query, subscribedStoresIds, null, trustedOnly,
-              sharedPreferences), getHost(sharedPreferences), bodyInterceptor, httpClient,
+              sharedPreferences, isMature), getHost(sharedPreferences), bodyInterceptor, httpClient,
           converterFactory, tokenInvalidator);
     } else {
       return new ListSearchAppsRequest(
-          new Body(Endless.DEFAULT_LIMIT, offset, query, trustedOnly, sharedPreferences),
+          new Body(Endless.DEFAULT_LIMIT, offset, query, trustedOnly, sharedPreferences, isMature),
           getHost(sharedPreferences), bodyInterceptor, httpClient, converterFactory,
           tokenInvalidator);
     }
@@ -116,6 +116,19 @@ public class ListSearchAppsRequest extends V7<ListSearchApps, ListSearchAppsRequ
       this.trusted = trusted;
     }
 
+    public Body(Integer limit, int offset, String query, List<Long> storeIds,
+        HashMapNotNull<String, List<String>> storesAuthMap, Boolean trusted,
+        SharedPreferences sharedPreferences, Boolean isMature) {
+      super(sharedPreferences);
+      this.limit = limit;
+      this.offset = offset;
+      this.query = query;
+      this.storeIds = storeIds;
+      this.storesAuthMap = storesAuthMap;
+      this.trusted = trusted;
+      this.setMature(isMature);
+    }
+
     public Body(Integer limit, int offset, String query, List<String> storeNames, Boolean trusted,
         SharedPreferences sharedPreferences) {
       super(sharedPreferences);
@@ -145,6 +158,16 @@ public class ListSearchAppsRequest extends V7<ListSearchApps, ListSearchAppsRequ
       this.offset = offset;
       this.query = query;
       this.trusted = trusted;
+    }
+
+    public Body(Integer limit, int offset, String query, Boolean trusted,
+        SharedPreferences sharedPreferences, Boolean isMature) {
+      super(sharedPreferences);
+      this.limit = limit;
+      this.offset = offset;
+      this.query = query;
+      this.trusted = trusted;
+      this.setMature(isMature);
     }
 
     public String getQuery() {


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix the problem with mature not being sent on listSearchApps request

**Database changed?**

No

**Where should the reviewer start?**

- [ ] SearchManager.java
- [ ] ListSearchAppsRequest.java

**How should this be manually tested?**

Open charles, do search, verify that the mature field matches the preference you have selected 

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-285](<https://aptoide.atlassian.net/browse/ASV-285>)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass