### PR TITLE
[ASV-1422] fix: installed service npe

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/install/InstalledIntentService.java
+++ b/app/src/main/java/cm/aptoide/pt/install/InstalledIntentService.java
@@ -171,8 +171,11 @@ public class InstalledIntentService extends IntentService {
               .value(), ManagerPreferences.allowRootInstallation(sharedPreferences));
       return;
     }
-
     // information about the package is null so we don't broadcast an event
+    reportPackageInfoNullEvent();
+  }
+
+  private void reportPackageInfoNullEvent() {
     CrashReport.getInstance()
         .log(new NullPointerException("PackageInfo is null."));
   }
@@ -248,6 +251,11 @@ public class InstalledIntentService extends IntentService {
   }
 
   private void sendCampaignConversion(String packageName, PackageInfo packageInfo) {
-    campaignAnalytics.convertCampaignEvent(packageName, packageInfo.versionCode);
+    if (packageInfo != null) {
+      campaignAnalytics.convertCampaignEvent(packageName, packageInfo.versionCode);
+    } else {
+      // information about the package is null so we don't broadcast an event
+      reportPackageInfoNullEvent();
+    }
   }
 }


### PR DESCRIPTION
**What does this PR do?**

   Null checking PackageInfo before trying to convert campaign - this goes inline with what the send install event implementation is doing, since the PackageInfo might be null.
  This fixes the crash in production but we will continue loosing some APPC campaign conversion events.
  What should be done in the future: Investigate why is the PackageInfo returning null. This might be a problem if we are not converting successfully installed campaigns.
  If there is a problem with the campaigns convertion, we should try to find a way to not depend on the PackageInfo to get the version code or find a version code alternative that does not make the event depend on the PackageInfo. This should only be considered if we are really loosing successfully installed appc campaigns event conversion.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] InstalledIntentService.java

**How should this be manually tested?**

  Since I cannot reproduce this problem - try to talk with Rafa if he, meanwhile, was able to reproduce this issue.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1422](https://aptoide.atlassian.net/browse/ASV-1422)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Unit tests pass
- [ ] Functional QA tests pass