### PR TITLE
[bugfix/ASV-1694] Duplicated list apps updates

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/notification/PullingContentService.java
+++ b/app/src/main/java/cm/aptoide/pt/notification/PullingContentService.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.BitmapFactory;
 import android.os.IBinder;
+import android.os.SystemClock;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
 import cm.aptoide.pt.AptoideApplication;
@@ -56,7 +57,8 @@ public class PullingContentService extends BaseService {
     intent.setAction(action);
     PendingIntent pendingIntent =
         PendingIntent.getService(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
-    am.setInexactRepeating(AlarmManager.ELAPSED_REALTIME, time, time, pendingIntent);
+    am.setInexactRepeating(AlarmManager.ELAPSED_REALTIME, getElapsedRealtimeTrigger(time),
+        getElapsedRealtimeTrigger(time), pendingIntent);
   }
 
   @Override public void onCreate() {
@@ -102,6 +104,10 @@ public class PullingContentService extends BaseService {
     Intent intent = new Intent(context, PullingContentService.class);
     intent.setAction(action);
     return (PendingIntent.getService(context, 0, intent, PendingIntent.FLAG_NO_CREATE) != null);
+  }
+
+  private long getElapsedRealtimeTrigger(long trigger) {
+    return SystemClock.elapsedRealtime() + trigger;
   }
 
   /**

--- a/app/src/main/java/cm/aptoide/pt/notification/PullingContentService.java
+++ b/app/src/main/java/cm/aptoide/pt/notification/PullingContentService.java
@@ -56,7 +56,7 @@ public class PullingContentService extends BaseService {
     intent.setAction(action);
     PendingIntent pendingIntent =
         PendingIntent.getService(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
-    am.setInexactRepeating(AlarmManager.ELAPSED_REALTIME, 5000, time, pendingIntent);
+    am.setInexactRepeating(AlarmManager.ELAPSED_REALTIME, time, time, pendingIntent);
   }
 
   @Override public void onCreate() {


### PR DESCRIPTION
**What does this PR do?**

   This essentially fixes a timer bug with the updates alarm, where it would trigger after the first 5000ms. Since we were also updating the updates list at the start of the application, this would mean we had duplicated requests in the first 5-20s. 

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] PullingContentService.java

**How should this be manually tested?**

  Check if there is no repeated listAppsUpdates and listAppcAppsUpgrades calls on first launch. 

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1694](https://aptoide.atlassian.net/browse/ASV-1694)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass