### PR TITLE
Hack/[AS-104] endless scroll on curation list

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/editorialList/CurationCard.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/CurationCard.java
@@ -5,15 +5,13 @@ public class CurationCard {
   private final String subTitle;
   private final String icon;
   private final String title;
-  private final String url;
 
-  public CurationCard(String id, String subTitle, String icon, String title, String url) {
+  public CurationCard(String id, String subTitle, String icon, String title) {
 
     this.id = id;
     this.subTitle = subTitle;
     this.icon = icon;
     this.title = title;
-    this.url = url;
   }
 
   public String getId() {
@@ -30,9 +28,5 @@ public class CurationCard {
 
   public String getTitle() {
     return title;
-  }
-
-  public String getUrl() {
-    return url;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListManager.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListManager.java
@@ -10,7 +10,19 @@ public class EditorialListManager {
     this.editorialListRepository = editorialListRepository;
   }
 
-  public Single<EditorialListViewModel> loadEditorialListViewModel() {
-    return editorialListRepository.loadEditorialListViewModel();
+  Single<EditorialListViewModel> loadEditorialListViewModel(boolean loadMore) {
+    if (loadMore) {
+      return loadMoreCurationCards();
+    } else {
+      return editorialListRepository.loadEditorialListViewModel();
+    }
+  }
+
+  public boolean hasMore() {
+    return editorialListRepository.hasMore();
+  }
+
+  private Single<EditorialListViewModel> loadMoreCurationCards() {
+    return editorialListRepository.loadMoreCurationCards();
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListNavigator.java
@@ -3,6 +3,7 @@ package cm.aptoide.pt.editorialList;
 import android.os.Bundle;
 import cm.aptoide.pt.app.view.EditorialFragment;
 import cm.aptoide.pt.navigator.FragmentNavigator;
+import cm.aptoide.pt.view.settings.MyAccountFragment;
 
 public class EditorialListNavigator {
 
@@ -19,5 +20,9 @@ public class EditorialListNavigator {
     EditorialFragment fragment = new EditorialFragment();
     fragment.setArguments(bundle);
     fragmentNavigator.navigateTo(fragment, true);
+  }
+
+  public void navigateToMyAccount() {
+    fragmentNavigator.navigateTo(MyAccountFragment.newInstance(), true);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListPresenter.java
@@ -1,5 +1,6 @@
 package cm.aptoide.pt.editorialList;
 
+import android.support.annotation.VisibleForTesting;
 import cm.aptoide.accountmanager.Account;
 import cm.aptoide.accountmanager.AptoideAccountManager;
 import cm.aptoide.pt.crashreports.CrashReport;
@@ -42,7 +43,7 @@ public class EditorialListPresenter implements Presenter {
     loadUserImage();
   }
 
-  private void onCreateLoadViewModel() {
+  @VisibleForTesting public void onCreateLoadViewModel() {
     view.getLifecycleEvent()
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
         .doOnNext(created -> view.showLoading())
@@ -51,7 +52,7 @@ public class EditorialListPresenter implements Presenter {
         }, crashReporter::log);
   }
 
-  private void loadUserImage() {
+  @VisibleForTesting public void loadUserImage() {
     view.getLifecycleEvent()
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
         .flatMap(created -> accountManager.accountStatus())
@@ -72,7 +73,7 @@ public class EditorialListPresenter implements Presenter {
         });
   }
 
-  private void handleEditorialCardClick() {
+  @VisibleForTesting public void handleEditorialCardClick() {
     view.getLifecycleEvent()
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
         .flatMap(__ -> view.editorialCardClicked()
@@ -89,7 +90,7 @@ public class EditorialListPresenter implements Presenter {
         });
   }
 
-  private void handleRetryClick() {
+  @VisibleForTesting public void handleRetryClick() {
     view.getLifecycleEvent()
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
         .flatMap(viewCreated -> view.retryClicked()
@@ -101,7 +102,7 @@ public class EditorialListPresenter implements Presenter {
         }, crashReporter::log);
   }
 
-  private void handleBottomReached() {
+  @VisibleForTesting public void handleBottomReached() {
     view.getLifecycleEvent()
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
         .flatMap(created -> view.reachesBottom()
@@ -134,7 +135,7 @@ public class EditorialListPresenter implements Presenter {
         .map(editorialViewModel -> editorialViewModel);
   }
 
-  private void handleUserImageClick() {
+  @VisibleForTesting public void handleUserImageClick() {
     view.getLifecycleEvent()
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
         .flatMap(created -> view.imageClick()

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListRepository.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListRepository.java
@@ -15,12 +15,24 @@ public class EditorialListRepository {
     if (cachedEditorialListViewModel != null) {
       return Single.just(cachedEditorialListViewModel);
     }
-    return editorialListService.loadEditorialListService()
+    return loadNewEditorialListViewModel(0);
+  }
+
+  private Single<EditorialListViewModel> loadNewEditorialListViewModel(int offset) {
+    return editorialListService.loadEditorialListViewModel(offset)
         .map(editorialListViewModel -> {
           if (!editorialListViewModel.hasError() && !editorialListViewModel.isLoading()) {
             cachedEditorialListViewModel = editorialListViewModel;
           }
           return editorialListViewModel;
         });
+  }
+
+  public boolean hasMore() {
+    return cachedEditorialListViewModel.getOffset() < cachedEditorialListViewModel.getTotal();
+  }
+
+  public Single<EditorialListViewModel> loadMoreCurationCards() {
+    return loadNewEditorialListViewModel(cachedEditorialListViewModel.getOffset());
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListRequest.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListRequest.java
@@ -15,10 +15,13 @@ import rx.Observable;
 
 public class EditorialListRequest extends V7<EditorialListResponse, GetActionItemRequest.Body> {
 
+  private final int limit;
+
   protected EditorialListRequest(GetActionItemRequest.Body body, String baseHost,
       OkHttpClient httpClient, Converter.Factory converterFactory, BodyInterceptor bodyInterceptor,
-      TokenInvalidator tokenInvalidator) {
+      TokenInvalidator tokenInvalidator, int limit) {
     super(body, baseHost, httpClient, converterFactory, bodyInterceptor, tokenInvalidator);
+    this.limit = limit;
   }
 
   public static String getHost(SharedPreferences sharedPreferences) {
@@ -26,18 +29,18 @@ public class EditorialListRequest extends V7<EditorialListResponse, GetActionIte
         : BuildConfig.APTOIDE_WEB_SERVICES_SCHEME)
         + "://"
         + BuildConfig.APTOIDE_WEB_SERVICES_V7_HOST
-        + "/api/7/";
+        + "/api/7.20181019/";
   }
 
   public static EditorialListRequest of(BodyInterceptor<BaseBody> bodyInterceptor,
       OkHttpClient httpClient, Converter.Factory converterFactory,
-      TokenInvalidator tokenInvalidator, SharedPreferences sharedPreferences) {
+      TokenInvalidator tokenInvalidator, SharedPreferences sharedPreferences, int limit) {
     return new EditorialListRequest(new GetActionItemRequest.Body(), getHost(sharedPreferences),
-        httpClient, converterFactory, bodyInterceptor, tokenInvalidator);
+        httpClient, converterFactory, bodyInterceptor, tokenInvalidator, limit);
   }
 
   @Override protected Observable<EditorialListResponse> loadDataFromNetwork(Interfaces interfaces,
       boolean bypassCache) {
-    return interfaces.getEditorialList(body);
+    return interfaces.getEditorialList(limit, body);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListService.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListService.java
@@ -38,7 +38,7 @@ public class EditorialListService {
       return Single.just(new EditorialListViewModel(true));
     }
     return EditorialListRequest.of(bodyInterceptorPoolV7, okHttpClient, converterFactory,
-        tokenInvalidator, sharedPreferences)
+        tokenInvalidator, sharedPreferences, 10)
         .observe()
         .doOnSubscribe(() -> loading = true)
         .doOnUnsubscribe(() -> loading = false)
@@ -67,8 +67,8 @@ public class EditorialListService {
     List<CurationCard> curationCards = new ArrayList<>();
     for (EditorialListData actionItemData : items) {
       CurationCard curationCard =
-          new CurationCard(actionItemData.getCard_id(), actionItemData.getMessage(),
-              actionItemData.getIcon(), actionItemData.getTitle(), actionItemData.getUrl());
+          new CurationCard(actionItemData.getId(), actionItemData.getCaption(),
+              actionItemData.getIcon(), actionItemData.getTitle());
       curationCards.add(curationCard);
     }
     return curationCards;

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListService.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListService.java
@@ -3,9 +3,11 @@ package cm.aptoide.pt.editorialList;
 import android.content.SharedPreferences;
 import cm.aptoide.pt.dataprovider.exception.NoNetworkConnectionException;
 import cm.aptoide.pt.dataprovider.interfaces.TokenInvalidator;
+import cm.aptoide.pt.dataprovider.model.v7.DataList;
 import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
 import cm.aptoide.pt.dataprovider.ws.v7.BaseBody;
 import cm.aptoide.pt.dataprovider.ws.v7.EditorialListData;
+import cm.aptoide.pt.dataprovider.ws.v7.EditorialListRequest;
 import cm.aptoide.pt.dataprovider.ws.v7.EditorialListResponse;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,25 +22,27 @@ public class EditorialListService {
   private final TokenInvalidator tokenInvalidator;
   private final Converter.Factory converterFactory;
   private final SharedPreferences sharedPreferences;
+  private final int limit;
   private boolean loading;
 
   public EditorialListService(BodyInterceptor<BaseBody> bodyInterceptorPoolV7,
       OkHttpClient okHttpClient, TokenInvalidator tokenInvalidator,
-      Converter.Factory converterFactory, SharedPreferences sharedPreferences) {
+      Converter.Factory converterFactory, SharedPreferences sharedPreferences, int limit) {
 
     this.bodyInterceptorPoolV7 = bodyInterceptorPoolV7;
     this.okHttpClient = okHttpClient;
     this.tokenInvalidator = tokenInvalidator;
     this.converterFactory = converterFactory;
     this.sharedPreferences = sharedPreferences;
+    this.limit = limit;
   }
 
-  public Single<EditorialListViewModel> loadEditorialListService() {
+  public Single<EditorialListViewModel> loadEditorialListViewModel(int offset) {
     if (loading) {
       return Single.just(new EditorialListViewModel(true));
     }
     return EditorialListRequest.of(bodyInterceptorPoolV7, okHttpClient, converterFactory,
-        tokenInvalidator, sharedPreferences, 10)
+        tokenInvalidator, sharedPreferences, limit, offset)
         .observe()
         .doOnSubscribe(() -> loading = true)
         .doOnUnsubscribe(() -> loading = false)
@@ -57,10 +61,13 @@ public class EditorialListService {
   }
 
   private EditorialListViewModel mapEditorialList(EditorialListResponse actionItemResponse) {
-    List<EditorialListData> items = actionItemResponse.getDataList()
-        .getList();
+    DataList<EditorialListData> dataList = actionItemResponse.getDataList();
+    List<EditorialListData> items = dataList.getList();
+    int offset = dataList.getOffset();
+    int limit = dataList.getLimit();
+    int total = dataList.getTotal();
     List<CurationCard> curationCards = buildCurationCardList(items);
-    return new EditorialListViewModel(curationCards);
+    return new EditorialListViewModel(curationCards, offset + limit, total);
   }
 
   private List<CurationCard> buildCurationCardList(List<EditorialListData> items) {

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListView.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListView.java
@@ -25,7 +25,13 @@ public interface EditorialListView extends View {
 
   void setUserImage(String userAvatarUrl);
 
+  Observable<Object> reachesBottom();
+
   void populateView(EditorialListViewModel editorialListViewModel);
 
   void showError(EditorialListViewModel.Error error);
+
+  void showLoadMore();
+
+  void hideLoadMore();
 }

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListViewModel.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListViewModel.java
@@ -8,21 +8,29 @@ class EditorialListViewModel {
   private final Error error;
   private final boolean loading;
   private final List<CurationCard> curationCards;
+  private final int offset;
+  private final int total;
 
   public EditorialListViewModel(Error error) {
     this.error = error;
     loading = false;
+    offset = 0;
+    total = 0;
     curationCards = Collections.emptyList();
   }
 
   public EditorialListViewModel(boolean loading) {
     this.loading = loading;
     error = null;
+    offset = 0;
+    total = 0;
     curationCards = Collections.emptyList();
   }
 
-  public EditorialListViewModel(List<CurationCard> curationCards) {
+  public EditorialListViewModel(List<CurationCard> curationCards, int offset, int total) {
     this.curationCards = curationCards;
+    this.offset = offset;
+    this.total = total;
     error = null;
     loading = false;
   }
@@ -41,6 +49,14 @@ class EditorialListViewModel {
 
   public List<CurationCard> getCurationCards() {
     return curationCards;
+  }
+
+  public int getOffset() {
+    return offset;
+  }
+
+  public int getTotal() {
+    return total;
   }
 
   public enum Error {

--- a/app/src/main/java/cm/aptoide/pt/editorialList/LoadingViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/LoadingViewHolder.java
@@ -1,0 +1,12 @@
+package cm.aptoide.pt.editorialList;
+
+import android.view.View;
+import cm.aptoide.pt.home.EditorialBundleViewHolder;
+import cm.aptoide.pt.home.HomeEvent;
+import rx.subjects.PublishSubject;
+
+class LoadingViewHolder extends EditorialBundleViewHolder {
+  public LoadingViewHolder(View inflate, PublishSubject<HomeEvent> uiEventsListener) {
+    super(inflate, uiEventsListener);
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/editorialList/ProgressCard.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/ProgressCard.java
@@ -1,0 +1,8 @@
+package cm.aptoide.pt.editorialList;
+
+public class ProgressCard extends CurationCard {
+
+  public ProgressCard() {
+    super("", "", "", "");
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -433,7 +433,7 @@ import rx.schedulers.Schedulers;
       @Named("default") OkHttpClient okHttpClient, TokenInvalidator tokenInvalidator,
       @Named("default") SharedPreferences sharedPreferences) {
     return new EditorialListService(bodyInterceptorPoolV7, okHttpClient, tokenInvalidator,
-        WebService.getDefaultConverter(), sharedPreferences);
+        WebService.getDefaultConverter(), sharedPreferences, 10);
   }
 
   @FragmentScope @Provides EditorialListNavigator providesEditorialListNavigator(

--- a/app/src/test/java/cm/aptoide/pt/editorialList/EditorialListPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/editorialList/EditorialListPresenterTest.java
@@ -1,0 +1,205 @@
+package cm.aptoide.pt.editorialList;
+
+import cm.aptoide.accountmanager.Account;
+import cm.aptoide.accountmanager.AptoideAccountManager;
+import cm.aptoide.pt.crashreports.CrashReport;
+import cm.aptoide.pt.home.EditorialHomeEvent;
+import cm.aptoide.pt.home.HomeEvent;
+import cm.aptoide.pt.presenter.View;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import rx.Single;
+import rx.schedulers.Schedulers;
+import rx.subjects.PublishSubject;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EditorialListPresenterTest {
+  @Mock EditorialListFragment view;
+  @Mock EditorialListManager editorialListManager;
+  @Mock AptoideAccountManager accountManager;
+  @Mock EditorialListNavigator editorialListNavigator;
+  @Mock EditorialListAnalytics editorialListAnalytics;
+  @Mock CrashReport crashReporter;
+  @Mock Account account;
+
+  private EditorialListPresenter presenter;
+  private EditorialListViewModel successEditorialViewModel;
+  private EditorialListViewModel loadingEditorialViewModel;
+  private EditorialListViewModel errorEditorialViewModel;
+
+  private PublishSubject<View.LifecycleEvent> lifecycleEvent;
+  private PublishSubject<Object> bottomReachedEvent;
+  private PublishSubject<Void> retryClickedEvent;
+  private PublishSubject<Account> accountStatusEvent;
+  private PublishSubject<Void> imageClickEvent;
+  private PublishSubject<EditorialHomeEvent> cardClickEvent;
+
+  @Before public void setupHomePresenter() {
+    MockitoAnnotations.initMocks(this);
+
+    lifecycleEvent = PublishSubject.create();
+    bottomReachedEvent = PublishSubject.create();
+    retryClickedEvent = PublishSubject.create();
+    accountStatusEvent = PublishSubject.create();
+    imageClickEvent = PublishSubject.create();
+    cardClickEvent = PublishSubject.create();
+
+    presenter = new EditorialListPresenter(view, editorialListManager, accountManager,
+        editorialListNavigator, editorialListAnalytics, crashReporter, Schedulers.immediate());
+    CurationCard curationCard = new CurationCard("1", "sub", "icon", "title");
+    List<CurationCard> curationCardList = Collections.singletonList(curationCard);
+    successEditorialViewModel = new EditorialListViewModel(curationCardList, 0, 0);
+    loadingEditorialViewModel = new EditorialListViewModel(true);
+    errorEditorialViewModel = new EditorialListViewModel(EditorialListViewModel.Error.GENERIC);
+
+    when(view.getLifecycleEvent()).thenReturn(lifecycleEvent);
+    when(view.reachesBottom()).thenReturn(bottomReachedEvent);
+    when(view.retryClicked()).thenReturn(retryClickedEvent);
+    when(view.editorialCardClicked()).thenReturn(cardClickEvent);
+    when(accountManager.accountStatus()).thenReturn(accountStatusEvent);
+    when(view.imageClick()).thenReturn(imageClickEvent);
+  }
+
+  @Test public void onCreateLoadSuccessViewModelTest() {
+    //When the viewModel is requested then it should return a viewModel
+    when(editorialListManager.loadEditorialListViewModel(false)).thenReturn(
+        Single.just(successEditorialViewModel));
+    //Given an initialized Presenter
+    presenter.onCreateLoadViewModel();
+    lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
+    //It should display loading
+    verify(view).showLoading();
+    //After a success viewModel it should hide the loading
+    verify(view).hideLoading();
+    //And populate the view with the cards from the viewModel
+    verify(view).populateView(successEditorialViewModel);
+    //And hide the loadMore card if there's one
+    verify(view).hideLoadMore();
+  }
+
+  @Test public void onCreateLoadLoadingViewModelTest() {
+    //When the viewModel is requested then it should return a viewModel
+    when(editorialListManager.loadEditorialListViewModel(false)).thenReturn(
+        Single.just(loadingEditorialViewModel));
+    //Given an initialized Presenter
+    presenter.onCreateLoadViewModel();
+    lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
+    //It should display loading
+    verify(view).showLoading();
+    //After a loading viewModel it should not hide the loading
+    verify(view, never()).hideLoading();
+    //And hide the loadMore card if there's one
+    verify(view).hideLoadMore();
+  }
+
+  @Test public void onCreateLoadErrorViewModelTest() {
+    //When the viewModel is requested then it should return a viewModel
+    when(editorialListManager.loadEditorialListViewModel(false)).thenReturn(
+        Single.just(errorEditorialViewModel));
+    //Given an initialized Presenter
+    presenter.onCreateLoadViewModel();
+    lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
+    //It should display loading
+    verify(view).showLoading();
+    //After an error viewModel it should hide the loading
+    verify(view).hideLoading();
+    //And show an error view
+    verify(view).showError(errorEditorialViewModel.getError());
+    //And shouldn't populate the view
+    verify(view, never()).populateView(errorEditorialViewModel);
+    //And hide the loadMore card if there's one
+    verify(view).hideLoadMore();
+  }
+
+  @Test public void handleEditorialCardClickTest() {
+    //Given an initialized Presenter
+    presenter.handleEditorialCardClick();
+    lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
+    //When there's is a click on an Editorial Card, it should emit an EditorialHomeEvent
+    cardClickEvent.onNext(new EditorialHomeEvent("1", null, -1, HomeEvent.Type.EDITORIAL));
+    //Then it should send editorial interact analytic event
+    verify(editorialListAnalytics).sendEditorialInteractEvent("1");
+    //And navigate to the specified editorial view
+    verify(editorialListNavigator).navigateToEditorial("1");
+  }
+
+  @Test public void handleRetryClickTest() {
+    //Given an initialised presenter
+    presenter.handleRetryClick();
+    when(editorialListManager.loadEditorialListViewModel(false)).thenReturn(
+        Single.just(successEditorialViewModel));
+    lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
+    //When pull to refresh is done
+    retryClickedEvent.onNext(null);
+    //Then bundles should be shown
+    verify(view).populateView(successEditorialViewModel);
+    //Then it should hide the loading indicator
+    verify(view).hideLoading();
+    //Then it should hide the load more indicator (if exists)
+    verify(view).hideLoadMore();
+  }
+
+  @Test public void handleBottomReachedTest() {
+    //Given an initialised presenter
+    presenter.handleBottomReached();
+    when(editorialListManager.loadEditorialListViewModel(true)).thenReturn(
+        Single.just(successEditorialViewModel));
+    when(editorialListManager.hasMore()).thenReturn(true);
+    lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
+    //When scrolling to the end of the view is reached
+    //And there are more cards available to load
+    bottomReachedEvent.onNext(new Object());
+    //Then it should show the load more progress indicator
+    verify(view).showLoadMore();
+    //Then it should request the next cards to the model repository
+    verify(editorialListManager).loadEditorialListViewModel(true);
+    //Then it should hide the load more progress indicator
+    verify(view).hideLoadMore();
+    verify(view).hideLoading();
+    //Then it should show the view again with old cards and added cards, retaining list position
+    verify(view).populateView(successEditorialViewModel);
+  }
+
+  @Test public void loadLoggedInUserImageUserTest() {
+    //When the user is logged in
+    when(account.getAvatar()).thenReturn("A string");
+    when(account.isLoggedIn()).thenReturn(true);
+    //Given an initialised presenter
+    presenter.loadUserImage();
+    lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
+    //And AccountManager returns an account
+    accountStatusEvent.onNext(account);
+    //Then it should show the image
+    verify(view).setUserImage("A string");
+    verify(view).showAvatar();
+  }
+
+  @Test public void loadNotLoggedInUserImageUserTest() {
+    //When the user is logged in
+    when(account.isLoggedIn()).thenReturn(false);
+    //Given an initialised presenter
+    presenter.loadUserImage();
+    lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
+    //And AccountManager returns an account
+    accountStatusEvent.onNext(account);
+    //Then it should show the image
+    verify(view).showAvatar();
+  }
+
+  @Test public void handleUserImageClickTest() {
+    //Given an initialised presenter
+    presenter.handleUserImageClick();
+    lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
+    //When an user clicks the profile image
+    imageClickEvent.onNext(null);
+    //Then it should navigate to the Settings Fragment
+    verify(editorialListNavigator).navigateToMyAccount();
+  }
+}

--- a/app/src/test/java/cm/aptoide/pt/editorialList/EditorialListPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/editorialList/EditorialListPresenterTest.java
@@ -136,9 +136,8 @@ public class EditorialListPresenterTest {
     when(editorialListManager.loadEditorialListViewModel(false)).thenReturn(
         Single.just(successEditorialViewModel));
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
-    //When pull to refresh is done
     retryClickedEvent.onNext(null);
-    //Then bundles should be shown
+    //Then the editorial cards should be shown
     verify(view).populateView(successEditorialViewModel);
     //Then it should hide the loading indicator
     verify(view).hideLoading();

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/EditorialListData.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/EditorialListData.java
@@ -2,38 +2,33 @@ package cm.aptoide.pt.dataprovider.ws.v7;
 
 public class EditorialListData {
 
-  public String card_id;
-  public String layout;
+  public String id;
+  public String type;
   public String title;
-  public String message;
+  public String caption;
   public String icon;
-  public String url;
 
   public EditorialListData() {
 
   }
 
-  public String getCard_id() {
-    return card_id;
+  public String getId() {
+    return id;
   }
 
-  public String getLayout() {
-    return layout;
+  public String getType() {
+    return type;
   }
 
   public String getTitle() {
     return title;
   }
 
-  public String getMessage() {
-    return message;
+  public String getCaption() {
+    return caption;
   }
 
   public String getIcon() {
     return icon;
-  }
-
-  public String getUrl() {
-    return url;
   }
 }

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/EditorialListData.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/EditorialListData.java
@@ -1,6 +1,8 @@
 package cm.aptoide.pt.dataprovider.ws.v7;
 
-public class EditorialListData {
+import cm.aptoide.pt.dataprovider.model.v7.BaseV7EndlessDataListResponse;
+
+public class EditorialListData extends BaseV7EndlessDataListResponse {
 
   public String id;
   public String type;

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/EditorialListRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/EditorialListRequest.java
@@ -1,24 +1,20 @@
-package cm.aptoide.pt.editorialList;
+package cm.aptoide.pt.dataprovider.ws.v7;
 
 import android.content.SharedPreferences;
 import cm.aptoide.pt.dataprovider.BuildConfig;
 import cm.aptoide.pt.dataprovider.interfaces.TokenInvalidator;
 import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
-import cm.aptoide.pt.dataprovider.ws.v7.BaseBody;
-import cm.aptoide.pt.dataprovider.ws.v7.EditorialListResponse;
-import cm.aptoide.pt.dataprovider.ws.v7.V7;
-import cm.aptoide.pt.dataprovider.ws.v7.home.GetActionItemRequest;
 import cm.aptoide.pt.preferences.toolbox.ToolboxManager;
 import okhttp3.OkHttpClient;
 import retrofit2.Converter;
 import rx.Observable;
 
-public class EditorialListRequest extends V7<EditorialListResponse, GetActionItemRequest.Body> {
+public class EditorialListRequest extends V7<EditorialListResponse, EditorialListRequest.Body> {
 
   private final int limit;
 
-  protected EditorialListRequest(GetActionItemRequest.Body body, String baseHost,
-      OkHttpClient httpClient, Converter.Factory converterFactory, BodyInterceptor bodyInterceptor,
+  protected EditorialListRequest(Body body, String baseHost, OkHttpClient httpClient,
+      Converter.Factory converterFactory, BodyInterceptor bodyInterceptor,
       TokenInvalidator tokenInvalidator, int limit) {
     super(body, baseHost, httpClient, converterFactory, bodyInterceptor, tokenInvalidator);
     this.limit = limit;
@@ -34,13 +30,37 @@ public class EditorialListRequest extends V7<EditorialListResponse, GetActionIte
 
   public static EditorialListRequest of(BodyInterceptor<BaseBody> bodyInterceptor,
       OkHttpClient httpClient, Converter.Factory converterFactory,
-      TokenInvalidator tokenInvalidator, SharedPreferences sharedPreferences, int limit) {
-    return new EditorialListRequest(new GetActionItemRequest.Body(), getHost(sharedPreferences),
-        httpClient, converterFactory, bodyInterceptor, tokenInvalidator, limit);
+      TokenInvalidator tokenInvalidator, SharedPreferences sharedPreferences, int limit,
+      int offset) {
+    Body body = new Body(limit, offset);
+    return new EditorialListRequest(body, getHost(sharedPreferences), httpClient, converterFactory,
+        bodyInterceptor, tokenInvalidator, limit);
   }
 
   @Override protected Observable<EditorialListResponse> loadDataFromNetwork(Interfaces interfaces,
       boolean bypassCache) {
     return interfaces.getEditorialList(limit, body);
+  }
+
+  public static class Body extends BaseBody implements Endless {
+    private int offset;
+    private int limit;
+
+    public Body(int limit, int offset) {
+      this.limit = limit;
+      this.offset = offset;
+    }
+
+    @Override public int getOffset() {
+      return offset;
+    }
+
+    @Override public void setOffset(int offset) {
+      this.offset = offset;
+    }
+
+    @Override public Integer getLimit() {
+      return limit;
+    }
   }
 }

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/V7.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/V7.java
@@ -562,8 +562,9 @@ public abstract class V7<U, B extends RefreshBody> extends WebService<V7.Interfa
     Observable<GetPromotionAppsResponse> getPromotionApps(@Path(value = "limit") int limit,
         @Body BaseBody body, @Header(WebService.BYPASS_HEADER_KEY) boolean bypassCache);
 
-    @POST("user/action/item/cards/get/type=CURATION_1")
-    Observable<EditorialListResponse> getEditorialList(@Body BaseBody body);
+    @POST("user/action/item/cards/get/type=CURATION_1/limit={limit}")
+    Observable<EditorialListResponse> getEditorialList(@Path(value = "limit") int limit,
+        @Body BaseBody body);
   }
 }
 

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/V7.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/V7.java
@@ -564,7 +564,7 @@ public abstract class V7<U, B extends RefreshBody> extends WebService<V7.Interfa
 
     @POST("user/action/item/cards/get/type=CURATION_1/limit={limit}")
     Observable<EditorialListResponse> getEditorialList(@Path(value = "limit") int limit,
-        @Body BaseBody body);
+        @Body EditorialListRequest.Body body);
   }
 }
 


### PR DESCRIPTION
**What does this PR do?**

   Adds the possibility to do an endless scroll on the curation list. (Needs to be mocked as API is still not ready to deliver more than 1)

**Database changed?**

 No

**Where should the reviewer start?**

EditorialiListFragment.java

**How should this be manually tested?**

Mock charles (change total and add curation cards), scroll to the bottom, repeat the mock, check if it appears new cards

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/AS-104


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass