### PR TITLE
[Bugfix/ASV-774] Refresh token account exception

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/networking/RefreshTokenInvalidator.java
+++ b/app/src/main/java/cm/aptoide/pt/networking/RefreshTokenInvalidator.java
@@ -71,7 +71,8 @@ public class RefreshTokenInvalidator implements TokenInvalidator {
                       return Completable.complete();
                     }
                   }
-                  throw new RuntimeException(throwable);
+                  logoutSubject.onNext(null);
+                  return Completable.error(throwable);
                 }));
   }
 }


### PR DESCRIPTION
**What does this PR do?**

   Solution to the crash that would happen when user tried to refresh token and ws would return 200 OK with errors. We would emit an AccountException that was not being handled in the retry (retry refresh token) and after max refresh token retries attempts failed, it would throw a RuntimeException, crashing the app. Now we logout the user and propagate the error through the chain.

**Database changed?**

    No

**Where should the reviewer start?**

- [ ] RefreshTokenInvalidator.java

**How should this be manually tested?**

   Charles > make a request that uses access token (like getSubscribed stores) with invalid access token > mock oAuth2Authentication ws response so it returns errors > fail 3 times > check if user logs out. 

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-774](https://aptoide.atlassian.net/browse/ASV-774)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass