### PR TITLE
[Bugfix/ASV-402] home bundles translations

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/AdsBundleViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/home/AdsBundleViewHolder.java
@@ -6,8 +6,10 @@ import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
+import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.utils.AptoideUtils;
+import cm.aptoide.pt.view.Translator;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +53,10 @@ class AdsBundleViewHolder extends AppBundleViewHolder {
       throw new IllegalStateException(this.getClass()
           .getName() + " is getting non AdBundle instance!");
     }
-    bundleTitle.setText(homeBundle.getTitle());
+    bundleTitle.setText(Translator.translate(homeBundle.getTitle(), itemView.getContext(),
+        ((AptoideApplication) itemView.getContext()
+            .getApplicationContext()).getMarketName()));
+
     appsInBundleAdapter.update((List<AdClick>) homeBundle.getContent());
 
     appsList.addOnScrollListener(new RecyclerView.OnScrollListener() {

--- a/app/src/main/java/cm/aptoide/pt/home/AppsBundleViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/home/AppsBundleViewHolder.java
@@ -6,8 +6,10 @@ import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
+import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.utils.AptoideUtils;
+import cm.aptoide.pt.view.Translator;
 import cm.aptoide.pt.view.app.Application;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -52,7 +54,9 @@ class AppsBundleViewHolder extends AppBundleViewHolder {
       throw new IllegalStateException(this.getClass()
           .getName() + " is getting non AppBundle instance!");
     }
-    bundleTitle.setText(homeBundle.getTitle());
+    bundleTitle.setText(Translator.translate(homeBundle.getTitle(), itemView.getContext(),
+        ((AptoideApplication) itemView.getContext()
+            .getApplicationContext()).getMarketName()));
     appsInBundleAdapter.updateBundle(homeBundle, position);
     appsInBundleAdapter.update((List<Application>) homeBundle.getContent());
     appsList.addOnScrollListener(new RecyclerView.OnScrollListener() {

--- a/app/src/main/java/cm/aptoide/pt/home/EditorsBundleViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/home/EditorsBundleViewHolder.java
@@ -6,8 +6,10 @@ import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
+import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.utils.AptoideUtils;
+import cm.aptoide.pt.view.Translator;
 import cm.aptoide.pt.view.app.Application;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -52,7 +54,9 @@ class EditorsBundleViewHolder extends AppBundleViewHolder {
       throw new IllegalStateException(this.getClass()
           .getName() + " is getting non AppBundle instance!");
     }
-    bundleTitle.setText(homeBundle.getTitle());
+    bundleTitle.setText(Translator.translate(homeBundle.getTitle(), itemView.getContext(),
+        ((AptoideApplication) itemView.getContext()
+            .getApplicationContext()).getMarketName()));
     graphicAppsAdapter.updateBundle(homeBundle, position);
     graphicAppsAdapter.update((List<Application>) homeBundle.getContent());
     graphicsList.addOnScrollListener(new RecyclerView.OnScrollListener() {


### PR DESCRIPTION
**What does this PR do?**

   Home bundle titles are now being translated again locally by the Translator.java class.

   Have in mind that this Translator class needs to be refactored in the future, here: [ASV-486](https://aptoide.atlassian.net/browse/ASV-486)

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] EditorsBundleViewHolder.java
- [ ] AppsBundleViewHolder.java
- [ ] AdsBundleViewHolder.java

**How should this be manually tested?**

  Get PT translations (you can copy the strings.xml to a values-pt folder in res/ and make your own translations). Change phone to portuguese and see if home bundle titles are being translated.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-402](https://aptoide.atlassian.net/browse/ASV-402)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass