### PR TITLE
[ASV-1445] Fixed visual bug with devices with API < 21

### DIFF
--- a/app/src/main/res/drawable-v21/appc_gradient_transition.xml
+++ b/app/src/main/res/drawable-v21/appc_gradient_transition.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <transition xmlns:android="http://schemas.android.com/apk/res/android">
   <!-- The drawables used here can be solid colors, gradients, shapes, images, etc. -->
-  <item android:drawable="@drawable/appc_gradient_toolbar"/>
+  <item android:drawable="?attr/toolbarBackground"/>
   <item android:drawable="@drawable/appc_gradient_toolbar"/>
 </transition>
 


### PR DESCRIPTION
**What does this PR do?**

   Fixed a bug with the last ASV-1445 ticket, where the app view would not load with devices with API lower than 21.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] appc_gradient_transition.xml

**How should this be manually tested?**

  Check if the app view loads fine in any supported API version. For devices with API lower than 21, the background transition will not appear.

**What are the relevant tickets?**

  [ASV-1445](https://aptoide.atlassian.net/browse/ASV-1445)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass