### PR TITLE
[ASV-1399] AppLovin native ads fix

### DIFF
--- a/app/src/main/java/com/mopub/nativeads/AppLovinCustomEventNative.java
+++ b/app/src/main/java/com/mopub/nativeads/AppLovinCustomEventNative.java
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.ads;
+package com.mopub.nativeads;
 
 import android.content.Context;
 import android.os.Handler;
@@ -16,10 +16,6 @@ import com.applovin.sdk.AppLovinSdk;
 import com.applovin.sdk.AppLovinSdkSettings;
 import com.mopub.common.MoPub;
 import com.mopub.common.privacy.PersonalInfoManager;
-import com.mopub.nativeads.CustomEventNative;
-import com.mopub.nativeads.NativeErrorCode;
-import com.mopub.nativeads.NativeImageHelper;
-import com.mopub.nativeads.StaticNativeAd;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/app/src/main/java/com/mopub/nativeads/AppLovinNativeAdapter.java
+++ b/app/src/main/java/com/mopub/nativeads/AppLovinNativeAdapter.java
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.ads;
+package com.mopub.nativeads;
 
 public class AppLovinNativeAdapter extends AppLovinCustomEventNative {
 }


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at fixing native ads in production from AppLovin. In a thread of emails, the AppLovin team suggested us to re-check the documentation and see if anything is wrong. I found out that we did import the correct adapter classes, but they were not put in the correct package (this information was only on mopub's documentation and not on the AppLovin documentation which is what was followed in the previous iteration).

**Database changed?**

   No

**Where should the reviewer start?**

- [x] AppLovinCustomEventNative.java

**How should this be manually tested?**

This is an attempt at fixing native ads with AppLovin. We will have to release it and check if we start getting impressions. Another alternative would be to lock all of the ad networks except for AppLovin (for the native ads) and see if there are any impressions.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1399](https://aptoide.atlassian.net/browse/ASV-1399)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [x] Architecture
- [x] Documentation on public interfaces
- [x] Database changed?
- [x] If yes - Database migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] Unit tests pass
- [x] Functional QA tests pass