### PR TITLE
[Feature/ASV-867] change appcoins_type parameter values in both App_Viewed_Open_From & OPEN_APP_VIEW events.

### DIFF
--- a/app/src/dev/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/dev/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -549,7 +549,7 @@ public class AppViewPresenter implements Presenter {
           appViewManager.sendAppViewOpenedFromEvent(model.getPackageName(), model.getDeveloper()
               .getName(), model.getMalware()
               .getRank()
-              .name(), model.getAppc());
+              .name(), model.hasBilling(), model.hasAdvertising());
         })
         .flatMap(appViewModel -> {
           if (appViewModel.getOpenType() == NewAppViewFragment.OpenType.OPEN_AND_INSTALL) {

--- a/app/src/main/java/cm/aptoide/pt/app/AppViewAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewAnalytics.java
@@ -86,17 +86,18 @@ public class AppViewAnalytics {
   }
 
   public void sendAppViewOpenedFromEvent(String packageName, String appPublisher, String badge,
-      double appc) {
+      boolean hasBilling, boolean hasAdvertising) {
     analyticsManager.logEvent(createAppViewedFromMap(navigationTracker.getPreviousScreen(),
-        navigationTracker.getCurrentScreen(), packageName, appPublisher, badge, appc),
-        APP_VIEW_OPEN_FROM, AnalyticsManager.Action.CLICK, getViewName(false));
+        navigationTracker.getCurrentScreen(), packageName, appPublisher, badge, hasBilling,
+        hasAdvertising), APP_VIEW_OPEN_FROM, AnalyticsManager.Action.CLICK, getViewName(false));
     analyticsManager.logEvent(createAppViewDataMap(navigationTracker.getPreviousScreen(),
-        navigationTracker.getCurrentScreen(), packageName, appc), OPEN_APP_VIEW,
-        AnalyticsManager.Action.CLICK, getViewName(false));
+        navigationTracker.getCurrentScreen(), packageName, hasBilling, hasAdvertising),
+        OPEN_APP_VIEW, AnalyticsManager.Action.CLICK, getViewName(false));
   }
 
   private Map<String, Object> createAppViewDataMap(ScreenTagHistory previousScreen,
-      ScreenTagHistory currentScreen, String packageName, double appc) {
+      ScreenTagHistory currentScreen, String packageName, boolean hasBilling,
+      boolean hasAdvertising) {
     Map<String, String> packageMap = new HashMap<>();
     packageMap.put("package", packageName);
     Map<String, Object> data = new HashMap<>();
@@ -111,14 +112,26 @@ public class AppViewAnalytics {
     } else {
       data.put("previous_tag", APP_SHORTCUT);
     }
-    if (appc > 0) data.put("appcoins_type", "appcoins ads");
+
+    data.put("appcoins_type", mapAppCoinsInfo(hasBilling, hasAdvertising));
 
     return data;
   }
 
+  private String mapAppCoinsInfo(boolean hasBilling, boolean hasAdvertising) {
+    if (hasBilling && hasAdvertising) {
+      return "AppCoins Ads IAB";
+    } else if (hasBilling) {
+      return "AppCoins IAB";
+    } else if (hasAdvertising) {
+      return "AppCoins Ads";
+    }
+    return "None";
+  }
+
   private HashMap<String, Object> createAppViewedFromMap(ScreenTagHistory previousScreen,
       ScreenTagHistory currentScreen, String packageName, String appPublisher, String badge,
-      double appc) throws NullPointerException {
+      boolean hasBilling, boolean hasAdvertising) throws NullPointerException {
     HashMap<String, Object> map = new HashMap<>();
     if (previousScreen != null) {
       if (previousScreen.getFragment() != null) {
@@ -133,7 +146,8 @@ public class AppViewAnalytics {
         map.put("tag", currentScreen.getTag());
       }
     }
-    if (appc > 0) map.put("appcoins_type", "appcoins ads");
+
+    map.put("appcoins_type", mapAppCoinsInfo(hasBilling, hasAdvertising));
 
     map.put("package_name", packageName);
     map.put("application_publisher", appPublisher);

--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -323,9 +323,10 @@ public class AppViewManager {
   }
 
   public void sendAppViewOpenedFromEvent(String packageName, String publisher, String badge,
-      double appc) {
+      boolean hasBilling, boolean hasAdvertising) {
     if (isFirstLoad) {
-      appViewAnalytics.sendAppViewOpenedFromEvent(packageName, publisher, badge, appc);
+      appViewAnalytics.sendAppViewOpenedFromEvent(packageName, publisher, badge, hasBilling,
+          hasAdvertising);
       isFirstLoad = false;
     }
   }

--- a/app/src/test/java/cm/aptoide/pt/app/AppViewPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/AppViewPresenterTest.java
@@ -169,7 +169,7 @@ public class AppViewPresenterTest {
         appViewViewModel.getDeveloper()
             .getName(), appViewViewModel.getMalware()
             .getRank()
-            .name(), appViewViewModel.getAppc());
+            .name(), appViewViewModel.hasBilling(), appViewViewModel.hasAdvertising());
   }
 
   @Test public void handleOpenAppViewEventsWithEmptyEditorsChoice() {
@@ -216,6 +216,7 @@ public class AppViewPresenterTest {
         emptyEditorsChoiceAppViewViewModel.getDeveloper()
             .getName(), emptyEditorsChoiceAppViewViewModel.getMalware()
             .getRank()
-            .name(), emptyEditorsChoiceAppViewViewModel.getAppc());
+            .name(), emptyEditorsChoiceAppViewViewModel.hasBilling(),
+        emptyEditorsChoiceAppViewViewModel.hasAdvertising());
   }
 }

--- a/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -1266,7 +1266,7 @@ public class AppViewFragment extends AptoideBaseFragment<BaseAdapter> implements
           .getName(), app.getFile()
           .getMalware()
           .getRank()
-          .name(), appRewardAppcoins);
+          .name(), app.hasBilling(), app.hasAdvertising());
       final Malware malware = app.getFile()
           .getMalware();
       badge.setOnClickListener(v -> {


### PR DESCRIPTION
**What does this PR do?**

   Changes the appcoins_type parameter values in both App_Viewed_Open_From & OPEN_APP_VIEW events based on billing & advertising permissions.
   if it has both billing & advertising -> "AppCoins Ads IAB"
   if only billing -> "AppCoins IAB"
   if only advertising -> "AppCoins Ads"
   if none -> "None"

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppViewAnalytics.java

**How should this be manually tested?**

   Charles mock getApp response to reflect all appcoins json possible combinations (billing advertising true true, true false, false true, false false)
   See if App_Viewed_Open_From & OPEN_APP_VIEW events are sending the correct information in the appcoins_type paramenter values.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-867](https://aptoide.atlassian.net/browse/ASV-867)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass