### PR TITLE
[ASV-1502] Blacklist Appc Card

### DIFF
--- a/app/src/cobrand/java/cm/aptoide/pt/ads/WalletAdsOfferCardManager.java
+++ b/app/src/cobrand/java/cm/aptoide/pt/ads/WalletAdsOfferCardManager.java
@@ -2,7 +2,7 @@ package cm.aptoide.pt.ads;
 
 public class WalletAdsOfferCardManager {
 
-  public boolean shouldShowWalletOfferCard(String blacklistId) {
+  public boolean shouldShowWalletOfferCard(String cardType, String id) {
     return false;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -1581,8 +1581,8 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
 
   @Singleton @Provides BundlesResponseMapper providesBundlesMapper(
       @Named("marketName") String marketName, InstallManager installManager,
-      WalletAdsOfferCardManager walletAdsOfferCardManager) {
-    return new BundlesResponseMapper(installManager, walletAdsOfferCardManager);
+      WalletAdsOfferCardManager walletAdsOfferCardManager, BlacklistManager blacklistManager) {
+    return new BundlesResponseMapper(installManager, walletAdsOfferCardManager, blacklistManager);
   }
 
   @Singleton @Provides UpdatesManager providesUpdatesManager(UpdateRepository updateRepository) {

--- a/app/src/main/java/cm/aptoide/pt/blacklist/BlacklistManager.java
+++ b/app/src/main/java/cm/aptoide/pt/blacklist/BlacklistManager.java
@@ -10,31 +10,32 @@ public class BlacklistManager {
     this.blacklistUnitMapper = blacklistUnitMapper;
   }
 
-  public boolean isBlacklisted(String blacklistId) {
-    return blacklister.isBlacklisted(blacklistUnitMapper.mapToBlacklistUnit(blacklistId));
+  public boolean isBlacklisted(String actionCardType, String id) {
+    return blacklister.isBlacklisted(
+        blacklistUnitMapper.mapActionCardToBlacklistUnit(actionCardType, id));
   }
 
-  public void addImpression(String blacklistId) {
-    blacklister.addImpression(blacklistUnitMapper.mapToBlacklistUnit(blacklistId));
+  public void addImpression(String actionCardType, String id) {
+    blacklister.addImpression(blacklistUnitMapper.mapActionCardToBlacklistUnit(actionCardType, id));
   }
 
-  public void blacklist(String blacklistId) {
-    blacklister.blacklist(blacklistUnitMapper.mapToBlacklistUnit(blacklistId));
+  public void blacklist(String actionCardType, String id) {
+    blacklister.blacklist(blacklistUnitMapper.mapActionCardToBlacklistUnit(actionCardType, id));
   }
 
-  public enum BlacklistUnit {
+  public enum BlacklistTypes {
     WALLET_ADS_OFFER("Wallet_Ads_Offer", 10), APPC_CARD_INFO("Appc_Card_Info", 10);
 
-    private String id;
+    private String type;
     private int maxPossibleImpressions;
 
-    BlacklistUnit(String id, int maxPossibleImpressions) {
-      this.id = id;
+    BlacklistTypes(String type, int maxPossibleImpressions) {
+      this.type = type;
       this.maxPossibleImpressions = maxPossibleImpressions;
     }
 
-    public String getId() {
-      return id;
+    public String getType() {
+      return type;
     }
 
     public int getMaxPossibleImpressions() {

--- a/app/src/main/java/cm/aptoide/pt/blacklist/BlacklistManager.java
+++ b/app/src/main/java/cm/aptoide/pt/blacklist/BlacklistManager.java
@@ -23,13 +23,13 @@ public class BlacklistManager {
     blacklister.blacklist(blacklistUnitMapper.mapActionCardToBlacklistUnit(actionCardType, id));
   }
 
-  public enum BlacklistTypes {
+  public enum BlacklistType {
     WALLET_ADS_OFFER("Wallet_Ads_Offer", 10), APPC_CARD_INFO("Appc_Card_Info", 10);
 
     private String type;
     private int maxPossibleImpressions;
 
-    BlacklistTypes(String type, int maxPossibleImpressions) {
+    BlacklistType(String type, int maxPossibleImpressions) {
       this.type = type;
       this.maxPossibleImpressions = maxPossibleImpressions;
     }

--- a/app/src/main/java/cm/aptoide/pt/blacklist/BlacklistUnit.java
+++ b/app/src/main/java/cm/aptoide/pt/blacklist/BlacklistUnit.java
@@ -1,0 +1,20 @@
+package cm.aptoide.pt.blacklist;
+
+public class BlacklistUnit {
+
+  private String id;
+  private int maxImpressions;
+
+  public BlacklistUnit(String id, int maxImpressions) {
+    this.id = id;
+    this.maxImpressions = maxImpressions;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public int getMaxImpressions() {
+    return maxImpressions;
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/blacklist/BlacklistUnitMapper.java
+++ b/app/src/main/java/cm/aptoide/pt/blacklist/BlacklistUnitMapper.java
@@ -5,11 +5,11 @@ public class BlacklistUnitMapper {
   public BlacklistUnit mapActionCardToBlacklistUnit(String type, String id) {
     switch (type) {
       case "WALLET_ADS_OFFER":
-        return new BlacklistUnit(BlacklistManager.BlacklistTypes.WALLET_ADS_OFFER.getType() + id,
-            BlacklistManager.BlacklistTypes.WALLET_ADS_OFFER.getMaxPossibleImpressions());
+        return new BlacklistUnit(BlacklistManager.BlacklistType.WALLET_ADS_OFFER.getType() + id,
+            BlacklistManager.BlacklistType.WALLET_ADS_OFFER.getMaxPossibleImpressions());
       case "INFO_BUNDLE":
-        return new BlacklistUnit(BlacklistManager.BlacklistTypes.APPC_CARD_INFO.getType() + id,
-            BlacklistManager.BlacklistTypes.APPC_CARD_INFO.getMaxPossibleImpressions());
+        return new BlacklistUnit(BlacklistManager.BlacklistType.APPC_CARD_INFO.getType() + id,
+            BlacklistManager.BlacklistType.APPC_CARD_INFO.getMaxPossibleImpressions());
       default:
         throw new IllegalArgumentException(
             "Wrong blacklist key. Please, make sure you are passing the correct action card type and id.");

--- a/app/src/main/java/cm/aptoide/pt/blacklist/BlacklistUnitMapper.java
+++ b/app/src/main/java/cm/aptoide/pt/blacklist/BlacklistUnitMapper.java
@@ -2,16 +2,17 @@ package cm.aptoide.pt.blacklist;
 
 public class BlacklistUnitMapper {
 
-  public BlacklistManager.BlacklistUnit mapToBlacklistUnit(String blacklistKey) {
-
-    switch (blacklistKey) {
-      case "WALLET_ADS_OFFER_51":
-        return BlacklistManager.BlacklistUnit.WALLET_ADS_OFFER;
-      case "appc_card_info_1":
-        return BlacklistManager.BlacklistUnit.APPC_CARD_INFO;
+  public BlacklistUnit mapActionCardToBlacklistUnit(String type, String id) {
+    switch (type) {
+      case "WALLET_ADS_OFFER":
+        return new BlacklistUnit(BlacklistManager.BlacklistTypes.WALLET_ADS_OFFER.getType() + id,
+            BlacklistManager.BlacklistTypes.WALLET_ADS_OFFER.getMaxPossibleImpressions());
+      case "appc_card_info":
+        return new BlacklistUnit(BlacklistManager.BlacklistTypes.WALLET_ADS_OFFER.getType() + id,
+            BlacklistManager.BlacklistTypes.WALLET_ADS_OFFER.getMaxPossibleImpressions());
       default:
         throw new IllegalArgumentException(
-            "Wrong blacklist key. Please, make sure you are passing the correct type and id.");
+            "Wrong blacklist key. Please, make sure you are passing the correct action card type and id.");
     }
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/blacklist/BlacklistUnitMapper.java
+++ b/app/src/main/java/cm/aptoide/pt/blacklist/BlacklistUnitMapper.java
@@ -7,9 +7,9 @@ public class BlacklistUnitMapper {
       case "WALLET_ADS_OFFER":
         return new BlacklistUnit(BlacklistManager.BlacklistTypes.WALLET_ADS_OFFER.getType() + id,
             BlacklistManager.BlacklistTypes.WALLET_ADS_OFFER.getMaxPossibleImpressions());
-      case "appc_card_info":
-        return new BlacklistUnit(BlacklistManager.BlacklistTypes.WALLET_ADS_OFFER.getType() + id,
-            BlacklistManager.BlacklistTypes.WALLET_ADS_OFFER.getMaxPossibleImpressions());
+      case "INFO_BUNDLE":
+        return new BlacklistUnit(BlacklistManager.BlacklistTypes.APPC_CARD_INFO.getType() + id,
+            BlacklistManager.BlacklistTypes.APPC_CARD_INFO.getMaxPossibleImpressions());
       default:
         throw new IllegalArgumentException(
             "Wrong blacklist key. Please, make sure you are passing the correct action card type and id.");

--- a/app/src/main/java/cm/aptoide/pt/blacklist/Blacklister.java
+++ b/app/src/main/java/cm/aptoide/pt/blacklist/Blacklister.java
@@ -8,17 +8,16 @@ public class Blacklister {
     this.blacklistPersistence = blacklistPersistence;
   }
 
-  public boolean isBlacklisted(BlacklistManager.BlacklistUnit blacklistUnit) {
+  public boolean isBlacklisted(BlacklistUnit blacklistUnit) {
     return blacklistPersistence.isBlacklisted(blacklistUnit.getId(),
-        blacklistUnit.getMaxPossibleImpressions());
+        blacklistUnit.getMaxImpressions());
   }
 
-  public void addImpression(BlacklistManager.BlacklistUnit blacklistUnit) {
-    blacklistPersistence.addImpression(blacklistUnit.getId(),
-        blacklistUnit.getMaxPossibleImpressions());
+  public void addImpression(BlacklistUnit blacklistUnit) {
+    blacklistPersistence.addImpression(blacklistUnit.getId(), blacklistUnit.getMaxImpressions());
   }
 
-  public void blacklist(BlacklistManager.BlacklistUnit blacklistUnit) {
+  public void blacklist(BlacklistUnit blacklistUnit) {
     blacklistPersistence.blacklist(blacklistUnit.getId());
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/BundlesResponseMapper.java
+++ b/app/src/main/java/cm/aptoide/pt/home/BundlesResponseMapper.java
@@ -1,6 +1,7 @@
 package cm.aptoide.pt.home;
 
 import cm.aptoide.pt.ads.WalletAdsOfferCardManager;
+import cm.aptoide.pt.blacklist.BlacklistManager;
 import cm.aptoide.pt.dataprovider.model.v2.GetAdsResponse;
 import cm.aptoide.pt.dataprovider.model.v7.AppCoinsCampaign;
 import cm.aptoide.pt.dataprovider.model.v7.Event;
@@ -29,11 +30,13 @@ public class BundlesResponseMapper {
 
   private final InstallManager installManager;
   private final WalletAdsOfferCardManager walletAdsOfferCardManager;
+  private final BlacklistManager blacklistManager;
 
   public BundlesResponseMapper(InstallManager installManager,
-      WalletAdsOfferCardManager walletAdsOfferCardManager) {
+      WalletAdsOfferCardManager walletAdsOfferCardManager, BlacklistManager blacklistManager) {
     this.installManager = installManager;
     this.walletAdsOfferCardManager = walletAdsOfferCardManager;
+    this.blacklistManager = blacklistManager;
   }
 
   public List<HomeBundle> fromWidgetsToBundles(List<GetStoreWidgets.WSWidget> widgetBundles) {
@@ -76,14 +79,18 @@ public class BundlesResponseMapper {
           appBundles.add(new AdBundle(title,
               new AdsTagWrapper(((GetAdsResponse) viewObject).getAds(), widgetTag),
               new Event().setName(Event.Name.getAds), widgetTag));
-        } else if (type.equals(HomeBundle.BundleType.INFO_BUNDLE) || type.equals(
-            HomeBundle.BundleType.EDITORIAL)) {
+        } else if (type.equals(HomeBundle.BundleType.EDITORIAL)) {
+          appBundles.add(new ActionBundle(title, type, event, widgetTag,
+              map((ActionItemResponse) viewObject)));
+        } else if (type.equals(HomeBundle.BundleType.INFO_BUNDLE)) {
           ActionItem actionItem = map((ActionItemResponse) viewObject);
-          appBundles.add(new ActionBundle(title, type, event, widgetTag, actionItem));
+          if (!blacklistManager.isBlacklisted(type.toString(), actionItem.getCardId())) {
+            appBundles.add(new ActionBundle(title, type, event, widgetTag, actionItem));
+          }
         } else if (type.equals(HomeBundle.BundleType.WALLET_ADS_OFFER)) {
           ActionItem actionItem = map((ActionItemResponse) viewObject);
-          if (walletAdsOfferCardManager.shouldShowWalletOfferCard(
-              type + "_" + actionItem.getCardId())) {
+          if (walletAdsOfferCardManager.shouldShowWalletOfferCard(type.toString(),
+              actionItem.getCardId())) {
             appBundles.add(new ActionBundle(title, type, event, widgetTag, actionItem));
           }
         }

--- a/app/src/main/java/cm/aptoide/pt/home/Home.java
+++ b/app/src/main/java/cm/aptoide/pt/home/Home.java
@@ -95,15 +95,15 @@ public class Home {
 
   public Completable remove(ActionBundle bundle) {
     return Completable.fromAction(() -> blacklistManager.blacklist(bundle.getType()
-        .toString() + "_" + bundle.getActionItem()
+        .toString(), bundle.getActionItem()
         .getCardId()))
         .andThen(bundlesRepository.remove(bundle));
   }
 
   public Completable actionBundleImpression(ActionBundle bundle) {
-    return Completable.fromAction(() -> blacklistManager.addImpression(
-        bundle.getType() + "_" + bundle.getActionItem()
-            .getCardId()));
+    return Completable.fromAction(() -> blacklistManager.addImpression(bundle.getType()
+        .toString(), bundle.getActionItem()
+        .getCardId()));
   }
 
   public Single<HomePromotionsWrapper> hasPromotionApps() {

--- a/app/src/vanilla/java/cm/aptoide/pt/ads/WalletAdsOfferCardManager.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/ads/WalletAdsOfferCardManager.java
@@ -14,8 +14,8 @@ public class WalletAdsOfferCardManager {
     this.packageRepository = packageRepository;
   }
 
-  public boolean shouldShowWalletOfferCard(String blacklistId) {
-    return !blacklistManager.isBlacklisted(blacklistId) && !packageRepository.isAppInstalled(
+  public boolean shouldShowWalletOfferCard(String type, String id) {
+    return !blacklistManager.isBlacklisted(type, id) && !packageRepository.isAppInstalled(
         "com.appcoins.wallet");
   }
 }


### PR DESCRIPTION
**What does this PR do?**
This PR aims at implementing the blacklisting on the appc card. Since the mark as read api was deprected, we changed the blacklisting to the clientside. The code regarding the impressions of this card had to be adapted to this new clientside blacklist manager.

Also, i refactored the blacklist manager a bit in order to allow dynamic card id blacklisting.

**Database changed?**

No

**Where should the reviewer start?**

- [x] BundlesResponseMapper.java
- [ ] Bar.kt

**How should this be manually tested?**
Since the APPC card is not live, you need to rewrite it on charles. Then scroll up and down to increase the impressions and check that after 10 impressions it was removed. Note: it is possible that it is cached so to check if it was correctly removed, you can just pull to refresh, which bypasses the cache.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1502](https://aptoide.atlassian.net/browse/ASV-1502)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [x] Architecture
- [x] Documentation on public interfaces
- [x] Database changed?
- [x] If yes - Database migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] Functional QA tests pass