### PR TITLE
[ASV-1288] Promotions notification and first dialog

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/Home.java
+++ b/app/src/main/java/cm/aptoide/pt/home/Home.java
@@ -66,17 +66,17 @@ public class Home {
 
   private HomePromotionsWrapper mapPromotions(List<PromotionApp> apps) {
     int promotions = 0;
-    float appcValue = 0;
+    float unclaimedAppcValue = 0;
     if (apps.size() > 0) {
       for (PromotionApp app : apps) {
         if (!app.isClaimed()) {
           promotions++;
-          appcValue += app.getAppcValue();
+          unclaimedAppcValue += app.getAppcValue();
         }
       }
     }
 
-    return new HomePromotionsWrapper(!apps.isEmpty(), promotions, appcValue,
-        promotionsPreferencesManager.shouldShowPromotionsDialog());
+    return new HomePromotionsWrapper(!apps.isEmpty(), promotions, unclaimedAppcValue,
+        (promotionsPreferencesManager.shouldShowPromotionsDialog() && unclaimedAppcValue > 0));
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/Home.java
+++ b/app/src/main/java/cm/aptoide/pt/home/Home.java
@@ -67,8 +67,11 @@ public class Home {
   private HomePromotionsWrapper mapPromotions(List<PromotionApp> apps) {
     int promotions = 0;
     float unclaimedAppcValue = 0;
+    float totalAppcValue = 0;
     if (apps.size() > 0) {
       for (PromotionApp app : apps) {
+        totalAppcValue += app.getAppcValue();
+
         if (!app.isClaimed()) {
           promotions++;
           unclaimedAppcValue += app.getAppcValue();
@@ -77,6 +80,7 @@ public class Home {
     }
 
     return new HomePromotionsWrapper(!apps.isEmpty(), promotions, unclaimedAppcValue,
-        (promotionsPreferencesManager.shouldShowPromotionsDialog() && unclaimedAppcValue > 0));
+        (promotionsPreferencesManager.shouldShowPromotionsDialog() && unclaimedAppcValue > 0),
+        totalAppcValue);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
@@ -550,7 +550,7 @@ public class HomePresenter implements Presenter {
         .observeOn(viewScheduler)
         .doOnNext(apps -> {
           view.showPromotionsHomeIcon(apps);
-          if (apps.getPromotions() > 0) {
+          if (apps.getPromotions() > 0 && apps.getTotalUnclaimedAppcValue() > 0) {
             if (apps.getPromotions() < 10) {
               view.setPromotionsTickerWithValue(apps.getPromotions());
             } else {

--- a/app/src/main/java/cm/aptoide/pt/home/HomePromotionsWrapper.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomePromotionsWrapper.java
@@ -6,13 +6,15 @@ public class HomePromotionsWrapper {
   private int promotions;
   private float totalUnclaimedAppcValue;
   private boolean showDialog;
+  private float totalAppcValue;
 
   public HomePromotionsWrapper(boolean hasPromotions, int promotions, float totalUnclaimedAppcValue,
-      boolean showDialog) {
+      boolean showDialog, float totalAppcValue) {
     this.hasPromotions = hasPromotions;
     this.promotions = promotions;
     this.totalUnclaimedAppcValue = totalUnclaimedAppcValue;
     this.showDialog = showDialog;
+    this.totalAppcValue = totalAppcValue;
   }
 
   public boolean hasPromotions() {
@@ -29,5 +31,9 @@ public class HomePromotionsWrapper {
 
   public boolean shouldShowDialog() {
     return showDialog;
+  }
+
+  public float getTotalAppcValue() {
+    return totalAppcValue;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/HomePromotionsWrapper.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomePromotionsWrapper.java
@@ -4,14 +4,14 @@ public class HomePromotionsWrapper {
 
   private boolean hasPromotions;
   private int promotions;
-  private float totalAppcValue;
+  private float totalUnclaimedAppcValue;
   private boolean showDialog;
 
-  public HomePromotionsWrapper(boolean hasPromotions, int promotions, float totalAppcValue,
+  public HomePromotionsWrapper(boolean hasPromotions, int promotions, float totalUnclaimedAppcValue,
       boolean showDialog) {
     this.hasPromotions = hasPromotions;
     this.promotions = promotions;
-    this.totalAppcValue = totalAppcValue;
+    this.totalUnclaimedAppcValue = totalUnclaimedAppcValue;
     this.showDialog = showDialog;
   }
 
@@ -23,8 +23,8 @@ public class HomePromotionsWrapper {
     return promotions;
   }
 
-  public float getTotalAppcValue() {
-    return totalAppcValue;
+  public float getTotalUnclaimedAppcValue() {
+    return totalUnclaimedAppcValue;
   }
 
   public boolean shouldShowDialog() {

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionsHomeDialog.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionsHomeDialog.java
@@ -56,7 +56,7 @@ public class PromotionsHomeDialog {
     dialog.show();
     TextView description = dialogView.findViewById(R.id.description);
     description.setText(context.getString(R.string.holidayspromotion_message_popup,
-        String.valueOf(wrapper.getTotalAppcValue())));
+        String.valueOf(wrapper.getTotalUnclaimedAppcValue())));
   }
 
   public void dismissDialog() {

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionsHomeDialog.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionsHomeDialog.java
@@ -56,7 +56,7 @@ public class PromotionsHomeDialog {
     dialog.show();
     TextView description = dialogView.findViewById(R.id.description);
     description.setText(context.getString(R.string.holidayspromotion_message_popup,
-        String.valueOf(wrapper.getTotalUnclaimedAppcValue())));
+        String.valueOf(wrapper.getTotalAppcValue())));
   }
 
   public void dismissDialog() {


### PR DESCRIPTION
**What does this PR do?**

   Showing promotions dialog only when there are apps to claim. Also changed the promotion dialog message to show the total promotion appc instead of the unclaimed promotion appc.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] HomePresenter.java

**How should this be manually tested?**

Open Aptoide, check that since everything is already claimed in the office, no dialog should popup and there should be no notification on the promotions toolbar icon. Then, rewrite on charles or active your mobile data to unclaimed apps and see that there will be the ticker and the promotions dialog will be shown with the total amount of appc instead of the unclaimed amount.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1288](https://aptoide.atlassian.net/browse/ASV-1288)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass