### PR TITLE
[ASV-422] Remove APPC bundle when empty

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/BundlesResponseMapper.java
+++ b/app/src/main/java/cm/aptoide/pt/home/BundlesResponseMapper.java
@@ -52,10 +52,13 @@ public class BundlesResponseMapper {
               ((ListApps) viewObject).getDataList()
                   .getList(), type, widgetTag), type, event, widgetTag));
         } else if (type.equals(HomeBundle.BundleType.APPCOINS_ADS)) {
-          appBundles.add(new AppBundle(title, appToRewardApp(
+          List<Application> applicationList = appToRewardApp(
               ((BaseV7EndlessDataListResponse<AppCoinsRewardApp>) viewObject).getDataList()
-                  .getList(), widgetTag), HomeBundle.BundleType.APPCOINS_ADS,
-              new Event().setName(Event.Name.getAppCoinsAds), widgetTag));
+                  .getList(), widgetTag);
+          if (!applicationList.isEmpty()) {
+            appBundles.add(new AppBundle(title, applicationList, HomeBundle.BundleType.APPCOINS_ADS,
+                new Event().setName(Event.Name.getAppCoinsAds), widgetTag));
+          }
         } else if (type.equals(HomeBundle.BundleType.ADS)) {
           appBundles.add(new AdBundle(title,
               new AdsTagWrapper(((GetAdsResponse) viewObject).getAds(), widgetTag),


### PR DESCRIPTION
**What does this PR do?**

Removes the "Get rewarded with AppCoins" bundle when the user has installed all the apps that come from the request.

**Database changed?**

   No

**Where should the reviewer start?**

BundlesResponseMapper.java

**How should this be manually tested?**

Install all the apps showed in the bundle, kill the app, get back in, the bundle should not be there
 
**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/ASV-422

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass