### PR TITLE
[AS-110] Error screen now hides cards

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListFragment.java
@@ -120,12 +120,14 @@ public class EditorialListFragment extends NavigationTrackFragment implements Ed
   @Override public void showGenericError() {
     genericErrorView.setVisibility(View.VISIBLE);
     noNetworkErrorView.setVisibility(View.GONE);
+    editorialList.setVisibility(View.GONE);
     progressBar.setVisibility(View.GONE);
   }
 
   @Override public void showNetworkError() {
     this.noNetworkErrorView.setVisibility(View.VISIBLE);
     this.genericErrorView.setVisibility(View.GONE);
+    this.editorialList.setVisibility(View.GONE);
     this.progressBar.setVisibility(View.GONE);
   }
 
@@ -162,17 +164,6 @@ public class EditorialListFragment extends NavigationTrackFragment implements Ed
 
   @Override public void populateView(EditorialListViewModel editorialListViewModel) {
     adapter.add(editorialListViewModel.getCurationCards());
-  }
-
-  @Override public void showError(EditorialListViewModel.Error error) {
-    switch (error) {
-      case NETWORK:
-        noNetworkErrorView.setVisibility(View.VISIBLE);
-        break;
-      case GENERIC:
-        genericErrorView.setVisibility(View.VISIBLE);
-        break;
-    }
   }
 
   @Override public void showLoadMore() {

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListPresenter.java
@@ -126,7 +126,11 @@ public class EditorialListPresenter implements Presenter {
             view.hideLoading();
           }
           if (editorialListViewModel.hasError()) {
-            view.showError(editorialListViewModel.getError());
+            if (editorialListViewModel.getError() == EditorialListViewModel.Error.NETWORK) {
+              view.showNetworkError();
+            } else {
+              view.showGenericError();
+            }
           } else {
             view.populateView(editorialListViewModel);
           }

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListView.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListView.java
@@ -29,8 +29,6 @@ public interface EditorialListView extends View {
 
   void populateView(EditorialListViewModel editorialListViewModel);
 
-  void showError(EditorialListViewModel.Error error);
-
   void showLoadMore();
 
   void hideLoadMore();

--- a/app/src/test/java/cm/aptoide/pt/editorialList/EditorialListPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/editorialList/EditorialListPresenterTest.java
@@ -32,7 +32,7 @@ public class EditorialListPresenterTest {
   private EditorialListPresenter presenter;
   private EditorialListViewModel successEditorialViewModel;
   private EditorialListViewModel loadingEditorialViewModel;
-  private EditorialListViewModel errorEditorialViewModel;
+  private EditorialListViewModel genericErrorEditorialViewModel;
 
   private PublishSubject<View.LifecycleEvent> lifecycleEvent;
   private PublishSubject<Object> bottomReachedEvent;
@@ -40,6 +40,7 @@ public class EditorialListPresenterTest {
   private PublishSubject<Account> accountStatusEvent;
   private PublishSubject<Void> imageClickEvent;
   private PublishSubject<EditorialHomeEvent> cardClickEvent;
+  private EditorialListViewModel networkErrorEditorialViewModel;
 
   @Before public void setupHomePresenter() {
     MockitoAnnotations.initMocks(this);
@@ -57,7 +58,10 @@ public class EditorialListPresenterTest {
     List<CurationCard> curationCardList = Collections.singletonList(curationCard);
     successEditorialViewModel = new EditorialListViewModel(curationCardList, 0, 0);
     loadingEditorialViewModel = new EditorialListViewModel(true);
-    errorEditorialViewModel = new EditorialListViewModel(EditorialListViewModel.Error.GENERIC);
+    genericErrorEditorialViewModel =
+        new EditorialListViewModel(EditorialListViewModel.Error.GENERIC);
+    networkErrorEditorialViewModel =
+        new EditorialListViewModel(EditorialListViewModel.Error.NETWORK);
 
     when(view.getLifecycleEvent()).thenReturn(lifecycleEvent);
     when(view.reachesBottom()).thenReturn(bottomReachedEvent);
@@ -99,10 +103,10 @@ public class EditorialListPresenterTest {
     verify(view).hideLoadMore();
   }
 
-  @Test public void onCreateLoadErrorViewModelTest() {
+  @Test public void onCreateLoadNetworkErrorViewModelTest() {
     //When the viewModel is requested then it should return a viewModel
     when(editorialListManager.loadEditorialListViewModel(false)).thenReturn(
-        Single.just(errorEditorialViewModel));
+        Single.just(networkErrorEditorialViewModel));
     //Given an initialized Presenter
     presenter.onCreateLoadViewModel();
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
@@ -111,9 +115,28 @@ public class EditorialListPresenterTest {
     //After an error viewModel it should hide the loading
     verify(view).hideLoading();
     //And show an error view
-    verify(view).showError(errorEditorialViewModel.getError());
+    verify(view).showNetworkError();
     //And shouldn't populate the view
-    verify(view, never()).populateView(errorEditorialViewModel);
+    verify(view, never()).populateView(networkErrorEditorialViewModel);
+    //And hide the loadMore card if there's one
+    verify(view).hideLoadMore();
+  }
+
+  @Test public void onCreateLoadGenericErrorViewModelTest() {
+    //When the viewModel is requested then it should return a viewModel
+    when(editorialListManager.loadEditorialListViewModel(false)).thenReturn(
+        Single.just(genericErrorEditorialViewModel));
+    //Given an initialized Presenter
+    presenter.onCreateLoadViewModel();
+    lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
+    //It should display loading
+    verify(view).showLoading();
+    //After an error viewModel it should hide the loading
+    verify(view).hideLoading();
+    //And show an error view
+    verify(view).showGenericError();
+    //And shouldn't populate the view
+    verify(view, never()).populateView(genericErrorEditorialViewModel);
     //And hide the loadMore card if there's one
     verify(view).hideLoadMore();
   }


### PR DESCRIPTION
**What does this PR do?**

 Makes it so that the error view hides the cards on the list

**Database changed?**

   No

**Where should the reviewer start?**

EditorialListFragment.java
EditorialListPresenter.java

**How should this be manually tested?**

ticket

**What are the relevant tickets?**

 https://aptoide.atlassian.net/browse/AS-110

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass