### PR TITLE
[ASV-1152] Repeated first download

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
@@ -98,7 +98,8 @@ public class AppsManager {
           return Observable.just(installations)
               .flatMapIterable(installs -> installs)
               .filter(install -> install.getType() != Install.InstallationType.UPDATE)
-              .flatMap(item -> installManager.filterInstalled(item))
+              .flatMap(item -> installManager.filterInstalled(item)
+                  .first())
               .toList()
               .map(installedApps -> appMapper.getDownloadApps(installedApps));
         });

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AptoideDownloadManager.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AptoideDownloadManager.java
@@ -45,6 +45,7 @@ public class AptoideDownloadManager implements DownloadManager {
         .filter(List::isEmpty)
         .flatMap(__ -> downloadsRepository.getInQueueDownloads()
             .first())
+        .distinctUntilChanged()
         .doOnError(throwable -> throwable.printStackTrace())
         .retry()
         .doOnNext(downloads -> Logger.getInstance()


### PR DESCRIPTION
**What does this PR do?**
The new download manager implementation has a queue. When a download is started, the downloads are added to the database in the IN_QUEUE download state. If the user presses update all, all the updates will be added to the database in the queued state which will trigger the queue and make the download manager start the first download. The problem is that since several downloads are added to the queue at the same time, it made the download manager start the first download more than once. This is PR fixes this aforementioned problem.

Also, took the chance to fix an open stream left in the Apps Manager, that would generate a leak and affect performance.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AptoideDownloadManager.java

**How should this be manually tested?**

Open the Apps section in the bottom navigation, press the update all button and see the logs for the "Starting download app file". Check that there are no repeated messages.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1152](https://aptoide.atlassian.net/browse/ASV-1152)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass