### PR TITLE
[ASV-1263] App card animation fix

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/EditorialFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/EditorialFragment.java
@@ -110,6 +110,7 @@ public class EditorialFragment extends NavigationTrackFragment
 
   private PublishSubject<EditorialEvent> uiEventsListener;
   private PublishSubject<Palette.Swatch> paletteSwatchSubject;
+  private PublishSubject<Boolean> movingCollapseSubject;
 
   @Override public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -118,6 +119,7 @@ public class EditorialFragment extends NavigationTrackFragment
     ready = PublishSubject.create();
     paletteSwatchSubject = PublishSubject.create();
     uiEventsListener = PublishSubject.create();
+    movingCollapseSubject = PublishSubject.create();
     setHasOptionsMenu(true);
   }
 
@@ -191,15 +193,18 @@ public class EditorialFragment extends NavigationTrackFragment
         Resources resources = getResources();
         switch (state) {
           case EXPANDED:
+            movingCollapseSubject.onNext(isItemShown());
             break;
           default:
           case IDLE:
           case MOVING:
+            movingCollapseSubject.onNext(isItemShown());
             configureAppBarLayout(
                 resources.getDrawable(R.drawable.editorial_up_bottom_black_gradient),
                 resources.getColor(R.color.tw__solid_white), false);
             break;
           case COLLAPSED:
+            movingCollapseSubject.onNext(isItemShown());
             configureAppBarLayout(resources.getDrawable(R.drawable.tw__transparent),
                 resources.getColor(R.color.black), true);
             break;
@@ -224,6 +229,7 @@ public class EditorialFragment extends NavigationTrackFragment
     window = null;
     paletteSwatchSubject = null;
     oneDecimalFormatter = null;
+    movingCollapseSubject = null;
   }
 
   @Override public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
@@ -498,6 +504,10 @@ public class EditorialFragment extends NavigationTrackFragment
     if (editorialItemsViewHolder != null) {
       editorialItemsViewHolder.setAllDescriptionsVisible();
     }
+  }
+
+  @Override public Observable<Boolean> handleMovingCollapse() {
+    return movingCollapseSubject.distinctUntilChanged();
   }
 
   private void populateAppContent(EditorialViewModel editorialViewModel) {

--- a/app/src/main/java/cm/aptoide/pt/app/view/EditorialPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/EditorialPresenter.java
@@ -59,6 +59,7 @@ public class EditorialPresenter implements Presenter {
     handlePlaceHolderVisibility();
     handleMediaListDescriptionVisibility();
     handleClickActionButtonCard();
+    handleMovingCollapse();
   }
 
   @VisibleForTesting public void onCreateLoadAppOfTheWeek() {
@@ -309,6 +310,25 @@ public class EditorialPresenter implements Presenter {
             view.manageMediaListDescriptionAnimationVisibility(editorialEvent);
           } else {
             view.setMediaListDescriptionsVisible(editorialEvent);
+          }
+        })
+        .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
+        .subscribe(__ -> {
+        }, throwable -> {
+          throw new OnErrorNotImplementedException(throwable);
+        });
+  }
+
+  @VisibleForTesting public void handleMovingCollapse() {
+    view.getLifecycleEvent()
+        .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
+        .flatMap(created -> view.handleMovingCollapse())
+        .observeOn(viewScheduler)
+        .doOnNext(isItemShown -> {
+          if (isItemShown) {
+            view.removeBottomCardAnimation();
+          } else {
+            view.addBottomCardAnimation();
           }
         })
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))

--- a/app/src/main/java/cm/aptoide/pt/app/view/EditorialView.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/EditorialView.java
@@ -62,4 +62,6 @@ public interface EditorialView extends View {
   void manageMediaListDescriptionAnimationVisibility(EditorialEvent editorialEvent);
 
   void setMediaListDescriptionsVisible(EditorialEvent editorialEvent);
+
+  Observable<Boolean> handleMovingCollapse();
 }

--- a/app/src/test/java/cm/aptoide/pt/app/view/EditorialPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/view/EditorialPresenterTest.java
@@ -284,4 +284,28 @@ public class EditorialPresenterTest {
     //Then it should deliver that swatch to the view
     verify(view).setMediaListDescriptionsVisible(editorialEvent);
   }
+
+  @Test public void handleMovingCollapseVisiblePlaceHolderTest() {
+    //Given an initialized presenter
+    editorialPresenter.handleMovingCollapse();
+    //If item is shown when collapse toolbar is moving
+    when(view.handleMovingCollapse()).thenReturn(Observable.just(true));
+
+    lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
+
+    //Then it should remove the bottom app card
+    verify(view).removeBottomCardAnimation();
+  }
+
+  @Test public void handleMovingCollapseNotVisiblePlaceHolderTest() {
+    //Given an initialized presenter
+    editorialPresenter.handleMovingCollapse();
+    //If item is shown when collapse toolbar is moving
+    when(view.handleMovingCollapse()).thenReturn(Observable.just(false));
+
+    lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
+
+    //Then it should add the bottom app card
+    verify(view).addBottomCardAnimation();
+  }
 }


### PR DESCRIPTION
**What does this PR do?**

   The animation was only working inside of the recycler view. When the app card was in a certain position (most of the times on the first, depending on screen size), the animation wouldn’t trigger because you were no longer scrolling the recycler view, but you’re scrolling the collapse.
  This ticket adds the trigger to check for the animation on the collapse toolbar state change

**Database changed?**

   No

**Where should the reviewer start?**

EditorialFragment.java

**How should this be manually tested?**

Go to EditorialFragment, put the app in the first position trough charles and check if the animation works

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/ASV-1263

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass