### PR TITLE
[ASV-1268] Not using cache

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionsService.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionsService.java
@@ -101,14 +101,16 @@ public class PromotionsService {
   public Single<List<PromotionApp>> getPromotionApps() {
     return GetPromotionAppsRequest.of(bodyInterceptorPoolV7, okHttpClient, converterFactory,
         tokenInvalidator, sharedPreferences)
-        .observe(true)
+        .observe(false, false)
         .map(this::mapGet)
         .toSingle();
   }
 
   private List<PromotionApp> mapGet(GetPromotionAppsResponse response) {
     List<PromotionApp> result = new ArrayList<>();
-    if (response != null && response.getDataList() != null && response.getDataList()
+    if (response != null
+        && response.getDataList() != null
+        && response.getDataList()
         .getList() != null) {
       for (GetPromotionAppsResponse.PromotionAppModel app : response.getDataList()
           .getList()) {

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/promotions/GetPromotionAppsRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/promotions/GetPromotionAppsRequest.java
@@ -29,6 +29,6 @@ public class GetPromotionAppsRequest extends V7<GetPromotionAppsResponse, BaseBo
   @Override
   protected Observable<GetPromotionAppsResponse> loadDataFromNetwork(V7.Interfaces interfaces,
       boolean bypassCache) {
-    return interfaces.getPromotionApps(30, body, true);
+    return interfaces.getPromotionApps(30, body, bypassCache);
   }
 }


### PR DESCRIPTION
**What does this PR do?**

   This PR aims to avoid the duplicate request to the getPromotionApps ws. Before this, we were making two requests, one when opening the app to load the promotions icon and another one when we opened the promotions main view. Now we cache the first request, meaning that a 2nd one won't be made.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] GetPromotionAppsRequest.java

**How should this be manually tested?**

  The cache is not working at the moment because we need a header on the response of the getPromotionApps request indicating cache control and the max age. That is currently being developed by Diogo S. on the following ticket [ASV-1302](https://aptoide.atlassian.net/browse/ASV-1302).
For that reason, please make a rewrite on charles to add a header attribute called Cache-Control and set the value to "max-age=1800, public", which is what should be returned on the response.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1268](https://aptoide.atlassian.net/browse/ASV-1268)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass