### PR TITLE
[ASV-760] Fixed reported bug with dialogs having white text on a whit…

### DIFF
--- a/app/src/main/res/layout/appview_uploaded_by_layout.xml
+++ b/app/src/main/res/layout/appview_uploaded_by_layout.xml
@@ -31,6 +31,7 @@
         android:id="@+id/store_icon"
         android:layout_width="42dp"
         android:layout_height="42dp"
+        android:layout_centerVertical="true"
         android:layout_marginLeft="18dp"
         android:layout_marginStart="18dp"
         tools:src="@mipmap/ic_launcher"
@@ -39,6 +40,7 @@
     <RelativeLayout
         android:layout_width="137dp"
         android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
         android:layout_marginLeft="12dp"
         android:layout_marginStart="12dp"
         android:layout_toEndOf="@id/store_icon"
@@ -117,7 +119,8 @@
         android:layout_marginEnd="16dp"
         android:layout_marginRight="16dp"
         android:text="@string/follow"
-        style="@style/Aptoide.Button.Ghost.S"
+        android:textSize="?attr/buttonTextSizeSmall"
+        style="@style/Aptoide.Button.Ghost"
         />
   </RelativeLayout>
 

--- a/app/src/main/res/layout/displayable_app_view_rate_and_comment.xml
+++ b/app/src/main/res/layout/displayable_app_view_rate_and_comment.xml
@@ -32,7 +32,7 @@
         android:textAllCaps="true"
         android:textColor="@color/silver_dark"
         android:textSize="@dimen/text_size_small"
-        style="@style/Aptoide.Button.Ghost.Grey"
+        style="@style/Aptoide.Button.Ghost.S.Grey"
         />
 
     <TextView
@@ -138,7 +138,7 @@
       android:textColor="@color/silver_dark"
       android:textSize="@dimen/text_size_small"
       tools:visibility="gone"
-      style="@style/Aptoide.Button.Ghost.Grey"
+      style="@style/Aptoide.Button.Ghost.S.Grey"
       />
   <RelativeLayout
       android:id="@+id/rating_layout"
@@ -160,7 +160,7 @@
         android:textColor="@color/silver_dark"
         android:textSize="@dimen/text_size_small"
         android:visibility="visible"
-        style="@style/Aptoide.Button.Ghost.Grey"
+        style="@style/Aptoide.Button.Ghost.S.Grey"
         />
 
     <RelativeLayout

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -501,9 +501,9 @@
   </style>
 
   <style name="AlertDialogAptoide" parent="@style/ThemeOverlay.AppCompat.Dialog.Alert">
+    <item name="android:theme">@style/AppBaseTheme</item>
     <item name="android:colorAccent">?attr/preferenceTitleColor</item>
-    <item name="android:textColor">?attr/preferenceTitleColor</item>
-    <item name="android:textColorPrimary">?attr/preferenceTitleColor</item>
+    <item name="android:textColorPrimary">@android:color/black</item>
     <item name="android:textColorSecondary">?attr/preferenceTitleColor</item>
     <item name="android:buttonStyle">@style/AlertTextAppearanceAptoide</item>
   </style>

--- a/app/src/main/res/values/styles_aptoide_button.xml
+++ b/app/src/main/res/values/styles_aptoide_button.xml
@@ -47,6 +47,11 @@
     <item name="android:textColor">@color/grey</item>
   </style>
 
+  <style name="Aptoide.Button.Ghost.S.Grey">
+    <item name="android:background">@drawable/btn_ghost_theme_grey_fog_light</item>
+    <item name="android:textColor">@color/grey</item>
+  </style>
+
   <style name="Aptoide.Button.S.Gradient">
     <item name="android:background">@drawable/aptoide_gradient</item>
   </style>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -54,7 +54,7 @@
 
     <!--text-->
     <item name="defaultTextStyle">@style/Widget.Aptoide.defaultColorText</item>
-    <item name="android:textColorPrimary">@android:color/white</item>
+    <item name="android:textColorPrimary">@android:color/black</item>
     <item name="android:textColorSecondary">@android:color/tertiary_text_light</item>
     <item name="tertiaryTextColor">@android:color/black</item>
     <item name="inverseTextColor">@android:color/white</item>


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix the reported bugs on some devices related to dialogs having white text over white backgrounds. It also fixed some buttons as requested by Luis.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] themes.xml
- [ ] styles.xml

**How should this be manually tested?**

 Rewrite the auto-update request in charles and verify that dialog. Also verify that the permissions dialog has orange buttons now;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-760](<https://aptoide.atlassian.net/browse/ASV-760>)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass