### PR TITLE
HOTFIX [ASV-1603] MoPub consent

### DIFF
--- a/app/src/cobrand/java/cm/aptoide/pt/FlavourApplicationModule.java
+++ b/app/src/cobrand/java/cm/aptoide/pt/FlavourApplicationModule.java
@@ -4,6 +4,9 @@ import cm.aptoide.accountmanager.AdultContent;
 import cm.aptoide.pt.abtesting.experiments.MoPubBannerAdExperiment;
 import cm.aptoide.pt.abtesting.experiments.MoPubInterstitialAdExperiment;
 import cm.aptoide.pt.abtesting.experiments.MoPubNativeAdExperiment;
+import cm.aptoide.pt.ads.MoPubConsentDialogManager;
+import cm.aptoide.pt.ads.MoPubConsentDialogView;
+import cm.aptoide.pt.ads.MoPubConsentManager;
 import cm.aptoide.pt.ads.WalletAdsOfferCardManager;
 import cm.aptoide.pt.ads.WalletAdsOfferManager;
 import cm.aptoide.pt.preferences.AdultContentManager;
@@ -54,5 +57,20 @@ import javax.inject.Singleton;
 
   @Singleton @Provides WalletAdsOfferCardManager providesWalletAdsOfferCardManager() {
     return new WalletAdsOfferCardManager();
+  }
+
+  @Singleton @Provides MoPubConsentManager providesMoPubConsentManager() {
+    return new MoPubConsentManager();
+  }
+
+  @Singleton @Provides @Named("mopub-consent-dialog-view")
+  MoPubConsentDialogView providesMoPubConsentDialogView(MoPubConsentManager moPubConsentManager) {
+    return moPubConsentManager;
+  }
+
+  @Singleton @Provides @Named("mopub-consent-dialog-manager")
+  MoPubConsentDialogManager providesMoPubConsentDialogManager(
+      MoPubConsentManager moPubConsentManager) {
+    return moPubConsentManager;
   }
 }

--- a/app/src/cobrand/java/cm/aptoide/pt/ads/MoPubConsentManager.java
+++ b/app/src/cobrand/java/cm/aptoide/pt/ads/MoPubConsentManager.java
@@ -1,0 +1,18 @@
+package cm.aptoide.pt.ads;
+
+import cm.aptoide.pt.logger.Logger;
+import rx.Single;
+
+public class MoPubConsentManager implements MoPubConsentDialogManager, MoPubConsentDialogView {
+
+
+
+  @Override public Single<Boolean> shouldShowConsentDialog() {
+    return Single.just(false);
+  }
+
+  @Override public void showConsentDialog() {
+    Logger.getInstance()
+        .d("MoPubConsentManager", "showConsentDialog is disabled");
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -76,6 +76,9 @@ import cm.aptoide.pt.ads.AdsRepository;
 import cm.aptoide.pt.ads.MinimalAdMapper;
 import cm.aptoide.pt.ads.MoPubAdsManager;
 import cm.aptoide.pt.ads.MoPubAnalytics;
+import cm.aptoide.pt.ads.MoPubConsentDialogManager;
+import cm.aptoide.pt.ads.MoPubConsentDialogView;
+import cm.aptoide.pt.ads.MoPubConsentManager;
 import cm.aptoide.pt.ads.PackageRepositoryVersionCodeProvider;
 import cm.aptoide.pt.ads.WalletAdsOfferCardManager;
 import cm.aptoide.pt.ads.WalletAdsOfferManager;
@@ -262,6 +265,7 @@ import com.jakewharton.rxrelay.BehaviorRelay;
 import com.jakewharton.rxrelay.PublishRelay;
 import com.liulishuo.filedownloader.FileDownloader;
 import com.liulishuo.filedownloader.services.DownloadMgrInitialParams;
+import com.mopub.common.MoPub;
 import com.twitter.sdk.android.core.TwitterAuthConfig;
 import com.twitter.sdk.android.core.TwitterCore;
 import com.twitter.sdk.android.core.identity.TwitterAuthClient;
@@ -1169,10 +1173,25 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
   @Singleton @Provides MoPubAdsManager providesMoPubAdsManager(
       MoPubInterstitialAdExperiment moPubInterstitialAdExperiment,
       MoPubBannerAdExperiment moPubBannerAdExperiment,
-      MoPubNativeAdExperiment moPubNativeAdExperiment,
-      WalletAdsOfferManager walletAdsOfferManager) {
+      MoPubNativeAdExperiment moPubNativeAdExperiment, WalletAdsOfferManager walletAdsOfferManager,
+      MoPubConsentManager moPubConsentDialogManager) {
     return new MoPubAdsManager(moPubInterstitialAdExperiment, moPubBannerAdExperiment,
-        moPubNativeAdExperiment, walletAdsOfferManager);
+        moPubNativeAdExperiment, walletAdsOfferManager, moPubConsentDialogManager);
+  }
+
+  @Singleton @Provides MoPubConsentManager providesMoPubConsentManager() {
+    return new MoPubConsentManager(MoPub.getPersonalInformationManager());
+  }
+
+  @Singleton @Provides @Named("mopub-consent-dialog-view")
+  MoPubConsentDialogView providesMoPubConsentDialogView(MoPubConsentManager moPubConsentManager) {
+    return moPubConsentManager;
+  }
+
+  @Singleton @Provides @Named("mopub-consent-dialog-manager")
+  MoPubConsentDialogManager providesMoPubConsentDialogManager(
+      MoPubConsentManager moPubConsentManager) {
+    return moPubConsentManager;
   }
 
   @Singleton @Provides Retrofit providesSearchSuggestionsRetrofit(

--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -76,8 +76,6 @@ import cm.aptoide.pt.ads.AdsRepository;
 import cm.aptoide.pt.ads.MinimalAdMapper;
 import cm.aptoide.pt.ads.MoPubAdsManager;
 import cm.aptoide.pt.ads.MoPubAnalytics;
-import cm.aptoide.pt.ads.MoPubConsentDialogManager;
-import cm.aptoide.pt.ads.MoPubConsentDialogView;
 import cm.aptoide.pt.ads.MoPubConsentManager;
 import cm.aptoide.pt.ads.PackageRepositoryVersionCodeProvider;
 import cm.aptoide.pt.ads.WalletAdsOfferCardManager;
@@ -265,7 +263,6 @@ import com.jakewharton.rxrelay.BehaviorRelay;
 import com.jakewharton.rxrelay.PublishRelay;
 import com.liulishuo.filedownloader.FileDownloader;
 import com.liulishuo.filedownloader.services.DownloadMgrInitialParams;
-import com.mopub.common.MoPub;
 import com.twitter.sdk.android.core.TwitterAuthConfig;
 import com.twitter.sdk.android.core.TwitterCore;
 import com.twitter.sdk.android.core.identity.TwitterAuthClient;
@@ -1177,21 +1174,6 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
       MoPubConsentManager moPubConsentDialogManager) {
     return new MoPubAdsManager(moPubInterstitialAdExperiment, moPubBannerAdExperiment,
         moPubNativeAdExperiment, walletAdsOfferManager, moPubConsentDialogManager);
-  }
-
-  @Singleton @Provides MoPubConsentManager providesMoPubConsentManager() {
-    return new MoPubConsentManager(MoPub.getPersonalInformationManager());
-  }
-
-  @Singleton @Provides @Named("mopub-consent-dialog-view")
-  MoPubConsentDialogView providesMoPubConsentDialogView(MoPubConsentManager moPubConsentManager) {
-    return moPubConsentManager;
-  }
-
-  @Singleton @Provides @Named("mopub-consent-dialog-manager")
-  MoPubConsentDialogManager providesMoPubConsentDialogManager(
-      MoPubConsentManager moPubConsentManager) {
-    return moPubConsentManager;
   }
 
   @Singleton @Provides Retrofit providesSearchSuggestionsRetrofit(

--- a/app/src/main/java/cm/aptoide/pt/ads/MoPubAdsManager.java
+++ b/app/src/main/java/cm/aptoide/pt/ads/MoPubAdsManager.java
@@ -11,15 +11,17 @@ public class MoPubAdsManager {
   private final MoPubBannerAdExperiment moPubBannerAdExperiment;
   private final MoPubNativeAdExperiment moPubNativeAdExperiment;
   private final WalletAdsOfferManager walletAdsOfferManager;
+  private final MoPubConsentDialogManager moPubConsentDialogManager;
 
   public MoPubAdsManager(MoPubInterstitialAdExperiment moPubInterstitialAdExperiment,
       MoPubBannerAdExperiment moPubBannerAdExperiment,
-      MoPubNativeAdExperiment moPubNativeAdExperiment,
-      WalletAdsOfferManager walletAdsOfferManager) {
+      MoPubNativeAdExperiment moPubNativeAdExperiment, WalletAdsOfferManager walletAdsOfferManager,
+      MoPubConsentDialogManager moPubConsentDialogManager) {
     this.moPubInterstitialAdExperiment = moPubInterstitialAdExperiment;
     this.moPubBannerAdExperiment = moPubBannerAdExperiment;
     this.moPubNativeAdExperiment = moPubNativeAdExperiment;
     this.walletAdsOfferManager = walletAdsOfferManager;
+    this.moPubConsentDialogManager = moPubConsentDialogManager;
   }
 
   public Single<Boolean> shouldHaveInterstitialAds() {
@@ -62,5 +64,9 @@ public class MoPubAdsManager {
 
   public Single<Boolean> shouldShowAds() {
     return walletAdsOfferManager.shouldRequestMoPubAd();
+  }
+
+  public Single<Boolean> shouldShowConsentDialog() {
+    return moPubConsentDialogManager.shouldShowConsentDialog();
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/ads/MoPubConsentDialogManager.java
+++ b/app/src/main/java/cm/aptoide/pt/ads/MoPubConsentDialogManager.java
@@ -1,0 +1,8 @@
+package cm.aptoide.pt.ads;
+
+import rx.Single;
+
+public interface MoPubConsentDialogManager {
+
+  Single<Boolean> shouldShowConsentDialog();
+}

--- a/app/src/main/java/cm/aptoide/pt/ads/MoPubConsentDialogView.java
+++ b/app/src/main/java/cm/aptoide/pt/ads/MoPubConsentDialogView.java
@@ -1,0 +1,6 @@
+package cm.aptoide.pt.ads;
+
+public interface MoPubConsentDialogView {
+
+  void showConsentDialog();
+}

--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -651,6 +651,10 @@ public class AppViewManager {
     return promotionStatus;
   }
 
+  public Single<Boolean> shouldShowConsentDialog() {
+    return moPubAdsManager.shouldShowConsentDialog();
+  }
+
   public enum PromotionStatus {
     NO_PROMOTION, NOT_CLAIMED, CLAIMED
   }

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -52,6 +52,7 @@ import cm.aptoide.pt.R;
 import cm.aptoide.pt.ads.AdsRepository;
 import cm.aptoide.pt.ads.MinimalAdMapper;
 import cm.aptoide.pt.ads.MoPubBannerAdListener;
+import cm.aptoide.pt.ads.MoPubConsentDialogView;
 import cm.aptoide.pt.ads.MoPubInterstitialAdClickType;
 import cm.aptoide.pt.ads.MoPubInterstitialAdListener;
 import cm.aptoide.pt.app.AppBoughtReceiver;
@@ -149,6 +150,7 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
   @Inject @Named("marketName") String marketName;
   @Inject @Named("aptoide-theme") String theme;
   @Inject @Named("rating-one-decimal-format") DecimalFormat oneDecimalFormat;
+  @Inject @Named("mopub-consent-dialog-view") MoPubConsentDialogView consentDialogView;
   private Menu menu;
   private Toolbar toolbar;
   private ActionBar actionBar;
@@ -1251,6 +1253,10 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
 
   @Override public void showDownloadingSimilarApps(boolean hasSimilarApps) {
     manageSimilarAppsVisibility(hasSimilarApps, true);
+  }
+
+  @Override public void showConsentDialog() {
+    consentDialogView.showConsentDialog();
   }
 
   private void setupInstallDependencyApp(WalletPromotionViewModel viewModel) {

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -201,6 +201,19 @@ public class AppViewPresenter implements Presenter {
 
   private Completable showBannerAd() {
     return appViewManager.shouldLoadBannerAd()
+        .flatMap(shouldLoadBanner -> {
+          if (shouldLoadBanner) {
+            return appViewManager.shouldShowConsentDialog()
+                .observeOn(viewScheduler)
+                .map(shouldShowConsent -> {
+                  if (shouldShowConsent) {
+                    view.showConsentDialog();
+                  }
+                  return true;
+                });
+          }
+          return Single.just(false);
+        })
         .observeOn(viewScheduler)
         .flatMapCompletable(shouldLoadBanner -> {
           if (shouldLoadBanner) {

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewView.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewView.java
@@ -185,4 +185,6 @@ public interface AppViewView extends InstallAppView {
   Observable<WalletPromotionViewModel> claimAppClick();
 
   void showDownloadingSimilarApps(boolean hasSimilarApps);
+
+  void showConsentDialog();
 }

--- a/app/src/main/java/cm/aptoide/pt/home/Home.java
+++ b/app/src/main/java/cm/aptoide/pt/home/Home.java
@@ -138,4 +138,8 @@ public class Home {
   public Single<Boolean> shouldLoadNativeAd() {
     return moPubAdsManager.shouldLoadNativeAds();
   }
+
+  public Single<Boolean> shouldShowConsentDialog() {
+    return moPubAdsManager.shouldShowConsentDialog();
+  }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
@@ -18,6 +18,7 @@ import android.widget.ProgressBar;
 import cm.aptoide.analytics.implementation.navigation.ScreenTagHistory;
 import cm.aptoide.pt.DeepLinkIntentReceiver;
 import cm.aptoide.pt.R;
+import cm.aptoide.pt.ads.MoPubConsentDialogView;
 import cm.aptoide.pt.bottomNavigation.BottomNavigationActivity;
 import cm.aptoide.pt.bottomNavigation.BottomNavigationItem;
 import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
@@ -44,6 +45,7 @@ import rx.subjects.PublishSubject;
 public class HomeFragment extends NavigationTrackFragment implements HomeView {
 
   private static final String LIST_STATE_KEY = "cm.aptoide.pt.BottomHomeFragment.ListState";
+  private static final String MOPUB_CONSENT_DIALOG_KEY = "MoPub Consent Dialog";
 
   /**
    * The minimum number of items to have below your current scroll position before loading more.
@@ -52,6 +54,7 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
   private static final BottomNavigationItem BOTTOM_NAVIGATION_ITEM = BottomNavigationItem.HOME;
   @Inject HomePresenter presenter;
   @Inject @Named("marketName") String marketName;
+  @Inject @Named("mopub-consent-dialog-view") MoPubConsentDialogView consentDialogView;
   private RecyclerView bundlesList;
   private BundlesAdapter adapter;
   private PublishSubject<HomeEvent> uiEventsListener;
@@ -153,6 +156,7 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
       promotionsHomeDialog.destroyDialog();
       promotionsHomeDialog = null;
     }
+    consentDialogView = null;
     super.onDestroyView();
   }
 
@@ -337,6 +341,10 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
     Intent intent = new Intent(this.getContext(), DeepLinkIntentReceiver.class);
     intent.setData(Uri.parse(url));
     startActivity(intent);
+  }
+
+  @Override public void showConsentDialog() {
+    consentDialogView.showConsentDialog();
   }
 
   private boolean isEndReached() {

--- a/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
@@ -74,6 +74,30 @@ public class HomePresenter implements Presenter {
 
     handleEditorialCardClick();
     handleInstallWalletOfferClick();
+
+    handleMoPubConsentDialog();
+  }
+
+  private void handleMoPubConsentDialog() {
+    view.getLifecycleEvent()
+        .filter(lifecycleEvent -> lifecycleEvent == View.LifecycleEvent.CREATE)
+        .flatMapSingle(model -> home.shouldLoadNativeAd())
+        .filter(loadInterstitial -> loadInterstitial)
+        .flatMapSingle(__ -> handleConsentDialog())
+        .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
+        .subscribe(__ -> {
+        }, throwable -> crashReporter.log(throwable));
+  }
+
+  private Single<Boolean> handleConsentDialog() {
+    return home.shouldShowConsentDialog()
+        .observeOn(viewScheduler)
+        .map(shouldShowConsent -> {
+          if (shouldShowConsent) {
+            view.showConsentDialog();
+          }
+          return true;
+        });
   }
 
   private void handleInstallWalletOfferClick() {

--- a/app/src/main/java/cm/aptoide/pt/home/HomeView.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeView.java
@@ -30,4 +30,6 @@ public interface HomeView extends BundleView {
   Observable<HomeEvent> walletOfferCardInstallWalletClick();
 
   void sendDeeplinkToWalletAppView(String url);
+
+  void showConsentDialog();
 }

--- a/app/src/vanilla/java/cm/aptoide/pt/FlavourApplicationModule.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/FlavourApplicationModule.java
@@ -7,6 +7,9 @@ import cm.aptoide.pt.abtesting.experiments.MoPubBannerAdExperiment;
 import cm.aptoide.pt.abtesting.experiments.MoPubInterstitialAdExperiment;
 import cm.aptoide.pt.abtesting.experiments.MoPubNativeAdExperiment;
 import cm.aptoide.pt.ads.MoPubAnalytics;
+import cm.aptoide.pt.ads.MoPubConsentDialogManager;
+import cm.aptoide.pt.ads.MoPubConsentDialogView;
+import cm.aptoide.pt.ads.MoPubConsentManager;
 import cm.aptoide.pt.ads.WalletAdsOfferCardManager;
 import cm.aptoide.pt.ads.WalletAdsOfferManager;
 import cm.aptoide.pt.ads.WalletAdsOfferService;
@@ -16,6 +19,7 @@ import cm.aptoide.pt.preferences.AdultContentManager;
 import cm.aptoide.pt.preferences.LocalPersistenceAdultContent;
 import cm.aptoide.pt.preferences.Preferences;
 import cm.aptoide.pt.preferences.SecurePreferences;
+import com.mopub.common.MoPub;
 import dagger.Module;
 import dagger.Provides;
 import javax.inject.Named;
@@ -75,5 +79,20 @@ import javax.inject.Singleton;
   @Singleton @Provides WalletAdsOfferCardManager providesWalletAdsOfferCardManager(
       BlacklistManager blacklistManager, PackageRepository packageRepository) {
     return new WalletAdsOfferCardManager(blacklistManager, packageRepository);
+  }
+
+  @Singleton @Provides MoPubConsentManager providesMoPubConsentManager() {
+    return new MoPubConsentManager(MoPub.getPersonalInformationManager());
+  }
+
+  @Singleton @Provides @Named("mopub-consent-dialog-view")
+  MoPubConsentDialogView providesMoPubConsentDialogView(MoPubConsentManager moPubConsentManager) {
+    return moPubConsentManager;
+  }
+
+  @Singleton @Provides @Named("mopub-consent-dialog-manager")
+  MoPubConsentDialogManager providesMoPubConsentDialogManager(
+      MoPubConsentManager moPubConsentManager) {
+    return moPubConsentManager;
   }
 }

--- a/app/src/vanilla/java/cm/aptoide/pt/ads/MoPubConsentManager.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/ads/MoPubConsentManager.java
@@ -1,0 +1,37 @@
+package cm.aptoide.pt.ads;
+
+import android.support.annotation.NonNull;
+import cm.aptoide.pt.logger.Logger;
+import com.mopub.common.privacy.ConsentDialogListener;
+import com.mopub.common.privacy.PersonalInfoManager;
+import com.mopub.mobileads.MoPubErrorCode;
+import rx.Single;
+
+public class MoPubConsentManager implements MoPubConsentDialogManager, MoPubConsentDialogView {
+
+  private final PersonalInfoManager personalInfoManager;
+
+  public MoPubConsentManager(PersonalInfoManager personalInfoManager) {
+    this.personalInfoManager = personalInfoManager;
+  }
+
+  @Override public void showConsentDialog() {
+    personalInfoManager.loadConsentDialog(new ConsentDialogListener() {
+      @Override public void onConsentDialogLoaded() {
+        if (personalInfoManager != null && personalInfoManager.isConsentDialogReady()) {
+          personalInfoManager.showConsentDialog();
+        }
+      }
+
+      @Override public void onConsentDialogLoadFailed(@NonNull MoPubErrorCode moPubErrorCode) {
+        Logger.getInstance()
+            .d("MoPubConsent",
+                "MoPub Consent dialog failed to load due to " + moPubErrorCode.toString());
+      }
+    });
+  }
+
+  @Override public Single<Boolean> shouldShowConsentDialog() {
+    return Single.just(personalInfoManager.shouldShowConsentDialog());
+  }
+}

--- a/app/src/vanilla/java/cm/aptoide/pt/ads/MoPubConsentManager.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/ads/MoPubConsentManager.java
@@ -10,6 +10,7 @@ import rx.Single;
 public class MoPubConsentManager implements MoPubConsentDialogManager, MoPubConsentDialogView {
 
   private final PersonalInfoManager personalInfoManager;
+  private boolean wasMoPubConsentDialogShown;
 
   public MoPubConsentManager(PersonalInfoManager personalInfoManager) {
     this.personalInfoManager = personalInfoManager;
@@ -18,7 +19,10 @@ public class MoPubConsentManager implements MoPubConsentDialogManager, MoPubCons
   @Override public void showConsentDialog() {
     personalInfoManager.loadConsentDialog(new ConsentDialogListener() {
       @Override public void onConsentDialogLoaded() {
-        if (personalInfoManager != null && personalInfoManager.isConsentDialogReady()) {
+        if (personalInfoManager != null
+            && personalInfoManager.isConsentDialogReady()
+            && !wasMoPubConsentDialogShown) {
+          wasMoPubConsentDialogShown = true;
           personalInfoManager.showConsentDialog();
         }
       }


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at showing mopub consent dialog. This is important in order to increase the revenue we get from showing ads.

PS: MoPub provides a method to ask if the consent dialog should be shown or not (where they check if the user already answered or if GDPR applies) but that method has inconsistencies as if we answer the dialog and then request if the dialog should be shown or not it will still answer yes.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] MoPubConsentManager.java

**How should this be manually tested?**
Open the app and you should get the mopub consent dialog straightaway, since it is being requested for the ads in home and for the ads in the appview. Interact with it and test both scenarios (yes or no). In order to get the dialog again, after interacting with it, just reset your advertising id and re-install the app (i thought reseting advertising id was enough but apparently it isn't and there is nothing on the documentation on how to reset it). 

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1603](https://aptoide.atlassian.net/browse/ASV-1603)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass