### PR TITLE
[Bugfix/ASV-499] home bundles centered title

### DIFF
--- a/app/src/main/res/layout/home_bundle_header.xml
+++ b/app/src/main/res/layout/home_bundle_header.xml
@@ -9,7 +9,7 @@
       android:id="@+id/bundle_title"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_gravity="start"
+      android:layout_gravity="center_vertical|start"
       android:layout_marginLeft="8dp"
       android:layout_marginStart="8dp"
       tools:text="random bundle"


### PR DESCRIPTION
**What does this PR do?**

   The bundles title in home is now aligned with the center of the More button

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] home_bundle_header.xml

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-499](https://aptoide.atlassian.net/browse/ASV-499)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass