### PR TITLE
[ASV-928] Changed Appc info fragment bottom card

### DIFF
--- a/app/src/main/res/layout/app_install_cardview.xml
+++ b/app/src/main/res/layout/app_install_cardview.xml
@@ -1,32 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="96dp"
     xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
     android:clickable="true"
     android:focusable="true"
     android:foreground="?android:attr/selectableItemBackground"
     >
-  <android.support.constraint.ConstraintLayout
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      >
 
     <ImageView
         android:id="@+id/app_icon_imageview"
-        android:layout_width="88dp"
-        android:layout_height="88dp"
-        android:layout_marginBottom="8dp"
-        android:layout_marginLeft="7dp"
-        android:layout_marginStart="7dp"
-        android:layout_marginTop="8dp"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginBottom="4dp"
+        android:layout_marginLeft="4dp"
+        android:layout_marginStart="4dp"
+        android:layout_marginTop="4dp"
         android:adjustViewBounds="true"
         android:src="@drawable/ad_icon"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         />
 
 
@@ -34,14 +26,12 @@
         android:id="@+id/app_title_textview"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
         android:layout_marginLeft="8dp"
         android:layout_marginStart="8dp"
-        android:layout_marginTop="15dp"
-        android:layout_toEndOf="@+id/app_icon_imageview"
-        android:layout_toRightOf="@+id/app_icon_imageview"
+        android:layout_toEndOf="@id/app_icon_imageview"
+        android:layout_toRightOf="@id/app_icon_imageview"
         tools:text="@string/appc_title_settings_appcoins_wallet"
-        app:layout_constraintStart_toEndOf="@+id/app_icon_imageview"
-        app:layout_constraintTop_toTopOf="parent"
         style="@style/Aptoide.TextView.Medium.M"
         />
 
@@ -49,22 +39,17 @@
         android:id="@+id/appview_install_button"
         android:layout_width="83dp"
         android:layout_height="32dp"
-        android:layout_marginBottom="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginRight="16dp"
-        android:layout_marginTop="48dp"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
         android:text="@string/install"
         android:textAlignment="center"
         android:textAllCaps="true"
         android:textSize="12sp"
         android:visibility="visible"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.0"
-        style="@style/Aptoide.Button"
+        style="@style/Aptoide.Button.S.Gradient"
         />
 
-
-  </android.support.constraint.ConstraintLayout>
-</android.support.v7.widget.CardView>
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_appcoints_info.xml
+++ b/app/src/main/res/layout/fragment_appcoints_info.xml
@@ -27,7 +27,6 @@
       android:layout_height="wrap_content"
       android:layout_above="@id/app_cardview"
       android:layout_below="@id/app_bar_layout"
-      android:layout_marginBottom="8dp"
       android:scrollbars="none"
       app:layout_behavior="@string/appbar_scrolling_view_behavior"
       >

--- a/app/src/main/res/layout/fragment_appcoints_info.xml
+++ b/app/src/main/res/layout/fragment_appcoints_info.xml
@@ -27,7 +27,7 @@
       android:layout_height="wrap_content"
       android:layout_above="@id/app_cardview"
       android:layout_below="@id/app_bar_layout"
-      android:layout_marginBottom="28dp"
+      android:layout_marginBottom="8dp"
       android:scrollbars="none"
       app:layout_behavior="@string/appbar_scrolling_view_behavior"
       >
@@ -332,13 +332,8 @@
       layout="@layout/app_install_cardview"
       android:id="@+id/app_cardview"
       android:layout_width="match_parent"
-      android:layout_height="96dp"
+      android:layout_height="wrap_content"
       android:layout_alignParentBottom="true"
-      android:layout_marginBottom="21dp"
-      android:layout_marginEnd="17dp"
-      android:layout_marginLeft="16dp"
-      android:layout_marginRight="17dp"
-      android:layout_marginStart="16dp"
       />
 
 


### PR DESCRIPTION
**What does this PR do?**

This PR aims to change the layout of the bottom card on the appc info fragment; The new card is smaller and has no elevation;

**Database changed?**

No

**Where should the reviewer start?**

- [ ] app_install_cardview.xml

**How should this be manually tested?**

Press "Know more" in the appc card in home. Check the new card at the bottom of the fragment this navigates you to;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-928](<https://aptoide.atlassian.net/browse/ASV-928>)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass