### PR TITLE
[ASV-1402] No ads for APPC apps

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppViewViewModel.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewViewModel.java
@@ -433,6 +433,10 @@ public class AppViewViewModel {
     return hasBilling;
   }
 
+  public boolean isAppCoinApp() {
+    return hasBilling || hasAdvertising;
+  }
+
   public boolean hasAdvertising() {
     return this.hasAdvertising;
   }

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -1788,16 +1788,13 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     /**
      * Only open the appview
      */
-    OPEN_ONLY,
-    /**
+    OPEN_ONLY, /**
      * opens the appView and starts the installation
      */
-    OPEN_AND_INSTALL,
-    /**
+    OPEN_AND_INSTALL, /**
      * open the appView and ask user if want to install the app
      */
-    OPEN_WITH_INSTALL_POPUP,
-    /**
+    OPEN_WITH_INSTALL_POPUP, /**
      * open the appView and ask user if want to install the app
      */
     APK_FY_INSTALL_POPUP

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -1788,13 +1788,16 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     /**
      * Only open the appview
      */
-    OPEN_ONLY, /**
+    OPEN_ONLY,
+    /**
      * opens the appView and starts the installation
      */
-    OPEN_AND_INSTALL, /**
+    OPEN_AND_INSTALL,
+    /**
      * open the appView and ask user if want to install the app
      */
-    OPEN_WITH_INSTALL_POPUP, /**
+    OPEN_WITH_INSTALL_POPUP,
+    /**
      * open the appView and ask user if want to install the app
      */
     APK_FY_INSTALL_POPUP

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -141,6 +141,7 @@ public class AppViewPresenter implements Presenter {
         .flatMap(create -> appViewManager.loadAppViewViewModel()
             .toObservable())
         .filter(app -> !app.isLoading())
+        .filter(app -> !app.isAppCoinApp())
         .flatMap(app -> appViewManager.loadDownloadAppViewModel(app.getMd5(), app.getPackageName(),
             app.getVersionCode(), app.isPaid(), app.getPay())
             .filter(model -> model.getDownloadModel()


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at removing interstitial ads from AppViews of APPC apps.

**Database changed?**

    No

**Where should the reviewer start?**

- [x] AppViewPresenter.java

**How should this be manually tested?**

Open an appview from a normal app and download. You should see and interstitial ad. Then, go to an appview of an appc app and you should not see an interstitial ad.
In case of failure of seeing any interstitial ads, please check you have all the correct keys and use try with a vpn (sometimes we can not see ads because we are in Portugal).

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1402](https://aptoide.atlassian.net/browse/ASV-1402)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [x] Architecture
- [x] Documentation on public interfaces
- [x] Database changed?
- [x] If yes - Database migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] Unit tests pass
- [x] Functional QA tests pass