### PR TITLE
Feature/asv 1525 appc migration in appview

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppViewViewModel.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewViewModel.java
@@ -195,7 +195,8 @@ public class AppViewViewModel {
     this.error = error;
     this.appId = -1;
     this.appName = "";
-    this.store = null;
+    this.store = new Store();
+    store.setId(-1);
     this.storeTheme = "";
     this.isGoodApp = false;
     this.malware = null;

--- a/app/src/main/java/cm/aptoide/pt/app/AppViewViewModel.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewViewModel.java
@@ -71,6 +71,7 @@ public class AppViewViewModel {
   private boolean hasAdvertising;
   private List<String> bdsFlags;
   private String campaignUrl;
+  private String signature;
 
   public AppViewViewModel(long appId, String appName, Store store, String storeTheme,
       boolean isGoodApp, Malware malware, AppFlags appFlags, List<String> tags,
@@ -82,7 +83,7 @@ public class AppViewViewModel {
       String paidAppPath, String paymentStatus, boolean isLatestTrustedVersion, String uniqueName,
       OpenType openType, double appc, SearchAdResult minimalAd, String editorsChoice,
       String originTag, boolean isStoreFollowed, String marketName, boolean hasBilling,
-      boolean hasAdvertising, List<String> bdsFlags, String campaignUrl) {
+      boolean hasAdvertising, List<String> bdsFlags, String campaignUrl, String signature) {
     this.appId = appId;
     this.appName = appName;
     this.store = store;
@@ -131,6 +132,7 @@ public class AppViewViewModel {
     this.hasAdvertising = hasAdvertising;
     this.bdsFlags = bdsFlags;
     this.campaignUrl = campaignUrl;
+    this.signature = signature;
     this.loading = false;
     this.error = null;
   }
@@ -181,6 +183,7 @@ public class AppViewViewModel {
     this.originTag = "";
     this.marketName = "";
     this.isStoreFollowed = false;
+    this.signature = "";
     this.error = null;
     this.hasBilling = false;
     this.hasAdvertising = false;
@@ -234,6 +237,7 @@ public class AppViewViewModel {
     this.originTag = "";
     this.marketName = "";
     this.isStoreFollowed = false;
+    this.signature = "";
     this.loading = false;
     this.hasBilling = false;
     this.hasAdvertising = false;
@@ -454,5 +458,9 @@ public class AppViewViewModel {
 
   public String getCampaignUrl() {
     return campaignUrl;
+  }
+
+  public String getSignature() {
+    return signature;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/app/AppcMigrationManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppcMigrationManager.java
@@ -1,7 +1,7 @@
 package cm.aptoide.pt.app;
 
 import cm.aptoide.pt.install.InstalledRepository;
-import rx.Single;
+import rx.Observable;
 
 public class AppcMigrationManager {
 
@@ -13,16 +13,13 @@ public class AppcMigrationManager {
     this.repository = repository;
   }
 
-  public Single<Boolean> isMigrationApp(String packageName, String signature, int versionCode,
+  public Observable<Boolean> isMigrationApp(String packageName, String signature, int versionCode,
       long storeId, boolean hasAppc) {
     return repository.getInstalled(packageName)
         .map(installed -> installed != null
             && !installed.getSignature()
             .equals(signature)
             && installed.getVersionCode() <= versionCode
-            && storeId == BDS_STORE_ID
-            && hasAppc)
-        .first()
-        .toSingle();
+            && storeId == BDS_STORE_ID && hasAppc);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/app/AppcMigrationManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppcMigrationManager.java
@@ -1,0 +1,28 @@
+package cm.aptoide.pt.app;
+
+import cm.aptoide.pt.install.InstalledRepository;
+import rx.Single;
+
+public class AppcMigrationManager {
+
+  private static final long BDS_STORE_ID = 1966380;
+
+  private InstalledRepository repository;
+
+  public AppcMigrationManager(InstalledRepository repository) {
+    this.repository = repository;
+  }
+
+  public Single<Boolean> isMigrationApp(String packageName, String signature, int versionCode,
+      long storeId, boolean hasAppc) {
+    return repository.getInstalled(packageName)
+        .map(installed -> installed != null
+            && !installed.getSignature()
+            .equals(signature)
+            && installed.getVersionCode() <= versionCode
+            && storeId == BDS_STORE_ID
+            && hasAppc)
+        .first()
+        .toSingle();
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/app/DownloadModel.java
+++ b/app/src/main/java/cm/aptoide/pt/app/DownloadModel.java
@@ -65,7 +65,7 @@ public class DownloadModel {
   }
 
   public enum Action {
-    UPDATE, INSTALL, DOWNGRADE, OPEN, PAY
+    UPDATE, INSTALL, DOWNGRADE, OPEN, PAY, MIGRATE
   }
 
   public enum DownloadState {

--- a/app/src/main/java/cm/aptoide/pt/app/DownloadStateParser.java
+++ b/app/src/main/java/cm/aptoide/pt/app/DownloadStateParser.java
@@ -47,10 +47,12 @@ public class DownloadStateParser {
   }
 
   public DownloadModel.Action parseDownloadType(Install.InstallationType type, boolean paidApp,
-      boolean wasPaid) {
+      boolean wasPaid, boolean isMigration) {
     DownloadModel.Action action;
     if (paidApp && !wasPaid) {
       action = DownloadModel.Action.PAY;
+    } else if (isMigration) {
+      action = DownloadModel.Action.MIGRATE;
     } else {
       switch (type) {
         case INSTALLED:

--- a/app/src/main/java/cm/aptoide/pt/app/DownloadStateParser.java
+++ b/app/src/main/java/cm/aptoide/pt/app/DownloadStateParser.java
@@ -87,6 +87,9 @@ public class DownloadStateParser {
       case DOWNGRADE:
         downloadAction = Download.ACTION_DOWNGRADE;
         break;
+      case MIGRATE:
+        downloadAction = Download.ACTION_DOWNGRADE;
+        break;
       default:
         throw new IllegalArgumentException("Invalid action");
     }

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -1615,6 +1615,8 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
                     .getSymbol(), model.getPay()
                     .getPrice()));
         break;
+      case MIGRATE:
+        install.setText(getResources().getString(R.string.appview_button_update_to_appc));
     }
   }
 

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -187,6 +187,7 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
   private TextView sizeInfo;
   private TextView ratingInfo;
   private View appcRewardView;
+  private View appcMigrationWarningMessage;
   private TextView appcRewardValue;
   private View versionsLayout;
   private TextView latestVersionTitle;
@@ -316,6 +317,7 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     sizeInfo = view.findViewById(R.id.header_size);
     ratingInfo = view.findViewById(R.id.header_rating);
     appcRewardView = view.findViewById(R.id.appc_layout);
+    appcMigrationWarningMessage = view.findViewById(R.id.migration_warning);
     appcRewardValue = view.findViewById(R.id.appcoins_reward_message);
     appcInfoView =
         new AppViewAppcInfoViewHolder((LinearLayout) view.findViewById(R.id.iap_appc_label),
@@ -1417,8 +1419,13 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
       manageSimilarAppsVisibility(similarAppsViewModel.hasSimilarApps(), true);
       setDownloadState(downloadModel.getProgress(), downloadModel.getDownloadState());
     } else {
-      appcInfoView.showInfo(appCoinsViewModel.hasAdvertising(), appCoinsViewModel.hasBilling(),
-          formatAppCoinsRewardMessage());
+      if (!action.equals(DownloadModel.Action.MIGRATE)) {
+        appcInfoView.showInfo(appCoinsViewModel.hasAdvertising(), appCoinsViewModel.hasBilling(),
+            formatAppCoinsRewardMessage());
+      } else {
+        appcRewardView.setVisibility(View.GONE);
+        appcMigrationWarningMessage.setVisibility(View.VISIBLE);
+      }
       downloadInfoLayout.setVisibility(View.GONE);
       install.setVisibility(View.VISIBLE);
       setButtonText(downloadModel);

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -225,8 +225,6 @@ public class AppViewPresenter implements Presenter {
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {
         }, throwable -> {
-          Logger.getInstance()
-              .e("BS", throwable.getMessage());
           crashReport.log(throwable);
         });
   }

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -940,6 +940,11 @@ public class AppViewPresenter implements Presenter {
                       .observeOn(viewScheduler)
                       .flatMapCompletable(appViewViewModel -> payApp(appViewViewModel.getAppId()));
                   break;
+                case MIGRATE:
+                  completable = appViewManager.loadAppViewViewModel()
+                      .observeOn(viewScheduler)
+                      .flatMapCompletable(appViewViewModel -> migrateApp(action, appViewViewModel));
+                  break;
                 default:
                   completable =
                       Completable.error(new IllegalArgumentException("Invalid type of action"));
@@ -978,6 +983,10 @@ public class AppViewPresenter implements Presenter {
         .doOnNext(__ -> view.showDowngradingMessage())
         .flatMapCompletable(__ -> downloadApp(action, appViewModel))
         .toCompletable();
+  }
+
+  private Completable migrateApp(DownloadModel.Action action, AppViewViewModel appViewViewModel) {
+    return downloadApp(action, appViewViewModel);
   }
 
   private Completable openInstalledApp(String packageName) {

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -142,7 +142,8 @@ public class AppViewPresenter implements Presenter {
         .filter(app -> !app.isLoading())
         .filter(app -> !app.isAppCoinApp())
         .flatMap(app -> appViewManager.loadDownloadAppViewModel(app.getMd5(), app.getPackageName(),
-            app.getVersionCode(), app.isPaid(), app.getPay())
+            app.getVersionCode(), app.isPaid(), app.getPay(), app.getSignature(), app.getStore()
+                .getId(), app.hasAdvertising() || app.hasBilling())
             .filter(model -> model.getDownloadModel()
                 .isDownloading())
             .first()
@@ -223,7 +224,11 @@ public class AppViewPresenter implements Presenter {
             .doOnNext(donations -> view.showDonations(donations)))
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {
-        }, throwable -> crashReport.log(throwable));
+        }, throwable -> {
+          Logger.getInstance()
+              .e("BS", throwable.getMessage());
+          crashReport.log(throwable);
+        });
   }
 
   private Single<SearchAdResult> manageOrganicAds(SearchAdResult searchAdResult) {
@@ -667,7 +672,9 @@ public class AppViewPresenter implements Presenter {
         .flatMap(
             appViewViewModel -> appViewManager.loadDownloadAppViewModel(appViewViewModel.getMd5(),
                 appViewViewModel.getPackageName(), appViewViewModel.getVersionCode(),
-                appViewViewModel.isPaid(), appViewViewModel.getPay())
+                appViewViewModel.isPaid(), appViewViewModel.getPay(),
+                appViewViewModel.getSignature(), appViewViewModel.getStore()
+                    .getId(), appViewViewModel.hasAdvertising() || appViewViewModel.hasBilling())
                 .first()
                 .observeOn(viewScheduler)
                 .doOnNext(downloadAppViewModel -> view.showDownloadAppModel(downloadAppViewModel,
@@ -1006,7 +1013,8 @@ public class AppViewPresenter implements Presenter {
             .toObservable())
         .filter(app -> !app.isLoading())
         .flatMap(app -> appViewManager.loadDownloadAppViewModel(app.getMd5(), app.getPackageName(),
-            app.getVersionCode(), app.isPaid(), app.getPay())
+            app.getVersionCode(), app.isPaid(), app.getPay(), app.getSignature(), app.getStore()
+                .getId(), app.hasAdvertising() || app.hasBilling())
             .observeOn(viewScheduler)
             .doOnNext(model -> view.showDownloadAppModel(model, app.hasDonations())))
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialManager.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialManager.java
@@ -94,7 +94,7 @@ public class EditorialManager {
     return installManager.getInstall(md5, packageName, versionCode)
         .map(install -> new EditorialDownloadModel(
             downloadStateParser.parseDownloadType(install.getType(), paidApp,
-                pay != null && pay.isPaid()), install.getProgress(),
+                pay != null && pay.isPaid(), false), install.getProgress(),
             downloadStateParser.parseDownloadState(install.getState()), pay, position));
   }
 

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionViewAppMapper.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionViewAppMapper.java
@@ -25,7 +25,7 @@ public class PromotionViewAppMapper {
 
   private DownloadModel getDownloadModel(Install.InstallationType type, int progress,
       Install.InstallationStatus state) {
-    return new DownloadModel(downloadStateParser.parseDownloadType(type, false, false), progress,
-        downloadStateParser.parseDownloadState(state), null);
+    return new DownloadModel(downloadStateParser.parseDownloadType(type, false, false, false),
+        progress, downloadStateParser.parseDownloadState(state), null);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -37,6 +37,7 @@ import cm.aptoide.pt.app.AppCoinsManager;
 import cm.aptoide.pt.app.AppNavigator;
 import cm.aptoide.pt.app.AppViewAnalytics;
 import cm.aptoide.pt.app.AppViewManager;
+import cm.aptoide.pt.app.AppcMigrationManager;
 import cm.aptoide.pt.app.CampaignAnalytics;
 import cm.aptoide.pt.app.DownloadStateParser;
 import cm.aptoide.pt.app.FlagManager;
@@ -99,6 +100,7 @@ import cm.aptoide.pt.home.apps.UpdatesManager;
 import cm.aptoide.pt.impressions.ImpressionManager;
 import cm.aptoide.pt.install.InstallAnalytics;
 import cm.aptoide.pt.install.InstallManager;
+import cm.aptoide.pt.install.InstalledRepository;
 import cm.aptoide.pt.navigator.ActivityNavigator;
 import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.navigator.FragmentResultNavigator;
@@ -323,6 +325,11 @@ import rx.subscriptions.CompositeSubscription;
         okHttpClient, tokenInvalidator, sharedPreferences);
   }
 
+  @FragmentScope @Provides AppcMigrationManager providesAppcMigrationManager(
+      InstalledRepository repository) {
+    return new AppcMigrationManager(repository);
+  }
+
   @FragmentScope @Provides AppViewManager providesAppViewManager(InstallManager installManager,
       DownloadFactory downloadFactory, AppCenter appCenter, ReviewsManager reviewsManager,
       AdsManager adsManager, StoreManager storeManager, FlagManager flagManager,
@@ -332,13 +339,13 @@ import rx.subscriptions.CompositeSubscription;
       NotificationAnalytics notificationAnalytics, InstallAnalytics installAnalytics,
       Resources resources, WindowManager windowManager, SocialRepository socialRepository,
       @Named("marketName") String marketName, AppCoinsManager appCoinsManager,
-      MoPubAdsManager moPubAdsManager) {
+      MoPubAdsManager moPubAdsManager, AppcMigrationManager appcMigrationManager) {
     return new AppViewManager(installManager, downloadFactory, appCenter, reviewsManager,
         adsManager, storeManager, flagManager, storeUtilsProxy, aptoideAccountManager,
         appViewConfiguration, moPubAdsManager, preferencesManager, downloadStateParser,
         appViewAnalytics, notificationAnalytics, installAnalytics,
         (Type.APPS_GROUP.getPerLineCount(resources, windowManager) * 6), socialRepository,
-        marketName, appCoinsManager);
+        marketName, appCoinsManager, appcMigrationManager);
   }
 
   @FragmentScope @Provides AppViewPresenter providesAppViewPresenter(

--- a/app/src/main/java/cm/aptoide/pt/view/app/AppService.java
+++ b/app/src/main/java/cm/aptoide/pt/view/app/AppService.java
@@ -232,7 +232,9 @@ public class AppService {
                   .getStringPath(), paidApp.getPayment()
                   .getStatus(), isLatestTrustedVersion(listAppVersions, file), uniqueName,
                   app.hasBilling(), app.hasAdvertising(), app.getBdsFlags(), app.getAge()
-                  .getRating() == MATURE_APP_RATING));
+                  .getRating() == MATURE_APP_RATING, app.getFile()
+                  .getSignature()
+                  .getSha1()));
         });
       }
 
@@ -245,7 +247,9 @@ public class AppService {
               appMedia, appStats, app.getObb(), app.getPay(), app.getUrls()
               .getW(), app.isPaid(), isLatestTrustedVersion(listAppVersions, file), uniqueName,
               app.hasBilling(), app.hasAdvertising(), app.getBdsFlags(), app.getAge()
-              .getRating() == MATURE_APP_RATING);
+              .getRating() == MATURE_APP_RATING, app.getFile()
+              .getSignature()
+              .getSha1());
       return Observable.just(new DetailedAppRequestResult(detailedApp));
     } else {
       return Observable.error(new IllegalStateException("Could not obtain request from server."));

--- a/app/src/main/java/cm/aptoide/pt/view/app/DetailedApp.java
+++ b/app/src/main/java/cm/aptoide/pt/view/app/DetailedApp.java
@@ -49,6 +49,7 @@ public class DetailedApp {
   private boolean hasAdvertising;
   private List<String> bdsFlags;
   private boolean isMature;
+  private String signature;
 
   public DetailedApp(long id, String name, String packageName, long size, String icon,
       String graphic, String added, String modified, boolean isGoodApp, Malware malware,
@@ -57,7 +58,7 @@ public class DetailedApp {
       AppDeveloper appDeveloper, Store store, AppMedia media, AppStats stats, Obb obb,
       GetAppMeta.Pay pay, String webUrls, boolean isPaid, boolean wasPaid, String paidAppPath,
       String paymentStatus, boolean isLatestTrustedVersion, String uniqueName, boolean hasBilling,
-      boolean hasAdvertising, List<String> bdsFlags, boolean isMature) {
+      boolean hasAdvertising, List<String> bdsFlags, boolean isMature, String signature) {
 
     this.id = id;
     this.name = name;
@@ -96,6 +97,7 @@ public class DetailedApp {
     this.hasAdvertising = hasAdvertising;
     this.bdsFlags = bdsFlags;
     this.isMature = isMature;
+    this.signature = signature;
   }
 
   public DetailedApp(long id, String name, String packageName, long size, String icon,
@@ -105,7 +107,7 @@ public class DetailedApp {
       AppDeveloper appDeveloper, Store store, AppMedia media, AppStats stats, Obb obb,
       GetAppMeta.Pay pay, String webUrls, boolean isPaid, boolean isLatestTrustedVersion,
       String uniqueName, boolean hasBilling, boolean hasAdvertising, List<String> bdsFlags,
-      boolean isMature) {
+      boolean isMature, String signature) {
 
     this.id = id;
     this.name = name;
@@ -142,6 +144,7 @@ public class DetailedApp {
     this.wasPaid = false;
     this.paidAppPath = "";
     this.paymentStatus = "";
+    this.signature = signature;
     this.isLatestTrustedVersion = isLatestTrustedVersion;
     this.uniqueName = uniqueName;
   }
@@ -304,5 +307,9 @@ public class DetailedApp {
 
   public boolean isMature() {
     return isMature;
+  }
+
+  public String getSignature() {
+    return signature;
   }
 }

--- a/app/src/main/res/drawable/ic_info_outline_appc.xml
+++ b/app/src/main/res/drawable/ic_info_outline_appc.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:tint="#FD6363"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0"
+    android:width="24dp">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M11,17h2v-6h-2v6zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM11,9h2L13,7h-2v2z"/>
+</vector>

--- a/app/src/main/res/layout/appview_migration_warning.xml
+++ b/app/src/main/res/layout/appview_migration_warning.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    >
+
+  <ImageView
+      android:layout_width="17dp"
+      android:layout_height="17dp"
+      android:layout_marginEnd="9dp"
+      android:layout_marginRight="9dp"
+      android:src="@drawable/ic_info_outline_appc"
+      />
+
+  <TextView
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:layout_gravity="center_horizontal"
+      android:gravity="center_vertical"
+      android:text="@string/promo_update2appc_data_disclaimer"
+      android:textColor="#fd6363"
+      style="@style/Aptoide.TextView.Medium.XXS"
+      />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_app_view.xml
+++ b/app/src/main/res/layout/fragment_app_view.xml
@@ -6,9 +6,9 @@
     android:id="@+id/coordinator_layout_appview"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/white"
     android:descendantFocusability="blocksDescendants"
     android:orientation="vertical"
-    android:background="@color/white"
     >
 
   <include
@@ -255,7 +255,15 @@
                 tools:visibility="visible"
                 />
           </FrameLayout>
-
+          <include
+              layout="@layout/appview_migration_warning"
+              android:id="@+id/migration_warning"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_gravity="center_horizontal"
+              android:layout_marginTop="12dp"
+              android:visibility="gone"
+              />
           <View
               android:id="@+id/similar_download_placeholder"
               android:layout_width="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
   <string name="appview_button_open">Open</string>
   <string name="appview_button_update">Update</string>
   <string name="appview_button_buy">Buy</string>
+  <string name="appview_button_update_to_appc">Update to Appc</string>
   <string name="appview_followers_count_text">%1$s   followers</string>
   <string name="appview_other_versions">Other versions</string>
   <string name="appview_newer_version">Newer version available</string>

--- a/app/src/test/java/cm/aptoide/pt/app/AppViewManagerTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/AppViewManagerTest.java
@@ -627,15 +627,16 @@ public class AppViewManagerTest {
 
     //When the presenter asks for the downloadModel
     when(installManager.getInstall("md5", "packageName", 1)).thenReturn(Observable.just(install));
+    when(migrationManager.isMigrationApp("packageName", "", 1, 2, false)).thenReturn(
+        Observable.just(false));
 
     DownloadModel downloadModel =
         appViewManager.loadDownloadModel("md5", "packageName", 1, false, null, "", 2, false)
             .toBlocking()
             .first();
 
-    //verify(migrationManager).isMigrationApp("packageName", "", 1, 2, false);
     ////Then it should ask the installManager to start the install
-    //verify(installManager).getInstall("md5", "packageName", 1);
+    verify(installManager).getInstall("md5", "packageName", 1);
 
     //And it should return a DownloadViewModel with the correct progress, action and download state
     Assert.assertEquals(2, downloadModel.getProgress());

--- a/app/src/test/java/cm/aptoide/pt/app/AppViewManagerTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/AppViewManagerTest.java
@@ -71,6 +71,7 @@ public class AppViewManagerTest {
   @Mock private DownloadFactory downloadFactory;
   @Mock private AppCoinsManager appCoinsManager;
   @Mock private MoPubAdsManager moPubAdsManager;
+  @Mock private AppcMigrationManager migrationManager;
   private DownloadStateParser downloadStateParser;
   private AppViewManager appViewManager;
   private AppStats appStats;
@@ -88,7 +89,7 @@ public class AppViewManagerTest {
             storeManager, flagManager, storeUtilsProxy, aptoideAccountManager, appViewConfiguration,
             moPubAdsManager, preferencesManager, downloadStateParser, appViewAnalytics,
             notificationAnalytics, installAnalytics, limit, socialRepository, "anyString",
-            appCoinsManager);
+            appCoinsManager, migrationManager);
   }
 
   @Test public void loadAppViewViewModelTestWithAppIdTest() {
@@ -97,7 +98,7 @@ public class AppViewManagerTest {
     DetailedApp detailedApp =
         new DetailedApp((long) 1, "any", "any", (long) 1, "any", "any", "any", "any", true, null,
             null, null, null, null, (long) 1, null, null, null, 1, null, null, store, null,
-            appStats, null, null, null, true, true, null, false, false, bdsFlags, false);
+            appStats, null, null, null, true, true, null, false, false, bdsFlags, false, "");
 
     DetailedAppRequestResult detailedAppRequestResult = new DetailedAppRequestResult(detailedApp);
     AppViewConfiguration appViewConfiguration =
@@ -109,7 +110,7 @@ public class AppViewManagerTest {
             storeManager, flagManager, storeUtilsProxy, aptoideAccountManager, appViewConfiguration,
             moPubAdsManager, preferencesManager, downloadStateParser, appViewAnalytics,
             notificationAnalytics, installAnalytics, limit, socialRepository, "anyString",
-            appCoinsManager);
+            appCoinsManager, migrationManager);
 
     //When the presenter ask for an App and the AppView was initialized with an AppId
     //And a result is returned
@@ -148,7 +149,7 @@ public class AppViewManagerTest {
     DetailedApp detailedApp =
         new DetailedApp((long) 1, "any", "any", (long) 1, "any", "any", "any", "any", true, null,
             null, null, null, null, (long) 1, "md5", null, null, 1, null, null, store, null,
-            appStats, null, null, null, true, true, null, false, false, bdsFlags, false);
+            appStats, null, null, null, true, true, null, false, false, bdsFlags, false, "");
     DetailedAppRequestResult detailedAppRequestResult = new DetailedAppRequestResult(detailedApp);
     AppViewConfiguration appViewConfiguration =
         new AppViewConfiguration((long) -1, "anyString", "anyString", "", null, null, "md5", "",
@@ -159,7 +160,7 @@ public class AppViewManagerTest {
             storeManager, flagManager, storeUtilsProxy, aptoideAccountManager, appViewConfiguration,
             moPubAdsManager, preferencesManager, downloadStateParser, appViewAnalytics,
             notificationAnalytics, installAnalytics, limit, socialRepository, "anyString",
-            appCoinsManager);
+            appCoinsManager, migrationManager);
 
     //When the presenter ask for an App and the AppView was initialized with a Md5
     //And a result is returned
@@ -198,7 +199,8 @@ public class AppViewManagerTest {
     DetailedApp detailedApp =
         new DetailedApp((long) 1, "any", "any", (long) 1, "any", "any", "any", "any", true, null,
             null, null, null, null, (long) 1, "any", null, null, 1, null, null, store, null,
-            appStats, null, null, null, true, true, "uniqueName", false, false, bdsFlags, false);
+            appStats, null, null, null, true, true, "uniqueName", false, false, bdsFlags, false,
+            "");
     DetailedAppRequestResult detailedAppRequestResult = new DetailedAppRequestResult(detailedApp);
     AppViewConfiguration appViewConfiguration =
         new AppViewConfiguration((long) -1, "anyString", "anyString", "", null, null, "",
@@ -209,7 +211,7 @@ public class AppViewManagerTest {
             storeManager, flagManager, storeUtilsProxy, aptoideAccountManager, appViewConfiguration,
             moPubAdsManager, preferencesManager, downloadStateParser, appViewAnalytics,
             notificationAnalytics, installAnalytics, limit, socialRepository, "anyString",
-            appCoinsManager);
+            appCoinsManager, migrationManager);
 
     //When the presenter ask for an App and the AppView was initialized with a uniqueName
     //And a result is returned with success
@@ -248,7 +250,7 @@ public class AppViewManagerTest {
     DetailedApp detailedApp =
         new DetailedApp((long) 1, "any", "", (long) 1, "any", "any", "any", "any", true, null, null,
             null, null, null, (long) 1, "any", null, null, 1, null, null, store, null, appStats,
-            null, null, null, true, true, "uniqueName", false, false, bdsFlags, false);
+            null, null, null, true, true, "uniqueName", false, false, bdsFlags, false, "");
     DetailedAppRequestResult detailedAppRequestResult = new DetailedAppRequestResult(detailedApp);
     AppViewConfiguration appViewConfiguration =
         new AppViewConfiguration((long) -1, "", "", "", null, null, "", "", 0.0, "", "", "");
@@ -258,7 +260,7 @@ public class AppViewManagerTest {
             storeManager, flagManager, storeUtilsProxy, aptoideAccountManager, appViewConfiguration,
             moPubAdsManager, preferencesManager, downloadStateParser, appViewAnalytics,
             notificationAnalytics, installAnalytics, limit, socialRepository, "anyString",
-            appCoinsManager);
+            appCoinsManager, migrationManager);
 
     //When the presenter ask for an App and the AppView was initialized with arguments other than appId, md5 or uniqueName
     //And a result is returned with success
@@ -301,7 +303,7 @@ public class AppViewManagerTest {
             storeManager, flagManager, storeUtilsProxy, aptoideAccountManager, appViewConfiguration,
             moPubAdsManager, preferencesManager, downloadStateParser, appViewAnalytics,
             notificationAnalytics, installAnalytics, limit, socialRepository, "anyString",
-            appCoinsManager);
+            appCoinsManager, migrationManager);
 
     //When the presenter ask for an App
     //And a result is returned
@@ -328,7 +330,7 @@ public class AppViewManagerTest {
             storeManager, flagManager, storeUtilsProxy, aptoideAccountManager, appViewConfiguration,
             moPubAdsManager, preferencesManager, downloadStateParser, appViewAnalytics,
             notificationAnalytics, installAnalytics, limit, socialRepository, "anyString",
-            appCoinsManager);
+            appCoinsManager, migrationManager);
 
     //When the presenter ask for an App
     //And a result is returned
@@ -355,7 +357,7 @@ public class AppViewManagerTest {
             storeManager, flagManager, storeUtilsProxy, aptoideAccountManager, appViewConfiguration,
             moPubAdsManager, preferencesManager, downloadStateParser, appViewAnalytics,
             notificationAnalytics, installAnalytics, limit, socialRepository, "anyString",
-            appCoinsManager);
+            appCoinsManager, migrationManager);
 
     //When the presenter ask for an App
     //And a result is returned
@@ -452,7 +454,7 @@ public class AppViewManagerTest {
     DetailedApp detailedApp =
         new DetailedApp((long) 1, "any", "anyString", (long) 1, "any", "any", "any", "any", true,
             null, null, null, null, null, (long) 1, null, null, null, 1, null, null, store, null,
-            appStats, null, null, null, true, true, null, false, false, bdsFlags, false);
+            appStats, null, null, null, true, true, null, false, false, bdsFlags, false, "");
     MinimalAd minimalAd =
         new MinimalAd("anyString", (long) 1, "", "", "", (long) 1, (long) 1, "", "", "", "", 1, 1,
             (long) 1);
@@ -467,7 +469,7 @@ public class AppViewManagerTest {
             storeManager, flagManager, storeUtilsProxy, aptoideAccountManager, appViewConfiguration,
             moPubAdsManager, preferencesManager, downloadStateParser, appViewAnalytics,
             notificationAnalytics, installAnalytics, limit, socialRepository, "marketName",
-            appCoinsManager);
+            appCoinsManager, migrationManager);
 
     when(appCenter.loadDetailedApp((long) 1, "anyString", "anyString")).thenReturn(
         Single.just(detailedAppRequestResult));
@@ -561,7 +563,7 @@ public class AppViewManagerTest {
     DetailedApp detailedApp =
         new DetailedApp((long) 1, "any", "packageName", (long) 1, "any", "any", "any", "any", true,
             null, null, null, null, null, (long) 1, "", null, null, 1, null, null, store, null,
-            appStats, null, null, null, true, true, "", false, false, bdsFlags, false);
+            appStats, null, null, null, true, true, "", false, false, bdsFlags, false, "");
 
     DetailedAppRequestResult detailedAppRequestResult = new DetailedAppRequestResult(detailedApp);
 
@@ -574,7 +576,7 @@ public class AppViewManagerTest {
             storeManager, flagManager, storeUtilsProxy, aptoideAccountManager, appViewConfiguration,
             moPubAdsManager, preferencesManager, downloadStateParser, appViewAnalytics,
             notificationAnalytics, installAnalytics, limit, socialRepository, "anyString",
-            appCoinsManager);
+            appCoinsManager, migrationManager);
 
     when(appCenter.loadDetailedApp((long) 1, "anyString", "packageName")).thenReturn(
         Single.just(detailedAppRequestResult));
@@ -627,12 +629,13 @@ public class AppViewManagerTest {
     when(installManager.getInstall("md5", "packageName", 1)).thenReturn(Observable.just(install));
 
     DownloadModel downloadModel =
-        appViewManager.loadDownloadModel("md5", "packageName", 1, false, null)
+        appViewManager.loadDownloadModel("md5", "packageName", 1, false, null, "", 2, false)
             .toBlocking()
             .first();
 
-    //Then it should ask the installManager to start the install
-    verify(installManager).getInstall("md5", "packageName", 1);
+    //verify(migrationManager).isMigrationApp("packageName", "", 1, 2, false);
+    ////Then it should ask the installManager to start the install
+    //verify(installManager).getInstall("md5", "packageName", 1);
 
     //And it should return a DownloadViewModel with the correct progress, action and download state
     Assert.assertEquals(2, downloadModel.getProgress());

--- a/app/src/test/java/cm/aptoide/pt/app/AppViewPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/AppViewPresenterTest.java
@@ -81,7 +81,7 @@ public class AppViewPresenterTest {
             Collections.emptyList(), Collections.emptyList()), "modified", "app added", null, null,
             "weburls", false, false, "paid path", "no", true, "aptoide",
             AppViewFragment.OpenType.OPEN_ONLY, 0, null, "editorsChoice", "origin", false,
-            "marketName", false, false, bdsFlags, "");
+            "marketName", false, false, bdsFlags, "", "");
 
     DownloadModel downloadModel =
         new DownloadModel(DownloadModel.Action.INSTALL, 0, DownloadModel.DownloadState.ACTIVE,
@@ -107,7 +107,10 @@ public class AppViewPresenterTest {
     //when the download model is requested
     when(appViewManager.loadDownloadAppViewModel(appViewViewModel.getMd5(),
         appViewViewModel.getPackageName(), appViewViewModel.getVersionCode(),
-        appViewViewModel.isPaid(), appViewViewModel.getPay())).thenReturn(
+        appViewViewModel.isPaid(), appViewViewModel.getPay(), appViewViewModel.getSignature(),
+        appViewViewModel.getStore()
+            .getId(),
+        appViewViewModel.hasAdvertising() || appViewViewModel.hasBilling())).thenReturn(
         Observable.just(downloadAppViewModel));
 
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
@@ -132,7 +135,10 @@ public class AppViewPresenterTest {
     //when the download model is requested
     when(appViewManager.loadDownloadAppViewModel(appViewViewModel.getMd5(),
         appViewViewModel.getPackageName(), appViewViewModel.getVersionCode(),
-        appViewViewModel.isPaid(), appViewViewModel.getPay())).thenReturn(
+        appViewViewModel.isPaid(), appViewViewModel.getPay(), appViewViewModel.getSignature(),
+        appViewViewModel.getStore()
+            .getId(),
+        appViewViewModel.hasAdvertising() || appViewViewModel.hasBilling())).thenReturn(
         Observable.just(downloadAppViewModel));
 
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
@@ -155,7 +161,10 @@ public class AppViewPresenterTest {
     //when the download model is requested
     when(appViewManager.loadDownloadAppViewModel(errorAppViewViewModel.getMd5(),
         errorAppViewViewModel.getPackageName(), errorAppViewViewModel.getVersionCode(),
-        errorAppViewViewModel.isPaid(), errorAppViewViewModel.getPay())).thenReturn(
+        errorAppViewViewModel.isPaid(), errorAppViewViewModel.getPay(),
+        appViewViewModel.getSignature(), appViewViewModel.getStore()
+            .getId(),
+        appViewViewModel.hasAdvertising() || appViewViewModel.hasBilling())).thenReturn(
         Observable.just(downloadAppViewModel));
 
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
@@ -180,7 +189,10 @@ public class AppViewPresenterTest {
     //when the download model is requested
     when(appViewManager.loadDownloadAppViewModel(appViewViewModel.getMd5(),
         appViewViewModel.getPackageName(), appViewViewModel.getVersionCode(),
-        appViewViewModel.isPaid(), appViewViewModel.getPay())).thenReturn(
+        appViewViewModel.isPaid(), appViewViewModel.getPay(), appViewViewModel.getSignature(),
+        appViewViewModel.getStore()
+            .getId(),
+        appViewViewModel.hasAdvertising() || appViewViewModel.hasBilling())).thenReturn(
         Observable.just(downloadAppViewModel));
 
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
@@ -213,7 +225,7 @@ public class AppViewPresenterTest {
             Collections.emptyList(), Collections.emptyList()), "modified", "app added", null, null,
             "weburls", false, false, "paid path", "no", true, "aptoide",
             AppViewFragment.OpenType.OPEN_ONLY, 0, null, "", "origin", false, "marketName", false,
-            false, bdsFlags, "");
+            false, bdsFlags, "", "");
 
     //Given an initialized presenter
     presenter.handleFirstLoad();
@@ -228,8 +240,10 @@ public class AppViewPresenterTest {
     when(appViewManager.loadDownloadAppViewModel(emptyEditorsChoiceAppViewViewModel.getMd5(),
         emptyEditorsChoiceAppViewViewModel.getPackageName(),
         emptyEditorsChoiceAppViewViewModel.getVersionCode(),
-        emptyEditorsChoiceAppViewViewModel.isPaid(),
-        emptyEditorsChoiceAppViewViewModel.getPay())).thenReturn(
+        emptyEditorsChoiceAppViewViewModel.isPaid(), emptyEditorsChoiceAppViewViewModel.getPay(),
+        appViewViewModel.getSignature(), appViewViewModel.getStore()
+            .getId(),
+        appViewViewModel.hasAdvertising() || appViewViewModel.hasBilling())).thenReturn(
         Observable.just(downloadAppViewModel));
 
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);

--- a/app/src/test/java/cm/aptoide/pt/app/AppViewPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/AppViewPresenterTest.java
@@ -162,9 +162,9 @@ public class AppViewPresenterTest {
     when(appViewManager.loadDownloadAppViewModel(errorAppViewViewModel.getMd5(),
         errorAppViewViewModel.getPackageName(), errorAppViewViewModel.getVersionCode(),
         errorAppViewViewModel.isPaid(), errorAppViewViewModel.getPay(),
-        appViewViewModel.getSignature(), appViewViewModel.getStore()
+        errorAppViewViewModel.getSignature(), errorAppViewViewModel.getStore()
             .getId(),
-        appViewViewModel.hasAdvertising() || appViewViewModel.hasBilling())).thenReturn(
+        errorAppViewViewModel.hasAdvertising() || errorAppViewViewModel.hasBilling())).thenReturn(
         Observable.just(downloadAppViewModel));
 
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);


### PR DESCRIPTION
**What does this PR do?**

This PR aims to add the appc app migration flow to the appview

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AppviewViewManager.java

**How should this be manually tested?**

Install Sky Champ on GPlay. Afterwards, look for the appc version on aptoide (should be in bds-store). You should see the update to appc button in this appview and, when pressed, your GPlay app should be deleted and the new appc app installed;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1525](https://aptoide.atlassian.net/browse/ASV-https://aptoide.atlassian.net/browse/ASV-1525)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass