### PR TITLE
[ASV-672] repeat failed request

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/networking/BodyInterceptorV7.java
+++ b/app/src/main/java/cm/aptoide/pt/networking/BodyInterceptorV7.java
@@ -45,6 +45,8 @@ public class BodyInterceptorV7 implements BodyInterceptor<BaseBody> {
 
           if (authentication.isAuthenticated()) {
             body.setAccessToken(authentication.getAccessToken());
+          } else {
+            body.setAccessToken(null);
           }
 
           body.setAptoideId(idsRepository.getUniqueIdentifier());

--- a/app/src/main/java/cm/aptoide/pt/networking/RefreshTokenInvalidator.java
+++ b/app/src/main/java/cm/aptoide/pt/networking/RefreshTokenInvalidator.java
@@ -63,11 +63,12 @@ public class RefreshTokenInvalidator implements TokenInvalidator {
                 (throwable, i) -> {
                   if (i < MAX_REFRESH_TOKEN_RETRIES) {
                     if (throwable instanceof AptoideWsV3Exception) {
-                      return Observable.just(null);
+                      return null;
                     }
                   } else {
                     if (throwable instanceof AptoideWsV3Exception) {
                       logoutSubject.onNext(null);
+                      return Completable.complete();
                     }
                   }
                   throw new RuntimeException(throwable);

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/V7.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/V7.java
@@ -237,10 +237,10 @@ public abstract class V7<U, B extends RefreshBody> extends WebService<V7.Interfa
         if (INVALID_ACCESS_TOKEN_CODE.equals(((AptoideWsV7Exception) throwable).getBaseResponse()
             .getError()
             .getCode())) {
-
           if (!accessTokenRetry) {
             accessTokenRetry = true;
             return tokenInvalidator.invalidateAccessToken()
+                .delay(500, TimeUnit.MILLISECONDS)
                 .andThen(V7.this.observe(bypassCache));
           } else {
             return Observable.error(new NetworkErrorException());


### PR DESCRIPTION
**What does this PR do?**

  This is an action that needs to be done following the ticket ASV-564. On that ticket, we are logging out the user but the request that failed was not being repeated. On this ticket we are repeating the request that failed, but now without the access token since it is invalid.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] BodyInterceptorV7.java

**How should this be manually tested?**

To test this, you should create an account (if you dont want to delete one that you already have), then delete it. Wait for the confirmation email that the account was deleted and then there 2 possible ways to test it : 
- 1) Leave the app open before receiving the confirmation email on any bottom navigation section (apps for example) and then as soon as you receive the confirmation email open the Home and confirm that all the home requests will be done (failing first and then repeated with no access token).
- 2) Close the app after deleting the account. Wait for the confirmation email, open the app as soon as you get the confirmation email and check that the first requests will fail and then the repetition will work (without the access token).

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-672](https://aptoide.atlassian.net/browse/ASV-672)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass