### PR TITLE
[ASV-1112] fixed beta updates being wrongly displayed;

### DIFF
--- a/aptoidepreferences/src/main/java/cm/aptoide/pt/preferences/managed/ManagerPreferences.java
+++ b/aptoidepreferences/src/main/java/cm/aptoide/pt/preferences/managed/ManagerPreferences.java
@@ -28,7 +28,8 @@ public class ManagerPreferences {
    * @return true when updates should hide alpha and beta versions.
    */
   public static boolean getUpdatesFilterAlphaBetaKey(SharedPreferences sharedPreferences) {
-    return sharedPreferences.getBoolean(ManagedKeys.UPDATES_FILTER_ALPHA_BETA_KEY, true);
+    //The preference considers true to be showing updates, unlike the rest of the flow. Negating that value here solves the issue
+    return !sharedPreferences.getBoolean(ManagedKeys.UPDATES_FILTER_ALPHA_BETA_KEY, false);
   }
 
   /**


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix a bug where beta versions were displaying when the permission was set not to. They were also not displaying when the permission was set to do so. 

**Database changed?**

   No

**How should this be manually tested?**

Set the beta updates permission to on/off and check the updates tab for behaviour consistent with that permission

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1112](<https://aptoide.atlassian.net/browse/ASV-1112>)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass