### PR TITLE
[ASV-1443] Adapt AppLovin to new MoPub version

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
+++ b/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
@@ -108,6 +108,8 @@ import com.jakewharton.rxrelay.BehaviorRelay;
 import com.jakewharton.rxrelay.PublishRelay;
 import com.mopub.common.MoPub;
 import com.mopub.common.SdkConfiguration;
+import com.mopub.common.logging.MoPubLog;
+import com.mopub.nativeads.AppLovinBaseAdapterConfiguration;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -342,8 +344,18 @@ public abstract class AptoideApplication extends Application {
     aptoideDownloadManager.start();
   }
 
-  private void initializeMoPub(Context context, String moPubKey) {
-    SdkConfiguration sdkConfiguration = new SdkConfiguration.Builder(moPubKey).build();
+  private void initializeMoPub(Context context, String adUnitPlacementId) {
+    Map<String, String> appLovinConfiguration = new HashMap<>();
+    appLovinConfiguration.put("Placement_Id", BuildConfig.MOPUB_BANNER_50_HOME_PLACEMENT_ID);
+
+    SdkConfiguration sdkConfiguration =
+        new SdkConfiguration.Builder(adUnitPlacementId).withAdditionalNetwork(
+            AppLovinBaseAdapterConfiguration.class.toString())
+            .withMediatedNetworkConfiguration(AppLovinBaseAdapterConfiguration.class.toString(),
+                appLovinConfiguration)
+            .withLogLevel(MoPubLog.LogLevel.DEBUG)
+            .build();
+
     MoPub.initializeSdk(context, sdkConfiguration, null);
   }
 

--- a/app/src/main/java/cm/aptoide/pt/view/MainActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/view/MainActivity.java
@@ -32,7 +32,6 @@ import cm.aptoide.pt.presenter.Presenter;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.design.ShowMessage;
 import com.adcolony.sdk.AdColony;
-import com.applovin.sdk.AppLovinSdk;
 import com.ironsource.mediationsdk.IronSource;
 import com.jakewharton.rxrelay.PublishRelay;
 import com.tapjoy.Tapjoy;
@@ -86,7 +85,6 @@ public class MainActivity extends BottomNavigationActivity
 
   private void initializeAdsMediation() {
     IronSource.init(this, BuildConfig.IRONSOURCE_APPLICATION_ID);
-    AppLovinSdk.initializeSdk(this);
     AdColony.configure(this, BuildConfig.ADCOLONY_APPLICATION_ID, BuildConfig.ADCOLONY_ZONE_ID_T7);
 
     Tapjoy.connect(getApplicationContext(), BuildConfig.TAPJOY_SDK_KEY,

--- a/app/src/main/java/com/mopub/nativeads/AppLovinBaseAdapterConfiguration.java
+++ b/app/src/main/java/com/mopub/nativeads/AppLovinBaseAdapterConfiguration.java
@@ -1,0 +1,37 @@
+package com.mopub.nativeads;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import com.applovin.sdk.AppLovinSdk;
+import com.mopub.common.BaseAdapterConfiguration;
+import com.mopub.common.OnNetworkInitializationFinishedListener;
+import com.mopub.mobileads.MoPubErrorCode;
+import java.util.Map;
+
+public class AppLovinBaseAdapterConfiguration extends BaseAdapterConfiguration {
+
+  @NonNull @Override public String getAdapterVersion() {
+    return "8.1.4.3";
+  }
+
+  @Nullable @Override public String getBiddingToken(@NonNull Context context) {
+    return null;
+  }
+
+  @NonNull @Override public String getMoPubNetworkName() {
+    return "applovin";
+  }
+
+  @NonNull @Override public String getNetworkSdkVersion() {
+    return "8.1.4";
+  }
+
+  @Override public void initializeNetwork(@NonNull Context context,
+      @Nullable Map<String, String> configuration,
+      @NonNull OnNetworkInitializationFinishedListener listener) {
+    AppLovinSdk.initializeSdk(context);
+    listener.onNetworkInitializationFinished(this.getClass(),
+        MoPubErrorCode.ADAPTER_INITIALIZATION_SUCCESS);
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

After upgrading mopub from version 5.4 to version 5.5, the initialization of non-certified networks should be done in a class that extends the BaseAdapterConfiguration class from MoPub. This PR implemented that and added that configuration to the mopub initialization

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppLovinBaseAdapterConfiguration.java

**How should this be manually tested?**
Open App check if there are ads. We should see in the nightly if there are AppLovin ads. If you want to do a more severe test, you could go to the mopub dashboard, disable all the networks except for AppLovin and see if you have ads (that way you would be sure that all the ads are coming from AppLovin, ensuring that it is correctly integrated.

These ads should be shown in: 
- Home (banner above editors choice, native ads in the highlighted)
- Search (banner on top and native ads in the middle of the search)
- AppView (banner bellow other versions and  native ads in the similar apps bundle)

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1443](https://aptoide.atlassian.net/browse/ASV-1443)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass