### PR TITLE
[ASV-1159] task: update gradle version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'io.fabric.tools:gradle:1.25.4'
+    classpath "io.fabric.tools:gradle:${FABRIC_VERSION}"
   }
 }
 
@@ -138,11 +138,6 @@ android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
-  }
-
-  variantFilter { variant ->
-    List<ProductFlavor> flavors = variant.getFlavors()
-
   }
 
   packagingOptions {
@@ -293,10 +288,9 @@ android {
 dependencies {
 
   implementation project(path: ':crashreports')
-  implementation project(path: ':downloadmanager', configuration: 'default')
-  implementation project(path: ':aptoide-database', configuration: 'default')
+  implementation project(path: ':downloadmanager')
+  implementation project(path: ':aptoide-database')
   implementation project(path: ':aptoidepreferences')
-  implementation project(path: ':downloadmanager', configuration: 'default')
   implementation project(path: ':aptoide-account-manager')
   implementation project(path: ':aptoide-analytics-core')
   implementation project(path: ':aptoide-analytics-default-implementation')

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,6 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
   <uses-sdk
-      android:minSdkVersion="15"
       tools:overrideLibrary="com.paypal.android.sdk.onetouch.core, com.paypal.android.sdk.payments, com.adyen.core, com.adyen.ui, com.braintreepayments.cardform, com.asf.appcoins.sdk.contractproxy, com.asf.appcoins.sdk.core"/>
 
   <application

--- a/app/src/main/res/values/strings_accountmanager.xml
+++ b/app/src/main/res/values/strings_accountmanager.xml
@@ -18,7 +18,7 @@
   <string name="accept_terms_message_loggedin">Please accept our %1$s and %2$s to continue using Aptoide. These documents include all details about our relationship and how we store your data.</string>
   <string name="accept_terms_loggedin_readTC">READ TERMS &amp; CONDITIONS</string>
   <string name="accept_terms_loggedin_readPP">READ PRIVACY POLICY</string>
-  <string name="accept_terms_loggedin_message">By pressing accept you agree to Aptoide's %1$s and %2$s</string>
+  <string name="accept_terms_loggedin_message">By pressing accept you agree to Aptoide\'s %1$s and %2$s</string>
   <string name="accept_terms_loggedin_button_accept">ACCEPT</string>
 
   <string name="user_upload_photo_failed">It wasn\'t possible to create a profile.</string>

--- a/aptoide-analytics-core/build.gradle
+++ b/aptoide-analytics-core/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion "27.0.3"
+  compileSdkVersion Integer.parseInt(project.COMPILE_SDK_VERSION)
+  buildToolsVersion BUILD_TOOLS_VERSION
 
 
   defaultConfig {
-    minSdkVersion 15
-    targetSdkVersion 25
+    minSdkVersion project.MINIMUM_SDK_VERSION
+    targetSdkVersion Integer.parseInt(project.TARGET_SDK_VERSION)
     versionCode 1
     versionName "1.0"
 

--- a/aptoide-analytics-default-implementation/build.gradle
+++ b/aptoide-analytics-default-implementation/build.gradle
@@ -11,22 +11,17 @@ buildscript {
   }
 
   dependencies {
-    classpath 'io.fabric.tools:gradle:1.22.0'
+    classpath "io.fabric.tools:gradle:${FABRIC_VERSION}"
   }
 }
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion "27.0.3"
+  compileSdkVersion Integer.parseInt(project.COMPILE_SDK_VERSION)
+  buildToolsVersion BUILD_TOOLS_VERSION
 
 
   defaultConfig {
-    minSdkVersion 15
-    targetSdkVersion 25
-    versionCode 1
-    versionName "1.0"
-
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    minSdkVersion project.MINIMUM_SDK_VERSION
   }
 
   lintOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,10 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.1.3'
+    classpath 'com.android.tools.build:gradle:3.2.1'
     classpath 'me.tatarka:gradle-retrolambda:3.7.0'
     classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.6.1'
     classpath 'io.realm:realm-gradle-plugin:3.5.0'
-    //classpath 'com.novoda:gradle-android-command-plugin:1.5.0'
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
   }
 }
@@ -35,7 +34,7 @@ task clean(type: Delete) {
 // from controlling version.
 // This will override gradle-wrapper.properties
 task wrapper(type: Wrapper) {
-  gradleVersion = '4.4'
+  gradleVersion = '4.6'
   distributionUrl = "https://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }
 
@@ -45,7 +44,7 @@ ext {
   // gradle build script vars
   //
   USE_JACK = false // http://tools.android.com/tech-docs/jackandjill
-  BUILD_TOOLS_VERSION = '27.0.3'
+  BUILD_TOOLS_VERSION = '28.0.3'
 
   //
   // gradle build script dependencies versions
@@ -123,6 +122,8 @@ ext {
 
   TEST_FAIRY_VERSION = '1.5.5'
   DAGGER_VERSION = '2.12'
+
+  FABRIC_VERSION = '1.25.4'
 }
 
 // see 'Multi-module reports' in https://developer.android.com/studio/test/command-line.html

--- a/downloadmanager/build.gradle
+++ b/downloadmanager/build.gradle
@@ -51,7 +51,7 @@ dependencies {
   //noinspection GradleDependency
   implementation "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
 
-  implementation "com.liulishuo.filedownloader:library:${FILE_DOWNLOADER_VERSION}"
+  api "com.liulishuo.filedownloader:library:${FILE_DOWNLOADER_VERSION}"
   implementation "cn.dreamtobe.filedownloader:filedownloader-okhttp3-connection:${FILE_DOWNLOADER_OKHTTP_IMP_VERSION}"
 
   implementation "io.reactivex:rxjava:${RXJAVA_VERSION}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jul 05 17:49:48 WEST 2018
+#Mon Nov 12 17:45:42 WET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
**What does this PR do?**

   Had to update build tools, update fabric, remove minimum sdk from manifest, fix string (since in this new build tools version they seem to be checked in compile time), minor gradle scripts fixes and refactor (like extracting variables - fix the variants dependencies when switching from debug to release - fix downloads lib scope).

from spike: "To update gradle we need to also update the gradle wrapper to 4.6, build tools need to be updated to 28.0.3 (current & default version - we probably should think of removing this, since we should always use the default version) and fabric update to 1.25.4.

Minimum sdk version has to be removed from the Manifest.

After this gradle scripts will work.

Compilation is failling because this version of build tools seem to verify strings in compile time for errors and accept_terms_loggedin_message

is missing an escape character, which has to be fixed."

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] build.gradle (project & app)

**How should this be manually tested?**

  Build in different variants (test debug/release). Navigate a bit in the app.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1159](https://aptoide.atlassian.net/browse/ASV-1159)
[ASV-1149](https://aptoide.atlassian.net/browse/ASV-1149)


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Unit tests pass
- [ ] Functional QA tests pass