### PR TITLE
[ASV-1583] Added category package name to get ads request from appview;

### DIFF
--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v2/aptwords/GetAdsRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v2/aptwords/GetAdsRequest.java
@@ -59,7 +59,6 @@ public class GetAdsRequest extends Aptwords<GetAdsResponse> {
     this.connectivityManager = connectivityManager;
     this.resources = resources;
     this.versionCodeProvider = versionCodeProvider;
-    this.groupPackageName = null;
   }
 
   public static String getForcedCountry() {
@@ -320,11 +319,11 @@ public class GetAdsRequest extends Aptwords<GetAdsResponse> {
     this.resources = resources;
   }
 
-  public String getGroupPackageName() {
+  private String getGroupPackageName() {
     return groupPackageName;
   }
 
-  public void setGroupPackageName(String groupPackageName) {
+  private void setGroupPackageName(String groupPackageName) {
     this.groupPackageName = groupPackageName;
   }
 

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v2/aptwords/GetAdsRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v2/aptwords/GetAdsRequest.java
@@ -43,6 +43,7 @@ public class GetAdsRequest extends Aptwords<GetAdsResponse> {
   private boolean mature;
   private ConnectivityManager connectivityManager;
   private Resources resources;
+  private String groupPackageName;
 
   private GetAdsRequest(String clientUniqueId, boolean googlePlayServicesAvailable, String oemid,
       boolean mature, Converter.Factory converterFactory, OkHttpClient httpClient, String q,
@@ -58,6 +59,7 @@ public class GetAdsRequest extends Aptwords<GetAdsResponse> {
     this.connectivityManager = connectivityManager;
     this.resources = resources;
     this.versionCodeProvider = versionCodeProvider;
+    this.groupPackageName = null;
   }
 
   public static String getForcedCountry() {
@@ -127,6 +129,7 @@ public class GetAdsRequest extends Aptwords<GetAdsResponse> {
             resources, versionCodeProvider);
 
     getAdsRequest.setRepo(storeName);
+    getAdsRequest.setGroupPackageName(packageName);
 
     return getAdsRequest;
   }
@@ -164,6 +167,7 @@ public class GetAdsRequest extends Aptwords<GetAdsResponse> {
 
     getAdsRequest.setExcludedPackage(excludedPackage);
     getAdsRequest.setKeyword(AptoideUtils.StringU.join(keywords, ",") + "," + "__null__");
+    getAdsRequest.setGroupPackageName(excludedPackage);
 
     return getAdsRequest;
   }
@@ -316,6 +320,14 @@ public class GetAdsRequest extends Aptwords<GetAdsResponse> {
     this.resources = resources;
   }
 
+  public String getGroupPackageName() {
+    return groupPackageName;
+  }
+
+  public void setGroupPackageName(String groupPackageName) {
+    this.groupPackageName = groupPackageName;
+  }
+
   public AdsApplicationVersionCodeProvider getVersionCodeProvider() {
     return versionCodeProvider;
   }
@@ -334,6 +346,7 @@ public class GetAdsRequest extends Aptwords<GetAdsResponse> {
     parameters.put("keywords", keyword);
     parameters.put("oem_id", oemid);
     parameters.put("country", forcedCountry);
+    parameters.put("group_package_name", groupPackageName);
 
     String forceCountry = ToolboxManager.getForceCountry(sharedPreferences);
     if (!TextUtils.isEmpty(forceCountry)) {


### PR DESCRIPTION
**What does this PR do?**

This PR aims to add a new field to send in the getAds request from appview with the packagename of the respective app. This will be used to return ads relative to the app category

**Database changed?**

No

**Where should the reviewer start?**

- [x] GetAdsRequest.java

**How should this be manually tested?**

This isn't in production from the backend side so the only way you can test this is by checking getAds requests on charles, verifying that the new field is being sent from the appview and nowhere else;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1583](https://aptoide.atlassian.net/browse/ASV-1583)

**Code Review Checklist**

- [x] Architecture
- [x] Documentation on public interfaces
- [x] Database changed?
- [x] If yes - Database migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] Functional QA tests pass