### PR TITLE
ASV-925 - Added appview message for when the app is both appc ad and …

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -358,15 +358,13 @@ public class AppViewManager {
     if (cachedAppCoinsViewModel == null) {
       return Completable.fromObservable(Observable.fromCallable(() -> cachedApp)
           .flatMapCompletable(app -> {
-            if (app.hasBilling()) {
-              cachedAppCoinsViewModel = new AppCoinsViewModel(false, true, false);
-            } else if (app.hasAdvertising()) {
+            if (app.hasAdvertising()) {
               return appCoinsManager.hasAdvertising(app.getPackageName(), app.getVersionCode())
                   .map(hasAdvertising -> cachedAppCoinsViewModel =
-                      new AppCoinsViewModel(false, false, hasAdvertising))
+                      new AppCoinsViewModel(false, app.hasBilling(), hasAdvertising))
                   .toCompletable();
             } else {
-              cachedAppCoinsViewModel = new AppCoinsViewModel(false, false, false);
+              cachedAppCoinsViewModel = new AppCoinsViewModel(false, app.hasBilling(), false);
             }
             return Completable.complete();
           }));

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewAppcInfoViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewAppcInfoViewHolder.java
@@ -9,23 +9,30 @@ public class AppViewAppcInfoViewHolder {
   private LinearLayout appcBillingSupported;
   private View appcRewardView;
   private TextView appcRewardValue;
+  private TextView appcRewardBilling;
 
   public AppViewAppcInfoViewHolder(LinearLayout appcBillingSupported, View appcRewardView,
-      TextView appcRewardValue) {
+      TextView appcRewardValue, TextView appcRewardBilling) {
     this.appcBillingSupported = appcBillingSupported;
     this.appcRewardView = appcRewardView;
     this.appcRewardValue = appcRewardValue;
+    this.appcRewardBilling = appcRewardBilling;
   }
 
   public void showInfo(boolean hasAdvertising, boolean hasBilling,
       SpannableString formattedMessage) {
-    if (hasBilling) {
-      this.appcBillingSupported.setVisibility(View.VISIBLE);
-      this.appcRewardView.setVisibility(View.GONE);
-    } else if (hasAdvertising) {
+    if(hasAdvertising){
       this.appcRewardView.setVisibility(View.VISIBLE);
       this.appcRewardValue.setText(formattedMessage);
       this.appcBillingSupported.setVisibility(View.GONE);
+      if(hasBilling){
+        this.appcRewardBilling.setVisibility(View.VISIBLE);
+      } else {
+        this.appcRewardBilling.setVisibility(View.GONE);
+      }
+    } else if (hasBilling){
+      this.appcBillingSupported.setVisibility(View.VISIBLE);
+      this.appcRewardView.setVisibility(View.GONE);
     }
   }
 

--- a/app/src/main/res/layout/appview_appc_reward.xml
+++ b/app/src/main/res/layout/appview_appc_reward.xml
@@ -28,16 +28,30 @@
       android:src="@drawable/ic_appcoins"
       />
 
-  <TextView
-      android:id="@+id/appcoins_reward_message"
+  <LinearLayout
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_gravity="center_vertical"
-      android:layout_marginEnd="15dp"
-      android:layout_marginRight="15dp"
-      tools:text="try this app and get a 100000 appcoins"
-      style="@style/Aptoide.TextView.Medium.S.BlackAlpha"
-      />
+      android:orientation="vertical"
+      >
 
+    <TextView
+        android:id="@+id/appcoins_reward_message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_marginEnd="15dp"
+        android:layout_marginRight="15dp"
+        tools:text="try this app and get a 100000 appcoins"
+        style="@style/Aptoide.TextView.Medium.S.BlackAlpha"
+        />
 
+    <TextView
+        android:id="@+id/appc_billing_text_secondary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="visible"
+        android:text="@string/appc_message_appview_appcoins_iab"
+        style="@style/Aptoide.TextView.Medium.XXS"
+        />
+  </LinearLayout>
 </LinearLayout>

--- a/app/src/vanilla/java/cm/aptoide/pt/app/view/NewAppViewFragment.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/view/NewAppViewFragment.java
@@ -276,7 +276,8 @@ public class NewAppViewFragment extends NavigationTrackFragment implements AppVi
     appcRewardValue = (TextView) view.findViewById(R.id.appcoins_reward_message);
     appcInfoView =
         new AppViewAppcInfoViewHolder((LinearLayout) view.findViewById(R.id.iap_appc_label),
-            appcRewardView, appcRewardValue);
+            appcRewardView, appcRewardValue,
+            (TextView) appcRewardView.findViewById(R.id.appc_billing_text_secondary));
     similarDownloadView = view.findViewById(R.id.similar_download_apps);
     similarDownloadApps = (RecyclerView) similarDownloadView.findViewById(R.id.similar_list);
     latestVersionTitle = (TextView) view.findViewById(R.id.latest_version_title);


### PR DESCRIPTION
**What does this PR do?**

   Adds a new message in appview when the app is both an appc ad and supports appc in-app billing.

**Database changed?**

No

**Where should the reviewer start?**

- AppViewAppcInfoViewHolder
- AppViewManager
- NewAppViewFragment

**How should this be manually tested?**

  Should be manually tested with Charles:
   - getApp response has to be rewritten. Advertising and billing fields in all the appcoin sections should be set to true.
   - appcoins/campaigns/get also has to be rewritten to include something in the list response.

Rewrite files on the ticket comment below.

**What are the relevant tickets?**

  [ASV-925](https://aptoide.atlassian.net/browse/ASV-925)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass