### PR TITLE
[ASV-1552] Category views fix

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/MoreBundleManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/MoreBundleManager.java
@@ -17,7 +17,16 @@ public class MoreBundleManager {
   }
 
   public Single<HomeBundlesModel> loadBundle(String title, String url) {
-    return bundlesRepository.loadBundles(title, url);
+    return bundlesRepository.loadBundles(title, url)
+        .flatMap(homeBundlesModel -> handleEmptyBundles(title, url, homeBundlesModel));
+  }
+
+  private Single<HomeBundlesModel> handleEmptyBundles(String title, String url,
+      HomeBundlesModel homeBundlesModel) {
+    if (isOnlyEmptyBundles(homeBundlesModel)) {
+      return loadNextBundles(title, url);
+    }
+    return Single.just(homeBundlesModel);
   }
 
   public Single<HomeBundlesModel> loadFreshBundles(String title, String url) {
@@ -26,12 +35,7 @@ public class MoreBundleManager {
 
   public Single<HomeBundlesModel> loadNextBundles(String title, String url) {
     return bundlesRepository.loadNextBundles(title, url)
-        .flatMap(homeBundlesModel -> {
-          if (isOnlyEmptyBundles(homeBundlesModel)) {
-            return loadNextBundles(title, url);
-          }
-          return Single.just(homeBundlesModel);
-        });
+        .flatMap(homeBundlesModel -> handleEmptyBundles(title, url, homeBundlesModel));
   }
 
   public boolean hasMore(String title) {


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing a bug where we wouldn't load the next bundles in home in case the first bundles returned from the api were empty.

**Database changed?**

No

**Where should the reviewer start?**

- [x] MoreBundleManager.java

**How should this be manually tested?**
Open the app, go to the spend your appcoins bundle, open the applications bundle by presisng the more button and then check if new categories were opened. Before fixing this, there wouldn't be any bundles because the first bundles in that category were all empty.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1552](https://aptoide.atlassian.net/browse/ASV-1552)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [x] Architecture
- [x] Documentation on public interfaces
- [x] Database changed?
- [x] If yes - Database migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] Functional QA tests pass