### PR TITLE
[ASV-1190] Remove accept TC and PP for Google and Facebook logins.

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/account/view/LoginSignUpCredentialsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/LoginSignUpCredentialsFragment.java
@@ -149,11 +149,10 @@ public class LoginSignUpCredentialsFragment extends GooglePlayServicesFragment
         .map(event -> termsConditionCheckBox.isChecked());
   }
 
-  @Override public Observable<Boolean> googleSignUpEvent() {
+  @Override public Observable<Void> googleSignUpEvent() {
     return RxView.clicks(googleLoginButton)
         .doOnNext(__ -> accountAnalytics.clickIn(AccountAnalytics.StartupClick.CONNECT_GOOGLE,
-            getStartupClickOrigin()))
-        .map(event -> termsConditionCheckBox.isChecked());
+            getStartupClickOrigin()));
   }
 
   @Override public Observable<Void> showHidePasswordClick() {
@@ -169,11 +168,10 @@ public class LoginSignUpCredentialsFragment extends GooglePlayServicesFragment
         .map(dialog -> null);
   }
 
-  @Override public Observable<Boolean> facebookSignUpEvent() {
+  @Override public Observable<Void> facebookSignUpEvent() {
     return RxView.clicks(facebookLoginButton)
         .doOnNext(__ -> accountAnalytics.clickIn(AccountAnalytics.StartupClick.CONNECT_FACEBOOK,
-            getStartupClickOrigin()))
-        .map(event -> termsConditionCheckBox.isChecked());
+            getStartupClickOrigin()));
   }
 
   @Override public Observable<AptoideCredentials> aptoideLoginEvent() {

--- a/app/src/main/java/cm/aptoide/pt/billing/view/login/PaymentLoginFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/billing/view/login/PaymentLoginFragment.java
@@ -323,14 +323,12 @@ public class PaymentLoginFragment extends GooglePlayServicesFragment implements 
     return upNavigationRelay;
   }
 
-  @Override public Observable<Boolean> facebookSignUpEvent() {
-    return RxView.clicks(facebookButton)
-        .map(event -> termsConditionCheckBox.isChecked());
+  @Override public Observable<Void> facebookSignUpEvent() {
+    return RxView.clicks(facebookButton);
   }
 
-  @Override public Observable<Boolean> googleSignUpEvent() {
-    return RxView.clicks(googleButton)
-        .map(event -> termsConditionCheckBox.isChecked());
+  @Override public Observable<Void> googleSignUpEvent() {
+    return RxView.clicks(googleButton);
   }
 
   @Override public Observable<Void> recoverPasswordEvent() {

--- a/app/src/main/java/cm/aptoide/pt/billing/view/login/PaymentLoginPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/billing/view/login/PaymentLoginPresenter.java
@@ -202,8 +202,6 @@ public class PaymentLoginPresenter implements Presenter {
     view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .flatMap(__ -> view.facebookSignUpEvent())
-        .doOnNext(this::showNotCheckedMessage)
-        .filter(event -> event)
         .doOnNext(__ -> view.showLoading())
         .doOnNext(click -> accountAnalytics.sendFacebookLoginButtonPressed())
         .doOnNext(__ -> accountNavigator.navigateToFacebookSignUpForResult(permissions))
@@ -215,8 +213,6 @@ public class PaymentLoginPresenter implements Presenter {
     view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .flatMap(__ -> view.googleSignUpEvent())
-        .doOnNext(this::showNotCheckedMessage)
-        .filter(event -> event)
         .doOnNext(event -> view.showLoading())
         .doOnNext(event -> accountAnalytics.sendGoogleLoginButtonPressed())
         .flatMapSingle(event -> accountNavigator.navigateToGoogleSignUpForResult(

--- a/app/src/main/java/cm/aptoide/pt/billing/view/login/PaymentLoginView.java
+++ b/app/src/main/java/cm/aptoide/pt/billing/view/login/PaymentLoginView.java
@@ -10,9 +10,9 @@ public interface PaymentLoginView extends GooglePlayServicesView {
 
   Observable<Void> upNavigationEvent();
 
-  Observable<Boolean> facebookSignUpEvent();
+  Observable<Void> facebookSignUpEvent();
 
-  Observable<Boolean> googleSignUpEvent();
+  Observable<Void> googleSignUpEvent();
 
   Observable<Void> recoverPasswordEvent();
 

--- a/app/src/main/java/cm/aptoide/pt/presenter/LoginSignUpCredentialsPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/presenter/LoginSignUpCredentialsPresenter.java
@@ -223,8 +223,6 @@ public class LoginSignUpCredentialsPresenter implements Presenter, BackButton.Cl
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .doOnNext(__ -> showOrHideGoogleSignUp())
         .flatMap(__ -> view.googleSignUpEvent())
-        .doOnNext(this::showNotCheckedMessage)
-        .filter(event -> event)
         .doOnNext(event -> {
           view.showLoading();
           accountAnalytics.sendGoogleLoginButtonPressed();
@@ -274,8 +272,6 @@ public class LoginSignUpCredentialsPresenter implements Presenter, BackButton.Cl
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .doOnNext(__ -> showOrHideFacebookSignUp())
         .flatMap(__ -> view.facebookSignUpEvent())
-        .doOnNext(this::showNotCheckedMessage)
-        .filter(event -> event)
         .doOnNext(event -> {
           view.showLoading();
           accountAnalytics.sendFacebookLoginButtonPressed();

--- a/app/src/main/java/cm/aptoide/pt/presenter/LoginSignUpCredentialsView.java
+++ b/app/src/main/java/cm/aptoide/pt/presenter/LoginSignUpCredentialsView.java
@@ -16,7 +16,7 @@ public interface LoginSignUpCredentialsView extends GooglePlayServicesView {
 
   Observable<Boolean> showAptoideSignUpAreaClick();
 
-  Observable<Boolean> googleSignUpEvent();
+  Observable<Void> googleSignUpEvent();
 
   Observable<Void> showHidePasswordClick();
 
@@ -24,7 +24,7 @@ public interface LoginSignUpCredentialsView extends GooglePlayServicesView {
 
   Observable<Void> facebookSignUpWithRequiredPermissionsInEvent();
 
-  Observable<Boolean> facebookSignUpEvent();
+  Observable<Void> facebookSignUpEvent();
 
   Observable<AptoideCredentials> aptoideLoginEvent();
 


### PR DESCRIPTION
**What does this PR do?**

   This PR removes the request for TC and PP acceptance when login in with Facebook or Google.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] LoginSignupCredentialsFragment.java
- [ ] LoginSignupCredentialsPresenter.java
- [ ] PaymentLoginFragment.java
- [ ] PaymentLoginPresenter.java

**How should this be manually tested?**

  Open the app, go to my account, try to login with google or facebook. The TC and PP toast should not appear and the flow should be completed.
  Open the app, search for a **paid** app, click buy, try to login with google or facebook. The TC and PP toast should not appear and the flow should be completed.

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/ASV-1190




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass