### PR TITLE
[ASV-1156] Fix pause flickering

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsCardViewHolderFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsCardViewHolderFactory.java
@@ -13,6 +13,7 @@ import static cm.aptoide.pt.home.apps.AppsAdapter.HEADER_DOWNLOADS;
 import static cm.aptoide.pt.home.apps.AppsAdapter.HEADER_INSTALLED;
 import static cm.aptoide.pt.home.apps.AppsAdapter.HEADER_UPDATES;
 import static cm.aptoide.pt.home.apps.AppsAdapter.INSTALLED;
+import static cm.aptoide.pt.home.apps.AppsAdapter.PAUSING_UPDATE;
 import static cm.aptoide.pt.home.apps.AppsAdapter.STANDBY_DOWNLOAD;
 import static cm.aptoide.pt.home.apps.AppsAdapter.STANDBY_UPDATE;
 import static cm.aptoide.pt.home.apps.AppsAdapter.UPDATE;
@@ -83,6 +84,10 @@ public class AppsCardViewHolderFactory {
       case INSTALLED:
         appViewHolder = new InstalledAppViewHolder(LayoutInflater.from(parent.getContext())
             .inflate(R.layout.apps_installed_app_item, parent, false));
+        break;
+      case PAUSING_UPDATE:
+        appViewHolder = new StandByUpdateAppViewHolder(LayoutInflater.from(parent.getContext())
+            .inflate(R.layout.apps_standby_update_app_item, parent, false), appItemClicks);
         break;
       default:
         throw new IllegalStateException("Wrong cardType" + viewType);

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
@@ -346,6 +346,10 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
         .loadUsingCircleTransform(R.drawable.ic_account_circle, userAvatar);
   }
 
+  @Override public void setPausingDownloadState(App app) {
+    adapter.setAppOnPausing(app);
+  }
+
   private void showAppsList() {
     recyclerView.scrollToPosition(0);
     hideLoadingProgressBar();

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragmentView.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragmentView.java
@@ -75,4 +75,6 @@ public interface AppsFragmentView extends View {
   void showIndeterminateAllUpdates();
 
   void setDefaultUserImage();
+
+  void setPausingDownloadState(App app);
 }

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
@@ -210,6 +210,7 @@ public class AppsPresenter implements Presenter {
         .filter(lifecycleEvent -> lifecycleEvent == View.LifecycleEvent.CREATE)
         .observeOn(viewScheduler)
         .flatMap(created -> view.pauseUpdate())
+        .doOnNext(app -> view.setPausingDownloadState(app))
         .doOnNext(app -> view.setStandbyState(app))
         .observeOn(ioScheduler)
         .flatMapCompletable(app -> appsManager.pauseUpdate(app))

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
@@ -211,7 +211,6 @@ public class AppsPresenter implements Presenter {
         .observeOn(viewScheduler)
         .flatMap(created -> view.pauseUpdate())
         .doOnNext(app -> view.setPausingDownloadState(app))
-        .doOnNext(app -> view.setStandbyState(app))
         .observeOn(ioScheduler)
         .flatMapCompletable(app -> appsManager.pauseUpdate(app))
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))

--- a/app/src/main/java/cm/aptoide/pt/home/apps/UpdateApp.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/UpdateApp.java
@@ -123,6 +123,6 @@ public class UpdateApp implements App {
   }
 
   public enum UpdateStatus {
-    UPDATE, STANDBY, UPDATING, ERROR
+    UPDATE, STANDBY, UPDATING, ERROR, PAUSING
   }
 }


### PR DESCRIPTION
**What does this PR do?**

Created a new state for an UpdateApp called PAUSING. This state represents when the app is waiting for the lib to send the paused state. Before we were just setting to standby but then that standby state would be overridden by another installing state. With this new pausing state, we are only listening to the error or paused stand by status updates.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppsAdapter.java

**How should this be manually tested?**

  Open the Apps Bottom Navigation section, start an update. Then, pause that update and you should see no flicker ( active -> standby -> active -> paused). Now it will be active -> standby -> paused.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1156](https://aptoide.atlassian.net/browse/ASV-1156)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass