### PR TITLE
[ASV-285] Mature switch working for every scenario (logged in and log…

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/search/SearchManager.java
+++ b/app/src/main/java/cm/aptoide/pt/search/SearchManager.java
@@ -58,12 +58,12 @@ import rx.Single;
 
   public Single<List<SearchAppResult>> searchInNonFollowedStores(String query,
       boolean onlyTrustedApps, int offset) {
-    return accountManager.accountStatus()
+    return accountManager.enabled()
         .first()
-        .flatMap(account -> ListSearchAppsRequest.of(query, offset, false, onlyTrustedApps,
+        .flatMap(enabled -> ListSearchAppsRequest.of(query, offset, false, onlyTrustedApps,
             StoreUtils.getSubscribedStoresIds(
                 AccessorFactory.getAccessorFor(database, Store.class)), bodyInterceptor, httpClient,
-            converterFactory, tokenInvalidator, sharedPreferences, account.isAdultContentEnabled())
+            converterFactory, tokenInvalidator, sharedPreferences, enabled)
             .observe(true))
         .filter(listSearchApps -> hasResults(listSearchApps))
         .map(data -> data.getDataList()
@@ -77,12 +77,12 @@ import rx.Single;
 
   public Single<List<SearchAppResult>> searchInFollowedStores(String query, boolean onlyTrustedApps,
       int offset) {
-    return accountManager.accountStatus()
+    return accountManager.enabled()
         .first()
-        .flatMap(account -> ListSearchAppsRequest.of(query, offset, true, onlyTrustedApps,
+        .flatMap(enabled -> ListSearchAppsRequest.of(query, offset, true, onlyTrustedApps,
             StoreUtils.getSubscribedStoresIds(
                 AccessorFactory.getAccessorFor(database, Store.class)), bodyInterceptor, httpClient,
-            converterFactory, tokenInvalidator, sharedPreferences, account.isAdultContentEnabled())
+            converterFactory, tokenInvalidator, sharedPreferences, enabled)
             .observe(true))
         .filter(listSearchApps -> hasResults(listSearchApps))
         .map(data -> data.getDataList()


### PR DESCRIPTION
…ged out)

**What does this PR do?**

Fixes the mature switch toggle not having effect when the user is logged out and searching for mature content.

**Database changed?**

   No

**Where should the reviewer start?**

- [x] SearchManager.java

**How should this be manually tested?**

  Search for mature content when the mature switch is on/off both when the user is logged in and logged out

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-285](https://aptoide.atlassian.net/browse/ASV-285)

**Code Review Checklist**

- [x] Architecture
- [x] Documentation on public interfaces
- [x] Database changed?
- [x] If yes - Database migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] Partners build
- [x] Unit tests pass
- [x] Functional QA tests pass