### PR TITLE
[ASV-1464] No ads on adult content

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -460,20 +460,23 @@ public class AppViewManager {
     return moPubInterstitialAdExperiment.loadInterstitial()
         .flatMap(shouldLoadAd -> Single.just(shouldLoadAd
             && !cachedAppCoinsViewModel.hasBilling()
-            && !cachedAppCoinsViewModel.hasAdvertising()));
+            && !cachedAppCoinsViewModel.hasAdvertising()
+            && !cachedApp.isMature()));
   }
 
   public Single<Boolean> shouldLoadBannerAd() {
     return moPubBannerAdExperiment.shouldLoadBanner()
         .flatMap(shouldLoadAd -> Single.just(shouldLoadAd
             && !cachedAppCoinsViewModel.hasBilling()
-            && !cachedAppCoinsViewModel.hasAdvertising()));
+            && !cachedAppCoinsViewModel.hasAdvertising()
+            && !cachedApp.isMature()));
   }
 
   public Single<Boolean> shouldLoadNativeAds() {
     return moPubNativeAdExperiment.shouldLoadNative()
         .flatMap(shouldLoadAd -> Single.just(shouldLoadAd
             && !cachedAppCoinsViewModel.hasBilling()
-            && !cachedAppCoinsViewModel.hasAdvertising()));
+            && !cachedAppCoinsViewModel.hasAdvertising()
+            && !cachedApp.isMature()));
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/view/app/AppService.java
+++ b/app/src/main/java/cm/aptoide/pt/view/app/AppService.java
@@ -35,6 +35,7 @@ import rx.Single;
  */
 
 public class AppService {
+  private static final int MATURE_APP_RATING = 18;
   private final StoreCredentialsProvider storeCredentialsProvider;
   private final BodyInterceptor<BaseBody> bodyInterceptorV7;
   private final BodyInterceptor<cm.aptoide.pt.dataprovider.ws.v3.BaseBody> bodyInterceptorV3;
@@ -230,7 +231,8 @@ public class AppService {
                   .isPaid(), paidApp.getPath()
                   .getStringPath(), paidApp.getPayment()
                   .getStatus(), isLatestTrustedVersion(listAppVersions, file), uniqueName,
-                  app.hasBilling(), app.hasAdvertising(), app.getBdsFlags()));
+                  app.hasBilling(), app.hasAdvertising(), app.getBdsFlags(), app.getAge()
+                  .getRating() == MATURE_APP_RATING));
         });
       }
 
@@ -242,7 +244,8 @@ public class AppService {
               file.getPathAlt(), file.getVercode(), file.getVername(), appDeveloper, app.getStore(),
               appMedia, appStats, app.getObb(), app.getPay(), app.getUrls()
               .getW(), app.isPaid(), isLatestTrustedVersion(listAppVersions, file), uniqueName,
-              app.hasBilling(), app.hasAdvertising(), app.getBdsFlags());
+              app.hasBilling(), app.hasAdvertising(), app.getBdsFlags(), app.getAge()
+              .getRating() == MATURE_APP_RATING);
       return Observable.just(new DetailedAppRequestResult(detailedApp));
     } else {
       return Observable.error(new IllegalStateException("Could not obtain request from server."));

--- a/app/src/main/java/cm/aptoide/pt/view/app/DetailedApp.java
+++ b/app/src/main/java/cm/aptoide/pt/view/app/DetailedApp.java
@@ -48,6 +48,7 @@ public class DetailedApp {
   private boolean hasBilling;
   private boolean hasAdvertising;
   private List<String> bdsFlags;
+  private boolean isMature;
 
   public DetailedApp(long id, String name, String packageName, long size, String icon,
       String graphic, String added, String modified, boolean isGoodApp, Malware malware,
@@ -56,7 +57,7 @@ public class DetailedApp {
       AppDeveloper appDeveloper, Store store, AppMedia media, AppStats stats, Obb obb,
       GetAppMeta.Pay pay, String webUrls, boolean isPaid, boolean wasPaid, String paidAppPath,
       String paymentStatus, boolean isLatestTrustedVersion, String uniqueName, boolean hasBilling,
-      boolean hasAdvertising, List<String> bdsFlags) {
+      boolean hasAdvertising, List<String> bdsFlags, boolean isMature) {
 
     this.id = id;
     this.name = name;
@@ -94,6 +95,7 @@ public class DetailedApp {
     this.hasBilling = hasBilling;
     this.hasAdvertising = hasAdvertising;
     this.bdsFlags = bdsFlags;
+    this.isMature = isMature;
   }
 
   public DetailedApp(long id, String name, String packageName, long size, String icon,
@@ -102,7 +104,8 @@ public class DetailedApp {
       long fileSize, String md5, String path, String pathAlt, int versionCode, String versionName,
       AppDeveloper appDeveloper, Store store, AppMedia media, AppStats stats, Obb obb,
       GetAppMeta.Pay pay, String webUrls, boolean isPaid, boolean isLatestTrustedVersion,
-      String uniqueName, boolean hasBilling, boolean hasAdvertising, List<String> bdsFlags) {
+      String uniqueName, boolean hasBilling, boolean hasAdvertising, List<String> bdsFlags,
+      boolean isMature) {
 
     this.id = id;
     this.name = name;
@@ -135,6 +138,7 @@ public class DetailedApp {
     this.hasBilling = hasBilling;
     this.hasAdvertising = hasAdvertising;
     this.bdsFlags = bdsFlags;
+    this.isMature = isMature;
     this.wasPaid = false;
     this.paidAppPath = "";
     this.paymentStatus = "";
@@ -296,5 +300,9 @@ public class DetailedApp {
 
   public void setBdsFlags(List<String> bdsFlags) {
     this.bdsFlags = bdsFlags;
+  }
+
+  public boolean isMature() {
+    return isMature;
   }
 }

--- a/app/src/test/java/cm/aptoide/pt/app/AppViewManagerTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/AppViewManagerTest.java
@@ -2,7 +2,6 @@ package cm.aptoide.pt.app;
 
 import cm.aptoide.accountmanager.AptoideAccountManager;
 import cm.aptoide.analytics.AnalyticsManager;
-import cm.aptoide.pt.abtesting.ABTestManager;
 import cm.aptoide.pt.abtesting.experiments.MoPubBannerAdExperiment;
 import cm.aptoide.pt.abtesting.experiments.MoPubInterstitialAdExperiment;
 import cm.aptoide.pt.abtesting.experiments.MoPubNativeAdExperiment;
@@ -71,7 +70,6 @@ public class AppViewManagerTest {
   @Mock private GenericResponseV2 genericResponseV2;
   @Mock private Download download;
   @Mock private DownloadFactory downloadFactory;
-  @Mock private ABTestManager abTestManager;
   @Mock private AppCoinsManager appCoinsManager;
   @Mock private MoPubInterstitialAdExperiment moPubInterstitialAdExperiment;
   @Mock private MoPubBannerAdExperiment moPubBannerAdExperiment;

--- a/app/src/test/java/cm/aptoide/pt/app/AppViewManagerTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/AppViewManagerTest.java
@@ -102,7 +102,7 @@ public class AppViewManagerTest {
     DetailedApp detailedApp =
         new DetailedApp((long) 1, "any", "any", (long) 1, "any", "any", "any", "any", true, null,
             null, null, null, null, (long) 1, null, null, null, 1, null, null, store, null,
-            appStats, null, null, null, true, true, null, false, false, bdsFlags);
+            appStats, null, null, null, true, true, null, false, false, bdsFlags, false);
 
     DetailedAppRequestResult detailedAppRequestResult = new DetailedAppRequestResult(detailedApp);
     AppViewConfiguration appViewConfiguration =
@@ -153,7 +153,7 @@ public class AppViewManagerTest {
     DetailedApp detailedApp =
         new DetailedApp((long) 1, "any", "any", (long) 1, "any", "any", "any", "any", true, null,
             null, null, null, null, (long) 1, "md5", null, null, 1, null, null, store, null,
-            appStats, null, null, null, true, true, null, false, false, bdsFlags);
+            appStats, null, null, null, true, true, null, false, false, bdsFlags, false);
     DetailedAppRequestResult detailedAppRequestResult = new DetailedAppRequestResult(detailedApp);
     AppViewConfiguration appViewConfiguration =
         new AppViewConfiguration((long) -1, "anyString", "anyString", "", null, null, "md5", "",
@@ -203,7 +203,7 @@ public class AppViewManagerTest {
     DetailedApp detailedApp =
         new DetailedApp((long) 1, "any", "any", (long) 1, "any", "any", "any", "any", true, null,
             null, null, null, null, (long) 1, "any", null, null, 1, null, null, store, null,
-            appStats, null, null, null, true, true, "uniqueName", false, false, bdsFlags);
+            appStats, null, null, null, true, true, "uniqueName", false, false, bdsFlags, false);
     DetailedAppRequestResult detailedAppRequestResult = new DetailedAppRequestResult(detailedApp);
     AppViewConfiguration appViewConfiguration =
         new AppViewConfiguration((long) -1, "anyString", "anyString", "", null, null, "",
@@ -253,7 +253,7 @@ public class AppViewManagerTest {
     DetailedApp detailedApp =
         new DetailedApp((long) 1, "any", "", (long) 1, "any", "any", "any", "any", true, null, null,
             null, null, null, (long) 1, "any", null, null, 1, null, null, store, null, appStats,
-            null, null, null, true, true, "uniqueName", false, false, bdsFlags);
+            null, null, null, true, true, "uniqueName", false, false, bdsFlags, false);
     DetailedAppRequestResult detailedAppRequestResult = new DetailedAppRequestResult(detailedApp);
     AppViewConfiguration appViewConfiguration =
         new AppViewConfiguration((long) -1, "", "", "", null, null, "", "", 0.0, "", "", "");
@@ -457,7 +457,7 @@ public class AppViewManagerTest {
     DetailedApp detailedApp =
         new DetailedApp((long) 1, "any", "anyString", (long) 1, "any", "any", "any", "any", true,
             null, null, null, null, null, (long) 1, null, null, null, 1, null, null, store, null,
-            appStats, null, null, null, true, true, null, false, false, bdsFlags);
+            appStats, null, null, null, true, true, null, false, false, bdsFlags, false);
     MinimalAd minimalAd =
         new MinimalAd("anyString", (long) 1, "", "", "", (long) 1, (long) 1, "", "", "", "", 1, 1,
             (long) 1);
@@ -566,7 +566,7 @@ public class AppViewManagerTest {
     DetailedApp detailedApp =
         new DetailedApp((long) 1, "any", "packageName", (long) 1, "any", "any", "any", "any", true,
             null, null, null, null, null, (long) 1, "", null, null, 1, null, null, store, null,
-            appStats, null, null, null, true, true, "", false, false, bdsFlags);
+            appStats, null, null, null, true, true, "", false, false, bdsFlags, false);
 
     DetailedAppRequestResult detailedAppRequestResult = new DetailedAppRequestResult(detailedApp);
 

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/model/v7/GetAppMeta.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/model/v7/GetAppMeta.java
@@ -68,6 +68,7 @@ public class GetAppMeta extends BaseV7Response {
     private String graphic;
     private String added;
     private String modified;
+    private Age age;
     private Developer developer;
     private Store store;
     private GetAppMetaFile file;
@@ -79,6 +80,14 @@ public class GetAppMeta extends BaseV7Response {
     private AppCoinsInfo appcoins;
 
     public App() {
+    }
+
+    public Age getAge() {
+      return age;
+    }
+
+    public void setAge(Age age) {
+      this.age = age;
     }
 
     public boolean isPaid() {
@@ -371,6 +380,48 @@ public class GetAppMeta extends BaseV7Response {
           + ", pay="
           + this.getPay()
           + ")";
+    }
+  }
+
+  public static class Age {
+    private String name;
+    private String title;
+    private String pegi;
+    private int rating;
+
+    public Age() {
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getTitle() {
+      return title;
+    }
+
+    public void setTitle(String title) {
+      this.title = title;
+    }
+
+    public String getPegi() {
+      return pegi;
+    }
+
+    public void setPegi(String pegi) {
+      this.pegi = pegi;
+    }
+
+    public int getRating() {
+      return rating;
+    }
+
+    public void setRating(int rating) {
+      this.rating = rating;
     }
   }
 


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at removing ads from appviews of apps which are considered mature.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppViewManager.java

**How should this be manually tested?**

Open Aptoide and if you don't have the show adult content option enabled, please enable it. Then, search for an adult content app and confirm that no ads are shown (or requested, see the logcat there should be an error log saying no banners found, which means that there was no network providing us an ad). Then, please confirm that everything is correct for the "normal" apps.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1464](https://aptoide.atlassian.net/browse/ASV-1464)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass