### PR TITLE
ASV-737_editor_choice

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/view/Translator.java
+++ b/app/src/main/java/cm/aptoide/pt/view/Translator.java
@@ -269,6 +269,7 @@ import cm.aptoide.pt.utils.AptoideUtils;
       case "Editor's Choice":
       case "Editors' Choice":
         translated = context.getString(R.string.home_title_editors_choice);
+        break;
       case "More Editors Choice":
       case "More Editor's Choice":
       case "More Editors' Choice":

--- a/app/src/main/java/cm/aptoide/pt/view/Translator.java
+++ b/app/src/main/java/cm/aptoide/pt/view/Translator.java
@@ -265,6 +265,10 @@ import cm.aptoide.pt.utils.AptoideUtils;
       case "Play-it!":
         translated = context.getString(R.string.title_play_it);
         break;
+      case "Editors Choice":
+      case "Editor's Choice":
+      case "Editors' Choice":
+        translated = context.getString(R.string.home_title_editors_choice);
       case "More Editors Choice":
       case "More Editor's Choice":
       case "More Editors' Choice":

--- a/app/src/main/java/cm/aptoide/pt/view/Translator.java
+++ b/app/src/main/java/cm/aptoide/pt/view/Translator.java
@@ -270,11 +270,6 @@ import cm.aptoide.pt.utils.AptoideUtils;
       case "Editors' Choice":
         translated = context.getString(R.string.home_title_editors_choice);
         break;
-      case "More Editors Choice":
-      case "More Editor's Choice":
-      case "More Editors' Choice":
-        translated = context.getString(R.string.more_editors_choice);
-        break;
       case "Comments in this store":
       case "Comments on this store":
         translated = context.getString(R.string.comment_store_title);

--- a/app/src/main/res/layout/button.xml
+++ b/app/src/main/res/layout/button.xml
@@ -8,7 +8,7 @@
     android:id="@+id/button"
     android:layout_width="match_parent"
     android:layout_height="48dp"
-    android:text="@string/more_editors_choice"
+    android:text=""
     android:textColor="@color/white"
     >
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,7 +270,6 @@
   <string name="essential_apps">Essential Apps</string>
   <string name="summer_apps">Summer Apps</string>
   <string name="title_play_it">Play-It!</string>
-  <string name="more_editors_choice">More Editors\' Choice</string>
   <string name="home_title_editors_choice">Editors\' Choice</string>
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,6 +270,8 @@
   <string name="essential_apps">Essential Apps</string>
   <string name="summer_apps">Summer Apps</string>
   <string name="title_play_it">Play-It!</string>
+  <string name="more_editors_choice">More Editors\' Choice</string>
+  <string name="home_title_editors_choice">Editors\' Choice</string>
 
 
   <!--home Fragment-->
@@ -443,7 +445,6 @@
   <string name="root_access_dialog">It seems you have root. Would you like to allow auto install app after download?</string>
 
   <string name="order_popup_title3">Adult Content</string>
-  <string name="more_editors_choice">More Editors\' Choice</string>
   <string name="more_versions">More Versions</string>
 
   <!-- Review Activity-->


### PR DESCRIPTION
**What does this PR do?**

   "Editor's choice" bundle title was not in the Translator.java file

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Translator.java
- [ ] string.xml

**How should this be manually tested?**

- Remember that translations are not in aptoide-client-v8 repo.
- Manually create values-pt
- Add strings file with 
  <string name="home_title_editors_choice">Escolha dos editores</string>
- Open the app

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/ASV-737

**Questions:**

   No




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass