### PR TITLE
[ASV-1269] Added loading to PromotionsFragment;

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionsFragment.java
@@ -62,6 +62,8 @@ public class PromotionsFragment extends NavigationTrackFragment implements Promo
   private TextView promotionFirstMessage;
   private View walletActiveView;
   private View walletInactiveView;
+  private View promotionsView;
+  private ProgressBar loading;
   private Button promotionAction;
 
   private Window window;
@@ -92,6 +94,8 @@ public class PromotionsFragment extends NavigationTrackFragment implements Promo
     walletActiveView = view.findViewById(R.id.promotion_wallet_active);
     walletInactiveView = view.findViewById(R.id.promotion_wallet_inactive);
     promotionAction = walletInactiveView.findViewById(R.id.promotion_app_action_button);
+    loading = view.findViewById(R.id.progress_bar);
+    promotionsView = view.findViewById(R.id.promotions_view);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       window.setStatusBarColor(getResources().getColor(R.color.black_87_alpha));
@@ -212,6 +216,8 @@ public class PromotionsFragment extends NavigationTrackFragment implements Promo
       }
       promotionsAdapter.setPromotionApp(promotionViewApp);
     }
+    loading.setVisibility(View.GONE);
+    promotionsView.setVisibility(View.VISIBLE);
   }
 
   @Override public Observable<PromotionViewApp> installButtonClick() {

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionsFragment.java
@@ -34,6 +34,7 @@ import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.view.ThemeUtils;
 import cm.aptoide.pt.view.fragment.NavigationTrackFragment;
+import com.jakewharton.rxbinding.view.RxView;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import javax.inject.Inject;
@@ -65,6 +66,10 @@ public class PromotionsFragment extends NavigationTrackFragment implements Promo
   private View promotionsView;
   private ProgressBar loading;
   private Button promotionAction;
+  private View genericErrorView;
+  private View genericErrorViewRetry;
+  private ImageView toolbarImage;
+  private ImageView toolbarImagePlaceholder;
 
   private Window window;
   private Toolbar toolbar;
@@ -90,12 +95,17 @@ public class PromotionsFragment extends NavigationTrackFragment implements Promo
     promotionsAdapter = new PromotionsAdapter(new ArrayList<>(),
         new PromotionsViewHolderFactory(promotionAppClick, decimalFormat));
 
+    toolbarImage = view.findViewById(R.id.app_graphic);
+    toolbarImagePlaceholder = view.findViewById(R.id.app_graphic_placeholder);
+
     promotionFirstMessage = view.findViewById(R.id.promotions_message_1);
     walletActiveView = view.findViewById(R.id.promotion_wallet_active);
     walletInactiveView = view.findViewById(R.id.promotion_wallet_inactive);
     promotionAction = walletInactiveView.findViewById(R.id.promotion_app_action_button);
     loading = view.findViewById(R.id.progress_bar);
     promotionsView = view.findViewById(R.id.promotions_view);
+    genericErrorView = view.findViewById(R.id.generic_error);
+    genericErrorViewRetry = genericErrorView.findViewById(R.id.retry);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       window.setStatusBarColor(getResources().getColor(R.color.black_87_alpha));
@@ -217,6 +227,8 @@ public class PromotionsFragment extends NavigationTrackFragment implements Promo
       promotionsAdapter.setPromotionApp(promotionViewApp);
     }
     loading.setVisibility(View.GONE);
+    toolbarImagePlaceholder.setVisibility(View.GONE);
+    toolbarImage.setVisibility(View.VISIBLE);
     promotionsView.setVisibility(View.VISIBLE);
   }
 
@@ -278,6 +290,25 @@ public class PromotionsFragment extends NavigationTrackFragment implements Promo
     } else {
       promotionsAdapter.updateClaimStatus(packageName);
     }
+  }
+
+  @Override public void showLoading() {
+    toolbarImagePlaceholder.setVisibility(View.VISIBLE);
+    toolbarImage.setVisibility(View.GONE);
+    promotionsView.setVisibility(View.GONE);
+    genericErrorView.setVisibility(View.GONE);
+    loading.setVisibility(View.VISIBLE);
+  }
+
+  @Override public void showErrorView() {
+    toolbarImage.setVisibility(View.GONE);
+    loading.setVisibility(View.GONE);
+    promotionsView.setVisibility(View.GONE);
+    genericErrorView.setVisibility(View.VISIBLE);
+  }
+
+  @Override public Observable<Void> retryClicked() {
+    return RxView.clicks(genericErrorViewRetry);
   }
 
   private void showWallet(PromotionViewApp promotionViewApp) {

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionsView.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionsView.java
@@ -24,4 +24,10 @@ public interface PromotionsView extends View {
   Observable<PromotionViewApp> claimAppClick();
 
   void updateClaimStatus(String packageName);
+
+  void showLoading();
+
+  void showErrorView();
+
+  Observable<Void> retryClicked();
 }

--- a/app/src/main/res/layout/fragment_promotions.xml
+++ b/app/src/main/res/layout/fragment_promotions.xml
@@ -60,10 +60,19 @@
     </android.support.design.widget.CollapsingToolbarLayout>
   </android.support.design.widget.AppBarLayout>
 
+  <ProgressBar
+      android:id="@+id/progress_bar"
+      android:layout_width="80dp"
+      android:layout_height="80dp"
+      android:layout_gravity="bottom|center_horizontal"
+      android:layout_marginBottom="140dp"
+      />
 
   <android.support.v4.widget.NestedScrollView
+      android:id="@+id/promotions_view"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
+      android:visibility="gone"
       app:layout_behavior="@string/appbar_scrolling_view_behavior"
       >
 

--- a/app/src/main/res/layout/fragment_promotions.xml
+++ b/app/src/main/res/layout/fragment_promotions.xml
@@ -24,12 +24,24 @@
         app:layout_scrollFlags="scroll|exitUntilCollapsed"
         >
       <ImageView
+          android:id="@+id/app_graphic_placeholder"
+          android:layout_width="match_parent"
+          android:layout_height="216dp"
+          android:adjustViewBounds="true"
+          android:scaleType="fitXY"
+          android:visibility="visible"
+          app:layout_collapseMode="parallax"
+          tools:background="@color/background_light_grey"
+          />
+
+      <ImageView
           android:id="@+id/app_graphic"
           android:layout_width="match_parent"
           android:layout_height="216dp"
           android:adjustViewBounds="true"
           android:scaleType="fitXY"
           android:src="@drawable/ic_winter_bundle_illustration"
+          android:visibility="gone"
           app:layout_collapseMode="parallax"
           tools:background="@color/grey_fog_normal"
           />
@@ -59,14 +71,6 @@
       </android.support.v7.widget.Toolbar>
     </android.support.design.widget.CollapsingToolbarLayout>
   </android.support.design.widget.AppBarLayout>
-
-  <ProgressBar
-      android:id="@+id/progress_bar"
-      android:layout_width="80dp"
-      android:layout_height="80dp"
-      android:layout_gravity="bottom|center_horizontal"
-      android:layout_marginBottom="140dp"
-      />
 
   <android.support.v4.widget.NestedScrollView
       android:id="@+id/promotions_view"
@@ -225,4 +229,21 @@
 
     </LinearLayout>
   </android.support.v4.widget.NestedScrollView>
+
+  <FrameLayout
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:layout_marginTop="?attr/actionBarSize"
+      >
+    <include
+        layout="@layout/partial_view_error"
+        tools:visibility="gone"
+        />
+
+    <include
+        layout="@layout/partial_view_progress_bar"
+        tools:visibility="gone"
+        />
+  </FrameLayout>
+
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
**What does this PR do?**

This PR aims to add a loading element to the promotions fragment, while the data to display loads; It also adds an error state with a retry button to the view;

**Database changed?**

No

**Where should the reviewer start?**

- [ ] PromotionsFragment.java

**How should this be manually tested?**

Open the promotions and check that it loads and then displays consistent information afterwards;
Open the promotions fragment without connection and check that everything about the error state is working

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1269](<https://aptoide.atlassian.net/browse/ASV-1269>)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass