### PR TITLE
[ASV-823] fix: share dialog ab test is not requested anymore if user is not logged in.

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -1,7 +1,6 @@
 package cm.aptoide.pt.app;
 
 import cm.aptoide.accountmanager.AptoideAccountManager;
-import cm.aptoide.accountmanager.AptoideAuthenticationException;
 import cm.aptoide.analytics.AnalyticsManager;
 import cm.aptoide.pt.abtesting.ABTestManager;
 import cm.aptoide.pt.abtesting.Experiment;
@@ -346,7 +345,7 @@ public class AppViewManager {
           if (account.isLoggedIn()) {
             return abTestManager.getExperiment(ABTestManager.ExperimentType.SHARE_DIALOG);
           } else {
-            return Observable.error(new AptoideAuthenticationException());
+            return Observable.just(new Experiment());
           }
         });
   }

--- a/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -606,14 +606,7 @@ public class AppViewPresenter implements Presenter {
         .observeOn(viewScheduler)
         .doOnNext(
             experiment -> showRecommendsDialog(account.isLoggedIn(), appViewModel.getPackageName(),
-                experiment))
-        .doOnError(throwable -> {
-          Logger.getInstance()
-              .w(this.getClass()
-                  .getName(), throwable.getMessage());
-          showRecommendsDialog(account.isLoggedIn(), appViewModel.getPackageName(),
-              new Experiment());
-        });
+                experiment));
   }
 
   private Observable<SimilarAppsViewModel> updateSuggestedApps(AppViewViewModel appViewModel) {

--- a/aptoide-account-manager/src/main/java/cm/aptoide/accountmanager/AptoideAuthenticationException.java
+++ b/aptoide-account-manager/src/main/java/cm/aptoide/accountmanager/AptoideAuthenticationException.java
@@ -1,7 +1,0 @@
-package cm.aptoide.accountmanager;
-
-public class AptoideAuthenticationException extends IllegalStateException {
-  public AptoideAuthenticationException() {
-    super("User not authenticated");
-  }
-}

--- a/aptoide-account-manager/src/main/java/cm/aptoide/accountmanager/AptoideAuthenticationException.java
+++ b/aptoide-account-manager/src/main/java/cm/aptoide/accountmanager/AptoideAuthenticationException.java
@@ -1,0 +1,7 @@
+package cm.aptoide.accountmanager;
+
+public class AptoideAuthenticationException extends IllegalStateException {
+  public AptoideAuthenticationException() {
+    super("User not authenticated");
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

   Share dialog ab test is not requested anymore if user is not logged in.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppViewManager.java

**How should this be manually tested?**

  Clear data > no login > app view > install > cancel > install > close on share diagram > check if ab testing ws was not called.
  Clear data > logged in > app view > install > share dialog pops up > check if ab testing ws was called.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-823](https://aptoide.atlassian.net/browse/ASV-823)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass