### PR TITLE
[ASV-972] Deleted removeAll in the onSharedPreferencesChanged method,…

### DIFF
--- a/app/src/vanilla/java/cm/aptoide/pt/view/settings/SettingsFragment.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/view/settings/SettingsFragment.java
@@ -38,10 +38,7 @@ import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.account.AdultContentAnalytics;
 import cm.aptoide.pt.crashreports.CrashReport;
-import cm.aptoide.pt.database.AccessorFactory;
 import cm.aptoide.pt.database.accessors.Database;
-import cm.aptoide.pt.database.accessors.UpdateAccessor;
-import cm.aptoide.pt.database.realm.Update;
 import cm.aptoide.pt.file.FileManager;
 import cm.aptoide.pt.link.CustomTabsHelper;
 import cm.aptoide.pt.logger.Logger;
@@ -229,12 +226,8 @@ public class SettingsFragment extends PreferenceFragmentCompat
 
   @Override public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
     if (shouldRefreshUpdates(key)) {
-      UpdateAccessor updateAccessor = AccessorFactory.getAccessorFor(database, Update.class);
-      updateAccessor.removeAll();
       repository.sync(true, false)
-          .andThen(repository.getAll(false))
-          .first()
-          .subscribe(updates -> Logger.getInstance()
+          .subscribe(() -> Logger.getInstance()
               .d(TAG, "updates refreshed"), throwable -> CrashReport.getInstance()
               .log(throwable));
     }


### PR DESCRIPTION
… to stop from wrongly removing all the updates from the db, before resetting them.

**What does this PR do?**

   Tries to fix a bug where the excluded updates were being cleared when changing beta versions, HW filter and system apps settings.
 
**Database changed?**

   No

**Where should the reviewer start?**

- [ ] SettingsFragment.java

**How should this be manually tested?**

  Go to updates, exclude some updates with long click. Then so to settings, change any of these filters (HW, beta versions, system apps). Then in settings so to excluded updates. The previously excluded updates should be there.

**What are the relevant tickets?**

ASV-972




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass