### PR TITLE
[ASV-1127] Fix cancel button

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsAdapter.java
@@ -297,7 +297,7 @@ public class AppsAdapter extends RecyclerView.Adapter<AppsViewHolder> {
     return appsByType;
   }
 
-  public void removeCanceledDownload(App app) {
+  public void removeCanceledAppDownload(App app) {
     if (listOfApps.contains(app)) {
       int indexOfCanceledDownload = listOfApps.indexOf(app);
       listOfApps.remove(app);

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
@@ -319,10 +319,6 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     recyclerView.smoothScrollToPosition(0);
   }
 
-  @Override public void removeInstalledUpdates(List<App> installedUpdatesList) {
-    adapter.removeUpdatesList(installedUpdatesList);
-  }
-
   @Override public Observable<Void> refreshApps() {
     return RxSwipeRefreshLayout.refreshes(swipeRefreshLayout);
   }

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
@@ -333,8 +333,8 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
     }
   }
 
-  @Override public void removeCanceledDownload(App app) {
-    adapter.removeCanceledDownload(app);
+  @Override public void removeCanceledAppDownload(App app) {
+    adapter.removeCanceledAppDownload(app);
   }
 
   @Override public void setStandbyState(App app) {

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragmentView.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragmentView.java
@@ -70,7 +70,7 @@ public interface AppsFragmentView extends View {
 
   void hidePullToRefresh();
 
-  void removeCanceledDownload(App app);
+  void removeCanceledAppDownload(App app);
 
   void setStandbyState(App app);
 

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragmentView.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragmentView.java
@@ -64,8 +64,6 @@ public interface AppsFragmentView extends View {
 
   void scrollToTop();
 
-  void removeInstalledUpdates(List<App> installedUpdatesList);
-
   Observable<Void> refreshApps();
 
   void hidePullToRefresh();

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
@@ -197,7 +197,7 @@ public class AppsPresenter implements Presenter {
         .filter(lifecycleEvent -> lifecycleEvent == View.LifecycleEvent.CREATE)
         .observeOn(viewScheduler)
         .flatMap(created -> view.cancelUpdate())
-        .doOnNext(app -> view.setStandbyState(app))
+        .doOnNext(app -> view.removeCanceledAppDownload(app))
         .observeOn(ioScheduler)
         .doOnNext(app -> appsManager.cancelUpdate(app))
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
@@ -292,7 +292,7 @@ public class AppsPresenter implements Presenter {
         .observeOn(ioScheduler)
         .doOnNext(app -> appsManager.cancelDownload(app))
         .observeOn(viewScheduler)
-        .doOnNext(app -> view.removeCanceledDownload(app))
+        .doOnNext(app -> view.removeCanceledAppDownload(app))
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(created -> {
         }, error -> crashReport.log(error));


### PR DESCRIPTION
**What does this PR do?**

   Before, after pressing the cancel button on an app card of the apps bottom navigation section, the card would stay in the Standby state (with the indeterminate progress bar). This pull request aims to fix this problem.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppsPresenter.java

**How should this be manually tested?**

Start a download, pause it and then press cancel. The card will disappear. In my opinion, the card should go back to the normal/initial state, but that will be done in the future.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1127](https://aptoide.atlassian.net/browse/ASV-1127)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass