### PR TITLE
ASV 974 - My Store shortcut bug

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/view/DeepLinkManager.java
+++ b/app/src/main/java/cm/aptoide/pt/view/DeepLinkManager.java
@@ -13,6 +13,8 @@ import cm.aptoide.pt.AppShortcutsAnalytics;
 import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.DeepLinkAnalytics;
 import cm.aptoide.pt.DeepLinkIntentReceiver;
+import cm.aptoide.pt.account.view.store.ManageStoreFragment;
+import cm.aptoide.pt.account.view.store.ManageStoreViewModel;
 import cm.aptoide.pt.ads.AdsRepository;
 import cm.aptoide.pt.app.AppNavigator;
 import cm.aptoide.pt.app.view.NewAppViewFragment;
@@ -313,9 +315,13 @@ public class DeepLinkManager {
             appShortcutsAnalytics.shortcutNavigation(ShortcutDestinations.MY_STORE);
             storeAnalytics.sendStoreOpenEvent(APP_SHORTCUT, navigation.getStore()
                 .getName(), false);
-            fragmentNavigator.navigateTo(StoreFragment.newInstance(navigation.getStore()
-                .getName(), navigation.getStore()
-                .getTheme(), StoreFragment.OpenType.GetHome), true);
+            if(!navigation.hasStore()){
+              fragmentNavigator.navigateTo(ManageStoreFragment.newInstance(new ManageStoreViewModel(), true), true);
+            } else {
+              fragmentNavigator.navigateTo(StoreFragment.newInstance(navigation.getStore()
+                  .getName(), navigation.getStore()
+                  .getTheme(), StoreFragment.OpenType.GetHome), true);
+            }
           } else {
             appShortcutsAnalytics.shortcutNavigation(ShortcutDestinations.MY_STORE_NOT_LOGGED_IN);
             bottomNavigationNavigator.navigateToStore();

--- a/app/src/main/java/cm/aptoide/pt/view/DeepLinkManager.java
+++ b/app/src/main/java/cm/aptoide/pt/view/DeepLinkManager.java
@@ -313,11 +313,11 @@ public class DeepLinkManager {
         .subscribe(navigation -> {
           if (navigation != null) {
             appShortcutsAnalytics.shortcutNavigation(ShortcutDestinations.MY_STORE);
-            storeAnalytics.sendStoreOpenEvent(APP_SHORTCUT, navigation.getStore()
-                .getName(), false);
             if(!navigation.hasStore()){
               fragmentNavigator.navigateTo(ManageStoreFragment.newInstance(new ManageStoreViewModel(), true), true);
             } else {
+              storeAnalytics.sendStoreOpenEvent(APP_SHORTCUT, navigation.getStore()
+                  .getName(), false);
               fragmentNavigator.navigateTo(StoreFragment.newInstance(navigation.getStore()
                   .getName(), navigation.getStore()
                   .getTheme(), StoreFragment.OpenType.GetHome), true);


### PR DESCRIPTION
**What does this PR do?**

   On My Home shortcut, checks if user has store. If he does, navigates to StoreFragment. If he doesn't navigates to ManageStoreFragment

**Database changed?**

   No

**Where should the reviewer start?**

- DeepLinkManager.java

**How should this be manually tested?**

  Click on My Home shortcut (Android Oreo) with 2 accounts: 1 with store, 1 without.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-974](https://aptoide.atlassian.net/browse/ASV-974)
