### PR TITLE
[ASV-1427] Created event to tell us whether apps in promotion need mi…

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -1365,7 +1365,8 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
         TimelineAnalytics.COMMENT, TimelineAnalytics.SHARE, TimelineAnalytics.SHARE_SEND,
         TimelineAnalytics.COMMENT_SEND, TimelineAnalytics.FAB, TimelineAnalytics.SCROLLING_EVENT,
         TimelineAnalytics.OPEN_TIMELINE_EVENT, AccountAnalytics.APTOIDE_EVENT_NAME,
-        DownloadAnalytics.DOWNLOAD_EVENT_NAME, InstallAnalytics.INSTALL_EVENT_NAME);
+        DownloadAnalytics.DOWNLOAD_EVENT_NAME, InstallAnalytics.INSTALL_EVENT_NAME,
+        PromotionsAnalytics.VALENTINE_MIGRATOR);
   }
 
   @Singleton @Provides @Named("fabricEvents") Collection<String> provideFabricEvents() {
@@ -1590,11 +1591,12 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
       PromotionViewAppMapper promotionViewAppMapper, DownloadFactory downloadFactory,
       DownloadStateParser downloadStateParser, PromotionsAnalytics promotionsAnalytics,
       NotificationAnalytics notificationAnalytics, InstallAnalytics installAnalytics,
-      PreferencesManager preferencesManager, PromotionsService promotionsService) {
+      PreferencesManager preferencesManager, PromotionsService promotionsService,
+      InstalledRepository installedRepository) {
     return new PromotionsManager(promotionViewAppMapper, installManager, downloadFactory,
         downloadStateParser, promotionsAnalytics, notificationAnalytics, installAnalytics,
         preferencesManager, application.getApplicationContext()
-        .getPackageManager(), promotionsService);
+        .getPackageManager(), promotionsService, installedRepository);
   }
 
   @Singleton @Provides PromotionViewAppMapper providesPromotionViewAppMapper(
@@ -1740,7 +1742,7 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
         NotLoggedInShareAnalytics.MESSAGE_IMPRESSION, NotLoggedInShareAnalytics.MESSAGE_INTERACT,
         DownloadAnalytics.DOWNLOAD_INTERACT, DonationsAnalytics.DONATIONS_INTERACT,
         EditorialAnalytics.CURATION_CARD_INSTALL, PromotionsAnalytics.PROMOTION_DIALOG,
-        PromotionsAnalytics.PROMOTIONS_INTERACT);
+        PromotionsAnalytics.PROMOTIONS_INTERACT, PromotionsAnalytics.VALENTINE_MIGRATOR);
   }
 
   @Singleton @Provides AptoideShortcutManager providesShortcutManager() {

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionApp.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionApp.java
@@ -20,11 +20,12 @@ public class PromotionApp {
   private String versionName;
   private Obb obb;
   private float appcValue;
+  private String signature;
 
   public PromotionApp(String name, String packageName, long appId, String downloadPath,
       String alternativePath, String appIcon, String description, long size, float rating,
       int numberOfDownloads, String md5, int versionCode, boolean isClaimed, String versionName,
-      Obb obb, float appcValue) {
+      Obb obb, float appcValue, String signature) {
     this.name = name;
     this.packageName = packageName;
     this.appId = appId;
@@ -41,6 +42,7 @@ public class PromotionApp {
     this.versionName = versionName;
     this.obb = obb;
     this.appcValue = appcValue;
+    this.signature = signature;
   }
 
   public String getName() {
@@ -105,5 +107,9 @@ public class PromotionApp {
 
   public float getAppcValue() {
     return appcValue;
+  }
+
+  public String getSignature() {
+    return signature;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionViewApp.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionViewApp.java
@@ -22,11 +22,12 @@ public class PromotionViewApp {
   private String versionName;
   private Obb obb;
   private float appcValue;
+  private String signature;
 
   public PromotionViewApp(DownloadModel downloadModel, String name, String packageName, long appId,
       String downloadPath, String alternativePath, String appIcon, boolean isClaimed,
       String description, long size, float rating, int numberOfDownloads, String md5,
-      int versionCode, String versionName, Obb obb, float appcValue) {
+      int versionCode, String versionName, Obb obb, float appcValue, String signature) {
     this.downloadModel = downloadModel;
     this.name = name;
     this.packageName = packageName;
@@ -44,6 +45,7 @@ public class PromotionViewApp {
     this.versionName = versionName;
     this.obb = obb;
     this.appcValue = appcValue;
+    this.signature = signature;
   }
 
   public String getName() {
@@ -148,5 +150,9 @@ public class PromotionViewApp {
 
   public float getAppcValue() {
     return appcValue;
+  }
+
+  public String getSignature() {
+    return signature;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionViewAppMapper.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionViewAppMapper.java
@@ -20,7 +20,7 @@ public class PromotionViewAppMapper {
         promotionApp.getAppIcon(), promotionApp.isClaimed(), promotionApp.getDescription(),
         promotionApp.getSize(), promotionApp.getRating(), promotionApp.getNumberOfDownloads(),
         promotionApp.getMd5(), promotionApp.getVersionCode(), promotionApp.getVersionName(),
-        promotionApp.getObb(), promotionApp.getAppcValue());
+        promotionApp.getObb(), promotionApp.getAppcValue(), promotionApp.getSignature());
   }
 
   private DownloadModel getDownloadModel(Install.InstallationType type, int progress,

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionsAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionsAnalytics.java
@@ -11,6 +11,7 @@ import java.util.Map;
 public class PromotionsAnalytics {
   public static final String PROMOTION_DIALOG = "Promotion_Dialog";
   public static final String PROMOTIONS_INTERACT = "Promotions_Interact";
+  public static final String VALENTINE_MIGRATOR = "Valentine_Migrator";
   private static final String ACTION = "action";
   private static final String ACTION_CLAIM = "claim";
   private static final String ACTION_UPDATE = "update";
@@ -25,6 +26,7 @@ public class PromotionsAnalytics {
   private final String CLAIM = "claim";
   private final String WALLET_DIALOG = "wallet dialog";
   private final String CAPTCHA_DIALOG = "captcha dialog";
+  private final String SIGNATURE = "signature";
   private final AnalyticsManager analyticsManager;
   private final NavigationTracker navigationTracker;
   private final DownloadAnalytics downloadAnalytics;
@@ -142,6 +144,15 @@ public class PromotionsAnalytics {
     data.put(VIEW, CAPTCHA_DIALOG);
 
     analyticsManager.logEvent(data, PROMOTION_DIALOG, AnalyticsManager.Action.CLICK,
+        navigationTracker.getViewName(true));
+  }
+
+  public void sendValentineMigratorEvent(String packageName, Boolean signatureMatch) {
+    final Map<String, Object> data = new HashMap<>();
+    data.put(PACKAGE, packageName);
+    data.put(SIGNATURE, signatureMatch ? "same" : "different");
+
+    analyticsManager.logEvent(data, VALENTINE_MIGRATOR, AnalyticsManager.Action.CLICK,
         navigationTracker.getViewName(true));
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionsManager.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionsManager.java
@@ -10,6 +10,7 @@ import cm.aptoide.pt.download.AppContext;
 import cm.aptoide.pt.download.DownloadFactory;
 import cm.aptoide.pt.install.InstallAnalytics;
 import cm.aptoide.pt.install.InstallManager;
+import cm.aptoide.pt.install.InstalledRepository;
 import cm.aptoide.pt.notification.NotificationAnalytics;
 import java.util.List;
 import rx.Completable;
@@ -29,13 +30,14 @@ public class PromotionsManager {
   private final PreferencesManager preferencesManager;
   private final PackageManager packageManager;
   private final PromotionsService promotionsService;
+  private final InstalledRepository installedRepository;
 
   public PromotionsManager(PromotionViewAppMapper promotionViewAppMapper,
       InstallManager installManager, DownloadFactory downloadFactory,
       DownloadStateParser downloadStateParser, PromotionsAnalytics promotionsAnalytics,
       NotificationAnalytics notificationAnalytics, InstallAnalytics installAnalytics,
       PreferencesManager preferencesManager, PackageManager packageManager,
-      PromotionsService promotionsService) {
+      PromotionsService promotionsService, InstalledRepository installedRepository) {
     this.promotionViewAppMapper = promotionViewAppMapper;
     this.installManager = installManager;
     this.downloadFactory = downloadFactory;
@@ -46,6 +48,7 @@ public class PromotionsManager {
     this.preferencesManager = preferencesManager;
     this.packageManager = packageManager;
     this.promotionsService = promotionsService;
+    this.installedRepository = installedRepository;
   }
 
   public Single<List<PromotionApp>> getPromotionApps() {
@@ -143,5 +146,16 @@ public class PromotionsManager {
   public Single<ClaimStatusWrapper> claimPromotion(String walletAddress, String packageName,
       String captcha) {
     return promotionsService.claimPromotion(walletAddress, packageName, captcha);
+  }
+
+  public Observable<String> getPackageSignature(String packageName) {
+    return installedRepository.getInstalled(packageName)
+        .map(installed -> {
+          if (installed != null) {
+            return installed.getSignature();
+          } else {
+            return "";
+          }
+        });
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionsService.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionsService.java
@@ -135,7 +135,10 @@ public class PromotionsService {
             .getVercode(), app.isClaimed(), app.getApp()
             .getFile()
             .getVername(), app.getApp()
-            .getObb(), app.getAppc()));
+            .getObb(), app.getAppc(), app.getApp()
+            .getFile()
+            .getSignature()
+            .getSha1()));
       }
     }
 

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/promotions/GetPromotionAppsResponse.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/promotions/GetPromotionAppsResponse.java
@@ -1,7 +1,7 @@
 package cm.aptoide.pt.dataprovider.ws.v7.promotions;
 
 import cm.aptoide.pt.dataprovider.model.v7.BaseV7EndlessDataListResponse;
-import cm.aptoide.pt.dataprovider.model.v7.listapp.App;
+import cm.aptoide.pt.dataprovider.model.v7.GetAppMeta;
 
 public class GetPromotionAppsResponse
     extends BaseV7EndlessDataListResponse<GetPromotionAppsResponse.PromotionAppModel> {
@@ -13,7 +13,7 @@ public class GetPromotionAppsResponse
     private boolean claimed;
     private float appc;
     private String promotionDescription;
-    private App app;
+    private GetAppMeta.App app;
 
     public PromotionAppModel() {
     }
@@ -34,11 +34,11 @@ public class GetPromotionAppsResponse
       this.appc = appc;
     }
 
-    public App getApp() {
+    public GetAppMeta.App getApp() {
       return app;
     }
 
-    public void setApp(App app) {
+    public void setApp(GetAppMeta.App app) {
       this.app = app;
     }
 


### PR DESCRIPTION
**What does this PR do?**

This PR aims to send a new event so we know, when an update is available in the promotions view, if the update needed would need to be migrated. The event has two fields: the package name of the app and whether it has the same signature as the app to download (this is how we check if play->catappult migration is needed, if the signatures are different)

**Database changed?**

No

**Where should the reviewer start?**

- [ ] PromotionsAnalytics.java
- [ ] PromotionsPresenter.java

**How should this be manually tested?**

Since no app being sent to us that has a different signature we need to use charles to test this.
First, to see promotions, you need to put a breakpoint in the promotions request and replace the aptoide_md5 with "00000000000000000000000000000000" (the number of 0s is important). From there, download previous versions of a couple of the apps. On the response of the request where you changed the md5, change the signature of one of the apps that you downloaded. After seeing the promotions view in the scenario described you should see 2 events going out to our BI and 2 (equal) to facebook. The one you changed the signature should have the "signature" field filled with "different" while the other update app should have that field filled with "same".

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1427](https://aptoide.atlassian.net/browse/ASV-1427)

**Code Review Checklist**

- [x] Architecture
- [x] Documentation on public interfaces
- [x] Database changed?
- [x] If yes - Database migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] Unit tests pass
- [x] Functional QA tests pass