### PR TITLE
[Bugfix/ASV-1690] fix resume download appview

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppViewAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewAnalytics.java
@@ -307,7 +307,7 @@ public class AppViewAnalytics {
       downloadAnalytics.installClicked(download.getMd5(), download.getPackageName(), trustedValue,
           editorsChoice, InstallType.INSTALL, action, offerResponseStatus);
     }
-    if (downloadAction.equals(DownloadModel.Action.MIGRATE)) {
+    if (DownloadModel.Action.MIGRATE.equals(downloadAction)) {
       downloadAnalytics.migrationClicked(download.getMd5(), download.getPackageName(), trustedValue,
           editorsChoice, InstallType.UPDATE_TO_APPC, action, offerResponseStatus);
     }

--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -343,7 +343,7 @@ public class AppViewManager {
             .doOnSuccess(status -> {
               setupDownloadEvents(download, downloadAction, appId, trustedValue,
                   editorsChoicePosition, status);
-              if (downloadAction.equals(DownloadModel.Action.MIGRATE)) {
+              if (DownloadModel.Action.MIGRATE.equals(downloadAction)) {
                 setupMigratorUninstallEvent(download.getPackageName());
               }
             })


### PR DESCRIPTION
**What does this PR do?**

   downloadAction is null on resume. avoiding npe by reverting the equals verification.
   For future investigation we should check why action is null on resume, might be the same reason we are not able to fire installations in some cases. 

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppViewManager.java
- [ ] AppViewAnalytics.java

**How should this be manually tested?**

  Test downloads in appview, editorial and apps. Pause/resume/cancel.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1690](https://aptoide.atlassian.net/browse/ASV-1690)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass