### PR TITLE
[ASV-1665] Remove base body from requests

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/AdsBundleViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/home/AdsBundleViewHolder.java
@@ -33,9 +33,9 @@ class AdsBundleViewHolder extends AppBundleViewHolder {
     super(view);
     this.marketName = marketName;
     this.uiEventsListener = uiEventsListener;
-    bundleTitle = (TextView) view.findViewById(R.id.bundle_title);
-    moreButton = (Button) view.findViewById(R.id.bundle_more);
-    appsList = (RecyclerView) view.findViewById(R.id.apps_list);
+    bundleTitle = view.findViewById(R.id.bundle_title);
+    moreButton = view.findViewById(R.id.bundle_more);
+    appsList = view.findViewById(R.id.apps_list);
     appsInBundleAdapter =
         new AdsInBundleAdapter(new ArrayList<>(), oneDecimalFormatter, adClickedEvents);
     LinearLayoutManager layoutManager =

--- a/app/src/main/java/cm/aptoide/pt/reactions/network/ReactionsRemoteService.java
+++ b/app/src/main/java/cm/aptoide/pt/reactions/network/ReactionsRemoteService.java
@@ -108,7 +108,7 @@ public class ReactionsRemoteService implements ReactionsService {
         @Path("uid") String uid, @retrofit2.http.Body Body body);
   }
 
-  public static class Body extends BaseBody {
+  public static class Body {
 
     private String objectUid;
     private String groupUid;


### PR DESCRIPTION
**What does this PR do?**

   This PR aims to remove the un-needed fields from the Reactions request Body.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] ReactionsRemoteService.java

**How should this be manually tested?**

  Open the editorial, react to a card, and check that request in charles. The body should only have:
```
BODY:
{  
    "type": "thumbs_up",
    "group_uid": "apps-group",
    "object_uid": "23r2f24f24f2e424f"
}
```    
 for the first reaction.

and:

```
BODY:
{  
    "type": "love"
}
```  
  for the second or higher reaction.

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/ASV-1665



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass