### PR TITLE
[Bugfix/ASV-1111] AppNext Action/Impressions

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/abtesting/ABTestService.java
+++ b/app/src/main/java/cm/aptoide/pt/abtesting/ABTestService.java
@@ -44,6 +44,10 @@ public class ABTestService {
 
   public Observable<Boolean> recordAction(String identifier, String assignment) {
     return service.recordAction(identifier, aptoideId, new ABTestRequestBody(assignment))
+        .doOnNext(voidResponse -> Logger.getInstance()
+            .d(this.getClass()
+                .getName(), "response : " + voidResponse.isSuccessful()))
+        .doOnError(throwable -> throwable.printStackTrace())
         .map(__ -> true);
   }
 

--- a/app/src/main/java/cm/aptoide/pt/abtesting/experiments/SimilarAdExperiment.java
+++ b/app/src/main/java/cm/aptoide/pt/abtesting/experiments/SimilarAdExperiment.java
@@ -4,6 +4,7 @@ import cm.aptoide.pt.abtesting.ABTestManager;
 import cm.aptoide.pt.app.AdsManager;
 import cm.aptoide.pt.app.ApplicationAdResult;
 import java.util.List;
+import rx.Observable;
 import rx.Scheduler;
 import rx.Single;
 
@@ -26,6 +27,7 @@ public class SimilarAdExperiment {
 
   public Single<ApplicationAdResult> getSimilarAd(String packageName, List<String> keywords){
     return abTestManager.getExperiment(EXPERIMENT_ID)
+        .observeOn(scheduler)
         .flatMapSingle(experiment -> {
           String experimentAssigment = "default";
           if(!experiment.isExperimentOver() && experiment.isPartOfExperiment()){
@@ -40,16 +42,15 @@ public class SimilarAdExperiment {
               return adsManager.loadAd(packageName, keywords);
           }
         })
-        .toSingle()
-        .observeOn(scheduler);
+        .toSingle();
   }
 
-  public void recordAdImpression(){
-    abTestManager.recordImpression(EXPERIMENT_ID);
+  public Observable<Boolean> recordAdImpression(){
+    return abTestManager.recordImpression(EXPERIMENT_ID);
   }
 
-  public void recordAdClick(){
-    abTestManager.recordAction(EXPERIMENT_ID);
+  public Observable<Boolean> recordAdClick(){
+    return abTestManager.recordAction(EXPERIMENT_ID);
   }
 
 }

--- a/app/src/main/java/cm/aptoide/pt/ads/AppNextAdRepository.java
+++ b/app/src/main/java/cm/aptoide/pt/ads/AppNextAdRepository.java
@@ -18,9 +18,11 @@ import rx.subjects.PublishSubject;
 public class AppNextAdRepository {
 
     private final Context context;
+    private PublishSubject<AppNextAdResult> clickSubject;
 
     public AppNextAdRepository(Context context){
         this.context = context;
+        this.clickSubject = PublishSubject.create();
     }
 
     public PublishSubject<AppNextAdResult> loadAd(List<String> keywords){
@@ -37,6 +39,7 @@ public class AppNextAdRepository {
             @Override
             public void onAdClicked(NativeAd nativeAd) {
                 super.onAdClicked(nativeAd);
+                clickSubject.onNext(new AppNextAdResult(nativeAd));
             }
 
             @Override
@@ -55,6 +58,10 @@ public class AppNextAdRepository {
                 .setCachingPolicy(NativeAdRequest.CachingPolicy.STATIC_ONLY)
                 .setCategories(getCategory(keywords)));
         return subject;
+    }
+
+    public PublishSubject<AppNextAdResult> clickAd(){
+        return clickSubject;
     }
 
     public String getCategory(List<String> keywords){

--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -32,6 +32,7 @@ import java.util.List;
 import rx.Completable;
 import rx.Observable;
 import rx.Single;
+import rx.subjects.PublishSubject;
 
 /**
  * Created by D01 on 04/05/18.
@@ -223,6 +224,10 @@ public class AppViewManager {
 
   private Single<AppNextAdResult> loadAppNextAdForSimilarApps(List<String> keywords) {
     return adsManager.loadAppnextAd(keywords);
+  }
+
+  public PublishSubject<AppNextAdResult> appNextAdClick(){
+    return adsManager.appNextAdClick();
   }
 
   private Single<Boolean> isStoreFollowed(long storeId) {

--- a/app/src/vanilla/java/cm/aptoide/pt/ads/AdsRepository.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/ads/AdsRepository.java
@@ -168,6 +168,10 @@ public class AdsRepository {
     return appNextAdRepository.loadAd(keywords);
   }
 
+  public PublishSubject<AppNextAdResult> appNextAdClick(){
+    return appNextAdRepository.clickAd();
+  }
+
 
   public Observable<MinimalAd> getAdsFromSearch(String query) {
     return accountManager.accountStatus()

--- a/app/src/vanilla/java/cm/aptoide/pt/app/AdsManager.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/AdsManager.java
@@ -50,6 +50,10 @@ public class AdsManager {
     return adsRepository.loadAppNextAd(keywords).toSingle();
   }
 
+  public PublishSubject<AppNextAdResult> appNextAdClick(){
+    return adsRepository.appNextAdClick();
+  }
+
   @NonNull private MinimalAdRequestResult createMinimalAdRequestResultError(Throwable throwable) {
     if (throwable instanceof NoNetworkConnectionException) {
       return new MinimalAdRequestResult(AppsList.Error.NETWORK);

--- a/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewView.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/view/AppViewView.java
@@ -12,6 +12,7 @@ import cm.aptoide.pt.share.ShareDialogs;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.view.app.DetailedAppRequestResult;
 import cm.aptoide.pt.view.app.FlagsVote;
+import com.jakewharton.rxbinding.view.ViewScrollChangeEvent;
 import rx.Observable;
 
 /**
@@ -50,7 +51,7 @@ public interface AppViewView extends InstallAppView {
 
   void displayStoreFollowedSnack(String storeName);
 
-  Observable<Void> handleScroll();
+  Observable<ViewScrollChangeEvent> scrollVisibleSimilarApps();
 
   boolean isSimilarAppsVisible();
 

--- a/app/src/vanilla/java/cm/aptoide/pt/app/view/NewAppViewFragment.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/view/NewAppViewFragment.java
@@ -94,8 +94,10 @@ import cm.aptoide.pt.view.dialog.DialogBadgeV7;
 import cm.aptoide.pt.view.dialog.DialogUtils;
 import cm.aptoide.pt.view.fragment.NavigationTrackFragment;
 import cm.aptoide.pt.view.recycler.LinearLayoutManagerWithSmoothScroller;
+import com.jakewharton.rxbinding.support.v4.widget.RxNestedScrollView;
 import com.jakewharton.rxbinding.support.v7.widget.RxToolbar;
 import com.jakewharton.rxbinding.view.RxView;
+import com.jakewharton.rxbinding.view.ViewScrollChangeEvent;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -149,7 +151,6 @@ public class NewAppViewFragment extends NavigationTrackFragment implements AppVi
   private PublishSubject<Void> dontShowAgainRecommendsDialogClick;
   private PublishSubject<AppBoughClickEvent> appBought;
   private PublishSubject<String> apkfyDialogConfirmSubject;
-  private PublishSubject<Void> scrollViewOnScroll;
 
   //Views
   private View noNetworkErrorView;
@@ -250,8 +251,6 @@ public class NewAppViewFragment extends NavigationTrackFragment implements AppVi
     skipRecommendsDialogClick = PublishSubject.create();
     dontShowAgainRecommendsDialogClick = PublishSubject.create();
     appBought = PublishSubject.create();
-
-    scrollViewOnScroll = PublishSubject.create();
 
     final AptoideApplication application =
         (AptoideApplication) getContext().getApplicationContext();
@@ -422,12 +421,6 @@ public class NewAppViewFragment extends NavigationTrackFragment implements AppVi
       scrollViewY = savedInstanceState.getInt(KEY_SCROLL_Y, 0);
     }
 
-    scrollView.getViewTreeObserver().addOnScrollChangedListener(
-        () -> {
-          if(scrollViewOnScroll != null) scrollViewOnScroll.onNext(null);
-        }
-    );
-
     collapsingToolbarLayout =
         ((CollapsingToolbarLayout) view.findViewById(R.id.collapsing_toolbar_layout));
     collapsingToolbarLayout.setExpandedTitleColor(
@@ -460,7 +453,6 @@ public class NewAppViewFragment extends NavigationTrackFragment implements AppVi
     genericRetryClick = null;
     dialogUtils = null;
     presenter = null;
-    scrollViewOnScroll = null;
   }
 
   @Override public void onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) {
@@ -664,8 +656,9 @@ public class NewAppViewFragment extends NavigationTrackFragment implements AppVi
     similarBottomView.setVisibility(View.VISIBLE);
   }
 
-  @Override public Observable<Void> handleScroll(){
-    return scrollViewOnScroll;
+  @Override public Observable<ViewScrollChangeEvent> scrollVisibleSimilarApps(){
+    return RxNestedScrollView.scrollChangeEvents(scrollView)
+        .filter(__ -> isSimilarAppsVisible());
   }
 
   @Override public boolean isSimilarAppsVisible(){


### PR DESCRIPTION
**What does this PR do?**

   Action/Impressions were not working, this essentially fixes it. The main problems were that the requests were being done on the main thread (and should be on IO thread), AppNext clicks were not being registered (as they have their own click listener) and for the default ads, actions were being sent after navigating to another screen.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] SimilarAdExperiment.java
- [ ] AppViewPresenter.java

**How should this be manually tested?**

  Should be checked in AB Testing platform and/or with Charles that action/impressions are correctly working. Note at most it will appear 1 action/impression per device on the platform as those are unique actions/impressions. Both AppNext ads (bucket: "appnext_ad") and Aptoide Ads (bucket: "default_ad") should be tested.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1111](https://aptoide.atlassian.net/browse/ASV-1111)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass