### PR TITLE
[ASV-955] Fixed appc events not being sent both when a click on appvi…

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppViewAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewAnalytics.java
@@ -205,6 +205,11 @@ public class AppViewAnalytics {
         AnalyticsManager.Action.CLICK, getViewName(true));
   }
 
+  public void sendAppcInfoInteractEvent() {
+    analyticsManager.logEvent(createMapData(ACTION, "AppCoins Info View"), APP_VIEW_INTERACT,
+        AnalyticsManager.Action.CLICK, getViewName(true));
+  }
+
   private Map<String, Object> createFlagAppEventData(String action, String flagDetail) {
     Map<String, Object> map = new HashMap<>();
     map.put(ACTION, action);

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -203,7 +203,10 @@ public class AppViewPresenter implements Presenter {
     view.getLifecycle()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .flatMap(__ -> view.clickGetAppcInfo())
-        .doOnNext(click -> appViewNavigator.navigateToAppCoinsInfo())
+        .doOnNext(click -> {
+          appViewAnalytics.sendAppcInfoInteractEvent();
+          appViewNavigator.navigateToAppCoinsInfo();
+        })
         .subscribe(__ -> {
         }, e -> crashReport.log(e));
   }
@@ -816,7 +819,7 @@ public class AppViewPresenter implements Presenter {
                 app.getStore()
                     .getId(), "install")
                 .doOnCompleted(() -> appViewAnalytics.sendTimelineLoggedInInstallRecommendEvents(
-                        app.getPackageName()))
+                    app.getPackageName()))
                 .doOnCompleted(() -> view.showRecommendsThanksMessage()))
             .retry())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))

--- a/app/src/main/java/cm/aptoide/pt/app/view/MoreBundleFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/MoreBundleFragment.java
@@ -262,13 +262,13 @@ public class MoreBundleFragment extends NavigationTrackFragment implements MoreB
         .debounce(200, TimeUnit.MILLISECONDS);
   }
 
-  @Override public Observable<HomeBundle> visibleBundles() {
+  @Override public Observable<HomeEvent> visibleBundles() {
     return RxRecyclerView.scrollEvents(bundlesList)
         .subscribeOn(AndroidSchedulers.mainThread())
         .map(recyclerViewScrollEvent -> layoutManager.findFirstVisibleItemPosition())
         .filter(position -> position != RecyclerView.NO_POSITION)
         .distinctUntilChanged()
-        .map(visibleItem -> adapter.getBundle(visibleItem));
+        .map(visibleItem -> new HomeEvent(adapter.getBundle(visibleItem), visibleItem, null));
   }
 
   @Override public void setToolbarInfo(String title) {

--- a/app/src/main/java/cm/aptoide/pt/home/HomeAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeAnalytics.java
@@ -109,8 +109,7 @@ public class HomeAnalytics {
         navigationTracker.getViewName(true));
   }
 
-  public void sendAppcKnowMoreInteractEvent(String bundleTag, int bundlePosition,
-      HomeEvent.Type type) {
+  public void sendAppcKnowMoreInteractEvent(String bundleTag, int bundlePosition) {
     final Map<String, Object> data = new HashMap<>();
     data.put("action", TAP_ON_CARD);
     data.put("bundle_tag", bundleTag);
@@ -119,8 +118,7 @@ public class HomeAnalytics {
     analyticsManager.logEvent(data, HOME_INTERACT, OPEN, navigationTracker.getViewName(true));
   }
 
-  public void sendAppcDismissInteractEvent(String bundleTag, int bundlePosition,
-      HomeEvent.Type type) {
+  public void sendAppcDismissInteractEvent(String bundleTag, int bundlePosition) {
     final Map<String, Object> data = new HashMap<>();
     data.put("action", TAP_ON_CARD_DISMISS);
     data.put("bundle_tag", bundleTag);

--- a/app/src/main/java/cm/aptoide/pt/home/HomeAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeAnalytics.java
@@ -5,6 +5,9 @@ import cm.aptoide.analytics.implementation.navigation.NavigationTracker;
 import java.util.HashMap;
 import java.util.Map;
 
+import static cm.aptoide.analytics.AnalyticsManager.Action.DISMISS;
+import static cm.aptoide.analytics.AnalyticsManager.Action.OPEN;
+
 /**
  * Created by jdandrade on 28/03/2018.
  */
@@ -17,6 +20,9 @@ public class HomeAnalytics {
   static final String PULL_REFRESH = "pull refresh";
   static final String PUSH_LOAD_MORE = "push load more";
   static final String TAP_ON_MORE = "tap on more";
+  static final String TAP_ON_CARD = "tap on card";
+  static final String TAP_ON_CARD_DISMISS = "tap on card dismiss";
+  static final String VIEW_CARD = "view card";
   private final NavigationTracker navigationTracker;
   private final AnalyticsManager analyticsManager;
 
@@ -103,9 +109,39 @@ public class HomeAnalytics {
         navigationTracker.getViewName(true));
   }
 
+  public void sendAppcKnowMoreInteractEvent(String bundleTag, int bundlePosition,
+      HomeEvent.Type type) {
+    final Map<String, Object> data = new HashMap<>();
+    data.put("action", TAP_ON_CARD);
+    data.put("bundle_tag", bundleTag);
+    data.put("bundle_position", bundlePosition);
+
+    analyticsManager.logEvent(data, HOME_INTERACT, OPEN, navigationTracker.getViewName(true));
+  }
+
+  public void sendAppcDismissInteractEvent(String bundleTag, int bundlePosition,
+      HomeEvent.Type type) {
+    final Map<String, Object> data = new HashMap<>();
+    data.put("action", TAP_ON_CARD_DISMISS);
+    data.put("bundle_tag", bundleTag);
+    data.put("bundle_position", bundlePosition);
+
+    analyticsManager.logEvent(data, HOME_INTERACT, DISMISS, navigationTracker.getViewName(true));
+  }
+
+  public void sendAppcImpressionEvent(String bundleTag, int bundlePosition) {
+    final Map<String, Object> data = new HashMap<>();
+    data.put("action", VIEW_CARD);
+    data.put("bundle_tag", bundleTag);
+    data.put("bundle_position", bundlePosition);
+
+    analyticsManager.logEvent(data, HOME_INTERACT, AnalyticsManager.Action.IMPRESSION,
+        navigationTracker.getViewName(true));
+  }
+
   private AnalyticsManager.Action parseAction(HomeEvent.Type type) {
     if (type.equals(HomeEvent.Type.SOCIAL_CLICK) || type.equals(HomeEvent.Type.AD)) {
-      return AnalyticsManager.Action.OPEN;
+      return OPEN;
     } else if (type.equals(HomeEvent.Type.SOCIAL_INSTALL)) {
       return AnalyticsManager.Action.INSTALL;
     }

--- a/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
@@ -250,13 +250,13 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
         .debounce(200, TimeUnit.MILLISECONDS);
   }
 
-  @Override public Observable<HomeBundle> visibleBundles() {
+  @Override public Observable<HomeEvent> visibleBundles() {
     return RxRecyclerView.scrollEvents(bundlesList)
         .subscribeOn(AndroidSchedulers.mainThread())
         .map(recyclerViewScrollEvent -> layoutManager.findFirstVisibleItemPosition())
         .filter(position -> position != RecyclerView.NO_POSITION)
         .distinctUntilChanged()
-        .map(visibleItem -> adapter.getBundle(visibleItem));
+        .map(visibleItem -> new HomeEvent(adapter.getBundle(visibleItem), visibleItem, null));
   }
 
   @Override public Observable<AppHomeEvent> recommendedAppClicked() {

--- a/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
@@ -98,7 +98,7 @@ public class HomePresenter implements Presenter {
         .observeOn(viewScheduler)
         .doOnNext(homeEvent -> {
           homeAnalytics.sendAppcKnowMoreInteractEvent(homeEvent.getBundle()
-              .getTag(), homeEvent.getBundlePosition(), homeEvent.getType());
+              .getTag(), homeEvent.getBundlePosition());
           homeNavigator.navigateToAppCoinsInformationView();
         })
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
@@ -114,7 +114,7 @@ public class HomePresenter implements Presenter {
         .flatMap(created -> view.dismissBundleClicked())
         .filter(homeEvent -> homeEvent.getBundle() instanceof ActionBundle)
         .doOnNext(homeEvent -> homeAnalytics.sendAppcDismissInteractEvent(homeEvent.getBundle()
-            .getTag(), homeEvent.getBundlePosition(), homeEvent.getType()))
+            .getTag(), homeEvent.getBundlePosition()))
         .flatMap(homeEvent -> home.remove((ActionBundle) homeEvent.getBundle())
             .andThen(Observable.just(homeEvent)))
         .observeOn(viewScheduler)

--- a/app/src/main/java/cm/aptoide/pt/home/apps/BundleView.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/BundleView.java
@@ -46,5 +46,5 @@ public interface BundleView extends View {
 
   Observable<HomeEvent> bundleScrolled();
 
-  Observable<HomeBundle> visibleBundles();
+  Observable<HomeEvent> visibleBundles();
 }

--- a/app/src/test/java/cm/aptoide/pt/navigation/HomePresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/navigation/HomePresenterTest.java
@@ -74,7 +74,7 @@ public class HomePresenterTest {
   private PublishSubject<HomeEvent> bundleScrolledEvent;
   private PublishSubject<HomeEvent> knowMoreEvent;
   private PublishSubject<HomeEvent> dismissEvent;
-  private PublishSubject<HomeBundle> visibleBundleEvent;
+  private PublishSubject<HomeEvent> visibleBundleEvent;
 
   @Before public void setupHomePresenter() {
     MockitoAnnotations.initMocks(this);
@@ -329,7 +329,7 @@ public class HomePresenterTest {
     presenter.handleKnowMoreClick();
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
     //When an user clicks on the KNOW MORE button in the AppCoins onboarding card
-    knowMoreEvent.onNext(new HomeEvent(null, 4, HomeEvent.Type.KNOW_MORE));
+    knowMoreEvent.onNext(new HomeEvent(getFakeActionBundle(), 4, HomeEvent.Type.KNOW_MORE));
     //Then it should navigate to the AppCoins wallet information view.
     verify(homeNavigator).navigateToAppCoinsInformationView();
   }
@@ -355,9 +355,10 @@ public class HomePresenterTest {
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
     //And an action bundle
     ActionBundle bundle = getFakeActionBundle();
+    HomeEvent event = new HomeEvent(bundle, 1, HomeEvent.Type.KNOW_MORE);
     when(home.actionBundleImpression(bundle)).thenReturn(Completable.complete());
     //When the bundle is visible to the user
-    visibleBundleEvent.onNext(bundle);
+    visibleBundleEvent.onNext(event);
     //Then bundle should be marked as read (impression)
     verify(home).actionBundleImpression(bundle);
   }


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix appc relate events in home and appview not being sent;

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AppViewAnalytics.java
- [ ] HomeAnalytics.java

**How should this be manually tested?**

Click the get Appc banner in appview as well as both buttons and the impression in home action card. Check that for every one of these, the corresponding facebook event is sent;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-955](<https://aptoide.atlassian.net/browse/ASV-955>)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass