### PR TITLE
[ASV-1459] Changed cacheValidator to validate being part of an experi…

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/abtesting/AbTestCacheValidator.java
+++ b/app/src/main/java/cm/aptoide/pt/abtesting/AbTestCacheValidator.java
@@ -14,7 +14,9 @@ public class AbTestCacheValidator {
     return localCache.containsKey(experimentId) && !localCache.get(experimentId)
         .hasError() && !localCache.get(experimentId)
         .getExperiment()
-        .isExperimentOver();
+        .isExperimentOver() && localCache.get(experimentId)
+        .getExperiment()
+        .isPartOfExperiment();
   }
 
   public boolean isExperimentValid(String experimentId) {

--- a/app/src/main/java/cm/aptoide/pt/abtesting/Experiment.java
+++ b/app/src/main/java/cm/aptoide/pt/abtesting/Experiment.java
@@ -17,7 +17,7 @@ public class Experiment {
     this.requestTime = requestTime;
     this.assignment = assignment;
     this.payload = payload;
-    this.partOfExperiment = true;
+    this.partOfExperiment = !(assignment == null);
     this.experimentOver = experimentOver;
   }
 


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix impressions/actions being sent in ab testing when a user isn't part of the experiment;

**Database changed?**

No

**Where should the reviewer start?**

- [ ] Experiment.java

**How should this be manually tested?**

Check that, while being unassigned to an experiment, after retrieving your group, you won't send out impression/action events;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1459](https://aptoide.atlassian.net/browse/ASV-1459)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass