### PR TITLE
[feature/ASV-1524] Google Play Protect event to BI

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -1390,7 +1390,8 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
   }
 
   @Singleton @Provides @Named("aptoideEvents") Collection<String> provideAptoideEvents() {
-    return Arrays.asList(AppViewAnalytics.OPEN_APP_VIEW,
+    return Arrays.asList(FirstLaunchAnalytics.FIRST_LAUNCH_BI,
+        FirstLaunchAnalytics.PLAY_PROTECT_EVENT, AppViewAnalytics.OPEN_APP_VIEW,
         NotificationAnalytics.NOTIFICATION_EVENT_NAME, TimelineAnalytics.OPEN_APP,
         TimelineAnalytics.UPDATE_APP, TimelineAnalytics.OPEN_STORE, TimelineAnalytics.OPEN_ARTICLE,
         TimelineAnalytics.LIKE, TimelineAnalytics.OPEN_BLOG, TimelineAnalytics.OPEN_VIDEO,

--- a/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
@@ -39,7 +39,7 @@ public class FirstLaunchAnalytics {
 
   public static final String FIRST_LAUNCH = "Aptoide_First_Launch";
   public static final String PLAY_PROTECT_EVENT = "Google_Play_Protect";
-  private static final String EVENT_NAME = "FIRST_LAUNCH";
+  public static final String FIRST_LAUNCH_BI = "FIRST_LAUNCH";
   private static final String GMS = "GMS";
   private static final String HAS_HGMS = "Has GMS";
   private static final String NO_GMS = "No GMS";
@@ -50,7 +50,6 @@ public class FirstLaunchAnalytics {
   private static final String SITE_VERSION = "site_version";
   private static final String USER_AGENT = "user_agent";
   private static final String UNKNOWN = "unknown";
-  private static final String BI_ACTION = "OPEN";
   private static final String CONTEXT = "APPLICATION";
   private static final String UTM_SOURCE = "UTM Source";
   private static final String UTM_MEDIUM = "UTM Medium";
@@ -84,7 +83,10 @@ public class FirstLaunchAnalytics {
       String utmContent, String entryPoint) {
     analyticsManager.logEvent(
         createFacebookFirstLaunchDataMap(utmSource, utmMedium, utmCampaign, utmContent, entryPoint),
-        FIRST_LAUNCH, AnalyticsManager.Action.OPEN, "");
+        FIRST_LAUNCH, AnalyticsManager.Action.OPEN, CONTEXT);
+    analyticsManager.logEvent(
+        createFacebookFirstLaunchDataMap(utmSource, utmMedium, utmCampaign, utmContent, entryPoint),
+        FIRST_LAUNCH_BI, AnalyticsManager.Action.OPEN, CONTEXT);
   }
 
   private void sendPlayProtectEvent() {
@@ -107,7 +109,8 @@ public class FirstLaunchAnalytics {
           data.put(IS_ACTIVE, isActive ? "true" : "false");
           data.put(FLAGGED, isFlagged ? "true" : "false");
           data.put(CATEGORY, category);
-          analyticsManager.logEvent(data, PLAY_PROTECT_EVENT, AnalyticsManager.Action.OPEN, "");
+          analyticsManager.logEvent(data, PLAY_PROTECT_EVENT, AnalyticsManager.Action.OPEN,
+              CONTEXT);
         });
   }
 
@@ -197,15 +200,6 @@ public class FirstLaunchAnalytics {
         .doOnNext(dimensions -> setupDimensions(application))
         .doOnNext(facebookFirstLaunch -> sendFirstLaunchEvent(utmSource, utmMedium, utmCampaign,
             utmContent, entryPoint))
-        .flatMap(facebookFirstLaunch -> {
-          UTMTrackingBuilder utmTrackingBuilder =
-              new UTMTrackingBuilder(getTracking(application), getUTM());
-          BiUtmAnalyticsRequestBody body =
-              new BiUtmAnalyticsRequestBody(utmTrackingBuilder.getUTMTrackingData());
-          return BiUtmAnalyticsRequest.of(BI_ACTION, EVENT_NAME, CONTEXT, body, bodyInterceptor,
-              okHttpClient, converterFactory, sharedPreferences, tokenInvalidator)
-              .observe();
-        })
         .toCompletable()
         .subscribeOn(Schedulers.io());
   }

--- a/app/src/main/java/cm/aptoide/pt/view/wizard/WizardPageTwoFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/wizard/WizardPageTwoFragment.java
@@ -28,6 +28,11 @@ public class WizardPageTwoFragment extends BackButtonFragment {
     return new WizardPageTwoFragment();
   }
 
+  @Override public void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    getFragmentComponent(savedInstanceState).inject(this);
+  }
+
   @Override public View onCreateView(LayoutInflater inflater, ViewGroup container,
       Bundle savedInstanceState) {
     final View view = inflater.inflate(R.layout.fragment_wizard_model_page, container, false);


### PR DESCRIPTION
**What does this PR do?**

   This PR does two things:
  
1. Adds context to Google_Play_Protect event so that it can be sent to BI and adds it to the BI event list.
2. For FIRST_LAUNCH event, removes unnecessary call to BI analytics and instead sends it through the library. Note that FIRST_LAUNCH and Aptoide_First_Launch should remain separate for record purposes.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] FirstLaunchAnalytics.java

**How should this be manually tested?**

  Check if both FIRST_LAUNCH and Google_Play_Protect events are being sent to BI. You might need to use Charles for this as I don't think Bi events are being logged.

**What are the relevant tickets?**

  [ASV-1524](https://aptoide.atlassian.net/browse/ASV-1524)


**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass