### PR TITLE
[Monetization/ASV-1141] NativeAdView encapsulation

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ads/model/AppNextNativeAd.java
+++ b/app/src/main/java/cm/aptoide/pt/ads/model/AppNextNativeAd.java
@@ -2,6 +2,7 @@ package cm.aptoide.pt.ads.model;
 
 import android.view.View;
 import com.appnext.nativeads.NativeAd;
+import com.appnext.nativeads.NativeAdView;
 
 /**
  * Created by franciscoaleixo on 04/10/2018.
@@ -36,5 +37,9 @@ public class AppNextNativeAd implements ApplicationAd {
 
   @Override public Network getNetwork() {
     return Network.APPNEXT;
+  }
+
+  @Override public void setAdView(View adView) {
+    nativeAd.setNativeAdView((NativeAdView) adView);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/ads/model/ApplicationAd.java
+++ b/app/src/main/java/cm/aptoide/pt/ads/model/ApplicationAd.java
@@ -19,6 +19,8 @@ public interface ApplicationAd {
 
   Network getNetwork();
 
+  void setAdView(View adView);
+
   enum Network {
     SERVER("Server"), APPNEXT("AppNext");
     private String name;

--- a/app/src/main/java/cm/aptoide/pt/ads/model/AptoideNativeAd.java
+++ b/app/src/main/java/cm/aptoide/pt/ads/model/AptoideNativeAd.java
@@ -103,6 +103,9 @@ public class AptoideNativeAd implements ApplicationAd {
     return Network.SERVER;
   }
 
+  @Override public void setAdView(View adView) {
+  }
+
   public String getCpdUrl() {
     return cpdUrl;
   }

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewSimilarAppViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewSimilarAppViewHolder.java
@@ -48,6 +48,8 @@ public class AppViewSimilarAppViewHolder extends RecyclerView.ViewHolder {
               .getIconUrl(), 8, iconView, R.drawable.placeholder_square);
       app.getAd()
           .registerClickableView(itemView);
+      app.getAd()
+          .setAdView(itemView.findViewById(R.id.na_view));
       float rating = app.getAd()
           .getStars();
       if (rating == 0) {

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewSimilarAppsAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewSimilarAppsAdapter.java
@@ -4,6 +4,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 import cm.aptoide.pt.R;
+import cm.aptoide.pt.ads.model.ApplicationAd;
 import cm.aptoide.pt.app.AppViewSimilarApp;
 import java.text.DecimalFormat;
 import java.util.List;
@@ -29,7 +30,13 @@ public class AppViewSimilarAppsAdapter extends RecyclerView.Adapter<AppViewSimil
     this.type = type;
   }
 
-  @Override public AppViewSimilarAppViewHolder onCreateViewHolder(ViewGroup viewGroup, int i) {
+  @Override
+  public AppViewSimilarAppViewHolder onCreateViewHolder(ViewGroup viewGroup, int viewType) {
+    if (viewType == ApplicationAd.Network.APPNEXT.ordinal()) {
+      return new AppViewSimilarAppViewHolder(LayoutInflater.from(viewGroup.getContext())
+          .inflate(R.layout.displayable_grid_ad_appnext, viewGroup, false), oneDecimalFormater,
+          appClicked);
+    }
     return new AppViewSimilarAppViewHolder(LayoutInflater.from(viewGroup.getContext())
         .inflate(R.layout.displayable_grid_ad, viewGroup, false), oneDecimalFormater, appClicked);
   }
@@ -46,5 +53,10 @@ public class AppViewSimilarAppsAdapter extends RecyclerView.Adapter<AppViewSimil
   public void update(List<AppViewSimilarApp> apps) {
     similarApps = apps;
     notifyDataSetChanged();
+  }
+
+  @Override public int getItemViewType(int position) {
+    return similarApps.get(position)
+        .getNetworkAdType();
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/AdInBundleViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/home/AdInBundleViewHolder.java
@@ -45,6 +45,8 @@ class AdInBundleViewHolder extends RecyclerView.ViewHolder {
     }
     adClick.getAd()
         .registerClickableView(itemView);
+    adClick.getAd()
+        .setAdView(itemView.findViewById(R.id.na_view));
     itemView.setOnClickListener(v -> adClickedEvents.onNext(
         new AdHomeEvent(adClick, position, homeBundle, bundlePosition, HomeEvent.Type.AD)));
   }

--- a/app/src/main/java/cm/aptoide/pt/home/AdsInBundleAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/AdsInBundleAdapter.java
@@ -4,6 +4,8 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 import cm.aptoide.pt.R;
+import cm.aptoide.pt.ads.model.ApplicationAd;
+import cm.aptoide.pt.app.view.AppViewSimilarAppViewHolder;
 import java.text.DecimalFormat;
 import java.util.List;
 import rx.subjects.PublishSubject;
@@ -38,7 +40,12 @@ class AdsInBundleAdapter extends RecyclerView.Adapter<AdInBundleViewHolder> {
     this.bundlePosition = bundlePosition;
   }
 
-  @Override public AdInBundleViewHolder onCreateViewHolder(ViewGroup parent, int position) {
+  @Override public AdInBundleViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    if (viewType == ApplicationAd.Network.APPNEXT.ordinal()) {
+      return new AdInBundleViewHolder(LayoutInflater.from(parent.getContext())
+          .inflate(R.layout.displayable_grid_ad_appnext, parent, false), adClickedEvents,
+          oneDecimalFormatter);
+    }
     return new AdInBundleViewHolder(LayoutInflater.from(parent.getContext())
         .inflate(R.layout.displayable_grid_ad, parent, false), adClickedEvents,
         oneDecimalFormatter);
@@ -50,5 +57,12 @@ class AdsInBundleAdapter extends RecyclerView.Adapter<AdInBundleViewHolder> {
 
   @Override public int getItemCount() {
     return ads.size();
+  }
+
+  @Override public int getItemViewType(int position) {
+    return ads.get(position)
+        .getAd()
+        .getNetwork()
+        .ordinal();
   }
 }

--- a/app/src/main/res/layout/displayable_grid_ad_appnext.xml
+++ b/app/src/main/res/layout/displayable_grid_ad_appnext.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="104dp"
+    android:layout_height="wrap_content"
+    android:clickable="true"
+    android:foreground="?selectableItemBackground"
+    >
+
+
+  <com.appnext.nativeads.NativeAdView
+      android:id="@+id/na_view"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      >
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:paddingBottom="5dp"
+        android:paddingTop="8dp"
+        style="?attr/backgroundCard"
+        >
+
+      <ImageView
+          android:id="@+id/icon"
+          android:layout_width="88dp"
+          android:layout_height="88dp"
+          android:layout_centerHorizontal="true"
+          android:adjustViewBounds="true"
+          android:contentDescription="@null"
+          />
+
+      <LinearLayout
+          android:layout_width="107dp"
+          android:layout_height="wrap_content"
+          android:layout_below="@+id/icon"
+          android:layout_marginBottom="5dp"
+          android:layout_marginEnd="8dp"
+          android:layout_marginLeft="8dp"
+          android:layout_marginRight="8dp"
+          android:layout_marginStart="8dp"
+          android:layout_marginTop="4dp"
+          android:orientation="vertical"
+          >
+
+        <TextView
+            android:id="@+id/name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lines="2"
+            style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
+            />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="1dp"
+            android:layout_marginLeft="1dp"
+            android:layout_marginRight="1dp"
+            android:layout_marginStart="1dp"
+            android:layout_marginTop="2dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            >
+
+          <ImageView
+              android:layout_width="10dp"
+              android:layout_height="10dp"
+              android:src="@drawable/ic_star_black"
+              />
+          <TextView
+              android:id="@+id/rating_label"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_marginLeft="5dp"
+              android:layout_marginStart="5dp"
+              tools:ignore="SmallSp"
+              tools:text="2.3"
+              style="@style/Aptoide.TextView.Regular.XXS.Black"
+              />
+
+          <TextView
+              android:id="@+id/ad_label"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:gravity="end"
+              android:text="@string/all_title_ad"
+              tools:ignore="SmallSp"
+              style="@style/Aptoide.TextView.Regular.XXS.Black"
+              />
+
+        </LinearLayout>
+
+      </LinearLayout>
+
+    </RelativeLayout>
+  </com.appnext.nativeads.NativeAdView>
+
+</android.support.v7.widget.CardView>

--- a/app/src/vanilla/java/cm/aptoide/pt/app/AppViewSimilarApp.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/app/AppViewSimilarApp.java
@@ -28,4 +28,10 @@ public class AppViewSimilarApp {
   public boolean isAd() {
     return app == null && ad != null;
   }
+
+  public int getNetworkAdType() {
+    if (ad == null) return 0;
+    return ad.getNetwork()
+        .ordinal();
+  }
 }


### PR DESCRIPTION
**What does this PR do?**

   AppNext ad views should be encapsulated with NativeAdView to make sure impressions work correctly. This PR does that.

**Database changed?**

   No

**How should this be manually tested?**

  Check if AppNext ads are actually encapsulated with NativeAdView. Impression analytics tests will probably be done later.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1141](https://aptoide.atlassian.net/browse/ASV-1141)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass