### PR TITLE
[Task/ASV-1388] repair notification cleaner tests

### DIFF
--- a/app/src/test/java/cm/aptoide/pt/notification/NotificationsCleanerTest.java
+++ b/app/src/test/java/cm/aptoide/pt/notification/NotificationsCleanerTest.java
@@ -14,8 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 import rx.Completable;
 import rx.Observable;
@@ -26,11 +24,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Created by trinkes on 28/08/2017.
  */
-@RunWith(Parameterized.class) public class NotificationsCleanerTest {
-
-  @Parameterized.Parameters public static Object[][] data() {
-    return new Object[100][0];
-  }
+public class NotificationsCleanerTest {
 
   @Test public void cleanOtherUsersNotifications() throws Exception {
     Map<String, Notification> list = new HashMap<>();


### PR DESCRIPTION
**What does this PR do?**

   This PR aims to fix the behaviour of the NotificationsCleanerTest.java tests. Most of the time they would pass, but once in a while they would fail. This has to do with the way we are testing this class, which is using timestamps and a fake db (in memory map). In the future we should try refactor this to not depend on time - which makes the test flaky, however the way it is still adds value and now it seems to be more robust. 
   This tests are not new, they were removed from the Jenkins build/test all variants fix PR.  [PR where tests were removed](https://github.com/Aptoide/aptoide-client-v8/pull/868/files#diff-73d947e3b3f29b48cdebb715b1cb4753) 

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] NotificationsCleanerTest.java
compare the "new" tests with the ones removed from: [PR where tests were removed](https://github.com/Aptoide/aptoide-client-v8/pull/868/files#diff-73d947e3b3f29b48cdebb715b1cb4753) 

**How should this be manually tested?**

  Other than checking the code, I suggest running a parameterized test in other to run the same tests more than once - this way I was more confident in the tests robustness.

Example: 

`@RunWith(Parameterized.class)
public class RunTenTimes {

    @Parameterized.Parameters
    public static Object[][] data() {
        return new Object[10][0];
    }

    public RunTenTimes() {
    }

    @Test
    public void runsTenTimes() {
        System.out.println("run");
    }
}`

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1388](https://aptoide.atlassian.net/browse/ASV-1388)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Partners build
- [ ] Unit tests pass
- [ ] Functional QA tests pass