### PR TITLE
[Feature/ASV-1356] cobrand remove newsletter and support

### DIFF
--- a/app/src/cobrand/java/cm/aptoide/pt/FlavourApplicationModule.java
+++ b/app/src/cobrand/java/cm/aptoide/pt/FlavourApplicationModule.java
@@ -9,7 +9,10 @@ import javax.inject.Singleton;
 
 @Module public class FlavourApplicationModule {
 
-  public FlavourApplicationModule() {
+  private final AptoideApplication application;
+
+  public FlavourApplicationModule(AptoideApplication application) {
+    this.application = application;
   }
 
   @Singleton @Provides AdultContent provideAdultContent() {

--- a/app/src/cobrand/java/cm/aptoide/pt/FlavourApplicationModule.java
+++ b/app/src/cobrand/java/cm/aptoide/pt/FlavourApplicationModule.java
@@ -19,4 +19,8 @@ import javax.inject.Singleton;
   @Singleton @Provides @Named("auto-update-store-name") String provideAutoUpdateStoreName() {
     return BuildConfig.COBRAND_APPLICATION_ID_SUFFIX;
   }
+
+  @Singleton @Provides @Named("support-email") String providesSupportEmail() {
+    return "n/a";
+  }
 }

--- a/app/src/cobrand/java/cm/aptoide/pt/account.view.user/NewsletterManager.java
+++ b/app/src/cobrand/java/cm/aptoide/pt/account.view.user/NewsletterManager.java
@@ -1,0 +1,7 @@
+package cm.aptoide.pt.account.view.user;
+
+public class NewsletterManager {
+  public boolean shouldShowNewsletter() {
+    return false;
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -60,6 +60,7 @@ import cm.aptoide.pt.account.GoogleSignUpAdapter;
 import cm.aptoide.pt.account.LoginPreferences;
 import cm.aptoide.pt.account.MatureContentPersistence;
 import cm.aptoide.pt.account.view.store.StoreManager;
+import cm.aptoide.pt.account.view.user.NewsletterManager;
 import cm.aptoide.pt.actions.PermissionManager;
 import cm.aptoide.pt.addressbook.AddressBookAnalytics;
 import cm.aptoide.pt.ads.AdsRepository;
@@ -1755,5 +1756,9 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
   @Singleton @Provides SupportEmailProvider providesSupportEmailProvider(
       @Named("support-email") String supportEmail) {
     return new SupportEmailProvider(supportEmail, application.getString(R.string.aptoide_email));
+  }
+
+  @Singleton @Provides NewsletterManager providesNewsletterManager() {
+    return new NewsletterManager();
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -1627,10 +1627,6 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
     return BuildConfig.MARKET_NAME;
   }
 
-  @Singleton @Provides @Named("support-email") String providesSupportEmail() {
-    return application.getString(R.string.aptoide_email);
-  }
-
   @Singleton @Provides @Named("partnerID") String providePartnerID() {
     return "";
   }
@@ -1758,6 +1754,6 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
 
   @Singleton @Provides SupportEmailProvider providesSupportEmailProvider(
       @Named("support-email") String supportEmail) {
-    return new SupportEmailProvider(supportEmail, "aptoide@aptoide.com");
+    return new SupportEmailProvider(supportEmail, application.getString(R.string.aptoide_email));
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -213,6 +213,7 @@ import cm.aptoide.pt.utils.q.QManager;
 import cm.aptoide.pt.view.app.AppCenter;
 import cm.aptoide.pt.view.app.AppCenterRepository;
 import cm.aptoide.pt.view.app.AppService;
+import cm.aptoide.pt.view.settings.SupportEmailProvider;
 import cm.aptoide.pt.view.share.NotLoggedInShareAnalytics;
 import cn.dreamtobe.filedownloader.OkHttp3Connection;
 import com.crashlytics.android.Crashlytics;
@@ -1626,6 +1627,10 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
     return BuildConfig.MARKET_NAME;
   }
 
+  @Singleton @Provides @Named("support-email") String providesSupportEmail() {
+    return application.getString(R.string.aptoide_email);
+  }
+
   @Singleton @Provides @Named("partnerID") String providePartnerID() {
     return "";
   }
@@ -1749,5 +1754,10 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
 
   @Singleton @Provides @Named("auto-update-base-host") String providesAutoUpdateBaseHost() {
     return "http://imgs.aptoide.com/";
+  }
+
+  @Singleton @Provides SupportEmailProvider providesSupportEmailProvider(
+      @Named("support-email") String supportEmail) {
+    return new SupportEmailProvider(supportEmail, "aptoide@aptoide.com");
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
+++ b/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
@@ -354,7 +354,7 @@ public abstract class AptoideApplication extends Application {
     if (applicationComponent == null) {
       applicationComponent = DaggerApplicationComponent.builder()
           .applicationModule(new ApplicationModule(this, getAptoideMd5sum()))
-          .flavourApplicationModule(new FlavourApplicationModule())
+          .flavourApplicationModule(new FlavourApplicationModule(this))
           .build();
     }
     return applicationComponent;

--- a/app/src/main/java/cm/aptoide/pt/account/view/user/ManageUserFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/user/ManageUserFragment.java
@@ -58,6 +58,7 @@ public class ManageUserFragment extends BackButtonFragment
   @Inject ImagePickerPresenter imagePickerPresenter;
   @Inject ManageUserPresenter manageUserPresenter;
   @Inject ScreenOrientationManager orientationManager;
+  @Inject NewsletterManager newsletterManager;
   private ImageView userPicture;
   private RelativeLayout userPictureLayout;
   private EditText userName;
@@ -145,7 +146,7 @@ public class ManageUserFragment extends BackButtonFragment
       cancelUserProfile.setVisibility(View.VISIBLE);
     } else {
       birthdayLayout.setVisibility(View.VISIBLE);
-      newsLetterLayout.setVisibility(View.VISIBLE);
+      handleNewsletterVisibility();
       setupDatePickerDialog(calendar);
     }
     attachPresenters();
@@ -154,6 +155,14 @@ public class ManageUserFragment extends BackButtonFragment
   @Override public ScreenTagHistory getHistoryTracker() {
     return ScreenTagHistory.Builder.build(this.getClass()
         .getSimpleName());
+  }
+
+  private void handleNewsletterVisibility() {
+    if (newsletterManager.shouldShowNewsletter()) {
+      newsLetterLayout.setVisibility(View.VISIBLE);
+    } else {
+      newsLetterLayout.setVisibility(View.GONE);
+    }
   }
 
   private void setupDatePickerDialog(Calendar calendar) {

--- a/app/src/main/java/cm/aptoide/pt/account/view/user/ManageUserFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/user/ManageUserFragment.java
@@ -16,7 +16,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.CheckBox;
-import android.widget.DatePicker;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
@@ -167,13 +166,11 @@ public class ManageUserFragment extends BackButtonFragment
 
   private void setupDatePickerDialog(Calendar calendar) {
     DatePickerDialog.OnDateSetListener datePickerDialogListener =
-        new DatePickerDialog.OnDateSetListener() {
-          @Override public void onDateSet(DatePicker datePicker, int year, int month, int day) {
-            int monthNumber = month
-                + 1; //Android starts counting months on 0 to better count time. e.g 22 jan is 0 months and 22 days
-            setupCalendar(calendar, year, monthNumber, day);
-            setupCalendarDateString(year, monthNumber, day);
-          }
+        (datePicker, year, month, day) -> {
+          int monthNumber = month
+              + 1; //Android starts counting months on 0 to better count time. e.g 22 jan is 0 months and 22 days
+          setupCalendar(calendar, year, monthNumber, day);
+          setupCalendarDateString(year, monthNumber, day);
         };
     datePickerDialog =
         new DatePickerDialog(getContext(), R.style.DatePickerDialog, datePickerDialogListener,

--- a/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
@@ -78,8 +78,6 @@ import static cm.aptoide.pt.preferences.managed.ManagedKeys.CAMPAIGN_SOCIAL_NOTI
 public class SettingsFragment extends PreferenceFragmentCompat
     implements SharedPreferences.OnSharedPreferenceChangeListener, NotBottomNavigationView {
   private static final String TAG = SettingsFragment.class.getSimpleName();
-
-  @Inject @Named("marketName") String marketName;
   private static final String ADULT_CONTENT_PIN_PREFERENCE_VIEW_KEY = "Maturepin";
   private static final String REMOVE_ADULT_CONTENT_PIN_PREFERENCE_VIEW_KEY = "removeMaturepin";
   private static final String ADULT_CONTENT_WITH_PIN_PREFERENCE_VIEW_KEY = "matureChkBoxWithPin";
@@ -91,6 +89,9 @@ public class SettingsFragment extends PreferenceFragmentCompat
   private static final String DELETE_ACCOUNT = "deleteAccount";
 
   protected Toolbar toolbar;
+
+  @Inject @Named("marketName") String marketName;
+
   private Context context;
   private CompositeSubscription subscriptions;
   private FileManager fileManager;

--- a/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
@@ -446,6 +446,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
             LinkMovementMethod.getInstance());
 
         LinearLayout contactLayout = view.findViewById(R.id.contact_layout);
+        ((TextView) view.findViewById(R.id.contact_text)).setText(supportEmailProvider.getEmail());
 
         if (supportEmailProvider.isAptoideSupport()) {
           contactLayout.setVisibility(View.VISIBLE);

--- a/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
@@ -31,6 +31,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import cm.aptoide.accountmanager.AptoideAccountManager;
 import cm.aptoide.analytics.implementation.navigation.NavigationTracker;
@@ -91,6 +92,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
   protected Toolbar toolbar;
 
   @Inject @Named("marketName") String marketName;
+  @Inject SupportEmailProvider supportEmailProvider;
 
   private Context context;
   private CompositeSubscription subscriptions;
@@ -442,6 +444,14 @@ public class SettingsFragment extends PreferenceFragmentCompat
 
         ((TextView) view.findViewById(R.id.credits)).setMovementMethod(
             LinkMovementMethod.getInstance());
+
+        LinearLayout contactLayout = view.findViewById(R.id.contact_layout);
+
+        if (supportEmailProvider.isAptoideSupport()) {
+          contactLayout.setVisibility(View.VISIBLE);
+        } else {
+          contactLayout.setVisibility(View.INVISIBLE);
+        }
 
         new AlertDialog.Builder(context).setView(view)
             .setTitle(getString(R.string.settings_about_us))

--- a/app/src/main/java/cm/aptoide/pt/view/settings/SupportEmailProvider.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/SupportEmailProvider.java
@@ -1,0 +1,15 @@
+package cm.aptoide.pt.view.settings;
+
+public class SupportEmailProvider {
+  private final String email;
+  private final String aptoideEmail;
+
+  public SupportEmailProvider(String email, String aptoideEmail) {
+    this.email = email;
+    this.aptoideEmail = aptoideEmail;
+  }
+
+  public boolean isAptoideSupport() {
+    return aptoideEmail.equals(email);
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/view/settings/SupportEmailProvider.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/SupportEmailProvider.java
@@ -12,4 +12,8 @@ public class SupportEmailProvider {
   public boolean isAptoideSupport() {
     return aptoideEmail.equals(email);
   }
+
+  public String getEmail() {
+    return email;
+  }
 }

--- a/app/src/main/res/layout/dialog_about.xml
+++ b/app/src/main/res/layout/dialog_about.xml
@@ -100,12 +100,12 @@
         />
 
     <TextView
+        android:id="@+id/contact_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginLeft="3dp"
         android:layout_marginStart="3dp"
         android:autoLink="email"
-        android:text="@string/aptoide_email"
         android:textAppearance="?android:attr/textAppearanceSmall"
         />
   </LinearLayout>

--- a/app/src/vanilla/java/cm/aptoide/pt/FlavourApplicationModule.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/FlavourApplicationModule.java
@@ -29,4 +29,8 @@ import javax.inject.Singleton;
   @Singleton @Provides @Named("auto-update-store-name") String provideAutoUpdateStoreName() {
     return "v9";
   }
+
+  @Singleton @Provides @Named("support-email") String providesSupportEmail() {
+    return application.getString(R.string.aptoide_email);
+  }
 }

--- a/app/src/vanilla/java/cm/aptoide/pt/FlavourApplicationModule.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/FlavourApplicationModule.java
@@ -13,7 +13,10 @@ import javax.inject.Singleton;
 
 @Module public class FlavourApplicationModule {
 
-  public FlavourApplicationModule() {
+  private final AptoideApplication application;
+
+  public FlavourApplicationModule(AptoideApplication application) {
+    this.application = application;
   }
 
   @Singleton @Provides AdultContent provideAdultContent(

--- a/app/src/vanilla/java/cm/aptoide/pt/account/view/user/NewsletterManager.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/account/view/user/NewsletterManager.java
@@ -1,0 +1,7 @@
+package cm.aptoide.pt.account.view.user;
+
+public class NewsletterManager {
+  public boolean shouldShowNewsletter() {
+    return true;
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

   Hides the Aptoide support email in cobrand versions.
   Hides the Newsletter checkbox in cobrand versions.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] ManagerUserFragment.java
- [ ] SettingsFragment.java

**How should this be manually tested?**

  Test both vanilla and cobrand variants - Aptoide Support email is in the about us under settings, newsletter is in the User creation view at the beginning of the signup process.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1356](https://aptoide.atlassian.net/browse/ASV-1356)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass