### PR TITLE
[ASV-967] Fixed 2 of the 3 requested events

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/HomeNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeNavigator.java
@@ -36,6 +36,12 @@ public class HomeNavigator {
     appNavigator.navigateWithAppId(appId, packageName, NewAppViewFragment.OpenType.OPEN_ONLY, tag);
   }
 
+  public void navigateWithEditorsPosition(long appId, String packageName, String storeTheme,
+      String storeName, String tag, String editorsPosition) {
+    appNavigator.navigatewithEditorsPosition(appId, packageName, storeTheme, storeName, tag,
+        editorsPosition);
+  }
+
   public void navigateToRecommendsAppView(long appId, String packageName, String tag,
       HomeEvent.Type type) {
     appNavigator.navigateWithAppId(appId, packageName, parseAction(type), tag);

--- a/app/src/test/java/cm/aptoide/pt/navigation/HomePresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/navigation/HomePresenterTest.java
@@ -101,7 +101,7 @@ public class HomePresenterTest {
     FakeBundleDataSource fakeBundleDataSource = new FakeBundleDataSource();
     bundlesModel = new HomeBundlesModel(fakeBundleDataSource.getFakeBundles(), false, 0);
     localTopAppsBundle = bundlesModel.getList()
-        .get(0);
+        .get(1);
 
     when(view.getLifecycle()).thenReturn(lifecycleEvent);
     when(view.appClicked()).thenReturn(appClickEvent);


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix the events related to editor's choice not being sent. These are:

- Editors_Choice_Clicks: Now being properly sent;

- Editors_Choice_Application_Install: Now being properly sent;

- Editors_Choice_Download_Completed: Out of the scope of this ticket; Should be fixed along with the other download events not being correctly sent to facebook;


**Database changed?**

No

**Where should the reviewer start?**

- [ ] HomePresenter.java

**How should this be manually tested?**

Click an app in the editor's choice bundle in home. Verify that this produces the corresponding event. Afterwards, download the app, install it and verify that the correct event is being sent;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-967](<https://aptoide.atlassian.net/browse/ASV-967>)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass