### PR TITLE
[ASV-718] Added default case for facebook error logging

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/account/AccountAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/account/AccountAnalytics.java
@@ -222,7 +222,7 @@ public class AccountAnalytics {
               USER_CANCELED, String.valueOf(facebookSignUpException.getCode()),
               facebookSignUpException.getFacebookMessage());
           break;
-        case FacebookSignUpException.ERROR:
+        default:
           sendEvents(LOGIN_EVENT_NAME, LoginMethod.FACEBOOK, SignUpLoginStatus.FAILED, SDK_ERROR,
               String.valueOf(facebookSignUpException.getCode()),
               facebookSignUpException.getFacebookMessage());


### PR DESCRIPTION
**What does this PR do?**

In this ticket we aimed to fix several login problems reported on facebook analytics.
Those problems were:

- several unknown records (with no status, status code, detail or description).
- change status detail from the the logs with User_cancelled and permissions denied from failed to invalid.
- the records with SDK ERROR or general error have unknown status code and status detail.

These mentioned problems don't happen in the most recent versions (from 8.6.4.1 -> 9.0.0.*)
The only fix done in this PR was to improve the facebook login errors log, by adding a default case to that switch statement.

**Database changed?**

 No

**Where should the reviewer start?**

- [ ] AccountAnalytics.java

**How should this be manually tested?**
Just added a default case to the switch statement. I can not reproduce any other error on the facebook sdk, so i could not reproduce any error to test this.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-718](https://aptoide.atlassian.net/browse/ASV-718)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass