### PR TITLE
[ASV-1678] Fixed bug related to reactions crashing view;

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/MoreBundleFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/MoreBundleFragment.java
@@ -291,8 +291,8 @@ public class MoreBundleFragment extends NavigationTrackFragment implements MoreB
         .map(visibleItem -> new HomeEvent(adapter.getBundle(visibleItem), visibleItem, null));
   }
 
-  @Override public void updateEditorialCards(List<HomeBundle> homeBundles) {
-    adapter.updateEditorials(homeBundles);
+  @Override public void updateEditorialCards() {
+    adapter.updateEditorials();
     if (listState != null) {
       bundlesList.getLayoutManager()
           .onRestoreInstanceState(listState);

--- a/app/src/main/java/cm/aptoide/pt/home/BundlesAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/BundlesAdapter.java
@@ -185,8 +185,7 @@ public class BundlesAdapter extends RecyclerView.Adapter<AppBundleViewHolder> {
     return bundles.get(visibleItem);
   }
 
-  public synchronized void updateEditorials(List<HomeBundle> homeBundles) {
-    this.bundles = homeBundles;
+  public synchronized void updateEditorials() {
     for (int i = 0; i < bundles.size(); i++) {
       if (bundles.get(i) instanceof ActionBundle) {
         notifyItemChanged(i);

--- a/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
@@ -288,8 +288,8 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
         .map(visibleItem -> new HomeEvent(adapter.getBundle(visibleItem), visibleItem, null));
   }
 
-  @Override public void updateEditorialCards(List<HomeBundle> homeBundles) {
-    adapter.updateEditorials(homeBundles);
+  @Override public void updateEditorialCards() {
+    adapter.updateEditorials();
     if (listState != null) {
       bundlesList.getLayoutManager()
           .onRestoreInstanceState(listState);

--- a/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
@@ -143,7 +143,7 @@ public class HomePresenter implements Presenter {
   private Single<List<HomeBundle>> loadReactionModel(String cardId, String groupId) {
     return home.loadReactionModel(cardId, groupId)
         .observeOn(viewScheduler)
-        .doOnSuccess(view::updateEditorialCards);
+        .doOnSuccess(homeBundles -> view.updateEditorialCards());
   }
 
   private Observable<List<HomeBundle>> loadHomeAndReactions() {

--- a/app/src/main/java/cm/aptoide/pt/home/apps/BundleView.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/BundleView.java
@@ -51,5 +51,5 @@ public interface BundleView extends View {
 
   Observable<HomeEvent> visibleBundles();
 
-  void updateEditorialCards(List<HomeBundle> homeBundles);
+  void updateEditorialCards();
 }

--- a/app/src/test/java/cm/aptoide/pt/navigation/HomePresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/navigation/HomePresenterTest.java
@@ -366,7 +366,7 @@ public class HomePresenterTest {
     //It should send the corresponding analytic and load the reactions and update the corresponding card
     verify(homeAnalytics).sendDeleteEvent();
     verify(home).loadReactionModel("1", GROUP_ID);
-    verify(view).updateEditorialCards(bundlesModel.getList());
+    verify(view).updateEditorialCards();
   }
 
   @Test public void handleReactionButtonLongPressTest() {
@@ -395,7 +395,7 @@ public class HomePresenterTest {
     //It should send the corresponding analytic and load the reactions and update the corresponding card
     verify(homeAnalytics).sendReactedEvent();
     verify(home).loadReactionModel("1", GROUP_ID);
-    verify(view).updateEditorialCards(bundlesModel.getList());
+    verify(view).updateEditorialCards();
   }
 
   @Test public void handleUserReactionWithSameReactionTest() {
@@ -412,7 +412,7 @@ public class HomePresenterTest {
     verify(homeAnalytics, times(0)).sendReactedEvent();
     when(home.loadReactionModel("1", GROUP_ID)).thenReturn(Single.just(bundlesModel.getList()));
     verify(home, times(0)).loadReactionModel("1", GROUP_ID);
-    verify(view, times(0)).updateEditorialCards(bundlesModel.getList());
+    verify(view, times(0)).updateEditorialCards();
   }
 
   @Test public void handleSnackLogInTest() {


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix the reported crash regarding reactions in home

**Database changed?**

No

**Where should the reviewer start?**

- [x] BundlesAdapter.java

**How should this be manually tested?**

Try to reproduce the bug (pull-to-refresh in home, followed by rapidly scrolling now). The crash should not be happening anymore

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1678](https://aptoide.atlassian.net/browse/ASV-1678)

**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass