### PR TITLE
[bugfix/ASV-1131] - Status Bar color on Read More 

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/view/fragment/DescriptionFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/fragment/DescriptionFragment.java
@@ -259,4 +259,14 @@ public class DescriptionFragment extends BaseLoaderToolbarFragment
     super.onCreateOptionsMenu(menu, inflater);
     inflater.inflate(R.menu.menu_empty, menu);
   }
+
+  @Override public void onDestroyView() {
+    super.onDestroyView();
+    ActionBar bar = ((AppCompatActivity) getActivity()).getSupportActionBar();
+    if (bar != null) {
+      ThemeUtils.setStatusBarThemeColor(getActivity(), StoreTheme.DEFAULT);
+      bar.setBackgroundDrawable(getActivity().getResources()
+          .getDrawable(StoreTheme.DEFAULT.getGradientDrawable()));
+    }
+  }
 }


### PR DESCRIPTION
**What does this PR do?**

   It changes the theme back to default when coming back from DescriptionFragment. Previously, if there was a store theme, when coming back to AppView, the theme would not reset back to default and the colors were mismatched.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] DescriptionFragment.java

**How should this be manually tested?**

  _Example described in the ticket:_

  In Home, click on an app with a store with theme (Metal Commando - Squad Metal... in Spend Your AppCoins bundle), click on the “Read More” in the description of the AppView, then go back to the AppView. When going back to AppView, the status bar color should be the default color, and not the store theme color.

**What are the relevant tickets?**

  [ASV-1131](https://aptoide.atlassian.net/browse/ASV-1131)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass