### PR TITLE
[Bugfix/ASV-1064] Campaign Notifications fix

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
+++ b/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
@@ -167,7 +167,6 @@ public abstract class AptoideApplication extends Application {
       bodyInterceptorV3;
   @Inject L2Cache httpClientCache;
   @Inject QManager qManager;
-  @Inject RootInstallationRetryHandler rootInstallationRetryHandler;
   @Inject TokenInvalidator tokenInvalidator;
   @Inject PackageRepository packageRepository;
   @Inject AdsApplicationVersionCodeProvider applicationVersionCodeProvider;
@@ -186,6 +185,7 @@ public abstract class AptoideApplication extends Application {
   @Inject InvalidRefreshTokenLogoutManager invalidRefreshTokenLogoutManager;
   @Inject ABTestService.ServiceV7 abTestService;
   @Inject RealmExperimentPersistence abTestExperimentPersistence;
+  @Inject RootInstallationRetryHandler rootInstallationRetryHandler;
   private LeakTool leakTool;
   private String aptoideMd5sum;
   private BillingAnalytics billingAnalytics;


### PR DESCRIPTION
**What does this PR do?**

   🔨

  This pull request is a fix for the campaigns notification showing problems. 
  Because the RootInstallationRetryHandler dependency in AptoideApplication depends on the AnalyticsManager & NavigationTracker, the SystemNotificationShower would be populated with null values. This fix only changes the order of when the dependencies are provided, making everything work. This will be subject of a refactor in a near-future task.


**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AptoideApplication.java

**How should this be manually tested?**

  Rewrite campaign notifications request - Please ask me for the rewrite file to not provide the webservice information here in public.
  Open the app, see if campaign notification is shown.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1064](https://aptoide.atlassian.net/browse/ASV-1064)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Unit tests pass
- [ ] Functional QA tests pass