### PR TITLE
[ASV-550] AppView open type

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -51,6 +51,7 @@ public class AppViewManager {
   private DetailedApp cachedApp;
   private SearchAdResult searchAdResult;
   private SocialRepository socialRepository;
+  private String marketName;
 
   public AppViewManager(InstallManager installManager, DownloadFactory downloadFactory,
       AppCenter appCenter, ReviewsManager reviewsManager, AdsManager adsManager,
@@ -58,7 +59,8 @@ public class AppViewManager {
       AptoideAccountManager aptoideAccountManager, AppViewConfiguration appViewConfiguration,
       PreferencesManager preferencesManager, DownloadStateParser downloadStateParser,
       AppViewAnalytics appViewAnalytics, NotificationAnalytics notificationAnalytics,
-      InstallAnalytics installAnalytics, int limit, SocialRepository socialRepository) {
+      InstallAnalytics installAnalytics, int limit, SocialRepository socialRepository,
+      String marketName) {
     this.installManager = installManager;
     this.downloadFactory = downloadFactory;
     this.appCenter = appCenter;
@@ -76,6 +78,7 @@ public class AppViewManager {
     this.installAnalytics = installAnalytics;
     this.socialRepository = socialRepository;
     this.limit = limit;
+    this.marketName = marketName;
   }
 
   public Single<AppViewViewModel> loadAppViewViewModel() {
@@ -194,7 +197,7 @@ public class AppViewManager {
             app.isLatestTrustedVersion(), app.getUniqueName(), appViewConfiguration.shouldInstall(),
             appViewConfiguration.getAppc(), appViewConfiguration.getMinimalAd(),
             appViewConfiguration.getEditorsChoice(), appViewConfiguration.getOriginTag(),
-            isStoreFollowed));
+            isStoreFollowed, marketName));
   }
 
   private Single<AppViewViewModel> map(DetailedAppRequestResult result) {
@@ -305,5 +308,9 @@ public class AppViewManager {
           .setPaid();
       cachedApp.setPath(path);
     });
+  }
+
+  public String getMarketName() {
+    return marketName;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -258,12 +258,14 @@ import rx.schedulers.Schedulers;
       AppViewConfiguration appViewConfiguration, PreferencesManager preferencesManager,
       DownloadStateParser downloadStateParser, AppViewAnalytics appViewAnalytics,
       NotificationAnalytics notificationAnalytics, InstallAnalytics installAnalytics,
-      Resources resources, WindowManager windowManager, SocialRepository socialRepository) {
+      Resources resources, WindowManager windowManager, SocialRepository socialRepository,
+      @Named("marketName") String marketName) {
     return new AppViewManager(installManager, downloadFactory, appCenter, reviewsManager,
         adsManager, storeManager, flagManager, storeUtilsProxy, aptoideAccountManager,
         appViewConfiguration, preferencesManager, downloadStateParser, appViewAnalytics,
         notificationAnalytics, installAnalytics,
-        (Type.APPS_GROUP.getPerLineCount(resources, windowManager) * 6), socialRepository);
+        (Type.APPS_GROUP.getPerLineCount(resources, windowManager) * 6), socialRepository,
+        marketName);
   }
 
   @FragmentScope @Provides AppViewPresenter providesAppViewPresenter(

--- a/app/src/vanilla/java/cm/aptoide/pt/app/AppViewViewModel.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/AppViewViewModel.java
@@ -31,7 +31,7 @@ public class AppViewViewModel {
   private final String paymentStatus;
   private final boolean isLatestTrustedVersion;
   private final String uniqueName;
-  private final OpenType shouldInstall;
+  private final OpenType openType;
   private final double appc;
   private final SearchAdResult minimalAd;
   private final String editorsChoice;
@@ -64,6 +64,7 @@ public class AppViewViewModel {
   private final String icon;
   private final boolean loading;
   private final DetailedAppRequestResult.Error error;
+  private final String marketName;
 
   public AppViewViewModel(long appId, String appName, Store store, String storeTheme,
       boolean isGoodApp, Malware malware, AppFlags appFlags, List<String> tags,
@@ -73,8 +74,8 @@ public class AppViewViewModel {
       AppDeveloper appDeveloper, String graphic, String icon, AppMedia media, String modified,
       String appAdded, Obb obb, GetAppMeta.Pay pay, String webUrls, boolean isPaid, boolean wasPaid,
       String paidAppPath, String paymentStatus, boolean isLatestTrustedVersion, String uniqueName,
-      OpenType shouldInstall, double appc, SearchAdResult minimalAd, String editorsChoice,
-      String originTag, boolean isStoreFollowed) {
+      OpenType openType, double appc, SearchAdResult minimalAd, String editorsChoice,
+      String originTag, boolean isStoreFollowed, String marketName) {
     this.appId = appId;
     this.appName = appName;
     this.store = store;
@@ -112,12 +113,13 @@ public class AppViewViewModel {
     this.paymentStatus = paymentStatus;
     this.isLatestTrustedVersion = isLatestTrustedVersion;
     this.uniqueName = uniqueName;
-    this.shouldInstall = shouldInstall;
+    this.openType = openType;
     this.appc = appc;
     this.minimalAd = minimalAd;
     this.editorsChoice = editorsChoice;
     this.originTag = originTag;
     this.isStoreFollowed = isStoreFollowed;
+    this.marketName = marketName;
     this.loading = false;
     this.error = null;
   }
@@ -161,11 +163,12 @@ public class AppViewViewModel {
     this.paymentStatus = "";
     this.isLatestTrustedVersion = false;
     this.uniqueName = "";
-    this.shouldInstall = null;
+    this.openType = null;
     this.appc = -1;
     this.minimalAd = null;
     this.editorsChoice = "";
     this.originTag = "";
+    marketName = "";
     this.isStoreFollowed = false;
     this.error = null;
   }
@@ -209,11 +212,12 @@ public class AppViewViewModel {
     this.paymentStatus = "";
     this.isLatestTrustedVersion = false;
     this.uniqueName = "";
-    this.shouldInstall = null;
+    this.openType = null;
     this.appc = -1;
     this.minimalAd = null;
     this.editorsChoice = "";
     this.originTag = "";
+    marketName = "";
     this.isStoreFollowed = false;
     this.loading = false;
   }
@@ -362,8 +366,8 @@ public class AppViewViewModel {
     return uniqueName;
   }
 
-  public OpenType getShouldInstall() {
-    return shouldInstall;
+  public OpenType getOpenType() {
+    return openType;
   }
 
   public double getAppc() {
@@ -400,5 +404,9 @@ public class AppViewViewModel {
 
   public String getPaymentStatus() {
     return paymentStatus;
+  }
+
+  public String getMarketName() {
+    return marketName;
   }
 }

--- a/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -534,7 +534,24 @@ public class AppViewPresenter implements Presenter {
           }
         })
         .flatMap(appViewModel -> {
-          if (appViewModel.getOpenType() == NewAppViewFragment.OpenType.OPEN_WITH_INSTALL_POPUP) {
+          if (appViewModel.getOpenType() == NewAppViewFragment.OpenType.OPEN_AND_INSTALL) {
+
+            return accountManager.accountStatus()
+                .observeOn(viewScheduler)
+                .flatMapCompletable(
+                    accountStatus -> downloadApp(DownloadAppViewModel.Action.INSTALL,
+                        appViewModel.getPackageName(), appViewModel.getAppId()).observeOn(
+                        viewScheduler)
+                        .doOnCompleted(() -> {
+                          appViewAnalytics.clickOnInstallButton(appViewModel.getPackageName(),
+                              appViewModel.getDeveloper()
+                                  .getName(), DownloadAppViewModel.Action.INSTALL.toString());
+                          showRecommendsDialog(accountStatus.isLoggedIn(),
+                              appViewModel.getPackageName());
+                        }))
+                .map(__ -> appViewModel);
+          } else if (appViewModel.getOpenType()
+              == NewAppViewFragment.OpenType.OPEN_WITH_INSTALL_POPUP) {
 
             return accountManager.accountStatus()
                 .observeOn(viewScheduler)

--- a/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewView.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewView.java
@@ -2,6 +2,7 @@ package cm.aptoide.pt.app.view;
 
 import android.view.MenuItem;
 import cm.aptoide.pt.app.AppViewViewModel;
+import cm.aptoide.pt.app.DownloadAppViewModel;
 import cm.aptoide.pt.app.ReviewsViewModel;
 import cm.aptoide.pt.app.SimilarAppsViewModel;
 import cm.aptoide.pt.app.view.screenshots.ScreenShotClickEvent;
@@ -131,4 +132,6 @@ public interface AppViewView extends InstallAppView {
   void extractReferrer(SearchAdResult searchAdResult);
 
   void recoverScrollViewState();
+
+  Observable<DownloadAppViewModel.Action> showOpenAndInstallDialog(String title, String appName);
 }

--- a/app/src/vanilla/java/cm/aptoide/pt/app/view/NewAppViewFragment.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/view/NewAppViewFragment.java
@@ -977,6 +977,14 @@ public class NewAppViewFragment extends NavigationTrackFragment implements AppVi
     scrollView.post(() -> scrollView.scrollTo(0, scrollViewY));
   }
 
+  @Override public Observable<DownloadAppViewModel.Action> showOpenAndInstallDialog(String title,
+      String appName) {
+    return GenericDialogs.createGenericOkCancelMessage(getContext(), title,
+        getContext().getString(R.string.installapp_alrt, appName))
+        .filter(response -> response.equals(YES))
+        .map(__ -> action);
+  }
+
   private void setTrustedBadge(Malware malware) {
     @DrawableRes int badgeResId;
     @StringRes int badgeMessageId;


### PR DESCRIPTION
**What does this PR do?**

Starts the installation after opening appview if the appview open type is OPEN_AND_INSTALL or OPEN_WITH_INSTALL_POPUP. If the type is OPEN_WITH_INSTALL_POPUP, then a dialog should be shown to the user asking confirmation if he really wants to install the app.
The start of the download should be the same as it is in the normal flow. The recommends dialog should be shown when it is needed (if not logged in, on the 2nd and 4th install click, if logged in, every time until the user presses don't show me again) and the same analytics should be logged.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppViewPresenter.java

**How should this be manually tested?**

Open any part of the app where these open types are passed.
If you want to test it in an easier way, just change the homeNavigator method to navigate to the appview, making it use the wanted open type instead of the open_only (which is the default open type).

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-550](https://aptoide.atlassian.net/browse/ASV-550)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass