### PR TITLE
[ASV-1234] Change analytics events for curation flow.

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -1524,11 +1524,13 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
         AccountAnalytics.CREATE_YOUR_STORE, DeepLinkAnalytics.FACEBOOK_APP_LAUNCH,
         AppViewAnalytics.CLICK_INSTALL, BillingAnalytics.PAYMENT_AUTH,
         BillingAnalytics.PAYMENT_LOGIN, BillingAnalytics.PAYMENT_POPUP, HomeAnalytics.HOME_INTERACT,
+        HomeAnalytics.CURATION_CARD_CLICK, HomeAnalytics.CURATION_CARD_IMPRESSION,
         TimelineAnalytics.MESSAGE_IMPRESSION, TimelineAnalytics.MESSAGE_INTERACT,
         AccountAnalytics.PROMOTE_APTOIDE_EVENT_NAME,
         BottomNavigationAnalytics.BOTTOM_NAVIGATION_INTERACT,
         NotLoggedInShareAnalytics.MESSAGE_IMPRESSION, NotLoggedInShareAnalytics.MESSAGE_INTERACT,
-        DownloadAnalytics.DOWNLOAD_INTERACT, DonationsAnalytics.DONATIONS_INTERACT);
+        DownloadAnalytics.DOWNLOAD_INTERACT, DonationsAnalytics.DONATIONS_INTERACT,
+        EditorialAnalytics.CURATION_CARD_INSTALL);
   }
 
   @Singleton @Provides AptoideShortcutManager providesShortcutManager() {

--- a/app/src/main/java/cm/aptoide/pt/app/view/EditorialAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/EditorialAnalytics.java
@@ -2,7 +2,6 @@ package cm.aptoide.pt.app.view;
 
 import cm.aptoide.analytics.AnalyticsManager;
 import cm.aptoide.analytics.implementation.navigation.NavigationTracker;
-import cm.aptoide.pt.app.AppViewAnalytics;
 import cm.aptoide.pt.database.realm.Download;
 import cm.aptoide.pt.download.DownloadAnalytics;
 import java.util.HashMap;
@@ -13,6 +12,7 @@ import java.util.HashMap;
 
 public class EditorialAnalytics {
   private static final String APPLICATION_NAME = "Application Name";
+  private static final String CURATION_CARD_INSTALL = "CURATION_CARD_INSTALL";
   private static final String TYPE = "type";
 
   private final DownloadAnalytics downloadAnalytics;
@@ -42,9 +42,9 @@ public class EditorialAnalytics {
 
   public void clickOnInstallButton(String packageName, String type) {
     HashMap<String, Object> map = new HashMap<>();
-    map.put(TYPE, type);
     map.put(APPLICATION_NAME, packageName);
-    analyticsManager.logEvent(map, AppViewAnalytics.CLICK_INSTALL, AnalyticsManager.Action.CLICK,
+    map.put(TYPE, type);
+    analyticsManager.logEvent(map, CURATION_CARD_INSTALL, AnalyticsManager.Action.CLICK,
         getViewName(true));
   }
 

--- a/app/src/main/java/cm/aptoide/pt/app/view/EditorialAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/EditorialAnalytics.java
@@ -12,7 +12,7 @@ import java.util.HashMap;
 
 public class EditorialAnalytics {
   private static final String APPLICATION_NAME = "Application Name";
-  private static final String CURATION_CARD_INSTALL = "CURATION_CARD_INSTALL";
+  public static final String CURATION_CARD_INSTALL = "CURATION_CARD_INSTALL";
   private static final String TYPE = "type";
 
   private final DownloadAnalytics downloadAnalytics;

--- a/app/src/main/java/cm/aptoide/pt/home/HomeAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeAnalytics.java
@@ -25,6 +25,8 @@ public class HomeAnalytics {
   static final String TAP_ON_CARD = "tap on card";
   static final String TAP_ON_CARD_DISMISS = "tap on card dismiss";
   static final String VIEW_CARD = "view card";
+  private static final String CURATION_CARD_IMPRESSION = "CURATION_CARD_IMPRESSION";
+  private static final String CURATION_CARD_CLICK = "CURATION_CARD_CLICK";
   private final NavigationTracker navigationTracker;
   private final AnalyticsManager analyticsManager;
 
@@ -166,20 +168,20 @@ public class HomeAnalytics {
     final Map<String, Object> data = new HashMap<>();
     data.put("action", TAP_ON_CARD);
     data.put("bundle_tag", bundleTag);
-    data.put("bundle_position", bundlePosition);
     data.put("card_id", cardId);
+    data.put("bundle_position", bundlePosition);
 
-    analyticsManager.logEvent(data, HOME_INTERACT, OPEN, navigationTracker.getViewName(true));
+    analyticsManager.logEvent(data, CURATION_CARD_CLICK, OPEN, navigationTracker.getViewName(true));
   }
 
   public void sendEditorialImpressionEvent(String bundleTag, int bundlePosition, String cardId) {
     final Map<String, Object> data = new HashMap<>();
     data.put("action", IMPRESSION);
     data.put("bundle_tag", bundleTag);
-    data.put("bundle_position", bundlePosition);
     data.put("card_id", cardId);
+    data.put("bundle_position", bundlePosition);
 
-    analyticsManager.logEvent(data, HOME_INTERACT, AnalyticsManager.Action.IMPRESSION,
+    analyticsManager.logEvent(data, CURATION_CARD_IMPRESSION, AnalyticsManager.Action.IMPRESSION,
         navigationTracker.getViewName(true));
   }
 

--- a/app/src/main/java/cm/aptoide/pt/home/HomeAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeAnalytics.java
@@ -25,8 +25,8 @@ public class HomeAnalytics {
   static final String TAP_ON_CARD = "tap on card";
   static final String TAP_ON_CARD_DISMISS = "tap on card dismiss";
   static final String VIEW_CARD = "view card";
-  private static final String CURATION_CARD_IMPRESSION = "CURATION_CARD_IMPRESSION";
-  private static final String CURATION_CARD_CLICK = "CURATION_CARD_CLICK";
+  public static final String CURATION_CARD_IMPRESSION = "CURATION_CARD_IMPRESSION";
+  public static final String CURATION_CARD_CLICK = "CURATION_CARD_CLICK";
   private final NavigationTracker navigationTracker;
   private final AnalyticsManager analyticsManager;
 


### PR DESCRIPTION
**What does this PR do?**

   This PR changes the events used for analytics from a global used string to a unique string. Now we have CURATION_CARD_IMPRESSION, CURATION_CARD_CLICK and CURATION_CARD_INSTALL instead of reusing home_interact and click.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] EditorialAnalytics.java
- [ ] HomeAnalytics.java

**How should this be manually tested?**

  Check the analytics on facebook analytics to see if the new events are entered correctly.

**What are the relevant tickets?**

  https://aptoide.atlassian.net/browse/ASV-1234



**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass