### PR TITLE
[ASV-406] Fixed the crash when you try to navigate to install wallet without internet connection

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
@@ -21,6 +21,7 @@ import cm.aptoide.pt.analytics.NavigationTracker;
 import cm.aptoide.pt.analytics.analytics.AnalyticsManager;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.dataprovider.WebService;
+import cm.aptoide.pt.dataprovider.exception.NoNetworkConnectionException;
 import cm.aptoide.pt.dataprovider.model.v2.GetAdsResponse;
 import cm.aptoide.pt.dataprovider.model.v7.GetApp;
 import cm.aptoide.pt.dataprovider.ws.v7.GetAppRequest;
@@ -463,15 +464,18 @@ public class DeepLinkIntentReceiver extends ActivityView {
     GetApp app = null;
     if (packageName != null) {
 
-      app = GetAppRequest.of(packageName,
-          ((AptoideApplication) getApplicationContext()).getAccountSettingsBodyInterceptorPoolV7(),
-          ((AptoideApplication) getApplicationContext()).getDefaultClient(),
-          WebService.getDefaultConverter(),
-          ((AptoideApplication) getApplicationContext()).getTokenInvalidator(),
-          ((AptoideApplication) getApplicationContext()).getDefaultSharedPreferences())
-          .observe()
-          .toBlocking()
-          .first();
+      try {
+
+        app = GetAppRequest.of(packageName, ((AptoideApplication) getApplicationContext()).getAccountSettingsBodyInterceptorPoolV7(),
+            ((AptoideApplication) getApplicationContext()).getDefaultClient(), WebService.getDefaultConverter(),
+            ((AptoideApplication) getApplicationContext()).getTokenInvalidator(), ((AptoideApplication) getApplicationContext()).getDefaultSharedPreferences())
+            .observe()
+            .toBlocking()
+            .first();
+      } catch (NoNetworkConnectionException exception) {
+        intent = startFromHome();
+        return intent;
+      }
     }
 
     if (app != null && app.isOk()) {

--- a/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
@@ -466,9 +466,12 @@ public class DeepLinkIntentReceiver extends ActivityView {
 
       try {
 
-        app = GetAppRequest.of(packageName, ((AptoideApplication) getApplicationContext()).getAccountSettingsBodyInterceptorPoolV7(),
-            ((AptoideApplication) getApplicationContext()).getDefaultClient(), WebService.getDefaultConverter(),
-            ((AptoideApplication) getApplicationContext()).getTokenInvalidator(), ((AptoideApplication) getApplicationContext()).getDefaultSharedPreferences())
+        app = GetAppRequest.of(packageName,
+            ((AptoideApplication) getApplicationContext()).getAccountSettingsBodyInterceptorPoolV7(),
+            ((AptoideApplication) getApplicationContext()).getDefaultClient(),
+            WebService.getDefaultConverter(),
+            ((AptoideApplication) getApplicationContext()).getTokenInvalidator(),
+            ((AptoideApplication) getApplicationContext()).getDefaultSharedPreferences())
             .observe()
             .toBlocking()
             .first();


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix a bug where aptoide would crash when you tried to install the ASF wallet without an internet connection

**Database changed?**

No

**Where should the reviewer start?**

- [ ] DeepLinkIntentReceiver.java

**How should this be manually tested?**

Make sure you don't have ASF Wallet installed -> install trivial drive -> turn off internet -> open trivial drive -> try to install the wallet through aptoide -> you should now go to the home no network empty state instead of crashing

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-406](<https://aptoide.atlassian.net/browse/ASV-406>)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass