### PR TITLE
Bugfix/asv 983 fix tc and pp snackbar

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/account/view/LoginSignUpCredentialsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/LoginSignUpCredentialsFragment.java
@@ -2,10 +2,13 @@ package cm.aptoide.pt.account.view;
 
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.design.widget.BottomSheetBehavior;
 import android.support.design.widget.Snackbar;
+import android.support.v4.widget.CompoundButtonCompat;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.method.LinkMovementMethod;
@@ -68,6 +71,7 @@ public class LoginSignUpCredentialsFragment extends GooglePlayServicesFragment
   private BottomSheetBehavior<View> bottomSheetBehavior;
   private View rootView;
   private CheckBox termsConditionCheckBox;
+  private Drawable checkboxDrawable;
 
   private String marketName;
   private PublishSubject<Void> privacyPolicySubject;
@@ -227,6 +231,14 @@ public class LoginSignUpCredentialsFragment extends GooglePlayServicesFragment
     Snackbar.make(rootView, getString(R.string.signup_message_no_tandc_error),
         Snackbar.LENGTH_SHORT)
         .show();
+    Drawable replacementDrawable = checkboxDrawable.getConstantState()
+        .newDrawable()
+        .mutate();
+    replacementDrawable.setColorFilter(getResources().getColor(R.color.red),
+        PorterDuff.Mode.SRC_ATOP);
+    termsConditionCheckBox.setButtonDrawable(replacementDrawable);
+    termsConditionCheckBox.setOnCheckedChangeListener(
+        (buttonView, isChecked) -> termsConditionCheckBox.setButtonDrawable(checkboxDrawable));
   }
 
   @Override public void showFacebookLogin() {
@@ -348,6 +360,8 @@ public class LoginSignUpCredentialsFragment extends GooglePlayServicesFragment
     signUpSelectionButton = (Button) view.findViewById(R.id.show_join_aptoide_area);
     loginSelectionButton = (Button) view.findViewById(R.id.show_login_with_aptoide_area);
     termsConditionCheckBox = (CheckBox) view.findViewById(R.id.tc_checkbox);
+    checkboxDrawable = CompoundButtonCompat.getButtonDrawable(termsConditionCheckBox);
+
     if ("vanilla".equalsIgnoreCase(BuildConfig.FLAVOR_product)) {
       buttonSignUp.setText(String.format(getString(R.string.onboarding_button_join_us)));
     } else {

--- a/app/src/main/res/layout/fragment_login_sign_up.xml
+++ b/app/src/main/res/layout/fragment_login_sign_up.xml
@@ -87,7 +87,7 @@ android:fitsSystemWindows="true"
       android:elevation="16dp"
       android:visibility="visible"
       app:behavior_hideable="false"
-      app:behavior_peekHeight="270dp"
+      app:behavior_peekHeight="360dp"
       app:layout_behavior="android.support.design.widget.BottomSheetBehavior"
       />
 

--- a/app/src/main/res/layout/fragment_login_sign_up_credentials.xml
+++ b/app/src/main/res/layout/fragment_login_sign_up_credentials.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:background="@color/white"
     android:orientation="vertical"
     android:paddingBottom="15dp"
@@ -112,4 +112,5 @@
         style="@style/Aptoide.TextView.Regular.XS"
         />
   </LinearLayout>
+
 </LinearLayout>


### PR DESCRIPTION
**What does this PR do?**

   Makes the checkbox on LoginSignup not be covered when the error message appears. Also makes the checkbox red when this happens.

**Database changed?**

   No

**Where should the reviewer start?**

- [x] LoginSignupCredentialsFragment.java

**How should this be manually tested?**

  Go to the sign in/sign up screen and try to press signup when the checkbox for TC and PP is unchecked. This should display a error message and also make the checkbox red.

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/ASV-983





**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass