### PR TITLE
[ASV-398]Changes permissions for wifi/mobile to prevent breaking the …

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/permission/PermissionServiceActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/permission/PermissionServiceActivity.java
@@ -158,7 +158,7 @@ import rx.functions.Action0;
     if ((AptoideUtils.SystemU.getConnectionType(connectivityManager)
         .equals("mobile") && !ManagerPreferences.getDownloadsWifiOnly(sharedPreferences))) {
 
-        message = R.string.general_downloads_dialog_only_wifi_message;
+      message = R.string.general_downloads_dialog_only_wifi_message;
 
       showMessageOKCancel(message, new SimpleSubscriber<GenericDialogs.EResponse>() {
 

--- a/app/src/main/java/cm/aptoide/pt/permission/PermissionServiceActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/permission/PermissionServiceActivity.java
@@ -153,26 +153,12 @@ import rx.functions.Action0;
 
   @Override public void requestDownloadAccess(@Nullable Action0 toRunWhenAccessIsGranted,
       @Nullable Action0 toRunWhenAccessIsDenied) {
-    int message = R.string.general_downloads_dialog_no_download_rule_message;
+    int message;
 
     if ((AptoideUtils.SystemU.getConnectionType(connectivityManager)
-        .equals("mobile") && !ManagerPreferences.getGeneralDownloadsMobile(sharedPreferences)) || (
-        AptoideUtils.SystemU.getConnectionType(connectivityManager)
-            .equals("wifi")
-            && !ManagerPreferences.getGeneralDownloadsWifi(sharedPreferences))) {
-      if ((AptoideUtils.SystemU.getConnectionType(connectivityManager)
-          .equals("wifi") || AptoideUtils.SystemU.getConnectionType(connectivityManager)
-          .equals("mobile"))
-          && !ManagerPreferences.getGeneralDownloadsWifi(sharedPreferences)
-          && !ManagerPreferences.getGeneralDownloadsMobile(sharedPreferences)) {
-        message = R.string.general_downloads_dialog_no_download_rule_message;
-      } else if (AptoideUtils.SystemU.getConnectionType(connectivityManager)
-          .equals("wifi") && !ManagerPreferences.getGeneralDownloadsWifi(sharedPreferences)) {
-        message = R.string.general_downloads_dialog_only_mobile_message;
-      } else if (AptoideUtils.SystemU.getConnectionType(connectivityManager)
-          .equals("mobile") && !ManagerPreferences.getGeneralDownloadsMobile(sharedPreferences)) {
+        .equals("mobile") && !ManagerPreferences.getDownloadsWifiOnly(sharedPreferences))) {
+
         message = R.string.general_downloads_dialog_only_wifi_message;
-      }
 
       showMessageOKCancel(message, new SimpleSubscriber<GenericDialogs.EResponse>() {
 

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -53,9 +53,7 @@
 
 
   <!--Dialog: general rules to download-->
-  <string name="general_downloads_dialog_only_mobile_message">You chose to download only on Mobile 3G/4G. Change settings?</string>
   <string name="general_downloads_dialog_only_wifi_message">You chose to download only on Wi-Fi. Change settings?</string>
-  <string name="general_downloads_dialog_no_download_rule_message">No download rule is set. Change settings?</string>
 
   <!--Adult content dialogs-->
   <string name="asksetadultpinmessage">Would you like to set a pin to unlock adult content?</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -15,7 +15,7 @@
         />
     <android.support.v7.preference.SwitchPreferenceCompat
         android:defaultValue="true"
-        android:key="generalnetworkmobile"
+        android:key="downloadwifionly"
         android:title="@string/setting_mobile"
         />
   </PreferenceCategory>

--- a/aptoidepreferences/src/main/java/cm/aptoide/pt/preferences/managed/ManagedKeys.java
+++ b/aptoidepreferences/src/main/java/cm/aptoide/pt/preferences/managed/ManagedKeys.java
@@ -12,7 +12,6 @@ public class ManagedKeys {
 
   public static final String HWSPECS_FILTER = "hwspecsChkBox";
   public static final String ANIMATIONS_ENABLED = "animationsEnabled";
-  public static final String GENERAL_DOWNLOADS_WIFI = "generalnetworkwifi";
   public static final String GENERAL_DOWNLOADS_WIFI_ONLY = "downloadwifionly";
   public static final String LAST_PUSH_NOTIFICATION_ID = "lastPushNotificationId";
   public static final String CHECK_AUTO_UPDATE = "checkautoupdate";

--- a/aptoidepreferences/src/main/java/cm/aptoide/pt/preferences/managed/ManagedKeys.java
+++ b/aptoidepreferences/src/main/java/cm/aptoide/pt/preferences/managed/ManagedKeys.java
@@ -13,7 +13,7 @@ public class ManagedKeys {
   public static final String HWSPECS_FILTER = "hwspecsChkBox";
   public static final String ANIMATIONS_ENABLED = "animationsEnabled";
   public static final String GENERAL_DOWNLOADS_WIFI = "generalnetworkwifi";
-  public static final String GENERAL_DOWNLOADS_MOBILE = "generalnetworkmobile";
+  public static final String GENERAL_DOWNLOADS_WIFI_ONLY = "downloadwifionly";
   public static final String LAST_PUSH_NOTIFICATION_ID = "lastPushNotificationId";
   public static final String CHECK_AUTO_UPDATE = "checkautoupdate";
   public static final String LAST_UPDATES_KEY = "last_updates_key";

--- a/aptoidepreferences/src/main/java/cm/aptoide/pt/preferences/managed/ManagerPreferences.java
+++ b/aptoidepreferences/src/main/java/cm/aptoide/pt/preferences/managed/ManagerPreferences.java
@@ -51,10 +51,6 @@ public class ManagerPreferences {
         .apply();
   }
 
-  public static boolean getGeneralDownloadsWifi(SharedPreferences sharedPreferences) {
-    return sharedPreferences.getBoolean(ManagedKeys.GENERAL_DOWNLOADS_WIFI, true);
-  }
-
   public static boolean getDownloadsWifiOnly(SharedPreferences sharedPreferences) {
     //returning the opposite because of the copy text on the preference was reverted from a version to another
     return !sharedPreferences.getBoolean(ManagedKeys.GENERAL_DOWNLOADS_WIFI_ONLY, true);

--- a/aptoidepreferences/src/main/java/cm/aptoide/pt/preferences/managed/ManagerPreferences.java
+++ b/aptoidepreferences/src/main/java/cm/aptoide/pt/preferences/managed/ManagerPreferences.java
@@ -55,9 +55,9 @@ public class ManagerPreferences {
     return sharedPreferences.getBoolean(ManagedKeys.GENERAL_DOWNLOADS_WIFI, true);
   }
 
-  public static boolean getGeneralDownloadsMobile(SharedPreferences sharedPreferences) {
+  public static boolean getDownloadsWifiOnly(SharedPreferences sharedPreferences) {
     //returning the opposite because of the copy text on the preference was reverted from a version to another
-    return !sharedPreferences.getBoolean(ManagedKeys.GENERAL_DOWNLOADS_MOBILE, true);
+    return !sharedPreferences.getBoolean(ManagedKeys.GENERAL_DOWNLOADS_WIFI_ONLY, true);
   }
 
   public static boolean getAnimationsEnabledStatus(SharedPreferences defaultSharedPreferences) {

--- a/downloadmanager/src/main/res/values/strings.xml
+++ b/downloadmanager/src/main/res/values/strings.xml
@@ -2,9 +2,7 @@
   <string name="aptoide_downloading">%s is downloading</string>
   <string name="pause_download">Pause</string>
   <string name="resume_download">Resume</string>
-  <string name="general_downloads_dialog_only_mobile_message">"You chose to download only on Mobile 3G/4G. Change settings?"</string>
   <string name="general_downloads_dialog_only_wifi_message">"You chose to download only on Wi-Fi. Change settings?"</string>
-  <string name="general_downloads_dialog_no_download_rule_message">No download rule is set. Change settings?</string>
 
   <!-- DownloadManager -->
   <string name="timeout">Network connection timeout</string>

--- a/downloadmanager/src/main/res/values/strings.xml
+++ b/downloadmanager/src/main/res/values/strings.xml
@@ -2,7 +2,6 @@
   <string name="aptoide_downloading">%s is downloading</string>
   <string name="pause_download">Pause</string>
   <string name="resume_download">Resume</string>
-  <string name="general_downloads_dialog_only_wifi_message">"You chose to download only on Wi-Fi. Change settings?"</string>
 
   <!-- DownloadManager -->
   <string name="timeout">Network connection timeout</string>


### PR DESCRIPTION
**What does this PR do?**

Fixed a bug with install rules updating from older version

**Database changed?**

No

**Where should the reviewer start?**

- [ ] PermissionServiceActivity.java

**How should this be manually tested?**

Install an old version of aptoide -> set your 3g and mobile preferences to off -> upgrade to the new version -> install an app -> should work normally now

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-398](<https://aptoide.atlassian.net/browse/ASV-398>)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass