### PR TITLE
[Bugfix/ASV-1556] entrypoint utm user properties not being set on second launch

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
+++ b/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
@@ -612,8 +612,7 @@ public abstract class AptoideApplication extends Application {
   private Completable sendAppStartToAnalytics() {
     return firstLaunchAnalytics.sendAppStart(this,
         SecurePreferencesImplementation.getInstance(getApplicationContext(),
-            getDefaultSharedPreferences()), WebService.getDefaultConverter(), getDefaultClient(),
-        getAccountSettingsBodyInterceptorPoolV7(), getTokenInvalidator());
+            getDefaultSharedPreferences()));
   }
 
   private Completable checkAppSecurity() {

--- a/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
@@ -11,8 +11,6 @@ import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.dataprovider.interfaces.TokenInvalidator;
 import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
 import cm.aptoide.pt.dataprovider.ws.v7.BaseBody;
-import cm.aptoide.pt.dataprovider.ws.v7.BiUtmAnalyticsRequest;
-import cm.aptoide.pt.dataprovider.ws.v7.BiUtmAnalyticsRequestBody;
 import cm.aptoide.pt.preferences.secure.SecurePreferences;
 import com.facebook.FacebookSdk;
 import com.facebook.appevents.AppEventsLogger;
@@ -196,10 +194,10 @@ public class FirstLaunchAnalytics {
       return null;
     })
         .doOnNext(__ -> sendPlayProtectEvent())
+        .doOnNext(__ -> setupDimensions(application))
         .filter(firstRun -> SecurePreferences.isFirstRun(sharedPreferences))
-        .doOnNext(dimensions -> setupDimensions(application))
-        .doOnNext(facebookFirstLaunch -> sendFirstLaunchEvent(utmSource, utmMedium, utmCampaign,
-            utmContent, entryPoint))
+        .doOnNext(
+            __ -> sendFirstLaunchEvent(utmSource, utmMedium, utmCampaign, utmContent, entryPoint))
         .toCompletable()
         .subscribeOn(Schedulers.io());
   }

--- a/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
@@ -64,7 +64,7 @@ public class FirstLaunchAnalytics {
     this.packageName = packageName;
   }
 
-  public void sendFirstLaunchEvent(String utmSource, String utmMedium, String utmCampaign,
+  private void sendFirstLaunchEvent(String utmSource, String utmMedium, String utmCampaign,
       String utmContent, String entryPoint) {
     analyticsManager.logEvent(
         createFacebookFirstLaunchDataMap(utmSource, utmMedium, utmCampaign, utmContent, entryPoint),

--- a/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
@@ -243,7 +243,6 @@ public class FirstLaunchAnalytics {
 
   /**
    * Responsible for setting facebook analytics user properties
-   * These were known as custom dimensions in localytics
    */
   private void setUserProperties(String key, String value) {
     Bundle parameters = new Bundle();


### PR DESCRIPTION
**What does this PR do?**

   Facebook UserProperties like UTM's/EntryPoint are only being sent on first launch.
   They should be set every launch so all session events have the correct user properties.
   Some code was deleted from FirstLaunch Analytics because it was not being used. This might be due to a bug that will be open on Jira.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] FirstLaunchAnalytics.java

**How should this be manually tested?**

  Check if all UTM's an entry point user properties are being correctly set in Facebook SDK 

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1556](https://aptoide.atlassian.net/browse/ASV-1556)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass