### PR TITLE
[ASV-1191] refactor: exclude web3j from appc proxy

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -452,7 +452,9 @@ dependencies {
 
   fairyImplementation "testfairy:testfairy-android-sdk:${TEST_FAIRY_VERSION}"
 
-  implementation "com.asfoundation:appcoins-contract-proxy:0.4.5.19b"
+  implementation("com.asfoundation:appcoins-contract-proxy:${APPC_CONTRACT_PROXY_VERSION}") {
+    exclude group: 'org.web3j'
+  }
 }
 
 String getDate() {

--- a/app/src/main/java/cm/aptoide/pt/app/view/donations/utils/GenericPaymentIntentBuilder.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/donations/utils/GenericPaymentIntentBuilder.java
@@ -6,13 +6,13 @@ import android.content.Intent;
 import android.net.Uri;
 import com.asf.appcoins.sdk.contractproxy.AppCoinsAddressProxyBuilder;
 import com.asf.appcoins.sdk.contractproxy.AppCoinsAddressProxySdk;
+import com.google.android.gms.common.util.Hex;
 import com.google.gson.Gson;
 import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.util.Formatter;
-import org.spongycastle.util.encoders.Hex;
 
 /**
  * This class contains the help method to build the intent to call the BDS Wallet for generic
@@ -93,7 +93,7 @@ public class GenericPaymentIntentBuilder {
 
   private static String buildUriData(String skuId, String packageName, String paymentType,
       String payload) throws UnsupportedEncodingException {
-    return "0x" + Hex.toHexString(
+    return "0x" + Hex.bytesToStringLowercase(
         new Gson().toJson(new TransactionData(paymentType, packageName, skuId, payload))
             .getBytes("UTF-8"));
   }

--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,8 @@ ext {
   DAGGER_VERSION = '2.12'
 
   FABRIC_VERSION = '1.25.4'
+
+  APPC_CONTRACT_PROXY_VERSION = '0.4.5.19b'
 }
 
 // see 'Multi-module reports' in https://developer.android.com/studio/test/command-line.html


### PR DESCRIPTION
**What does this PR do?**

   Remove web3j dependency from the APPC proxy lib to shrink apk size.
   Extract appc proxy lib version to the project build.gradle
   Instead of using the SpongyCastle lib to do the Hex encoding and then to string, used the common utils from google already in the Android framework. 

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] build.gradle (project)
- [ ] build.gradle (app)
- [ ] GenericPaymentIntentBuilder.java

**How should this be manually tested?**

  Check apk size. Test donation flow.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1191](https://aptoide.atlassian.net/browse/ASV-1191)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Unit tests pass
- [ ] Functional QA tests pass