### PR TITLE
[hotfix/ASV-1431] Action bar logo/cobrand name is now centered in home

### DIFF
--- a/app/src/main/res/layout/action_bar.xml
+++ b/app/src/main/res/layout/action_bar.xml
@@ -41,7 +41,8 @@
           android:layout_marginLeft="14dp"
           android:layout_marginStart="14dp"
           android:src="@drawable/ic_promotions_home"
-          android:visibility="visible"
+          android:visibility="gone"
+          tools:visibility="visible"
           />
 
       <TextView

--- a/app/src/main/res/layout/fragment_home_container.xml
+++ b/app/src/main/res/layout/fragment_home_container.xml
@@ -15,6 +15,8 @@
       android:background="?attr/toolbarBackground"
       android:gravity="center"
       android:minHeight="112dp"
+      app:contentInsetRight="0dp"
+      app:contentInsetStart="0dp"
       app:layout_collapseMode="pin"
       app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
       >
@@ -32,16 +34,19 @@
           android:layout_centerHorizontal="true"
           android:layout_centerVertical="true"
           android:layout_gravity="center"
+          android:layout_marginLeft="14dp"
+          android:layout_marginStart="14dp"
           android:src="@drawable/ic_promotions_home"
           android:visibility="gone"
+          tools:visibility="visible"
           />
 
       <TextView
           android:id="@+id/promotions_ticker"
           android:layout_width="wrap_content"
           android:layout_height="16dp"
-          android:layout_marginLeft="26dp"
-          android:layout_marginStart="26dp"
+          android:layout_marginLeft="36dp"
+          android:layout_marginStart="36dp"
           android:layout_marginTop="12dp"
           android:background="@drawable/promotions_ticker_badge"
           android:gravity="center"
@@ -49,12 +54,13 @@
           android:textStyle="bold"
           android:visibility="gone"
           tools:text="9+"
+          tools:visibility="visible"
           style="@style/Aptoide.TextView.Medium.XXS"
           />
 
       <include
           layout="@layout/action_bar_logo"
-          android:layout_width="232dp"
+          android:layout_width="242dp"
           android:layout_height="wrap_content"
           android:layout_centerHorizontal="true"
           android:layout_centerVertical="true"


### PR DESCRIPTION
**What does this PR do?**

  One of the ASV-1431 tasks was to center the action bar logo/name, this ended up not being done due to changes on dev that were not taken into account at the time

**Database changed?**

No

**Where should the reviewer start?**

action_bar.xml
fragment_home_container.xml

**How should this be manually tested?**

Change between home, stores and apps fragment

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/ASV-1431

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass