### PR TITLE
[ASV-1341] fix to gdpr dialog leaks

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/LoggedInTermsAndConditionsDialog.java
+++ b/app/src/main/java/cm/aptoide/pt/home/LoggedInTermsAndConditionsDialog.java
@@ -23,7 +23,6 @@ import rx.subjects.PublishSubject;
 public class LoggedInTermsAndConditionsDialog {
   private static final String GDPR_DIALOG_EVENT_LISTENER_IS_NULL =
       "GDPR_DIALOG_EVENT_LISTENER_IS_NULL";
-
   private AlertDialog dialog;
   private Button continueButton;
   private Button logOutButton;
@@ -68,7 +67,16 @@ public class LoggedInTermsAndConditionsDialog {
   }
 
   public void destroyDialog() {
+    if (dialog.isShowing()) {
+      dialog.dismiss();
+    }
     dialog = null;
+    if (continueButton != null) {
+      continueButton.setOnClickListener(null);
+    }
+    if (logOutButton != null) {
+      logOutButton.setOnClickListener(null);
+    }
     continueButton = null;
     logOutButton = null;
     uiEvents = null;


### PR DESCRIPTION
**What does this PR do?**

   Releases button listeners to avoid leaks. Also hides dialog if destroy dialog is called.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] LoggedInTermsAndConditionsDialog.java

**How should this be manually tested?**

  Remove HomePresenter's filter from line 483 so it is easy to test the dialog while logged in.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1341](https://aptoide.atlassian.net/browse/ASV-1341)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass