### PR TITLE
[ASV-1005] fix: App View now correctly checks if campaign is valid when app has no AppCoins billing flow but has AppCoins advertising flow.

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -361,11 +361,10 @@ public class AppViewManager {
             if (app.hasBilling()) {
               cachedAppCoinsViewModel = new AppCoinsViewModel(false, true, false);
             } else if (app.hasAdvertising()) {
-              appCoinsManager.hasAdvertising(app.getPackageName(), app.getVersionCode())
-                  .map(hasAdvertising -> {
-                    cachedAppCoinsViewModel = new AppCoinsViewModel(false, false, hasAdvertising);
-                    return Completable.complete();
-                  });
+              return appCoinsManager.hasAdvertising(app.getPackageName(), app.getVersionCode())
+                  .map(hasAdvertising -> cachedAppCoinsViewModel =
+                      new AppCoinsViewModel(false, false, hasAdvertising))
+                  .toCompletable();
             } else {
               cachedAppCoinsViewModel = new AppCoinsViewModel(false, false, false);
             }


### PR DESCRIPTION
**What does this PR do?**

   AppView is now checking correctly if campaign is valid when it doesn't have the billing permission flag (that comes from the getApp) but has the advertising one.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Foo.java
- [ ] Bar.kt

**How should this be manually tested?**

  Mock appview in charges with billing = false  & advertising = true > should make a call to this ws: 
https://ws75.aptoide.com/api/7/appcoins/campaigns/get/limit=5

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1005](https://aptoide.atlassian.net/browse/ASV-1005)


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass