### PR TITLE
[ASV-878] fix: make excluded updates fragment layout xml not use theme properties, because it isn't supported by widgets/displayables.

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/updates/view/excluded/ExcludedUpdatesFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/updates/view/excluded/ExcludedUpdatesFragment.java
@@ -41,7 +41,7 @@ public class ExcludedUpdatesFragment extends AptoideBaseFragment<BaseAdapter>
   }
 
   @Override public int getContentViewId() {
-    return R.layout.fragment_with_toolbar;
+    return R.layout.fragment_with_toolbar_no_theme;
   }
 
   @Override public void bindViews(View view) {


### PR DESCRIPTION
**What does this PR do?**

  Make excluded updates fragment layout xml not use theme properties, because it isn't supported by widgets/displayables.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] ExcludedUpdatesFragment.java

**How should this be manually tested?**

  Ignore an Update and go to excluded updates in the settings.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-878](https://aptoide.atlassian.net/browse/ASV-878)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass