### PR TITLE
[ASV-1101] Requests to abtesting regarding notifications are now only…

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/notification/PullingContentService.java
+++ b/app/src/main/java/cm/aptoide/pt/notification/PullingContentService.java
@@ -126,6 +126,7 @@ public class PullingContentService extends Service {
             return Observable.just(updates);
           }
         }))
+        .filter(__ -> ManagerPreferences.isUpdateNotificationEnable(sharedPreferences))
         .observeOn(Schedulers.io())
         .flatMap(updates -> getNotificationsExperiment(application.getIdsRepository(),
             application.getAbTestService(),


### PR DESCRIPTION
**What does this PR do?**

This PR aims to only make requests to notifications ab test when the user has notification permissions activated;

**Database changed?**

No

**Where should the reviewer start?**

- [ ] PullingContentService.java

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1101](<https://aptoide.atlassian.net/browse/ASV-1101>)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass