### PR TITLE
[ASV-803] Removed fixed width from editors choice more item

### DIFF
--- a/app/src/main/res/layout/brick_app_item_list.xml
+++ b/app/src/main/res/layout/brick_app_item_list.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/brick_app_item"
     android:layout_width="match_parent"
-    android:layout_height="184dp"
+    android:layout_height="wrap_content"
     app:cardCornerRadius="6dp"
     app:cardUseCompatPadding="true"
     >


### PR DESCRIPTION
**What does this PR do?**

   If you opened the more section from the editors choice bundle and you rotated the screen, the feature graphic image would be stretched out. This happened because the item card had fixed size values.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] brick_app_item_list.java

**How should this be manually tested?**

  Open more from editors choice , rotate device and check if the image is too stretched.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-803](https://aptoide.atlassian.net/browse/ASV-803)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass