### PR TITLE
[ASV-606] Change on install on tv dialog layout

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/install/view/remote/ReceiverDeviceAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/install/view/remote/ReceiverDeviceAdapter.java
@@ -1,6 +1,7 @@
 package cm.aptoide.pt.install.view.remote;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -19,7 +20,6 @@ public class ReceiverDeviceAdapter
   private Context context;
   private List<ReceiverDevice> devices;
   private int resource;
-  private String appId;
 
   public ReceiverDeviceAdapter(Context context, int resource, List<ReceiverDevice> devices) {
     super(context, resource, devices);
@@ -43,7 +43,8 @@ public class ReceiverDeviceAdapter
     }
   }
 
-  @Override public View getView(int position, View convertView, ViewGroup parent) {
+  @NonNull @Override
+  public View getView(int position, View convertView, @NonNull ViewGroup parent) {
     ReceiverDevice app = getItem(position);
 
     if (convertView == null) {
@@ -51,12 +52,8 @@ public class ReceiverDeviceAdapter
           .inflate(R.layout.row_remote_install, parent, false);
     }
     TextView deviceName = (TextView) convertView.findViewById(R.id.deviceNameText);
-    deviceName.setText(app.getDeviceName());
+    if (app != null) deviceName.setText(app.getDeviceName());
 
     return convertView;
-  }
-
-  public void setAppId(String appId) {
-    this.appId = appId;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/install/view/remote/RemoteInstallDialog.java
+++ b/app/src/main/java/cm/aptoide/pt/install/view/remote/RemoteInstallDialog.java
@@ -125,7 +125,6 @@ public class RemoteInstallDialog extends BaseDialog implements RemoteInstallatio
     List<ReceiverDevice> devices = new ArrayList<>();
     adapter = new ReceiverDeviceAdapter(getActivity().getApplicationContext(),
         R.layout.row_remote_install, devices);
-    adapter.setAppId(app);
     listView.setAdapter(adapter);
   }
 

--- a/app/src/main/res/layout/dialog_remote_install.xml
+++ b/app/src/main/res/layout/dialog_remote_install.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/rounded_corners_bg"
@@ -20,9 +21,9 @@
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
-        android:layout_marginStart="8sp"
+        android:layout_marginLeft="15dp"
+        android:layout_marginStart="15dp"
         android:layout_marginTop="17dp"
-        android:paddingLeft="7dp"
         android:text="@string/remote_install_title"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="#ff6600"
@@ -81,6 +82,7 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:orientation="vertical"
+      tools:visibility="gone"
       >
 
     <ListView
@@ -164,46 +166,58 @@
       android:layout_height="wrap_content"
       android:orientation="vertical"
       android:visibility="gone"
+      tools:visibility="visible"
       >
 
-    <LinearLayout
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
         android:layout_marginBottom="17dp"
         android:layout_marginTop="17dp"
-        android:gravity="center"
         android:orientation="horizontal"
         android:visibility="visible"
         >
-
-      <TextView
-          android:id="@+id/no_connection_text"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginEnd="50.7dp"
-          android:layout_marginRight="50.7dp"
-          android:autoLink="web"
-          android:text="@string/remote_install_nowifi"
-          android:textColor="#999999"
-          android:textSize="14.1sp"
-          android:visibility="visible"
-          style="?android:textAppearanceSmall"
-          />
 
       <Button
           android:id="@+id/help_btn"
           android:layout_width="53.7dp"
           android:layout_height="25.7dp"
+          android:layout_alignParentEnd="true"
+          android:layout_alignParentRight="true"
           android:layout_gravity="center_vertical"
+          android:layout_marginEnd="17dp"
+          android:layout_marginRight="17dp"
           android:background="@drawable/rounded_corners_primary3"
           android:ellipsize="none"
           android:text="@string/remote_install_help"
           android:textColor="@color/white"
-          android:textSize="12.5sp"
+          android:textSize="12.0sp"
           />
 
-    </LinearLayout>
+      <TextView
+          android:id="@+id/no_connection_text"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_alignEnd="@id/help_btn"
+          android:layout_alignParentLeft="true"
+          android:layout_alignParentStart="true"
+          android:layout_alignRight="@id/help_btn"
+          android:layout_centerHorizontal="true"
+          android:layout_centerVertical="true"
+          android:layout_marginEnd="60dp"
+          android:layout_marginLeft="25dp"
+          android:layout_marginRight="60dp"
+          android:layout_marginStart="25dp"
+          android:autoLink="web"
+          android:text="@string/remote_install_nowifi"
+          android:textColor="#999999"
+          android:textSize="12.5sp"
+          android:visibility="visible"
+          style="?android:textAppearanceSmall"
+          />
+
+
+    </RelativeLayout>
 
     <View
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_app_view_description.xml
+++ b/app/src/main/res/layout/fragment_app_view_description.xml
@@ -23,8 +23,6 @@
       tools:visibility="gone"
       />
 
-
-  <!-- is this necessary ?? -->
   <RelativeLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
@@ -54,14 +52,6 @@
       tools:text="@string/no_excluded_updates_msg"
       tools:visibility="visible"
       />
-
-  <!--
-      android:paddingLeft="@dimen/label_padding"
-      android:paddingStart="@dimen/label_padding"
-      android:paddingRight="@dimen/label_padding"
-      android:paddingEnd="@dimen/label_padding"
-      android:paddingBottom="@dimen/label_padding"
-  -->
 
   <ScrollView
       android:layout_width="match_parent"

--- a/app/src/main/res/layout/row_remote_install.xml
+++ b/app/src/main/res/layout/row_remote_install.xml
@@ -7,14 +7,14 @@
 
   <ImageView
       android:id="@+id/imageView"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
+      android:layout_width="55dp"
+      android:layout_height="55dp"
       android:layout_marginBottom="5dp"
-      android:layout_marginEnd="14dp"
-      android:layout_marginLeft="0dp"
+      android:layout_marginEnd="10dp"
+      android:layout_marginLeft="5dp"
       android:layout_marginRight="14dp"
-      android:layout_marginStart="0dp"
-      android:layout_marginTop="6dp"
+      android:layout_marginStart="5dp"
+      android:layout_marginTop="1dp"
       android:src="@drawable/ic_tv"
       />
 
@@ -26,6 +26,6 @@
       android:text="BRAVIA 2015"
       android:textAppearance="?android:attr/textAppearanceMedium"
       android:textColor="#ff6600"
-      android:textSize="14.1sp"
+      android:textSize="15sp"
       />
 </LinearLayout>

--- a/app/src/vanilla/java/cm/aptoide/pt/app/view/NewAppViewFragment.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/view/NewAppViewFragment.java
@@ -76,7 +76,6 @@ import cm.aptoide.pt.repository.RepositoryFactory;
 import cm.aptoide.pt.reviews.LanguageFilterHelper;
 import cm.aptoide.pt.search.model.SearchAdResult;
 import cm.aptoide.pt.share.ShareDialogs;
-import cm.aptoide.pt.store.StoreTheme;
 import cm.aptoide.pt.timeline.SocialRepository;
 import cm.aptoide.pt.timeline.TimelineAnalytics;
 import cm.aptoide.pt.util.AppUtils;
@@ -537,7 +536,6 @@ public class NewAppViewFragment extends NavigationTrackFragment implements AppVi
 
   @Override public void populateAppDetails(AppViewViewModel model) {
     collapsingToolbarLayout.setTitle(model.getAppName());
-    StoreTheme storeThemeEnum = StoreTheme.get(model.getStore());
 
     appName.setText(model.getAppName());
     ImageLoader.with(getContext())


### PR DESCRIPTION
**What does this PR do?**

  Changes the image size when there's a tv found. Changes the text layout in case no tvs were found.

**Database changed?**

   No

**Where should the reviewer start?**

dialog_remote_install.xml

**How should this be manually tested?**

Change the language to pt-pt (go to crowdin github page and download the project, then go to AndroidAppStore -> Vanilla -> app and copy all the files from the language you want to the local aptoide-client-v8 project you have on the res file)
Click on the install on tv button and wait for it to say that there's no devices and see if the text doesn't overlap the button.
Click on the install on tv button with aptoide-guest and check if the image on the found device has the correct size (image on the ticket)
This is just a quick fix and a layout with specific measures will be added later

**What are the relevant tickets?**

 https://aptoide.atlassian.net/browse/ASV-702

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass