### PR TITLE
[ASV-1457] Fixed open/downgrade button not working for editorials wit…

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialDownloadEvent.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialDownloadEvent.java
@@ -84,6 +84,24 @@ public class EditorialDownloadEvent {
     this.action = null;
   }
 
+  public EditorialDownloadEvent(Type button, String appName, String packageName, String md5sum,
+      String icon, String verName, int verCode, String path, String pathAlt, Obb obb,
+      DownloadModel.Action action) {
+
+    this.button = button;
+    this.appName = appName;
+    this.packageName = packageName;
+    this.md5sum = md5sum;
+    this.icon = icon;
+    this.verName = verName;
+    this.verCode = verCode;
+    this.path = path;
+    this.pathAlt = pathAlt;
+    this.obb = obb;
+    this.appId = -1;
+    this.action = action;
+  }
+
   public Type getClickType() {
     return button;
   }

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialFragment.java
@@ -395,9 +395,7 @@ public class EditorialFragment extends NavigationTrackFragment
     return RxView.clicks(appCardButton)
         .map(__ -> new EditorialDownloadEvent(editorialViewModel, action))
         .mergeWith(downloadEventListener.filter(editorialEvent -> editorialEvent.getClickType()
-            .equals(EditorialEvent.Type.BUTTON))
-            .map(editorialDownloadEvent -> new EditorialDownloadEvent(editorialDownloadEvent,
-                action)));
+            .equals(EditorialEvent.Type.BUTTON)));
   }
 
   @Override

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialItemsViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialItemsViewHolder.java
@@ -64,6 +64,7 @@ class EditorialItemsViewHolder extends RecyclerView.ViewHolder {
   private RelativeLayout cardInfoLayout;
   private int currentMediaPosition;
   private boolean mediaDescriptionVisible;
+  private DownloadModel.Action action;
 
   public EditorialItemsViewHolder(View view, DecimalFormat oneDecimalFormat,
       PublishSubject<EditorialEvent> uiEventListener,
@@ -294,7 +295,7 @@ class EditorialItemsViewHolder extends RecyclerView.ViewHolder {
 
   private void setButtonText(DownloadModel model, String update, String install, String open,
       String downgrade) {
-    DownloadModel.Action action = model.getAction();
+    action = model.getAction();
     switch (action) {
       case UPDATE:
         appCardButton.setText(update);
@@ -369,7 +370,7 @@ class EditorialItemsViewHolder extends RecyclerView.ViewHolder {
             verName, verCode, path, pathAlt, obb)));
     appCardButton.setOnClickListener(click -> downloadEventListener.onNext(
         new EditorialDownloadEvent(EditorialEvent.Type.BUTTON, appName, packageName, md5sum, icon,
-            verName, verCode, path, pathAlt, obb)));
+            verName, verCode, path, pathAlt, obb, action)));
     appCardLayout.setOnClickListener(click -> uiEventListener.onNext(
         new EditorialEvent(EditorialEvent.Type.APPCARD, id, packageName)));
   }

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialPresenter.java
@@ -150,13 +150,13 @@ public class EditorialPresenter implements Presenter {
                       .flatMapCompletable(
                           viewModel -> downloadApp(editorialDownloadEvent).observeOn(viewScheduler)
                               .doOnCompleted(() -> editorialAnalytics.clickOnInstallButton(
-                                  viewModel.getBottomCardPackageName(), action.toString())));
+                                  editorialDownloadEvent.getPackageName(), action.toString())));
                   break;
                 case OPEN:
                   completable = editorialManager.loadEditorialViewModel()
                       .observeOn(viewScheduler)
                       .flatMapCompletable(appViewViewModel -> openInstalledApp(
-                          appViewViewModel.getBottomCardPackageName()));
+                          editorialDownloadEvent.getPackageName()));
                   break;
                 case DOWNGRADE:
                   completable = editorialManager.loadEditorialViewModel()


### PR DESCRIPTION
**What does this PR do?**

  This PR aims to fix editorial apps open/downgrade button not working with multiple apps

**Database changed?**

No

**Where should the reviewer start?**

- [ ] EditorialPresenter.java

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1457](https://aptoide.atlassian.net/browse/ASV-1457)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass