### PR TITLE
[ASV-860] fix: aptoide bi events are now correctly sending the aptoide id parameter as "aptoide_uid" instead of "aptoide_id"

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/analytics/analytics/AnalyticsBodyInterceptorV7.java
+++ b/app/src/main/java/cm/aptoide/pt/analytics/analytics/AnalyticsBodyInterceptorV7.java
@@ -43,7 +43,7 @@ public class AnalyticsBodyInterceptorV7 implements AnalyticsBodyInterceptor<Anal
             body.setAccessToken(authentication.getAccessToken());
           }
 
-          body.setAptoideId(idsRepository.getUniqueIdentifier());
+          body.setAptoideUid(idsRepository.getUniqueIdentifier());
           body.setAptoideVercode(aptoideVersionCode);
           body.setLang(AptoideUtils.SystemU.getCountryCode(resources));
           body.setQ(qManager.getFilters(ManagerPreferences.getHWSpecsFilter(sharedPreferences)));

--- a/aptoide-analytics-default-implementation/src/main/java/cm/aptoide/analytics/implementation/network/AnalyticsBaseBody.java
+++ b/aptoide-analytics-default-implementation/src/main/java/cm/aptoide/analytics/implementation/network/AnalyticsBaseBody.java
@@ -1,7 +1,7 @@
 package cm.aptoide.analytics.implementation.network;
 
 public class AnalyticsBaseBody {
-  private String aptoideId;
+  private String aptoideUid;
   private String accessToken;
   private int aptoideVercode;
   private String aptoideMd5sum;
@@ -11,11 +11,11 @@ public class AnalyticsBaseBody {
   private String q;
 
   public String getAptoideId() {
-    return aptoideId;
+    return aptoideUid;
   }
 
   public void setAptoideId(String aptoideId) {
-    this.aptoideId = aptoideId;
+    this.aptoideUid = aptoideId;
   }
 
   public String getAccessToken() {

--- a/aptoide-analytics-default-implementation/src/main/java/cm/aptoide/analytics/implementation/network/AnalyticsBaseBody.java
+++ b/aptoide-analytics-default-implementation/src/main/java/cm/aptoide/analytics/implementation/network/AnalyticsBaseBody.java
@@ -10,12 +10,15 @@ public class AnalyticsBaseBody {
   private boolean mature;
   private String q;
 
-  public String getAptoideId() {
+  public AnalyticsBaseBody() {
+  }
+
+  public String getAptoideUid() {
     return aptoideUid;
   }
 
-  public void setAptoideId(String aptoideId) {
-    this.aptoideUid = aptoideId;
+  public void setAptoideUid(String aptoideUid) {
+    this.aptoideUid = aptoideUid;
   }
 
   public String getAccessToken() {


### PR DESCRIPTION
**What does this PR do?**

   In Aptoide BI events, calls to the addEvent were being made with the aptoide id parameter as: "aptoide_id". Now it is corrected to "aptoide_uid". 

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AnalyticsBaseBody.java

**How should this be manually tested?**

  Make an aptoide bi event call and check charles request body.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-860](https://aptoide.atlassian.net/browse/ASV-860)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass