### PR TITLE
[ASV-1457] Editorial Fragment download now supports downgrades;

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -142,6 +142,7 @@ import cm.aptoide.pt.downloadmanager.FileDownloaderProvider;
 import cm.aptoide.pt.downloadmanager.RetryFileDownloadManagerProvider;
 import cm.aptoide.pt.downloadmanager.RetryFileDownloaderProvider;
 import cm.aptoide.pt.editorial.EditorialAnalytics;
+import cm.aptoide.pt.editorial.EditorialRepository;
 import cm.aptoide.pt.editorial.EditorialService;
 import cm.aptoide.pt.file.CacheHelper;
 import cm.aptoide.pt.home.AdMapper;
@@ -1846,5 +1847,10 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
   @Singleton @Provides SearchExperiment providesSearchExperiment(
       @Named("search-ab-test") ABTestManager abTestManager) {
     return new SearchExperiment(abTestManager);
+  }
+
+  @Singleton @Provides EditorialRepository providesEditorialRepository(
+      EditorialService editorialService) {
+    return new EditorialRepository(editorialService);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -142,7 +142,6 @@ import cm.aptoide.pt.downloadmanager.FileDownloaderProvider;
 import cm.aptoide.pt.downloadmanager.RetryFileDownloadManagerProvider;
 import cm.aptoide.pt.downloadmanager.RetryFileDownloaderProvider;
 import cm.aptoide.pt.editorial.EditorialAnalytics;
-import cm.aptoide.pt.editorial.EditorialRepository;
 import cm.aptoide.pt.editorial.EditorialService;
 import cm.aptoide.pt.file.CacheHelper;
 import cm.aptoide.pt.home.AdMapper;
@@ -1847,10 +1846,5 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
   @Singleton @Provides SearchExperiment providesSearchExperiment(
       @Named("search-ab-test") ABTestManager abTestManager) {
     return new SearchExperiment(abTestManager);
-  }
-
-  @Singleton @Provides EditorialRepository providesEditorialRepository(
-      EditorialService editorialService) {
-    return new EditorialRepository(editorialService);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialFragment.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.CollapsingToolbarLayout;
+import android.support.design.widget.Snackbar;
 import android.support.v4.graphics.ColorUtils;
 import android.support.v4.widget.NestedScrollView;
 import android.support.v7.app.ActionBar;
@@ -337,6 +338,7 @@ public class EditorialFragment extends NavigationTrackFragment
   @Override public void populateView(EditorialViewModel editorialViewModel) {
     populateAppContent(editorialViewModel);
     populateCardContent(editorialViewModel);
+    ready.onNext(null);
   }
 
   @Override public void showError(EditorialViewModel.Error error) {
@@ -369,7 +371,8 @@ public class EditorialFragment extends NavigationTrackFragment
         placeHolderViewHolder.setPlaceHolderDefaultStateInfo(downloadModel,
             getResources().getString(R.string.appview_button_update),
             getResources().getString(R.string.appview_button_install),
-            getResources().getString(R.string.appview_button_open));
+            getResources().getString(R.string.appview_button_open),
+            getResources().getString(R.string.appview_button_downgrade));
       }
       if (downloadModel.hasError()) {
         handleDownloadError(downloadModel.getDownloadState());
@@ -534,6 +537,18 @@ public class EditorialFragment extends NavigationTrackFragment
     return movingCollapseSubject.distinctUntilChanged();
   }
 
+  @Override public Observable<Boolean> showDowngradeMessage() {
+    return GenericDialogs.createGenericContinueCancelMessage(getContext(), null,
+        getContext().getResources()
+            .getString(R.string.downgrade_warning_dialog))
+        .map(eResponse -> eResponse.equals(YES));
+  }
+
+  @Override public void showDowngradingMessage() {
+    Snackbar.make(getView(), R.string.downgrading_msg, Snackbar.LENGTH_SHORT)
+        .show();
+  }
+
   private void populateAppContent(EditorialViewModel editorialViewModel) {
     placeHolderPositions = editorialViewModel.getPlaceHolderPositions();
     shouldAnimate = editorialViewModel.shouldHaveAnimation();
@@ -580,6 +595,9 @@ public class EditorialFragment extends NavigationTrackFragment
         break;
       case OPEN:
         appCardButton.setText(getResources().getString(R.string.appview_button_open));
+        break;
+      case DOWNGRADE:
+        appCardButton.setText(getResources().getString(R.string.appview_button_downgrade));
         break;
     }
   }

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialFragment.java
@@ -434,10 +434,6 @@ public class EditorialFragment extends NavigationTrackFragment
     return ready;
   }
 
-  @Override public void readyToDownload() {
-    ready.onNext(null);
-  }
-
   @Override public Observable<ScrollEvent> placeHolderVisibilityChange() {
     return RxNestedScrollView.scrollChangeEvents(scrollView)
         .flatMap(viewScrollChangeEvent -> Observable.just(viewScrollChangeEvent)

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialItemsViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialItemsViewHolder.java
@@ -286,13 +286,14 @@ class EditorialItemsViewHolder extends RecyclerView.ViewHolder {
   }
 
   public void setPlaceHolderDefaultStateInfo(DownloadModel downloadModel, String update,
-      String install, String open) {
+      String install, String open, String downgrade) {
     downloadInfoLayout.setVisibility(View.GONE);
     cardInfoLayout.setVisibility(View.VISIBLE);
-    setButtonText(downloadModel, update, install, open);
+    setButtonText(downloadModel, update, install, open, downgrade);
   }
 
-  private void setButtonText(DownloadModel model, String update, String install, String open) {
+  private void setButtonText(DownloadModel model, String update, String install, String open,
+      String downgrade) {
     DownloadModel.Action action = model.getAction();
     switch (action) {
       case UPDATE:
@@ -303,6 +304,9 @@ class EditorialItemsViewHolder extends RecyclerView.ViewHolder {
         break;
       case OPEN:
         appCardButton.setText(open);
+        break;
+      case DOWNGRADE:
+        appCardButton.setText(downgrade);
         break;
     }
   }

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialView.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialView.java
@@ -63,4 +63,8 @@ public interface EditorialView extends View {
   void setMediaListDescriptionsVisible(EditorialEvent editorialEvent);
 
   Observable<Boolean> handleMovingCollapse();
+
+  Observable<Boolean> showDowngradeMessage();
+
+  void showDowngradingMessage();
 }

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialView.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialView.java
@@ -40,8 +40,6 @@ public interface EditorialView extends View {
 
   Observable<Void> isViewReady();
 
-  void readyToDownload();
-
   Observable<ScrollEvent> placeHolderVisibilityChange();
 
   void removeBottomCardAnimation();

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -66,7 +66,6 @@ import cm.aptoide.pt.editorial.EditorialManager;
 import cm.aptoide.pt.editorial.EditorialNavigator;
 import cm.aptoide.pt.editorial.EditorialPresenter;
 import cm.aptoide.pt.editorial.EditorialRepository;
-import cm.aptoide.pt.editorial.EditorialService;
 import cm.aptoide.pt.editorial.EditorialView;
 import cm.aptoide.pt.home.AdMapper;
 import cm.aptoide.pt.home.AptoideBottomNavigator;
@@ -364,11 +363,6 @@ import rx.schedulers.Schedulers;
     return new AppCoinsInfoPresenter((AppCoinsInfoView) fragment, appCoinsInfoNavigator,
         installManager, crashReport, AppCoinsInfoNavigator.APPC_WALLET_PACKAGE_NAME,
         AndroidSchedulers.mainThread());
-  }
-
-  @FragmentScope @Provides EditorialRepository providesEditorialRepository(
-      EditorialService editorialService) {
-    return new EditorialRepository(editorialService);
   }
 
   @FragmentScope @Provides EditorialManager providesEditorialManager(

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -66,6 +66,7 @@ import cm.aptoide.pt.editorial.EditorialManager;
 import cm.aptoide.pt.editorial.EditorialNavigator;
 import cm.aptoide.pt.editorial.EditorialPresenter;
 import cm.aptoide.pt.editorial.EditorialRepository;
+import cm.aptoide.pt.editorial.EditorialService;
 import cm.aptoide.pt.editorial.EditorialView;
 import cm.aptoide.pt.home.AdMapper;
 import cm.aptoide.pt.home.AptoideBottomNavigator;
@@ -373,6 +374,11 @@ import rx.schedulers.Schedulers;
     return new EditorialManager(editorialRepository, arguments.getString("cardId", ""),
         installManager, preferencesManager, downloadFactory, downloadStateParser,
         notificationAnalytics, installAnalytics, editorialAnalytics);
+  }
+
+  @FragmentScope @Provides EditorialRepository providesEditorialRepository(
+      EditorialService editorialService) {
+    return new EditorialRepository(editorialService);
   }
 
   @FragmentScope @Provides EditorialPresenter providesEditorialPresenter(

--- a/app/src/test/java/cm/aptoide/pt/app/view/EditorialPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/view/EditorialPresenterTest.java
@@ -88,7 +88,6 @@ public class EditorialPresenterTest {
     //And then populate the view
     verify(view).populateView(editorialViewModel);
     //And signal that it's ready to download
-    verify(view).readyToDownload();
   }
 
   @Test public void onCreateLoadAppOfTheWeekWithErrorViewModelTest() {
@@ -141,7 +140,6 @@ public class EditorialPresenterTest {
     verify(view).showLoading();
     //And then do the normal behaviour when creating the view
     view.populateView(editorialViewModel);
-    view.readyToDownload();
   }
 
   @Test public void handleClickOnMediaTest() {


### PR DESCRIPTION
**What does this PR do?**

   This PR aims to fix the button on the card at the bottom of the curation view not working. It also fixed this card not supporting the downgrade of apps;

**Database changed?**

No

**Where should the reviewer start?**

- [ ] EditorialPresenter.java

**How should this be manually tested?**

You'll need to have a editorial with the card at the bottom (if you need a rewrite for charles, talk to me). In that card make sure you can do all the actions regarding downloads;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1457](https://aptoide.atlassian.net/browse/ASV-1457)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass