### PR TITLE
[ASV-444] Set App Card Width to 104dp

### DIFF
--- a/app/src/main/res/layout/app_home_item.xml
+++ b/app/src/main/res/layout/app_home_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    android:layout_width="104dp"
     android:layout_height="wrap_content"
     android:clickable="true"
     android:focusable="true"

--- a/app/src/main/res/layout/displayable_grid_ad.xml
+++ b/app/src/main/res/layout/displayable_grid_ad.xml
@@ -2,7 +2,7 @@
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
+    android:layout_width="104dp"
     android:layout_height="wrap_content"
     android:clickable="true"
     android:foreground="?selectableItemBackground"

--- a/app/src/main/res/layout/displayable_grid_app.xml
+++ b/app/src/main/res/layout/displayable_grid_app.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    android:layout_width="104dp"
     android:layout_height="wrap_content"
     android:clickable="true"
     android:focusable="true"

--- a/app/src/main/res/layout/reward_app_home_item.xml
+++ b/app/src/main/res/layout/reward_app_home_item.xml
@@ -2,7 +2,7 @@
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
+    android:layout_width="104dp"
     android:layout_height="wrap_content"
     android:clickable="true"
     android:focusable="true"


### PR DESCRIPTION
**What does this PR do?**

   Sets the width of the App Card to the one in zeplin
   **NOTE:** In the bundles that it's just a list of apps (Highlights, specific bundles...) there's a small odd space on the right, don't know if it's suppose or not or if it's ok. Still need to talk to Luis about it.

**Database changed?**

No

**How should this be manually tested?**

See if there's any problem with the size of the appCard in different devices

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/ASV-444

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass