### PR TITLE
[bugfix/ASV-1469] Item position bug fix

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/abtesting/AbTestSearchRepository.java
+++ b/app/src/main/java/cm/aptoide/pt/abtesting/AbTestSearchRepository.java
@@ -50,7 +50,7 @@ public class AbTestSearchRepository implements AbTestRepository {
     return getExperimentResponse(identifier).flatMap(response -> {
       if (cacheValidator.isCacheValid(response.getAbSearchId())) {
         return getExperiment(identifier).flatMap(experiment -> {
-          if (position <= response.getItems()) {
+          if (position < response.getItems()) {
             return service.recordAction(response.getAbSearchId(), experiment.getAssignment());
           }
           return Observable.just(false);


### PR DESCRIPTION
**What does this PR do?**

   Wasabi action for search ab test was being recorded even when it shouldn't, this essentially fixes it. E.g. if items = 5, position 5 was being recorded where it shouldn't (only 0-4).

**Database changed?**

   No


**How should this be manually tested?**

  Check the flow again to make sure it doesn't happen.

**What are the relevant tickets?**

  [ASV-1469](https://aptoide.atlassian.net/browse/ASV-1469)


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass