### PR TITLE
[ASV-1463/ASV-1441] editorial scale type to crop. store meta followers/following swapped.

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/view/recycler/displayable/DisplayablesFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/view/recycler/displayable/DisplayablesFactory.java
@@ -371,7 +371,7 @@ public class DisplayablesFactory {
         displayables.add(new StoreDisplayable(store.getGetHomeMeta()
             .getData()
             .getStore(), storeContext, followerStats.getFollowing(), followerStats.getFollowers(),
-            R.string.storetab_short_followers, R.string.storetab_short_followings, true,
+            R.string.storetab_short_followings, R.string.storetab_short_followers, true,
             getStoreDescriptionMessage(context, store.getGetHomeMeta()
                 .getData()
                 .getStore())));

--- a/app/src/main/res/layout/editorial_item_layout.xml
+++ b/app/src/main/res/layout/editorial_item_layout.xml
@@ -77,7 +77,7 @@
         android:layout_width="match_parent"
         android:layout_height="200dp"
         android:adjustViewBounds="true"
-        android:scaleType="fitXY"
+        android:scaleType="centerCrop"
         android:visibility="gone"
         tools:background="@color/light_blue"
         tools:visibility="gone"
@@ -94,7 +94,7 @@
           android:layout_width="match_parent"
           android:layout_height="match_parent"
           android:adjustViewBounds="true"
-          android:scaleType="fitXY"
+          android:scaleType="centerCrop"
           android:src="@color/black_87_alpha"
           android:tint="@color/semi_transparent_black"
           />
@@ -104,7 +104,7 @@
           android:layout_height="50dp"
           android:layout_gravity="center"
           android:adjustViewBounds="true"
-          android:scaleType="fitXY"
+          android:scaleType="centerCrop"
           android:src="@drawable/btn_movie_play_normal"
           />
     </FrameLayout>

--- a/app/src/main/res/layout/editorial_layout.xml
+++ b/app/src/main/res/layout/editorial_layout.xml
@@ -25,7 +25,7 @@
           android:layout_width="match_parent"
           android:layout_height="248dp"
           android:adjustViewBounds="true"
-          android:scaleType="fitXY"
+          android:scaleType="centerCrop"
           app:layout_collapseMode="parallax"
           tools:background="@color/grey_fog_normal"
           />

--- a/app/src/main/res/layout/media_layout.xml
+++ b/app/src/main/res/layout/media_layout.xml
@@ -15,7 +15,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:adjustViewBounds="true"
-        android:scaleType="fitXY"
+        android:scaleType="centerCrop"
         android:visibility="gone"
         tools:background="@color/grey_fog_normal"
         tools:visibility="visible"
@@ -33,7 +33,7 @@
           android:layout_width="match_parent"
           android:layout_height="match_parent"
           android:adjustViewBounds="true"
-          android:scaleType="fitXY"
+          android:scaleType="centerCrop"
           android:src="@color/black_87_alpha"
           android:tint="@color/semi_transparent_black"
           />
@@ -43,7 +43,7 @@
           android:layout_height="50dp"
           android:layout_gravity="center"
           android:adjustViewBounds="true"
-          android:scaleType="fitXY"
+          android:scaleType="centerCrop"
           android:src="@drawable/btn_movie_play_normal"
           />
     </FrameLayout>


### PR DESCRIPTION
**What does this PR do?**

   fix: editorial content images/graphics/thumbnails are now with centerCrop scale type.
   home meta followers/following are now correct (numbers were swapped).

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] editorial_item_layout.xml

**How should this be manually tested?**

  home > click oscars article (or current editorial content article) > check feature graphic on top and screenshots inside.
  stores > check if followers/following numbers make sense.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1463](https://aptoide.atlassian.net/browse/ASV-1463)
[ASV-1441](https://aptoide.atlassian.net/browse/ASV-1441)


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass