### PR TITLE
[ASV-1652] Changed flurry keys so that the release key is only used i…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,7 +122,6 @@ android {
     debug {
       testCoverageEnabled = false
       buildConfigField "boolean", "CRASH_REPORTS_DISABLED", "true"
-      buildConfigField "String", "FLURRY_KEY", "\"" + project.FLURRY_DEBUG_KEY + "\""
       ext.enableCrashlytics = false
       zipAlignEnabled false
       minifyEnabled false
@@ -134,7 +133,6 @@ android {
     release {
       testCoverageEnabled = true
       buildConfigField "boolean", "CRASH_REPORTS_DISABLED", "false"
-      buildConfigField "String", "FLURRY_KEY", "\"" + project.FLURRY_KEY + "\""
       zipAlignEnabled true
       minifyEnabled true
       shrinkResources true
@@ -277,6 +275,15 @@ android {
       variant.buildConfigField "String", "PAYPAL_ENVIRONMENT",
           "\"" + project.PAYPAL_ENVIRONMENT_LIVE + "\""
       variant.buildConfigField "String", "PAYPAL_KEY", "\"" + project.PAYPAL_PRODUCTION_KEY + "\""
+    }
+
+    def type = variant.variantData.variantConfiguration.buildType.name
+
+    if(flavors[1].name.contains('prod') && type == 'release'){
+      buildConfigField "String", "FLURRY_KEY", "\"" + project.FLURRY_KEY + "\""
+    }
+    else{
+      buildConfigField "String", "FLURRY_KEY", "\"" + project.FLURRY_DEBUG_KEY + "\""
     }
 
     variant.buildConfigField "String", "MOPUB_IRONSOURCE_APPLICATION_ID",

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -279,10 +279,9 @@ android {
 
     def type = variant.variantData.variantConfiguration.buildType.name
 
-    if(flavors[1].name.contains('prod') && type == 'release'){
+    if (flavors[1].name.contains('prod') && type == 'release') {
       buildConfigField "String", "FLURRY_KEY", "\"" + project.FLURRY_KEY + "\""
-    }
-    else{
+    } else {
       buildConfigField "String", "FLURRY_KEY", "\"" + project.FLURRY_DEBUG_KEY + "\""
     }
 
@@ -300,7 +299,6 @@ android {
         "\"" + project.MOPUB_FYBER_INTERSTITIAL_SPOT_ID + "\""
     variant.buildConfigField "String", "MOPUB_FYBER_BANNER_SPOT_ID",
         "\"" + project.MOPUB_FYBER_BANNER_SPOT_ID + "\""
-
 
     variant.buildConfigField "String", "MOPUB_VIDEO_APPVIEW_PLACEMENT_ID",
         "\"" + project.MOPUB_VIDEO_PLACEMENT_ID_PROD + "\""
@@ -560,7 +558,6 @@ dependencies {
 
   //careful updating this because of support library conflicts
   implementation "com.airbnb.android:lottie:${LOTTIE_VERSION}"
-
 }
 
 String getDate() {


### PR DESCRIPTION
**What does this PR do?**

This PR aims to use flurry release key only for vanillaProdRelease and CobrandProdRelease builds;

**Database changed?**

No

**Where should the reviewer start?**

- [x] build.gradle


**How should this be manually tested?**

Run all the build variants and check the generated buildconfig file to make sure that only those are using the prod key and all others are using dev key;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1652](https://aptoide.atlassian.net/browse/ASV-1652)

**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass