### PR TITLE
[Bugfix/ASV-1708] fix deep link play

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
@@ -134,7 +134,7 @@ public class DeepLinkIntentReceiver extends ActivityView {
         intent = startFromPackageName(u.getQueryParameter("id"));
       } else if (u.getHost()
           .contains("play.google.com") && u.getPath()
-          .equalsIgnoreCase("store/apps/details")) {
+          .contains("store/apps/details")) {
         intent = dealWithGoogleHost(u);
       } else if ("aptword".equalsIgnoreCase(u.getScheme())) {
         intent = dealWithAptword(uri);


### PR DESCRIPTION
**What does this PR do?**

   Fixes the store/apps/details http deeplink that is used in many apps/web clients to redirect users to an App view. uri.getPath returns the path with a trailling slash and we were comparing with an equals with (store/apps/details) which would return false with /store/apps/details. Since I feel this behaviour was working correctly in the past and no one touchs this validation for more than one year, I think is safer to use contains to support store/apps/details.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] DeepLinkIntentReceiver.java

**How should this be manually tested?**

  There is an app called Deep Link Tester which makes deeplink testing easier.

  Flow on how to test this or QA Tickets related to this use-case: [ASV-1708](https://aptoide.atlassian.net/browse/ASV-1708)


**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1708](https://aptoide.atlassian.net/browse/ASV-1708)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass