### PR TITLE
[ASV-1403] Fix wallet ads offer events

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -1857,7 +1857,7 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
         EditorialAnalytics.CURATION_CARD_INSTALL,
         EditorialAnalytics.EDITORIAL_BN_CURATION_CARD_INSTALL, PromotionsAnalytics.PROMOTION_DIALOG,
         PromotionsAnalytics.PROMOTIONS_INTERACT, PromotionsAnalytics.VALENTINE_MIGRATOR,
-        AppViewAnalytics.ADS_WALLET_PROMOTION_EVENT);
+        AppViewAnalytics.ADS_BLOCK_BY_OFFER);
   }
 
   @Singleton @Provides AptoideShortcutManager providesShortcutManager() {

--- a/app/src/main/java/cm/aptoide/pt/app/AppViewAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewAnalytics.java
@@ -31,7 +31,7 @@ public class AppViewAnalytics {
   public static final String CLICK_INSTALL = "Clicked on install button";
   public static final String DONATIONS_IMPRESSION = "Donations_Impression";
   public static final String SIMILAR_APP_INTERACT = "Similar_App_Interact";
-  public static final String ADS_WALLET_PROMOTION_EVENT = "Ads_Wallet_Promotion";
+  public static final String ADS_BLOCK_BY_OFFER = "Ads_Block_By_Offer";
   private static final String APPLICATION_NAME = "Application Name";
   private static final String APPLICATION_PUBLISHER = "Application Publisher";
   private static final String ACTION = "Action";
@@ -400,8 +400,8 @@ public class AppViewAnalytics {
             : AnalyticsManager.Action.CLICK, navigationTracker.getViewName(true));
   }
 
-  public void sendAdsWalletPromotionEvent() {
-    analyticsManager.logEvent(null, ADS_WALLET_PROMOTION_EVENT, AnalyticsManager.Action.CLICK,
+  public void sendAdsBlockByOfferEvent() {
+    analyticsManager.logEvent(null, ADS_BLOCK_BY_OFFER, AnalyticsManager.Action.CLICK,
         navigationTracker.getViewName(true));
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -491,7 +491,7 @@ public class AppViewManager {
             return moPubAdsManager.shouldShowAds()
                 .doOnSuccess(showAds -> {
                   if (!showAds) {
-                    sendAdsWalletPromotionEvent();
+                    sendAdsBlockByOfferEvent();
                   }
                 });
           } else {
@@ -504,8 +504,8 @@ public class AppViewManager {
             && !cachedApp.isMature()));
   }
 
-  private void sendAdsWalletPromotionEvent() {
-    appViewAnalytics.sendAdsWalletPromotionEvent();
+  private void sendAdsBlockByOfferEvent() {
+    appViewAnalytics.sendAdsBlockByOfferEvent();
   }
 
   public Single<Boolean> shouldLoadBannerAd() {

--- a/app/src/main/java/cm/aptoide/pt/download/DownloadAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/download/DownloadAnalytics.java
@@ -53,7 +53,7 @@ public class DownloadAnalytics implements cm.aptoide.pt.downloadmanager.Analytic
   private static final String TELECO = "teleco";
   private static final String TRUSTED_BADGE = "Trusted Badge";
   private static final String URL = "url";
-  private static final String ADS_WALLET_PROMOTION = "ads_wallet_promotion";
+  private static final String ADS_BLOCK_BY_OFFER = "ads_block_by_offer";
   private final Map<String, DownloadEvent> cache;
   private final ConnectivityManager connectivityManager;
   private final TelephonyManager telephonyManager;
@@ -266,7 +266,7 @@ public class DownloadAnalytics implements cm.aptoide.pt.downloadmanager.Analytic
       downloadCompleteEvent(navigationTracker.getPreviousScreen(),
           navigationTracker.getCurrentScreen(), md5, packageName, trustedValue, action,
           previousContext,
-          offerResponseStatus.equals(WalletAdsOfferManager.OfferResponseStatus.ADS_SHOW));
+          offerResponseStatus.equals(WalletAdsOfferManager.OfferResponseStatus.ADS_HIDE));
     } else {
       downloadCompleteEvent(navigationTracker.getPreviousScreen(),
           navigationTracker.getCurrentScreen(), md5, packageName, trustedValue, action,
@@ -282,7 +282,7 @@ public class DownloadAnalytics implements cm.aptoide.pt.downloadmanager.Analytic
 
       downloadCompleteEvent(navigationTracker.getPreviousScreen(),
           navigationTracker.getCurrentScreen(), md5, packageName, null, action, previousContext,
-          offerResponseStatus.equals(WalletAdsOfferManager.OfferResponseStatus.ADS_SHOW));
+          offerResponseStatus.equals(WalletAdsOfferManager.OfferResponseStatus.ADS_HIDE));
     } else {
       downloadCompleteEvent(navigationTracker.getPreviousScreen(),
           navigationTracker.getCurrentScreen(), md5, packageName, null, action, previousContext);
@@ -294,7 +294,7 @@ public class DownloadAnalytics implements cm.aptoide.pt.downloadmanager.Analytic
       String previousContext, boolean areAdsBlockedByOffer) {
     HashMap<String, Object> downloadMap =
         createDownloadCompleteEventMap(previousScreen, currentScreen, packageName, trustedValue);
-    downloadMap.put(ADS_WALLET_PROMOTION, areAdsBlockedByOffer);
+    downloadMap.put(ADS_BLOCK_BY_OFFER, areAdsBlockedByOffer);
     DownloadEvent downloadEvent =
         new DownloadEvent(DOWNLOAD_COMPLETE_EVENT, downloadMap, previousContext, action);
     cache.put(id + DOWNLOAD_COMPLETE_EVENT, downloadEvent);
@@ -377,7 +377,7 @@ public class DownloadAnalytics implements cm.aptoide.pt.downloadmanager.Analytic
 
       downloadCompleteEvent(previousScreen, currentScreen, id, packageName, trustedValue, action,
           previousContext,
-          offerResponseStatus.equals(WalletAdsOfferManager.OfferResponseStatus.ADS_SHOW));
+          offerResponseStatus.equals(WalletAdsOfferManager.OfferResponseStatus.ADS_HIDE));
     } else {
       downloadCompleteEvent(previousScreen, currentScreen, id, packageName, trustedValue, action,
           previousContext);


### PR DESCRIPTION
**What does this PR do?**
This PR aims at fixing wallet ads offer analytics events.
If the wallet ads offer is active then an attribute to the download complete event is added saying if the offer blocked the ads (true) or not (false).
Also, if the user does not see an interstitial ad due to the offer, an event without parameters is sent (Ads_Block_By_Offer).

**Database changed?**

   No

**Where should the reviewer start?**

- [x] AppViewAnalytics.java
- [x] DownloadAnalytics.java

**How should this be manually tested?**
Do a download, check that the event is sent with the ads_block_by_offer false. Then install the wallet. Do another download, check that the same parameter is with true. Also, no interstitial ad should be shown there and the Ads_Block_By_Offer event should also be sent.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1403](https://aptoide.atlassian.net/browse/ASV-1403)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [x] Architecture
- [x] Documentation on public interfaces
- [x] Database changed?
- [x] If yes - Database migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] Functional QA tests pass