### PR TITLE
[ASV-970] fix: first_launch event is now correctly populated with the entry_point + utms. First_launch is also only sent once.

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
+++ b/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
@@ -635,8 +635,9 @@ public abstract class AptoideApplication extends Application {
   }
 
   private Completable sendAppStartToAnalytics() {
-    return firstLaunchAnalytics.sendAppStart(this, defaultSharedPreferences,
-        WebService.getDefaultConverter(), getDefaultClient(),
+    return firstLaunchAnalytics.sendAppStart(this,
+        SecurePreferencesImplementation.getInstance(getApplicationContext(),
+            getDefaultSharedPreferences()), WebService.getDefaultConverter(), getDefaultClient(),
         getAccountSettingsBodyInterceptorPoolV7(), getTokenInvalidator());
   }
 

--- a/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
@@ -141,11 +141,11 @@ public class FirstLaunchAnalytics {
       UTMTrackingFileParser utmTrackingFileParser = new UTMTrackingFileParser(utmInputStream);
       myZipFile.close();
 
-      utmSource = utmTrackingFileParser.valueExtracter(UTM_SOURCE);
-      utmMedium = utmTrackingFileParser.valueExtracter(UTM_MEDIUM);
-      utmCampaign = utmTrackingFileParser.valueExtracter(UTM_CAMPAIGN);
-      utmContent = utmTrackingFileParser.valueExtracter(UTM_CONTENT);
-      entryPoint = utmTrackingFileParser.valueExtracter(ENTRY_POINT);
+      utmSource = utmTrackingFileParser.valueExtracter("utm_source");
+      utmMedium = utmTrackingFileParser.valueExtracter("utm_medium");
+      utmCampaign = utmTrackingFileParser.valueExtracter("utm_campaign");
+      utmContent = utmTrackingFileParser.valueExtracter("utm_content");
+      entryPoint = utmTrackingFileParser.valueExtracter("entry_point");
 
       utmInputStream.close();
     } catch (IOException e) {


### PR DESCRIPTION
**What does this PR do?**

   Title

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] FirstLaunchAnalytics.java
- [ ] AptoideApplication.java

**How should this be manually tested?**

  Download this apk: https://my-wafa.pt.aptoide.com/ > Generate an Aptoide APK (vanillaProdRelease) > unzip it > unzip my-wafa in another directory > cp 3 files (aob, utm, tracking) from META/INF wafa directory into the META/INF Aptoide directory >  zip -r aptoide.apk > run Aptoide > check if utms and entry point are populated in the First_Launch event > close Aptoide > open Aptoide > check if First_launch is not sent anymore.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-970](https://aptoide.atlassian.net/browse/ASV-970)


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass