### PR TITLE
[Bugfix/ASV-1135] Highlighted Impression

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/abtesting/experiments/HighlightedAdExperiment.java
+++ b/app/src/main/java/cm/aptoide/pt/abtesting/experiments/HighlightedAdExperiment.java
@@ -10,6 +10,7 @@ import rx.Single;
 
 public class HighlightedAdExperiment {
 
+  public static final String DEFAULT_ASSIGNMENT_ERROR = "Default_AB_Assignment";
   private final String EXPERIMENT_ID = "ASV-1106-AppNext_Highlighted";
 
   private ABTestManager abTestManager;
@@ -37,7 +38,7 @@ public class HighlightedAdExperiment {
             case "default":
             case "no_appnext_ad":
             default:
-              return Single.just(new AppNextAdResult(new AppnextError("No ads")));
+              return Single.just(new AppNextAdResult(new AppnextError(DEFAULT_ASSIGNMENT_ERROR)));
           }
         })
         .toSingle();

--- a/app/src/main/java/cm/aptoide/pt/ads/data/ApplicationAdError.java
+++ b/app/src/main/java/cm/aptoide/pt/ads/data/ApplicationAdError.java
@@ -24,4 +24,10 @@ public class ApplicationAdError {
   public boolean hasError() {
     return nativeAdError != null || minimalAdError != null;
   }
+
+  public String getErrorMessage() {
+    if (nativeAdError != null) return nativeAdError.getErrorMessage();
+    if (minimalAdError != null) return minimalAdError.name();
+    return null;
+  }
 }

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -125,8 +125,9 @@ public class AppViewPresenter implements Presenter {
           if (similarAppsViewModel != null
               && similarAppsViewModel.hasAd()
               && !similarAdExperiment.isImpressionRecorded()) {
-            appViewAnalytics.similarAppBundleImpression(similarAppsViewModel.getAd()
-                .getNetwork(), true);
+            appViewAnalytics.
+                similarAppBundleImpression(similarAppsViewModel.getAd()
+                    .getNetwork(), true);
             return similarAdExperiment.recordAdImpression();
           }
           return Observable.empty();

--- a/app/src/main/java/cm/aptoide/pt/home/HomeAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeAnalytics.java
@@ -118,6 +118,16 @@ public class HomeAnalytics {
         network);
   }
 
+  public void sendHighlightedImpressionEvent() {
+    final Map<String, Object> data = new HashMap<>();
+    data.put("action", IMPRESSION);
+    data.put("bundle_tag", "ads-highlighted");
+    data.put("network", ApplicationAd.Network.SERVER);
+
+    analyticsManager.logEvent(data, HOME_INTERACT, parseAction(HomeEvent.Type.AD),
+        navigationTracker.getViewName(true));
+  }
+
   public void sendAdClickEvent(int appRating, String packageName, int bundlePosition,
       String bundleTag, HomeEvent.Type type, ApplicationAd.Network network) {
     sendAdInteractEvent(TAP_ON_APP, appRating, packageName, bundlePosition, bundleTag, type,

--- a/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
@@ -18,6 +18,7 @@ import rx.Single;
 import rx.exceptions.OnErrorNotImplementedException;
 import rx.schedulers.Schedulers;
 
+import static cm.aptoide.pt.abtesting.experiments.HighlightedAdExperiment.DEFAULT_ASSIGNMENT_ERROR;
 import static cm.aptoide.pt.home.HomeBundle.BundleType.ADS;
 import static cm.aptoide.pt.home.HomeBundle.BundleType.EDITORS;
 
@@ -222,6 +223,13 @@ public class HomePresenter implements Presenter {
           if (ad != null) {
             homeAnalytics.sendAdImpressionEvent(ad.getStars(), ad.getPackageName(), 0, bundleTag,
                 HomeEvent.Type.AD, ApplicationAd.Network.APPNEXT);
+            return home.recordAppNextImpression()
+                .map(__ -> appNextAdResult)
+                .toSingle();
+          } else if (appNextAdResult.getError()
+              .getErrorMessage()
+              .equals(DEFAULT_ASSIGNMENT_ERROR)) {
+            homeAnalytics.sendHighlightedImpressionEvent();
             return home.recordAppNextImpression()
                 .map(__ -> appNextAdResult)
                 .toSingle();


### PR DESCRIPTION
**What does this PR do?**

   Registers impression when there's no AppNext ad in the highlighted bundle. 

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] HighlightedAdExperiment.java
- [ ] HomePresenter.java.java

**How should this be manually tested?**

  Check if when the Highlighted ad experiment AB test bucket is 'no_appnext_ad', impressions events are being sent.

**What are the relevant tickets?**

  [ASV-1135](https://aptoide.atlassian.net/browse/ASV-1135)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass