### PR TITLE
[AS-1497] Fixed curation link to appview not working on first click

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialPresenter.java
@@ -113,9 +113,8 @@ public class EditorialPresenter implements Presenter {
   @VisibleForTesting public void handleClickOnAppCard() {
     view.getLifecycleEvent()
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
-        .flatMap(__ -> editorialManager.loadEditorialViewModel()
-            .toObservable())
-        .flatMap(model -> view.appCardClicked(model))
+        .flatMap(__ -> setUpViewModelOnViewReady())
+        .flatMap(view::appCardClicked)
         .doOnNext(editorialEvent -> {
           editorialNavigator.navigateToAppView(editorialEvent.getId(),
               editorialEvent.getPackageName());

--- a/app/src/test/java/cm/aptoide/pt/app/view/EditorialPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/view/EditorialPresenterTest.java
@@ -174,6 +174,9 @@ public class EditorialPresenterTest {
     //Given an initialized presenter
     editorialPresenter.handleClickOnAppCard();
 
+    //When the view is ready
+    when(view.isViewReady()).thenReturn(Observable.just(null));
+
     //Then it should request and load the editorialViewModel
     when(editorialManager.loadEditorialViewModel()).thenReturn(Single.just(editorialViewModel));
 


### PR DESCRIPTION
**What does this PR do?**

  Fixed curation link from the bottom appeared in editorial content to appview not working on first click (not loading the app view)

**Database changed?**

 No

**Where should the reviewer start?**

-EditorialPresenter.java

**How should this be manually tested?**

  Go to the editorial view and click on the editorial card. It should navigate to the app view loading the app that was clicked.

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/ASV-1497

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass