### PR TITLE
[feature/ASV-1430] Separated specific strings for Cobrand/Aptoide

### DIFF
--- a/app/src/cobrand/java/cm/aptoide/pt/util/MarketResourceFormatter.java
+++ b/app/src/cobrand/java/cm/aptoide/pt/util/MarketResourceFormatter.java
@@ -1,0 +1,34 @@
+package cm.aptoide.pt.util;
+
+import android.content.Context;
+import cm.aptoide.pt.R;
+
+public class MarketResourceFormatter {
+
+  private String marketName;
+
+  public MarketResourceFormatter(String marketName) {
+    this.marketName = marketName;
+  }
+
+  public String formatString(Context context, int id, String... optParamaters) {
+    switch (id) {
+      case R.string.my_account_product_card_section_title:
+      case R.string.reviewappview_highlighted_reviews_explanation_4:
+      case R.string.update_self_msg:
+      case R.string.hello_follow_me_on_aptoide:
+      case R.string.wizard_sub_title_viewpager_two:
+      case R.string.create_profile_pub_pri:
+      case R.string.addressbook_2nd_msg:
+      case R.string.addressbook_share_phone:
+      case R.string.addressbook_data_about:
+      case R.string.we_didn_t_find_any_contacts_that_are_using_aptoide:
+      case R.string.setting_category_autoupdate_message:
+      case R.string.setting_category_autoupdate_title:
+        return context.getString(id, marketName);
+      case R.string.addressbook_success_connected_friends:
+        return context.getString(id, optParamaters, marketName);
+    }
+    return context.getString(id);
+  }
+}

--- a/app/src/cobrand/res/values/strings.xml
+++ b/app/src/cobrand/res/values/strings.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="app_name">Co-brand</string>
+
+  <string name="my_account_product_card_section_title">%1$s Products</string>
+  <string name="reviewappview_highlighted_reviews_explanation_4">Be a user of %1$s for over 3 months</string>
+  <string name="update_self_msg">There is a new version of %1$s available\nDo you want to update?</string>
+  <string name="hello_follow_me_on_aptoide">Hello! Follow me on %1$s</string>
 </resources>

--- a/app/src/cobrand/res/values/strings_accountmanager.xml
+++ b/app/src/cobrand/res/values/strings_accountmanager.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="wizard_sub_title_viewpager_two">Share your favorite apps \n with the %1$s community</string>
+  <string name="create_profile_pub_pri">%1$s\'s Community</string>
+
+</resources>

--- a/app/src/cobrand/res/values/strings_appstimeline.xml
+++ b/app/src/cobrand/res/values/strings_appstimeline.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="addressbook_2nd_msg">We\'ll search in your address book for friends and family
-    that are using our app store. To protect your privacy, no private data will be sent out to our
+    <string name="addressbook_2nd_msg">%1$s will search in your address book for friends and family
+    that are using our app store. To protect your privacy, no private data will be sent out to %1$s
     servers.</string>
+  <string name="addressbook_share_phone">Share your phone number so your friends can easily find you on %1$s</string>
+  <string name="addressbook_data_about"><b>How %1$s uses your data</b>
+    \n\n%1$s will search in your address book for friends and family that are using our app store. We\'ll
+    only use this information to improve your experience by connecting you to more people
+    that can share apps-related content with you.\n\n\nTo protect your privacy, no clear private data
+    will be sent out to %1$s servers. An anonymous signature (hash) will be created with your data
+    and that hash can\'t be reversed into the original contact info.
+  </string>
+  <string name="addressbook_success_connected_friends">We successfully connected you with %1$s friends that use %2$s</string>
+  <string name="we_didn_t_find_any_contacts_that_are_using_aptoide">We didn\'t find any contacts that use %1$s</string>
+
 </resources>

--- a/app/src/cobrand/res/values/strings_settings.xml
+++ b/app/src/cobrand/res/values/strings_settings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="setting_category_autoupdate_title">Update %1$s</string>
+  <string name="setting_category_autoupdate_message">Periodically check for new versions of %1$s</string>
+</resources>

--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -220,6 +220,7 @@ import cm.aptoide.pt.sync.alarm.SyncStorage;
 import cm.aptoide.pt.timeline.TimelineAnalytics;
 import cm.aptoide.pt.updates.UpdateRepository;
 import cm.aptoide.pt.updates.UpdatesAnalytics;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.FileUtils;
 import cm.aptoide.pt.utils.q.QManager;
@@ -1709,6 +1710,11 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
 
   @Singleton @Provides @Named("marketName") String provideMarketName() {
     return BuildConfig.MARKET_NAME;
+  }
+
+  @Singleton @Provides MarketResourceFormatter provideMarketResourceFormatter(
+      @Named("marketName") String marketName) {
+    return new MarketResourceFormatter(marketName);
   }
 
   @Singleton @Provides @Named("homePromotionsId") String provideHomePromotionsId() {

--- a/app/src/main/java/cm/aptoide/pt/account/view/user/ProfileStepTwoFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/user/ProfileStepTwoFragment.java
@@ -8,6 +8,7 @@ import android.support.annotation.Nullable;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.widget.Button;
+import android.widget.TextView;
 import cm.aptoide.accountmanager.AptoideAccountManager;
 import cm.aptoide.analytics.implementation.navigation.ScreenTagHistory;
 import cm.aptoide.pt.AptoideApplication;
@@ -17,6 +18,7 @@ import cm.aptoide.pt.account.AccountAnalytics;
 import cm.aptoide.pt.account.view.AccountNavigator;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.navigator.ActivityResultNavigator;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.utils.design.ShowMessage;
 import cm.aptoide.pt.view.NotBottomNavigationView;
@@ -32,8 +34,10 @@ public class ProfileStepTwoFragment extends BaseToolbarFragment
   @LayoutRes private static final int LAYOUT = R.layout.fragment_profile_step_two;
   @Inject AccountAnalytics accountAnalytics;
   @Inject LoginSignupManager loginSignupManager;
+  @Inject MarketResourceFormatter marketResourceFormatter;
   private Button continueBtn;
   private Button privateProfileBtn;
+  private TextView createProfileTitle;
   private ProgressDialog waitDialog;
   private boolean externalLogin;
   private AccountNavigator accountNavigator;
@@ -130,5 +134,8 @@ public class ProfileStepTwoFragment extends BaseToolbarFragment
     super.bindViews(view);
     continueBtn = (Button) view.findViewById(R.id.logged_in_continue);
     privateProfileBtn = (Button) view.findViewById(R.id.logged_in_private_button);
+    createProfileTitle = view.findViewById(R.id.create_profile_title);
+    createProfileTitle.setText(
+        marketResourceFormatter.formatString(getContext(), R.string.create_profile_pub_pri));
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/addressbook/view/AddressBookFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/addressbook/view/AddressBookFragment.java
@@ -29,6 +29,7 @@ import cm.aptoide.pt.dataprovider.ws.v7.BaseBody;
 import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.presenter.AddressBookContract;
 import cm.aptoide.pt.presenter.AddressBookPresenter;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.utils.design.ShowMessage;
 import cm.aptoide.pt.view.NotBottomNavigationView;
@@ -61,7 +62,7 @@ public class AddressBookFragment extends UIComponentFragment
   @Inject TwitterAuthClient mTwitterAuthClient;
   @Inject AnalyticsManager analyticsManager;
   @Inject NavigationTracker navigationTracker;
-  @Inject @Named("marketName") String marketName;
+  @Inject MarketResourceFormatter marketResourceFormatter;
   @Inject @Named("aptoide-theme") String theme;
   private AddressBookContract.UserActionsListener mActionsListener;
   private Button addressBookSyncButton;
@@ -104,7 +105,8 @@ public class AddressBookFragment extends UIComponentFragment
             application.getDefaultSharedPreferences()), analytics,
         new AddressBookNavigationManager(getFragmentNavigator(), getTag(),
             getString(R.string.addressbook_about),
-            getString(R.string.addressbook_data_about, marketName), theme),
+            marketResourceFormatter.formatString(getContext(), R.string.addressbook_data_about),
+            theme),
         application.getDefaultSharedPreferences());
     callbackManager = CallbackManager.Factory.create();
     registerFacebookCallback();
@@ -124,7 +126,8 @@ public class AddressBookFragment extends UIComponentFragment
   }
 
   @Override public void setupViews() {
-    addressbook_2nd_msg.setText(getString(R.string.addressbook_2nd_msg));
+    addressbook_2nd_msg.setText(
+        marketResourceFormatter.formatString(getContext(), R.string.addressbook_2nd_msg));
     mActionsListener.getButtonsState();
     //dismissV.setPaintFlags(dismissV.getPaintFlags() | Paint.UNDERLINE_TEXT_FLAG);
     about.setPaintFlags(about.getPaintFlags() | Paint.UNDERLINE_TEXT_FLAG);

--- a/app/src/main/java/cm/aptoide/pt/addressbook/view/InviteFriendsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/addressbook/view/InviteFriendsFragment.java
@@ -15,6 +15,7 @@ import cm.aptoide.pt.addressbook.AddressBookAnalytics;
 import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.presenter.InviteFriendsContract;
 import cm.aptoide.pt.presenter.InviteFriendsPresenter;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.view.NotBottomNavigationView;
 import cm.aptoide.pt.view.fragment.UIComponentFragment;
 import com.jakewharton.rxbinding.view.RxView;
@@ -31,6 +32,7 @@ public class InviteFriendsFragment extends UIComponentFragment
   @Inject AnalyticsManager analyticsManager;
   @Inject NavigationTracker navigationTracker;
   @Inject @Named("marketName") String marketName;
+  @Inject MarketResourceFormatter marketResourceFormatter;
   @Inject @Named("aptoide-theme") String theme;
   private InviteFriendsContract.UserActionsListener mActionsListener;
   private OpenMode openMode;
@@ -60,7 +62,8 @@ public class InviteFriendsFragment extends UIComponentFragment
     mActionsListener = new InviteFriendsPresenter(this,
         new AddressBookNavigationManager(getFragmentNavigator(), entranceTag,
             getString(R.string.addressbook_about),
-            getString(R.string.addressbook_data_about, marketName), theme), openMode,
+            marketResourceFormatter.formatString(getContext(), R.string.addressbook_data_about),
+            theme), openMode,
         new AddressBookAnalytics(analyticsManager, navigationTracker), marketName);
   }
 
@@ -86,7 +89,8 @@ public class InviteFriendsFragment extends UIComponentFragment
         message.setText(getString(R.string.addressbook_insuccess_connection));
         break;
       case NO_FRIENDS:
-        message.setText(getString(R.string.we_didn_t_find_any_contacts_that_are_using_aptoide));
+        message.setText(marketResourceFormatter.formatString(getContext(),
+            R.string.we_didn_t_find_any_contacts_that_are_using_aptoide));
         break;
       case CONTACTS_PERMISSION_DENIAL:
         message.setText(R.string.addressbook_we_werent_able_to_connect_you);

--- a/app/src/main/java/cm/aptoide/pt/addressbook/view/PhoneInputFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/addressbook/view/PhoneInputFragment.java
@@ -28,6 +28,7 @@ import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
 import cm.aptoide.pt.dataprovider.ws.v7.BaseBody;
 import cm.aptoide.pt.presenter.PhoneInputContract;
 import cm.aptoide.pt.presenter.PhoneInputPresenter;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.view.NotBottomNavigationView;
 import cm.aptoide.pt.view.fragment.UIComponentFragment;
@@ -46,7 +47,7 @@ public class PhoneInputFragment extends UIComponentFragment
   public static final String TAG = "TAG";
   @Inject AnalyticsManager analyticsManager;
   @Inject NavigationTracker navigationTracker;
-  @Inject @Named("marketName") String marketName;
+  @Inject MarketResourceFormatter marketResourceFormatter;
   @Inject @Named("aptoide-theme") String theme;
   private PhoneInputContract.UserActionsListener mActionsListener;
   private TextView mNotNowV;
@@ -89,7 +90,8 @@ public class PhoneInputFragment extends UIComponentFragment
         new AddressBookAnalytics(analyticsManager, navigationTracker),
         new AddressBookNavigationManager(getFragmentNavigator(), entranceTag,
             getString(R.string.addressbook_about),
-            getString(R.string.addressbook_data_about, marketName), theme));
+            marketResourceFormatter.formatString(getContext(), R.string.addressbook_data_about),
+            theme));
     mGenericPleaseWaitDialog = GenericDialogs.createGenericPleaseWaitDialog(getContext());
     contactUtils = new ContactUtils(
         (TelephonyManager) getContext().getSystemService(Context.TELEPHONY_SERVICE),
@@ -103,7 +105,8 @@ public class PhoneInputFragment extends UIComponentFragment
 
   @Override public void setupViews() {
     mNotNowV.setPaintFlags(mNotNowV.getPaintFlags() | Paint.UNDERLINE_TEXT_FLAG);
-    mSharePhoneV.setText(getString(R.string.addressbook_share_phone));
+    mSharePhoneV.setText(
+        marketResourceFormatter.formatString(getContext(), R.string.addressbook_share_phone));
 
     String countryCodeE164 = contactUtils.getCountryCodeForRegion();
     if (!countryCodeE164.isEmpty()) {

--- a/app/src/main/java/cm/aptoide/pt/addressbook/view/SyncResultFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/addressbook/view/SyncResultFragment.java
@@ -17,6 +17,7 @@ import cm.aptoide.pt.addressbook.AddressBookAnalytics;
 import cm.aptoide.pt.addressbook.data.Contact;
 import cm.aptoide.pt.presenter.SyncResultContract;
 import cm.aptoide.pt.presenter.SyncResultPresenter;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.view.NotBottomNavigationView;
 import cm.aptoide.pt.view.fragment.UIComponentFragment;
 import com.google.gson.Gson;
@@ -39,7 +40,7 @@ public class SyncResultFragment extends UIComponentFragment
   private static final String TAG = "TAG";
   @Inject AnalyticsManager analyticsManager;
   @Inject NavigationTracker navigationTracker;
-  @Inject @Named("marketName") String marketName;
+  @Inject MarketResourceFormatter marketResourceFormatter;
   @Inject @Named("aptoide-theme") String theme;
   private SyncResultContract.UserActionsListener mActionsListener;
   private List<Contact> contacts;
@@ -86,7 +87,8 @@ public class SyncResultFragment extends UIComponentFragment
         new SyncResultPresenter(this, new AddressBookAnalytics(analyticsManager, navigationTracker),
             new AddressBookNavigationManager(getFragmentNavigator(), entranceTag,
                 getString(R.string.addressbook_about),
-                getString(R.string.addressbook_data_about, marketName), theme));
+                marketResourceFormatter.formatString(getContext(), R.string.addressbook_data_about),
+                theme));
     mListAdapter = new SyncResultAdapter((ArrayList<Contact>) contacts, getContext());
   }
 
@@ -104,7 +106,8 @@ public class SyncResultFragment extends UIComponentFragment
     recyclerView.setLayoutManager(
         new GridLayoutManager(getContext(), SYNCED_LIST_NUMBER_OF_COLUMNS));
 
-    successMessage.setText(getString(R.string.addressbook_success_connected_friends,
+    successMessage.setText(marketResourceFormatter.formatString(getContext(),
+        R.string.addressbook_success_connected_friends,
         Integer.toString(contacts.size())));
 
     RxView.clicks(allowFind)

--- a/app/src/main/java/cm/aptoide/pt/addressbook/view/ThankYouConnectingFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/addressbook/view/ThankYouConnectingFragment.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.widget.Button;
 import cm.aptoide.analytics.implementation.navigation.ScreenTagHistory;
 import cm.aptoide.pt.R;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.view.NotBottomNavigationView;
 import cm.aptoide.pt.view.fragment.UIComponentFragment;
 import com.jakewharton.rxbinding.view.RxView;
@@ -19,7 +20,7 @@ public class ThankYouConnectingFragment extends UIComponentFragment
     implements NotBottomNavigationView {
   public static final String TAG = "TAG";
   @Inject @Named("aptoide-theme") String theme;
-  @Inject @Named("marketName") String marketName;
+  @Inject MarketResourceFormatter marketResourceFormatter;
   private Button done;
   private String entranceTag;
 
@@ -50,7 +51,7 @@ public class ThankYouConnectingFragment extends UIComponentFragment
     AddressBookNavigationManager addressBookNavigationManager =
         new AddressBookNavigationManager(getFragmentNavigator(), entranceTag,
             getString(R.string.addressbook_about),
-            getString(R.string.addressbook_data_about, marketName),
+            marketResourceFormatter.formatString(getContext(), R.string.addressbook_data_about),
             theme);
     RxView.clicks(done)
         .subscribe(clicks -> addressBookNavigationManager.leaveAddressBook(),

--- a/app/src/main/java/cm/aptoide/pt/reviews/RateAndReviewsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/reviews/RateAndReviewsFragment.java
@@ -41,6 +41,7 @@ import cm.aptoide.pt.preferences.managed.ManagerPreferences;
 import cm.aptoide.pt.repository.RepositoryFactory;
 import cm.aptoide.pt.store.StoreCredentialsProvider;
 import cm.aptoide.pt.store.StoreCredentialsProviderImpl;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.view.ThemeUtils;
 import cm.aptoide.pt.view.dialog.DialogUtils;
 import cm.aptoide.pt.view.fragment.AptoideBaseFragment;
@@ -63,6 +64,7 @@ public class RateAndReviewsFragment extends AptoideBaseFragment<CommentsAdapter>
   private static final String TAG = RateAndReviewsFragment.class.getSimpleName();
   @Inject AppNavigator appNavigator;
   @Inject @Named("marketName") String marketName;
+  @Inject MarketResourceFormatter marketResourceFormatter;
   @Inject @Named("aptoide-theme") String theme;
   private SharedPreferences preferences;
   private DialogUtils dialogUtils;
@@ -211,7 +213,7 @@ public class RateAndReviewsFragment extends AptoideBaseFragment<CommentsAdapter>
         ((ActivityResultNavigator) getContext()).getAccountNavigator(), baseBodyInterceptor,
         httpClient, converterFactory, installedRepository, tokenInvalidator,
         ((AptoideApplication) getContext().getApplicationContext()).getDefaultSharedPreferences(),
-        getContext().getResources(), marketName);
+        getContext().getResources(), marketName, marketResourceFormatter);
   }
 
   private void fetchRating(boolean refresh) {

--- a/app/src/main/java/cm/aptoide/pt/share/ShareStoreHelper.java
+++ b/app/src/main/java/cm/aptoide/pt/share/ShareStoreHelper.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.crashreports.CrashReport;
-import java.util.Locale;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import rx.Observable;
 
 /**
@@ -13,11 +13,11 @@ import rx.Observable;
 public class ShareStoreHelper {
 
   private final Context context;
-  private final String marketName;
+  private final MarketResourceFormatter marketResourceFormatter;
 
-  public ShareStoreHelper(Context context, String marketName) {
+  public ShareStoreHelper(Context context, MarketResourceFormatter marketResourceFormatter) {
     this.context = context;
-    this.marketName = marketName;
+    this.marketResourceFormatter = marketResourceFormatter;
   }
 
   public void shareStore(String storeUrl, String storeIconPath) {
@@ -34,8 +34,9 @@ public class ShareStoreHelper {
   }
 
   private void caseDefaultShare(String storeUrl) {
-    String msg = String.format(Locale.ENGLISH,
-        context.getString(R.string.hello_follow_me_on_aptoide) + " " + storeUrl, marketName);
+    String msg = marketResourceFormatter.formatString(context, R.string.hello_follow_me_on_aptoide)
+        + " "
+        + storeUrl;
 
     Intent sharingIntent = new Intent(Intent.ACTION_SEND);
     sharingIntent.setType("text/plain");

--- a/app/src/main/java/cm/aptoide/pt/store/view/StoreFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/StoreFragment.java
@@ -60,6 +60,7 @@ import cm.aptoide.pt.store.StoreCredentialsProvider;
 import cm.aptoide.pt.store.StoreCredentialsProviderImpl;
 import cm.aptoide.pt.store.StoreTheme;
 import cm.aptoide.pt.store.StoreUtils;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.view.ThemeUtils;
 import cm.aptoide.pt.view.custom.AptoideViewPager;
@@ -90,6 +91,7 @@ public class StoreFragment extends BasePagerToolbarFragment {
   @Inject AppNavigator appNavigator;
   @Inject @Named("aptoide-theme") String theme;
   @Inject @Named("marketName") String marketName;
+  @Inject MarketResourceFormatter marketResourceFormatter;
   private AptoideAccountManager accountManager;
   private String storeName;
   private String title;
@@ -221,7 +223,7 @@ public class StoreFragment extends BasePagerToolbarFragment {
     converterFactory = WebService.getDefaultConverter();
     sharedPreferences = application.getDefaultSharedPreferences();
     storeAnalytics = new StoreAnalytics(analyticsManager, navigationTracker);
-    shareStoreHelper = new ShareStoreHelper(getActivity(), marketName);
+    shareStoreHelper = new ShareStoreHelper(getActivity(), marketResourceFormatter);
 
     if (hasSearchFromStoreFragment()) {
       searchAnalytics = new SearchAnalytics(analyticsManager, navigationTracker);

--- a/app/src/main/java/cm/aptoide/pt/view/ActivityModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/ActivityModule.java
@@ -73,6 +73,7 @@ import cm.aptoide.pt.search.analytics.SearchAnalytics;
 import cm.aptoide.pt.store.StoreAnalytics;
 import cm.aptoide.pt.store.StoreUtilsProxy;
 import cm.aptoide.pt.util.ApkFy;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.view.app.ListStoreAppsNavigator;
 import cm.aptoide.pt.view.dialog.DialogUtils;
 import cm.aptoide.pt.view.settings.MyAccountNavigator;
@@ -265,10 +266,10 @@ import static android.content.Context.WINDOW_SERVICE;
       @Named("default") OkHttpClient httpClient, Converter.Factory converterFactory,
       InstalledRepository installedRepository, TokenInvalidator tokenInvalidator,
       @Named("default") SharedPreferences sharedPreferences, Resources resources,
-      @Named("marketName") String marketName) {
+      @Named("marketName") String marketName, MarketResourceFormatter marketResourceFormatter) {
     return new DialogUtils(accountManager, accountNavigator, bodyInterceptor, httpClient,
         converterFactory, installedRepository, tokenInvalidator, sharedPreferences, resources,
-        marketName);
+        marketName, marketResourceFormatter);
   }
 
   @ActivityScope @Provides AppNavigator providesAppNavigator(

--- a/app/src/main/java/cm/aptoide/pt/view/MainActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/view/MainActivity.java
@@ -28,6 +28,7 @@ import cm.aptoide.pt.home.BottomNavigationActivity;
 import cm.aptoide.pt.install.InstallManager;
 import cm.aptoide.pt.presenter.MainView;
 import cm.aptoide.pt.presenter.Presenter;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.design.ShowMessage;
 import com.ironsource.mediationsdk.IronSource;
@@ -43,7 +44,7 @@ public class MainActivity extends BottomNavigationActivity
 
   @Inject Presenter presenter;
   @Inject Resources resources;
-  @Inject @Named("marketName") String marketName;
+  @Inject MarketResourceFormatter marketResourceFormatter;
   private InstallManager installManager;
   private View snackBarLayout;
   private PublishRelay<Void> installErrorsDismissEvent;
@@ -178,7 +179,7 @@ public class MainActivity extends BottomNavigationActivity
     updateSelfDialog.setTitle(getText(R.string.update_self_title));
     updateSelfDialog.setIcon(R.mipmap.ic_launcher);
     updateSelfDialog.setMessage(
-        AptoideUtils.StringU.getFormattedString(R.string.update_self_msg, resources, marketName));
+        marketResourceFormatter.formatString(getApplicationContext(), R.string.update_self_msg));
     updateSelfDialog.setCancelable(false);
     updateSelfDialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(android.R.string.yes),
         (arg0, arg1) -> {

--- a/app/src/main/java/cm/aptoide/pt/view/dialog/DialogUtils.java
+++ b/app/src/main/java/cm/aptoide/pt/view/dialog/DialogUtils.java
@@ -36,6 +36,7 @@ import cm.aptoide.pt.dataprovider.ws.v7.PostReviewRequest;
 import cm.aptoide.pt.install.InstalledRepository;
 import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.preferences.managed.ManagerPreferences;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.utils.design.ShowMessage;
@@ -65,12 +66,13 @@ import rx.subscriptions.Subscriptions;
   private final SharedPreferences sharedPreferences;
   private final Resources resources;
   private final String marketName;
+  private final MarketResourceFormatter marketResourceFormatter;
 
   public DialogUtils(AptoideAccountManager accountManager, AccountNavigator accountNavigator,
       BodyInterceptor<BaseBody> bodyInterceptor, OkHttpClient httpClient,
       Converter.Factory converterFactory, InstalledRepository installedRepository,
       TokenInvalidator tokenInvalidator, SharedPreferences sharedPreferences, Resources resources,
-      String marketName) {
+      String marketName, MarketResourceFormatter marketResourceFormatter) {
     this.accountManager = accountManager;
     this.accountNavigator = accountNavigator;
     this.bodyInterceptor = bodyInterceptor;
@@ -81,6 +83,7 @@ import rx.subscriptions.Subscriptions;
     this.sharedPreferences = sharedPreferences;
     this.resources = resources;
     this.marketName = marketName;
+    this.marketResourceFormatter = marketResourceFormatter;
   }
 
   public Observable<GenericDialogs.EResponse> showRateDialog(@NonNull Activity activity,
@@ -200,8 +203,9 @@ import rx.subscriptions.Subscriptions;
           .getString(R.string.reviewappview_highlighted_reviews_explanation_2));
       setBulletText(highlightedReviewsExplained_3, activity.getResources()
           .getString(R.string.reviewappview_highlighted_reviews_explanation_3));
-      setBulletText(highlightedReviewsExplained_4, activity.getResources()
-          .getString(R.string.reviewappview_highlighted_reviews_explanation_4, marketName));
+      setBulletText(highlightedReviewsExplained_4,
+          marketResourceFormatter.formatString(view.getContext(),
+              R.string.reviewappview_highlighted_reviews_explanation_4));
 
       // create and show rating dialog
       dialog.show();

--- a/app/src/main/java/cm/aptoide/pt/view/settings/MyAccountFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/MyAccountFragment.java
@@ -36,6 +36,7 @@ import cm.aptoide.pt.dataprovider.ws.v7.store.GetStoreRequest;
 import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
 import cm.aptoide.pt.link.CustomTabsHelper;
 import cm.aptoide.pt.networking.image.ImageLoader;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.view.BackButtonFragment;
 import cm.aptoide.pt.view.NotBottomNavigationView;
 import com.jakewharton.rxbinding.view.RxView;
@@ -60,6 +61,7 @@ public class MyAccountFragment extends BackButtonFragment
   @Inject AccountAnalytics accountAnalytics;
   @Inject MyAccountManager myAccountManager;
   @Inject @Named("marketName") String marketName;
+  @Inject MarketResourceFormatter marketFormatter;
   @Inject @Named("aptoide-theme") String theme;
   private AptoideAccountManager accountManager;
   private Converter.Factory converterFactory;
@@ -87,6 +89,7 @@ public class MyAccountFragment extends BackButtonFragment
   //Navigation buttons
   private View notificationHistory;
   private View settings;
+  private TextView myAccountProductCardTitle;
 
   public static Fragment newInstance() {
     return new MyAccountFragment();
@@ -113,6 +116,9 @@ public class MyAccountFragment extends BackButtonFragment
     toolbar = (Toolbar) view.findViewById(R.id.toolbar);
     notificationHistory = view.findViewById(R.id.notifications_history);
     settings = view.findViewById(R.id.settings);
+    myAccountProductCardTitle = view.findViewById(R.id.my_account_product_card_title);
+    myAccountProductCardTitle.setText(
+        marketFormatter.formatString(getContext(), R.string.my_account_product_card_section_title));
 
     setAccountViews(view);
     setupToolbar();

--- a/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
@@ -53,6 +53,7 @@ import cm.aptoide.pt.preferences.managed.ManagerPreferences;
 import cm.aptoide.pt.repository.RepositoryFactory;
 import cm.aptoide.pt.updates.UpdateRepository;
 import cm.aptoide.pt.updates.view.excluded.ExcludedUpdatesFragment;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.util.SettingsConstants;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.GenericDialogs;
@@ -90,6 +91,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
   private static final String DELETE_ACCOUNT = "deleteAccount";
   protected Toolbar toolbar;
   @Inject @Named("marketName") String marketName;
+  @Inject MarketResourceFormatter marketResourceFormatter;
   @Inject @Named("aptoide-theme") String theme;
   @Inject SupportEmailProvider supportEmailProvider;
   private Context context;
@@ -294,11 +296,10 @@ public class SettingsFragment extends PreferenceFragmentCompat
   private void setupClickHandlers() {
     handleDeleteAccountVisibility();
     Preference autoUpdatePreference = findPreference(SettingsConstants.CHECK_AUTO_UPDATE);
-    autoUpdatePreference.setTitle(
-        AptoideUtils.StringU.getFormattedString(R.string.setting_category_autoupdate_title,
-            getContext().getResources(), marketName));
-    autoUpdatePreference.setSummary(getContext().getResources()
-        .getString(R.string.setting_category_autoupdate_message));
+    autoUpdatePreference.setTitle(marketResourceFormatter.formatString(getContext(),
+        R.string.setting_category_autoupdate_title));
+    autoUpdatePreference.setSummary(marketResourceFormatter.formatString(getContext(),
+        R.string.setting_category_autoupdate_message));
 
     subscriptions.add(RxPreference.clicks(deleteAccount)
         .flatMapSingle(__ -> authenticationPersistence.getAuthentication())

--- a/app/src/main/java/cm/aptoide/pt/view/wizard/WizardPageTwoFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/wizard/WizardPageTwoFragment.java
@@ -10,8 +10,10 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import cm.aptoide.analytics.implementation.navigation.ScreenTagHistory;
 import cm.aptoide.pt.R;
+import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.view.BackButton;
 import cm.aptoide.pt.view.BackButtonFragment;
+import javax.inject.Inject;
 
 /**
  * Created by jdandrade on 18-07-2016.
@@ -19,6 +21,7 @@ import cm.aptoide.pt.view.BackButtonFragment;
  */
 public class WizardPageTwoFragment extends BackButtonFragment {
 
+  @Inject MarketResourceFormatter marketResourceFormatter;
   private ClickHandler clickHandler;
 
   public static Fragment newInstance() {
@@ -35,7 +38,8 @@ public class WizardPageTwoFragment extends BackButtonFragment {
   private void setText(View view) {
     ((TextView) view.findViewById(R.id.title)).setText(R.string.wizard_title_viewpager_two);
     ((TextView) view.findViewById(R.id.description)).setText(
-        R.string.wizard_sub_title_viewpager_two);
+        marketResourceFormatter.formatString(getContext(),
+            R.string.wizard_sub_title_viewpager_two));
     ((ImageView) view.findViewById(android.R.id.icon)).setImageResource(R.drawable.wizard_2);
   }
 

--- a/app/src/main/res/layout/fragment_my_account.xml
+++ b/app/src/main/res/layout/fragment_my_account.xml
@@ -203,6 +203,7 @@
 
 
     <TextView
+        android:id="@+id/my_account_product_card_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"

--- a/app/src/main/res/layout/fragment_profile_step_two.xml
+++ b/app/src/main/res/layout/fragment_profile_step_two.xml
@@ -85,6 +85,7 @@
         >
 
       <TextView
+          android:id="@+id/create_profile_title"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginTop="@dimen/padding_medium_small"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,7 +163,6 @@
   <string name="remote_install_help_url" translatable="false">http://blog.aptoide.com/remote-tv-install</string>
 
   <!-- Product cards -->
-  <string name="my_account_product_card_section_title">Aptoide Products</string>
   <string name="product_card_aptoide_tv_title">Aptoide TV</string>
   <string name="product_card_aptoide_tv_subtitle">The best solution for your Set Top Box and Smart TV</string>
   <string name="product_card_aptoide_uploader_title">Aptoide Uploader</string>
@@ -185,7 +184,6 @@
   <string name="reviewappview_highlighted_reviews_explanation_1">Want to write a highlighted review?</string>
   <string name="reviewappview_highlighted_reviews_explanation_2">Write more than 100 characters</string>
   <string name="reviewappview_highlighted_reviews_explanation_3">Write about an app you have installed</string>
-  <string name="reviewappview_highlighted_reviews_explanation_4">Be a user of %1$s for over 3 months</string>
 
   <!--Rate: app view: review:comments-->
   <string name="reviewappview_short_comments_by_language_all">All languages</string>
@@ -363,7 +361,6 @@
 
   <!-- Auto Update -->
   <string name="update_self_title">Update available</string>
-  <string name="update_self_msg">There is a new version of %s available\nDo you want to update?</string>
   <string name="retrieving_update">Retrieving update…</string>
 
   <string name="menu_search_item_go_to_store">Go to store</string>
@@ -472,7 +469,6 @@
   <string name="notifications_empty_state_icon_description">emptyStateIcon</string>
 
   <string name="stores_message_private_user">This user is private or doesn\'t have a store.</string>
-  <string name="hello_follow_me_on_aptoide">Hello! Follow me on %s</string>
 
   <!-- Not Logged in Fragment -->
   <string name="not_logged_in_share_short_start_interacting">Start interacting:</string>

--- a/app/src/main/res/values/strings_accountmanager.xml
+++ b/app/src/main/res/values/strings_accountmanager.xml
@@ -33,7 +33,6 @@
   <!-- WIZARD PAGE 2 -->
   <string name="wizard_title_viewpager_two">Create a Personal Store</string>
   <!--Says Aptoide instead of having a placeholder because this is never shown in cobrand builds-->
-  <string name="wizard_sub_title_viewpager_two">Share your favorite apps \n with the Aptoide community</string>
 
   <!-- WIZARD PAGE 3 -->
   <string name="login_sign_up_title">Join Our Community</string>
@@ -79,7 +78,6 @@
   <!--Public/Private-->
   <string name="create_profile_pub_pri_suc_login">Welcome!</string>
   <string name="create_profile_pub_pri_suc_login_sub_text">Your friends are now able to follow your store and see the apps you share!</string>
-  <string name="create_profile_pub_pri">Aptoide\'s Community</string>
   <string name="create_profile_pub_pri_sub_text_1">Your friends can get app recommendations based on your downloads!</string>
   <string name="create_profile_pub_pri_sub_text_2">App discovery is easier when based on friend\'s taste,</string>
   <string name="create_profile_pub_pri_sub_text_3">but you can also make your profile private.</string>

--- a/app/src/main/res/values/strings_appstimeline.xml
+++ b/app/src/main/res/values/strings_appstimeline.xml
@@ -19,29 +19,16 @@
   <string name="addressbook_increase_network_message">Increase your network.</string>
   <string name="addressbook_connect_with_friends_message">Connect with friends.</string>
   <string name="addressbook_sync">Sync address book</string>
-  <string name="not_now">Not now</string>
-  <string name="addressbook_data_about"><b>How %1$s uses your data</b>
-    \n\n%1$s will search in your address book for friends and family that are using our app store. We\'ll
-    only use this information to improve your %1$s experience by connecting you to more people
-    that can share apps-related content with you.\n\n\nTo protect your privacy, no clear private data
-    will be sent out to %1$s servers. An anonymous signature (hash) will be created with your data
-    and that hash can\'t be reversed into the original contact info.
-  </string>
+  <string name="not_now">Not now</string>+
   <string name="addressbook_success">Success!</string>
   <string name="addressbook_allow_friends_find">Allow friends to find you</string>
   <string name="google">Google</string>
   <string name="connect_google">Connect with Google</string>
   <string name="done">Done</string>
-  <string name="addressbook_share_phone">Share your phone number so your friends can easily find you!</string>
   <string name="addressbook_phone_number">Phone number</string>
   <string name="addressbook_insuccess_connection">We weren\'t able to connect with your address book!</string>
   <string name="addressbook_invite_friends">Invite friends to join you!</string>
   <string name="addressbook_thanks_for_connecting">Thank you for connecting</string>
-  <string name="addressbook_success_connected_friends">We successfully connected you with %s friends that use our platform!</string>
-  <string name="we_didn_t_find_any_contacts_that_are_using_aptoide">We didn\'t find any contacts that are using our app store.</string>
-  <string name="addressbook_2nd_msg">Aptoide will search in your address book for friends and family
-    that are using our app store. To protect your privacy, no private data will be sent out to Aptoide
-    servers.</string>
   <string name="addressbook_3rd_msg">LEARN MORE</string>
   <string name="address_book_twitter_error">Twitter authorization error</string>
   <string name="follow_my_store">Hello, follow my %1$s store here %2$s</string>

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -21,8 +21,6 @@
   <string name="setting_notifications_sub_sub_section_1">Show notifications for app updates</string>
   <string name="setting_notifications_sub_section_2">Campaigns</string>
   <string name="setting_notifications_sub_sub_section_2">Show notifications for app campaigns</string>
-  <string name="setting_category_autoupdate_title">Update %s</string>
-  <string name="setting_category_autoupdate_message">Periodically check for new versions of this app</string>
 
   <string name="setting_clear_memory">Storage</string>
   <string name="settings_clearcache_title">Clear cache</string>

--- a/app/src/vanilla/java/cm/aptoide/pt/util/MarketResourceFormatter.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/util/MarketResourceFormatter.java
@@ -1,0 +1,17 @@
+package cm.aptoide.pt.util;
+
+import android.content.Context;
+import cm.aptoide.pt.R;
+
+public class MarketResourceFormatter {
+
+  private String marketName;
+
+  public MarketResourceFormatter(String marketName) {
+    this.marketName = marketName;
+  }
+
+  public String formatString(Context context, int id, String... optParamaters) {
+    return context.getString(id);
+  }
+}

--- a/app/src/vanilla/res/values/strings.xml
+++ b/app/src/vanilla/res/values/strings.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="app_name">Aptoide</string>
+
+  <string name="my_account_product_card_section_title">Aptoide Products</string>
+  <string name="reviewappview_highlighted_reviews_explanation_4">Be a user of Aptoide for over 3 months</string>
+  <string name="update_self_msg">There is a new version of Aptoide available\nDo you want to update?</string>
+  <string name="hello_follow_me_on_aptoide">Hello! Follow me on Aptoide</string>
+
 </resources>

--- a/app/src/vanilla/res/values/strings_accountmanager.xml
+++ b/app/src/vanilla/res/values/strings_accountmanager.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="wizard_sub_title_viewpager_two">Share your favorite apps \n with the Aptoide community</string>
+  <string name="create_profile_pub_pri">Aptoide\'s Community</string>
+
+</resources>

--- a/app/src/vanilla/res/values/strings_appstimeline.xml
+++ b/app/src/vanilla/res/values/strings_appstimeline.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="addressbook_2nd_msg">Aptoide will search in your address book for friends and family
+    that are using our app store. To protect your privacy, no private data will be sent out to Aptoide
+    servers.</string>
+  <string name="addressbook_share_phone">Share your phone number so your friends can easily find you on Aptoide</string>
+  <string name="addressbook_data_about"><b>How Aptoide uses your data</b>
+    \n\n%Aptoide will search in your address book for friends and family that are using our app store. We\'ll
+    only use this information to improve your experience by connecting you to more people
+    that can share apps-related content with you.\n\n\nTo protect your privacy, no clear private data
+    will be sent out to %1$s servers. An anonymous signature (hash) will be created with your data
+    and that hash can\'t be reversed into the original contact info.
+  </string>
+  <string name="addressbook_success_connected_friends">We successfully connected you with %1$s friends that use Aptoide</string>
+  <string name="we_didn_t_find_any_contacts_that_are_using_aptoide">We didn\'t find any contacts that use Aptoide</string>
+
+</resources>

--- a/app/src/vanilla/res/values/strings_settings.xml
+++ b/app/src/vanilla/res/values/strings_settings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="setting_category_autoupdate_title">Update Aptoide</string>
+  <string name="setting_category_autoupdate_message">Periodically check for new versions of Aptoide</string>
+</resources>


### PR DESCRIPTION
**What does this PR do?**

   Creates a new formatter for strings that have dynamic arguments (namely ones with the market name). Previously this wasn't working as intended for the cobrand flavour (instead of showing up the correct market name, some showed 'Aptoide'). Along with the new formatter, different versions of the strings xmls were created for the vanilla and cobrand flavour (reasoning explained in the ticket comments).

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] MarketResourceFormatter.java

**How should this be manually tested?**

  For every string specified in the ticket, test for each vanilla and cobrand flavour if the dynamic arguments in those strings are being replaced correctly (vanilla should be "Aptoide" and be static, while for Cobrand should have the market name and be dynamic).

**What are the relevant tickets?**

  [ASV-1430](https://aptoide.atlassian.net/browse/ASV-1430)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass