### PR TITLE
[ASV-580] delete account client

### DIFF
--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -131,8 +131,9 @@
         android:key="hwspecs"
         android:summary="@string/setting_hwspecssum"
         android:title="@string/setting_hwspecstitle"/>
-    <!--<Preference-->
-    <!--android:key="deleteAccount"-->
-    <!--android:title="@string/settings_delete_account"/>-->
+    <Preference
+        android:key="deleteAccount"
+        android:title="@string/settings_delete_account"/>
+
   </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/vanilla/java/cm/aptoide/pt/view/settings/SettingsFragment.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/view/settings/SettingsFragment.java
@@ -249,13 +249,19 @@ public class SettingsFragment extends PreferenceFragmentCompat
     }
   }
 
+  private void handleDeleteAccountVisibility() {
+    subscriptions.add(accountManager.accountStatus()
+        .doOnNext(account -> deleteAccount.setVisible(account.isLoggedIn()))
+        .subscribe());
+  }
+
   private boolean shouldRefreshUpdates(String key) {
     return key.equals(ManagedKeys.UPDATES_FILTER_ALPHA_BETA_KEY) || key.equals(
         ManagedKeys.HWSPECS_FILTER) || key.equals(ManagedKeys.UPDATES_SYSTEM_APPS_KEY);
   }
 
   private void setupClickHandlers() {
-
+    handleDeleteAccountVisibility();
     Preference autoUpdatepreference = findPreference(SettingsConstants.CHECK_AUTO_UPDATE);
     autoUpdatepreference.setTitle(
         AptoideUtils.StringU.getFormattedString(R.string.setting_category_autoupdate_title,


### PR DESCRIPTION
**What does this PR do?**

   Added the delete account preference. If the user clicks on it, it will open a webview where the user can delete his account. This preference is only available if the user is logged in.
**Database changed?**

   No

**Where should the reviewer start?**

- [ ] SettingsFragment.java

**How should this be manually tested?**

Open settings after being logged in.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-580](https://aptoide.atlassian.net/browse/ASV-580)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass