### PR TITLE
[ASV-1666] Reactions related views are now hidden, and calls are not …

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialPresenter.java
@@ -62,11 +62,7 @@ public class EditorialPresenter implements Presenter {
     handleClickActionButtonCard();
     handleMovingCollapse();
 
-    handleReactionButtonClick();
-    handleUserReaction();
-    handleLongPressReactionButton();
     handleSnackLogInClick();
-    onCreateLoadReactionModel();
   }
 
   @VisibleForTesting public void onCreateLoadAppOfTheWeek() {

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListPresenter.java
@@ -44,9 +44,6 @@ public class EditorialListPresenter implements Presenter {
     handleBottomReached();
     handleUserImageClick();
     loadUserImage();
-    handleReactionButtonClick();
-    handleLongPressReactionButton();
-    handleUserReaction();
     handleSnackLogInClick();
   }
 
@@ -68,9 +65,7 @@ public class EditorialListPresenter implements Presenter {
 
   private Observable<CurationCard> loadEditorialAndReactions(boolean loadMore, boolean refresh) {
     return loadEditorialListViewModel(loadMore, refresh).toObservable()
-        .flatMapIterable(EditorialListViewModel::getCurationCards)
-        .flatMapSingle(
-            curationCard -> loadReactionModel(curationCard.getId(), curationCard.getType()));
+        .flatMapIterable(EditorialListViewModel::getCurationCards);
   }
 
   @VisibleForTesting public void loadUserImage() {

--- a/app/src/main/java/cm/aptoide/pt/home/EditorialBundleViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/home/EditorialBundleViewHolder.java
@@ -69,7 +69,6 @@ public class EditorialBundleViewHolder extends AppBundleViewHolder {
       String numberOfViews, String type, String date, int position, HomeBundle homeBundle,
       List<TopReaction> reactions, int numberOfReactions, String userReaction) {
     clearReactions();
-    setReactions(reactions, numberOfReactions, userReaction);
     ImageLoader.with(itemView.getContext())
         .load(icon, backgroundImage);
     editorialTitle.setText(title);
@@ -78,14 +77,6 @@ public class EditorialBundleViewHolder extends AppBundleViewHolder {
         formatNumberOfViews(numberOfViews)));
     setCurationCardBubble(subTitle);
     setupCalendarDateString(date);
-    reactButton.setOnClickListener(view -> uiEventsListener.onNext(
-        new EditorialHomeEvent(cardId, type, homeBundle, position,
-            HomeEvent.Type.REACT_SINGLE_PRESS)));
-    reactButton.setOnLongClickListener(view -> {
-      uiEventsListener.onNext(new EditorialHomeEvent(cardId, type, homeBundle, position,
-          HomeEvent.Type.REACT_LONG_PRESS));
-      return true;
-    });
     editorialCard.setOnClickListener(view -> uiEventsListener.onNext(
         new EditorialHomeEvent(cardId, type, homeBundle, position, HomeEvent.Type.EDITORIAL)));
   }

--- a/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
@@ -74,12 +74,6 @@ public class HomePresenter implements Presenter {
 
     handleInstallWalletOfferClick();
 
-    handleReactionButtonClick();
-
-    handleLongPressedReactionButton();
-
-    handleUserReaction();
-
     handleSnackLogInClick();
 
     handleMoPubConsentDialog();
@@ -312,7 +306,7 @@ public class HomePresenter implements Presenter {
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
         .observeOn(viewScheduler)
         .doOnNext(created -> view.showLoading())
-        .flatMap(__ -> loadHomeAndReactions())
+        .flatMapSingle(__ -> loadHome())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {
         }, crashReporter::log);

--- a/app/src/main/res/layout/editorial_action_item.xml
+++ b/app/src/main/res/layout/editorial_action_item.xml
@@ -87,6 +87,7 @@
           android:layout_height="wrap_content"
           android:layout_marginLeft="16dp"
           android:layout_marginStart="16dp"
+          android:visibility="gone"
           />
 
       <include

--- a/app/src/main/res/layout/editorial_layout.xml
+++ b/app/src/main/res/layout/editorial_layout.xml
@@ -126,6 +126,7 @@
             android:layout_marginBottom="8dp"
             android:layout_marginLeft="8dp"
             android:layout_marginStart="8dp"
+            android:visibility="gone"
             />
       </android.support.v7.widget.CardView>
     </RelativeLayout>


### PR DESCRIPTION
…being done.

**What does this PR do?**

   This PR aims to hide reactions views and remove calls for the reactions WS.

**Database changed?**

    No

**Where should the reviewer start?**

- [ ] EditorialPresenter.java

**How should this be manually tested?**

  Check on charles if the requests regarding reactions are not being done (api.aptoide.pt), and check the view if the reactions are hidden.

**What are the relevant tickets?**

   https://aptoide.atlassian.net/browse/ASV-1666



**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass