### PR TITLE
[Hotfix/ASV-1675] Recycler View IndexOutOfBoundsException

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
@@ -518,7 +518,7 @@ public class HomePresenter implements Presenter {
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
         .flatMap(created -> view.refreshes()
             .doOnNext(__ -> homeAnalytics.sendPullRefreshInteractEvent())
-            .flatMap(refreshed -> loadFreshBundlesAndReactions())
+            .flatMapSingle(refreshed -> loadFreshBundles())
             .retry())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(bundles -> {


### PR DESCRIPTION
**What does this PR do?**

  Attempt to fix recycler view IndexOutOfBoundsException. First, reactions should not be called on pull to refresh, second - it seems that the updateEditorial method in the BundlesAdapter is causing this problem. By disabling reactions completely we will be able to measure if this specific method was indeed crashing the app.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] HomePresenter.java

**How should this be manually tested?**

  Open home, pull-to-refresh > swipe down until load more - repeat very fast 100 times until it crashes (this would crash in my hands in 20~ secs)

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1675](https://aptoide.atlassian.net/browse/ASV-1675)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass