### PR TITLE
[ASV-777] Fixed editors choice more item margins

### DIFF
--- a/app/src/main/res/layout/brick_app_item_list.xml
+++ b/app/src/main/res/layout/brick_app_item_list.xml
@@ -38,12 +38,12 @@
 
       <TextView
           android:id="@+id/app_name"
-          android:layout_width="260dp"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginEnd="11dp"
-          android:layout_marginLeft="70dp"
-          android:layout_marginRight="11dp"
-          android:layout_marginStart="70dp"
+          android:layout_marginEnd="45dp"
+          android:layout_marginLeft="55dp"
+          android:layout_marginRight="45dp"
+          android:layout_marginStart="55dp"
           android:layout_marginTop="6dp"
           android:ellipsize="end"
           android:maxLines="1"


### PR DESCRIPTION
**What does this PR do?**

On more of the editors choice bundle, the appname of some apps was overlaying the rating. This pull request aims to fix it.
   
**Database changed?**

    No

**Where should the reviewer start?**

- [ ] brick_app_item_list.java

**How should this be manually tested?**

Open more from editors choice bundle, check if any app (specially the ones with longer app names) overlay the rating.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-777](https://aptoide.atlassian.net/browse/ASV-777)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass