### PR TITLE
[ASV-559] Get app request error

### DIFF
--- a/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -514,6 +514,14 @@ public class AppViewPresenter implements Presenter {
                 .toSingle()
                 .map(downloadAppViewModel -> appViewViewModel))
         .toObservable()
+        .observeOn(viewScheduler)
+        .doOnNext(appViewModel -> {
+          if (appViewModel.hasError()) {
+            view.handleError(appViewModel.getError());
+          } else {
+            view.populateAppDetails(appViewModel);
+          }
+        })
         .doOnNext(model -> {
           if (!model.getEditorsChoice()
               .isEmpty()) {
@@ -524,14 +532,6 @@ public class AppViewPresenter implements Presenter {
               .getName(), model.getMalware()
               .getRank()
               .name(), model.getAppc());
-        })
-        .observeOn(viewScheduler)
-        .doOnNext(appViewModel -> {
-          if (appViewModel.hasError()) {
-            view.handleError(appViewModel.getError());
-          } else {
-            view.populateAppDetails(appViewModel);
-          }
         })
         .doOnNext(appViewViewModel -> view.recoverScrollViewState())
         .filter(model -> !model.hasError())

--- a/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -480,9 +480,10 @@ public class AppViewPresenter implements Presenter {
   private void handleClickOnRetry() {
     view.getLifecycle()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
-        .flatMap(__ -> Observable.merge(view.clickNoNetworkRetry(), view.clickGenericRetry()))
-        .doOnNext(__ -> view.showLoading())
-        .flatMap(__ -> loadApp())
+        .flatMap(__ -> Observable.merge(view.clickNoNetworkRetry(), view.clickGenericRetry())
+            .doOnNext(__1 -> view.showLoading())
+            .flatMap(__2 -> loadApp())
+            .retry())
         .subscribe(__ -> {
         }, e -> crashReport.log(e));
   }


### PR DESCRIPTION
**What does this PR do?**

Before, when the appview get app request was done, if the response had an error, the appview would be locked on the loading state. Now it navigates to the error view.

Also fixed the retry button click. Before, if you pressed the retry button and there was an error again, that chain would also break and the retry button would stop working.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppViewPresenter.java

**How should this be manually tested?**
Turn off network before opening appview to force an error on the getApp request. Then check if the no network view is shown.
Check if the retry button also works.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-559](https://aptoide.atlassian.net/browse/ASV-559)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass