### PR TITLE
[ASV-1653] - Login button toast

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialFragment.java
@@ -585,6 +585,7 @@ public class EditorialFragment extends NavigationTrackFragment
   @Override public void showLoginDialog() {
     Snackbar.make(getView(), getString(R.string.editorial_reactions_login_short),
         Snackbar.LENGTH_LONG)
+        .setAction(R.string.login, snackView -> snackListener.onNext(null))
         .show();
   }
 


### PR DESCRIPTION
**What does this PR do?**

   Fixes a bug where no login button appeared on the toast on the Editorial.

**Database changed?**

  No

**Where should the reviewer start?**

- [ ] EditorialFragment.java

**How should this be manually tested?**

  Without being logged in, navigate to editorial, chose an article, an try to react more than 5 times. The toast should be displayed and have a button to log in.

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/ASV-1653


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass