### PR TITLE
[ASV-1628] MoPub GDPR Dialog fix

### DIFF
--- a/app/src/vanilla/java/cm/aptoide/pt/FlavourApplicationModule.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/FlavourApplicationModule.java
@@ -19,7 +19,6 @@ import cm.aptoide.pt.preferences.AdultContentManager;
 import cm.aptoide.pt.preferences.LocalPersistenceAdultContent;
 import cm.aptoide.pt.preferences.Preferences;
 import cm.aptoide.pt.preferences.SecurePreferences;
-import com.mopub.common.MoPub;
 import dagger.Module;
 import dagger.Provides;
 import javax.inject.Named;
@@ -82,7 +81,7 @@ import javax.inject.Singleton;
   }
 
   @Singleton @Provides MoPubConsentManager providesMoPubConsentManager() {
-    return new MoPubConsentManager(MoPub.getPersonalInformationManager());
+    return new MoPubConsentManager();
   }
 
   @Singleton @Provides @Named("mopub-consent-dialog-view")

--- a/app/src/vanilla/java/cm/aptoide/pt/ads/MoPubConsentManager.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/ads/MoPubConsentManager.java
@@ -2,6 +2,7 @@ package cm.aptoide.pt.ads;
 
 import android.support.annotation.NonNull;
 import cm.aptoide.pt.logger.Logger;
+import com.mopub.common.MoPub;
 import com.mopub.common.privacy.ConsentDialogListener;
 import com.mopub.common.privacy.PersonalInfoManager;
 import com.mopub.mobileads.MoPubErrorCode;
@@ -9,14 +10,13 @@ import rx.Single;
 
 public class MoPubConsentManager implements MoPubConsentDialogManager, MoPubConsentDialogView {
 
-  private final PersonalInfoManager personalInfoManager;
   private boolean wasMoPubConsentDialogShown;
 
-  public MoPubConsentManager(PersonalInfoManager personalInfoManager) {
-    this.personalInfoManager = personalInfoManager;
+  public MoPubConsentManager() {
   }
 
   @Override public void showConsentDialog() {
+    PersonalInfoManager personalInfoManager = MoPub.getPersonalInformationManager();
     personalInfoManager.loadConsentDialog(new ConsentDialogListener() {
       @Override public void onConsentDialogLoaded() {
         if (personalInfoManager != null
@@ -36,6 +36,7 @@ public class MoPubConsentManager implements MoPubConsentDialogManager, MoPubCons
   }
 
   @Override public Single<Boolean> shouldShowConsentDialog() {
+    PersonalInfoManager personalInfoManager = MoPub.getPersonalInformationManager();
     return Single.just(personalInfoManager.shouldShowConsentDialog());
   }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing the MoPub GDPR impression. There was a bug created after merging this code from release/v9.7.0.2 to dev because when adding the ads entry point, the MoPubAdsManager started being initialized on the app startup and here the MoPub wasn't initialized yet, meaning that the personalInfoManager was null, leading to a crash when trying to show the MoPub GDPR dialog.

**Database changed?**

   No

**Where should the reviewer start?**

- [x] MoPubConsentManager.java

**How should this be manually tested?**

  Reset advertising id and open the app. You should see the MoPub GDPR dialog.
Please remember that this is only shown to the users that should see ads, so make sure you are on the correct ab test group and that you dont have the Appcoins wallet installed.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1628](https://aptoide.atlassian.net/browse/ASV-1628)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [x] Documentation on public interfaces
- [x] Database changed?
- [x] If yes - Database migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] Functional QA tests pass