### PR TITLE
[ASV-1030] Extracted GDPR dialgo logic to it's own class so as to iso…

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
@@ -6,20 +6,13 @@ import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.support.v4.widget.SwipeRefreshLayout;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.text.SpannableString;
-import android.text.Spanned;
-import android.text.method.LinkMovementMethod;
-import android.text.style.ClickableSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
-import android.widget.TextView;
 import cm.aptoide.analytics.implementation.navigation.ScreenTagHistory;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
@@ -66,11 +59,9 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
   private View retryButton;
   private ImageView userAvatar;
   private BottomNavigationActivity bottomNavigationActivity;
+  private LoggedInTermsAndConditionsDialog gdprDialog;
 
-  private PublishSubject<Void> termsAndConditionsAccept;
-  private PublishSubject<Void> termsAndConditionsLogOut;
-  private PublishSubject<Void> termsAndConditionsSubject;
-  private PublishSubject<Void> privacyPolicySubject;
+  private PublishSubject<String> gdprDialogUiSubject;
 
   @Override public void onAttach(Activity activity) {
     super.onAttach(activity);
@@ -82,10 +73,7 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
   @Override public void onDestroy() {
     uiEventsListener = null;
     oneDecimalFormatter = null;
-    termsAndConditionsAccept = null;
-    termsAndConditionsLogOut = null;
-    termsAndConditionsSubject = null;
-    privacyPolicySubject = null;
+    gdprDialogUiSubject = null;
     adClickedEvents = null;
     userAvatar = null;
     super.onDestroy();
@@ -97,10 +85,7 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
 
     uiEventsListener = PublishSubject.create();
     adClickedEvents = PublishSubject.create();
-    termsAndConditionsAccept = PublishSubject.create();
-    termsAndConditionsLogOut = PublishSubject.create();
-    termsAndConditionsSubject = PublishSubject.create();
-    privacyPolicySubject = PublishSubject.create();
+    gdprDialogUiSubject = PublishSubject.create();
     oneDecimalFormatter = new DecimalFormat("0.0");
   }
 
@@ -162,6 +147,10 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
     genericErrorView = null;
     noNetworkErrorView = null;
     progressBar = null;
+    if (gdprDialog != null) {
+      gdprDialog.destroyDialog();
+      gdprDialog = null;
+    }
     super.onDestroyView();
   }
 
@@ -292,6 +281,10 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
         .cast(EditorialHomeEvent.class);
   }
 
+  @Override public Observable<String> gdprDialogClicked() {
+    return gdprDialogUiSubject;
+  }
+
   @Override public Observable<HomeEvent> infoBundleKnowMoreClicked() {
     return this.uiEventsListener.filter(homeEvent -> homeEvent.getType()
         .equals(HomeEvent.Type.KNOW_MORE));
@@ -321,22 +314,6 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
         .equals(HomeEvent.Type.DISMISS_BUNDLE));
   }
 
-  @Override public Observable<Void> termsAndConditionsContinueClicked() {
-    return termsAndConditionsAccept;
-  }
-
-  @Override public Observable<Void> termsAndConditionsLogOutClicked() {
-    return termsAndConditionsLogOut;
-  }
-
-  @Override public Observable<Void> privacyPolicyClicked() {
-    return privacyPolicySubject;
-  }
-
-  @Override public Observable<Void> termsAndConditionsClicked() {
-    return termsAndConditionsSubject;
-  }
-
   @Override public void hideBundle(int bundlePosition) {
     adapter.remove(bundlePosition);
   }
@@ -351,75 +328,11 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
   }
 
   @Override public void showTermsAndConditionsDialog() {
-    LayoutInflater inflater = LayoutInflater.from(getActivity());
-    AlertDialog alertDialog = new AlertDialog.Builder(getActivity()).create();
-    View dialogView = inflater.inflate(R.layout.dialog_logged_in_accept_tos, null);
-    alertDialog.setView(dialogView);
-    Button continueButton = dialogView.findViewById(R.id.accept_continue);
-
-    setPrivacyPolicyLinks(dialogView);
-    alertDialog.setCancelable(false);
-    alertDialog.setCanceledOnTouchOutside(false);
-
-    continueButton.setOnClickListener(__ -> {
-      termsAndConditionsAccept.onNext(null);
-      alertDialog.dismiss();
-    });
-
-    dialogView.findViewById(R.id.log_out)
-        .setOnClickListener(__ -> {
-          termsAndConditionsLogOut.onNext(null);
-          alertDialog.dismiss();
-        });
-    alertDialog.show();
+    new LoggedInTermsAndConditionsDialog(getContext(), gdprDialogUiSubject).showDialog();
   }
 
   private boolean isEndReached() {
     return layoutManager.getItemCount() - layoutManager.findLastVisibleItemPosition()
         <= VISIBLE_THRESHOLD;
-  }
-
-  private void setPrivacyPolicyLinks(View dialogView) {
-
-    ClickableSpan termsAndConditionsClickListener = new ClickableSpan() {
-      @Override public void onClick(View view) {
-        if (termsAndConditionsSubject != null) {
-          termsAndConditionsSubject.onNext(null);
-        }
-      }
-    };
-
-    ClickableSpan privacyPolicyClickListener = new ClickableSpan() {
-      @Override public void onClick(View view) {
-        if (privacyPolicySubject != null) {
-          privacyPolicySubject.onNext(null);
-        }
-      }
-    };
-
-    String baseString = getString(R.string.accept_terms_message_loggedin);
-    String buttonString = getString(R.string.terms_and_conditions_privacy_sign_up_message);
-    String termsAndConditionsPlaceHolder = getString(R.string.settings_terms_conditions);
-    String privacyPolicyPlaceHolder = getString(R.string.settings_privacy_policy);
-    String privacyAndTerms =
-        String.format(baseString, termsAndConditionsPlaceHolder, privacyPolicyPlaceHolder);
-    String buttonAccept =
-        String.format(buttonString, termsAndConditionsPlaceHolder, privacyPolicyPlaceHolder);
-    Button continueButton = dialogView.findViewById(R.id.accept_continue);
-    continueButton.setText(buttonAccept);
-
-    SpannableString privacyAndTermsSpan = new SpannableString(privacyAndTerms);
-    privacyAndTermsSpan.setSpan(termsAndConditionsClickListener,
-        privacyAndTerms.indexOf(termsAndConditionsPlaceHolder),
-        privacyAndTerms.indexOf(termsAndConditionsPlaceHolder)
-            + termsAndConditionsPlaceHolder.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-    privacyAndTermsSpan.setSpan(privacyPolicyClickListener,
-        privacyAndTerms.indexOf(privacyPolicyPlaceHolder),
-        privacyAndTerms.indexOf(privacyPolicyPlaceHolder) + privacyPolicyPlaceHolder.length(),
-        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-
-    TextView info = dialogView.findViewById(R.id.tos_info);
-    info.setText(privacyAndTermsSpan);
-    info.setMovementMethod(LinkMovementMethod.getInstance());
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
@@ -468,7 +468,8 @@ public class HomePresenter implements Presenter {
   private void handleTermsAndConditionsContinueClicked() {
     view.getLifecycle()
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
-        .flatMap(__ -> view.termsAndConditionsContinueClicked())
+        .flatMap(__ -> view.gdprDialogClicked())
+        .filter(action -> action.equals("continue"))
         .flatMapCompletable(__ -> accountManager.updateTermsAndConditions())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {
@@ -480,7 +481,8 @@ public class HomePresenter implements Presenter {
   private void handleTermsAndConditionsLogOutClicked() {
     view.getLifecycle()
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
-        .flatMap(__ -> view.termsAndConditionsLogOutClicked())
+        .flatMap(__ -> view.gdprDialogClicked())
+        .filter(action -> action.equals("logout"))
         .flatMapCompletable(__ -> accountManager.logout())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {
@@ -492,7 +494,8 @@ public class HomePresenter implements Presenter {
   private void handleClickOnTermsAndConditions() {
     view.getLifecycle()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
-        .flatMap(__ -> view.termsAndConditionsClicked())
+        .flatMap(__ -> view.gdprDialogClicked())
+        .filter(action -> action.equals("terms"))
         .doOnNext(__ -> homeNavigator.navigateToTermsAndConditions())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {
@@ -504,7 +507,8 @@ public class HomePresenter implements Presenter {
   private void handleClickOnPrivacyPolicy() {
     view.getLifecycle()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
-        .flatMap(__ -> view.privacyPolicyClicked())
+        .flatMap(__ -> view.gdprDialogClicked())
+        .filter(action -> action.equals("privacy"))
         .doOnNext(__ -> homeNavigator.navigateToPrivacyPolicy())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {

--- a/app/src/main/java/cm/aptoide/pt/home/HomeView.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeView.java
@@ -13,6 +13,8 @@ public interface HomeView extends BundleView {
 
   Observable<EditorialHomeEvent> editorialCardClicked();
 
+  Observable<String> gdprDialogClicked();
+
   Observable<HomeEvent> infoBundleKnowMoreClicked();
 
   void scrollToTop();
@@ -22,14 +24,6 @@ public interface HomeView extends BundleView {
   Observable<Void> imageClick();
 
   Observable<HomeEvent> dismissBundleClicked();
-
-  Observable<Void> termsAndConditionsContinueClicked();
-
-  Observable<Void> termsAndConditionsLogOutClicked();
-
-  Observable<Void> privacyPolicyClicked();
-
-  Observable<Void> termsAndConditionsClicked();
 
   void hideBundle(int bundlePosition);
 

--- a/app/src/main/java/cm/aptoide/pt/home/LoggedInTermsAndConditionsDialog.java
+++ b/app/src/main/java/cm/aptoide/pt/home/LoggedInTermsAndConditionsDialog.java
@@ -1,0 +1,98 @@
+package cm.aptoide.pt.home;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.method.LinkMovementMethod;
+import android.text.style.ClickableSpan;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+import cm.aptoide.pt.R;
+import rx.subjects.PublishSubject;
+
+/**
+ * Created by franciscocalado on 20/09/2018.
+ */
+
+public class LoggedInTermsAndConditionsDialog {
+
+  private AlertDialog dialog;
+
+  public LoggedInTermsAndConditionsDialog(Context context, PublishSubject<String> uiEvents) {
+    LayoutInflater inflater = LayoutInflater.from(context);
+    dialog = new AlertDialog.Builder(context).create();
+    View dialogView = inflater.inflate(R.layout.dialog_logged_in_accept_tos, null);
+    dialog.setView(dialogView);
+    Button continueButton = dialogView.findViewById(R.id.accept_continue);
+
+    setPrivacyPolicyLinks(dialogView, context, uiEvents);
+    dialog.setCancelable(false);
+    dialog.setCanceledOnTouchOutside(false);
+
+    continueButton.setOnClickListener(__ -> {
+      uiEvents.onNext("continue");
+      dialog.dismiss();
+    });
+
+    dialogView.findViewById(R.id.log_out)
+        .setOnClickListener(__ -> {
+          uiEvents.onNext("logout");
+          dialog.dismiss();
+        });
+  }
+
+  public void showDialog() {
+    dialog.show();
+  }
+
+  public void destroyDialog() {
+    dialog = null;
+  }
+
+  private void setPrivacyPolicyLinks(View dialogView, Context context,
+      PublishSubject<String> uiEvents) {
+    ClickableSpan termsAndConditionsClickListener = new ClickableSpan() {
+      @Override public void onClick(View view) {
+        if (uiEvents != null) {
+          uiEvents.onNext("terms");
+        }
+      }
+    };
+
+    ClickableSpan privacyPolicyClickListener = new ClickableSpan() {
+      @Override public void onClick(View view) {
+        if (uiEvents != null) {
+          uiEvents.onNext("privacy");
+        }
+      }
+    };
+
+    String baseString = context.getString(R.string.accept_terms_message_loggedin);
+    String buttonString = context.getString(R.string.terms_and_conditions_privacy_sign_up_message);
+    String termsAndConditionsPlaceHolder = context.getString(R.string.settings_terms_conditions);
+    String privacyPolicyPlaceHolder = context.getString(R.string.settings_privacy_policy);
+    String privacyAndTerms =
+        String.format(baseString, termsAndConditionsPlaceHolder, privacyPolicyPlaceHolder);
+    String buttonAccept =
+        String.format(buttonString, termsAndConditionsPlaceHolder, privacyPolicyPlaceHolder);
+    Button continueButton = dialogView.findViewById(R.id.accept_continue);
+    continueButton.setText(buttonAccept);
+
+    SpannableString privacyAndTermsSpan = new SpannableString(privacyAndTerms);
+    privacyAndTermsSpan.setSpan(termsAndConditionsClickListener,
+        privacyAndTerms.indexOf(termsAndConditionsPlaceHolder),
+        privacyAndTerms.indexOf(termsAndConditionsPlaceHolder)
+            + termsAndConditionsPlaceHolder.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    privacyAndTermsSpan.setSpan(privacyPolicyClickListener,
+        privacyAndTerms.indexOf(privacyPolicyPlaceHolder),
+        privacyAndTerms.indexOf(privacyPolicyPlaceHolder) + privacyPolicyPlaceHolder.length(),
+        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+    TextView info = dialogView.findViewById(R.id.tos_info);
+    info.setText(privacyAndTermsSpan);
+    info.setMovementMethod(LinkMovementMethod.getInstance());
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

This PR aims to extract the logic for the GDPR dialog in home to it's own class, so as to isolate it;

**Database changed?**

No

**Where should the reviewer start?**

- [ ] LoggedInTermsAndConditionsDialog.java

**How should this be manually tested?**

Log in to an account that still hasn't accepted the terms and privacy. Once you navigate to home you should see the dialog and it everything should still work as before;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1030](<https://aptoide.atlassian.net/browse/ASV-1030>)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass