### PR TITLE
[ASV-1654] Fix home navigation

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/HomeContainerNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeContainerNavigator.java
@@ -10,17 +10,20 @@ import cm.aptoide.pt.store.view.StoreTabGridRecyclerFragment;
 public class HomeContainerNavigator {
 
   private FragmentNavigator fragmentNavigator;
+  private String homeTag;
+  private String gamesTag;
+  private String appsTag;
 
   public HomeContainerNavigator(FragmentNavigator fragmentNavigator) {
     this.fragmentNavigator = fragmentNavigator;
   }
 
   public void loadMainHomeContent() {
-    Fragment fragment = fragmentNavigator.peekLast();
-    if (fragment != null && fragment instanceof HomeFragment) {
+    Fragment fragment = fragmentNavigator.getFragment(homeTag);
+    if (fragment != null) {
       fragmentNavigator.navigateToWithoutBackSave(fragment, true);
     } else {
-      fragmentNavigator.navigateTo(new HomeFragment(), true);
+      homeTag = fragmentNavigator.navigateTo(new HomeFragment(), true);
     }
   }
 
@@ -33,7 +36,15 @@ public class HomeContainerNavigator {
         "https://ws75.aptoide.com/api/7/getStoreWidgets/store_id=15/context=games/widget=apps_list%3A0%262%3Adownloads7d");
     args.putBoolean(StoreTabGridRecyclerFragment.BundleCons.TOOLBAR, false);
     fragment.setArguments(args);
-    fragmentNavigator.navigateToWithoutBackSave(fragment, true);
+
+    Fragment gamesFragment = fragmentNavigator.getFragment(gamesTag);
+    if (gamesFragment != null) {
+      //fragmentNavigator.cleanBackStackUntil(homeTag);
+      fragmentNavigator.navigateToWithoutBackSave(gamesFragment, true);
+    } else {
+      //fragmentNavigator.cleanBackStackUntil(homeTag);
+      gamesTag = fragmentNavigator.navigateTo(fragment, true);
+    }
   }
 
   public void loadAppsHomeContent() {
@@ -45,6 +56,14 @@ public class HomeContainerNavigator {
         "https://ws75.aptoide.com/api/7/getStoreWidgets/store_id=15/context=apps/widget=apps_list%3A0%262%3Apdownloads7d");
     args.putBoolean(StoreTabGridRecyclerFragment.BundleCons.TOOLBAR, false);
     fragment.setArguments(args);
-    fragmentNavigator.navigateToWithoutBackSave(fragment, true);
+
+    Fragment appsFragment = fragmentNavigator.getFragment(appsTag);
+    if (appsFragment != null) {
+      //fragmentNavigator.cleanBackStackUntil(homeTag);
+      fragmentNavigator.navigateToWithoutBackSave(appsFragment, true);
+    } else {
+      //fragmentNavigator.cleanBackStackUntil(homeTag);
+      appsTag = fragmentNavigator.navigateTo(fragment, true);
+    }
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/HomeContainerNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeContainerNavigator.java
@@ -9,57 +9,59 @@ import cm.aptoide.pt.store.view.StoreTabGridRecyclerFragment;
 
 public class HomeContainerNavigator {
 
-  private FragmentNavigator fragmentNavigator;
+  private FragmentNavigator childFragmentNavigator;
   private String homeTag;
   private String gamesTag;
   private String appsTag;
 
-  public HomeContainerNavigator(FragmentNavigator fragmentNavigator) {
-    this.fragmentNavigator = fragmentNavigator;
+  public HomeContainerNavigator(FragmentNavigator childFragmentNavigator) {
+    this.childFragmentNavigator = childFragmentNavigator;
   }
 
   public void loadMainHomeContent() {
-    Fragment fragment = fragmentNavigator.getFragment(homeTag);
+    Fragment fragment = childFragmentNavigator.getFragment(homeTag);
     if (fragment != null) {
-      fragmentNavigator.navigateToWithoutBackSave(fragment, true);
+      childFragmentNavigator.navigateToWithoutBackSave(fragment, true);
     } else {
-      homeTag = fragmentNavigator.navigateTo(new HomeFragment(), true);
+      homeTag = childFragmentNavigator.navigateTo(new HomeFragment(), true);
     }
   }
 
   public void loadGamesHomeContent() {
     Fragment fragment = new MoreBundleFragment();
     Bundle args = new Bundle();
-    args.putString(StoreTabGridRecyclerFragment.BundleCons.TITLE, fragmentNavigator.getFragment()
-        .getString(R.string.home_chip_games));
+    args.putString(StoreTabGridRecyclerFragment.BundleCons.TITLE,
+        childFragmentNavigator.getFragment()
+            .getString(R.string.home_chip_games));
     args.putString(StoreTabGridRecyclerFragment.BundleCons.ACTION,
         "https://ws75.aptoide.com/api/7/getStoreWidgets/store_id=15/context=games/widget=apps_list%3A0%262%3Adownloads7d");
     args.putBoolean(StoreTabGridRecyclerFragment.BundleCons.TOOLBAR, false);
     fragment.setArguments(args);
 
-    Fragment gamesFragment = fragmentNavigator.getFragment(gamesTag);
+    Fragment gamesFragment = childFragmentNavigator.getFragment(gamesTag);
     if (gamesFragment != null) {
-      fragmentNavigator.navigateToWithoutBackSave(gamesFragment, true);
+      childFragmentNavigator.navigateToWithoutBackSave(gamesFragment, true);
     } else {
-      gamesTag = fragmentNavigator.navigateTo(fragment, true);
+      gamesTag = childFragmentNavigator.navigateTo(fragment, true);
     }
   }
 
   public void loadAppsHomeContent() {
     Fragment fragment = new MoreBundleFragment();
     Bundle args = new Bundle();
-    args.putString(StoreTabGridRecyclerFragment.BundleCons.TITLE, fragmentNavigator.getFragment()
-        .getString(R.string.home_chip_apps));
+    args.putString(StoreTabGridRecyclerFragment.BundleCons.TITLE,
+        childFragmentNavigator.getFragment()
+            .getString(R.string.home_chip_apps));
     args.putString(StoreTabGridRecyclerFragment.BundleCons.ACTION,
         "https://ws75.aptoide.com/api/7/getStoreWidgets/store_id=15/context=apps/widget=apps_list%3A0%262%3Apdownloads7d");
     args.putBoolean(StoreTabGridRecyclerFragment.BundleCons.TOOLBAR, false);
     fragment.setArguments(args);
 
-    Fragment appsFragment = fragmentNavigator.getFragment(appsTag);
+    Fragment appsFragment = childFragmentNavigator.getFragment(appsTag);
     if (appsFragment != null) {
-      fragmentNavigator.navigateToWithoutBackSave(appsFragment, true);
+      childFragmentNavigator.navigateToWithoutBackSave(appsFragment, true);
     } else {
-      appsTag = fragmentNavigator.navigateTo(fragment, true);
+      appsTag = childFragmentNavigator.navigateTo(fragment, true);
     }
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/HomeContainerNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeContainerNavigator.java
@@ -16,7 +16,12 @@ public class HomeContainerNavigator {
   }
 
   public void loadMainHomeContent() {
-    fragmentNavigator.navigateToWithoutBackSave(new HomeFragment(), true);
+    Fragment fragment = fragmentNavigator.peekLast();
+    if (fragment != null && fragment instanceof HomeFragment) {
+      fragmentNavigator.navigateToWithoutBackSave(fragment, true);
+    } else {
+      fragmentNavigator.navigateTo(new HomeFragment(), true);
+    }
   }
 
   public void loadGamesHomeContent() {

--- a/app/src/main/java/cm/aptoide/pt/home/HomeContainerNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeContainerNavigator.java
@@ -39,10 +39,8 @@ public class HomeContainerNavigator {
 
     Fragment gamesFragment = fragmentNavigator.getFragment(gamesTag);
     if (gamesFragment != null) {
-      //fragmentNavigator.cleanBackStackUntil(homeTag);
       fragmentNavigator.navigateToWithoutBackSave(gamesFragment, true);
     } else {
-      //fragmentNavigator.cleanBackStackUntil(homeTag);
       gamesTag = fragmentNavigator.navigateTo(fragment, true);
     }
   }
@@ -59,10 +57,8 @@ public class HomeContainerNavigator {
 
     Fragment appsFragment = fragmentNavigator.getFragment(appsTag);
     if (appsFragment != null) {
-      //fragmentNavigator.cleanBackStackUntil(homeTag);
       fragmentNavigator.navigateToWithoutBackSave(appsFragment, true);
     } else {
-      //fragmentNavigator.cleanBackStackUntil(homeTag);
       appsTag = fragmentNavigator.navigateTo(fragment, true);
     }
   }

--- a/app/src/main/java/cm/aptoide/pt/navigator/FragmentNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/navigator/FragmentNavigator.java
@@ -24,8 +24,6 @@ public interface FragmentNavigator {
 
   void cleanBackStack();
 
-  void cleanBackStackUntil(String fragmentTag);
-
   Fragment peekLast();
 
   Fragment getFragment();

--- a/app/src/main/java/cm/aptoide/pt/navigator/FragmentNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/navigator/FragmentNavigator.java
@@ -24,11 +24,13 @@ public interface FragmentNavigator {
 
   void cleanBackStack();
 
-  boolean cleanBackStackUntil(String fragmentTag);
+  void cleanBackStackUntil(String fragmentTag);
 
   Fragment peekLast();
 
   Fragment getFragment();
+
+  Fragment getFragment(String tag);
 
   void navigateToDialogFragment(DialogFragment fragment);
 

--- a/app/src/main/java/cm/aptoide/pt/navigator/FragmentResultNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/navigator/FragmentResultNavigator.java
@@ -95,22 +95,8 @@ public class FragmentResultNavigator implements FragmentNavigator {
     fragmentManager.executePendingTransactions();
   }
 
-  @Override public boolean cleanBackStackUntil(String fragmentTag) {
-    if (fragmentManager.getBackStackEntryCount() == 0) {
-      return false;
-    }
-
-    boolean popped = false;
-
-    while (fragmentManager.getBackStackEntryCount() > 0 && !popped) {
-      if (fragmentManager.getBackStackEntryAt(fragmentManager.getBackStackEntryCount() - 1)
-          .getName()
-          .equals(fragmentTag)) {
-        popped = true;
-      }
-      fragmentManager.popBackStackImmediate();
-    }
-    return popped;
+  @Override public void cleanBackStackUntil(String fragmentTag) {
+    fragmentManager.popBackStackImmediate(fragmentTag, 0);
   }
 
   @Override public Fragment peekLast() {
@@ -125,6 +111,10 @@ public class FragmentResultNavigator implements FragmentNavigator {
 
   @Override public Fragment getFragment() {
     return fragmentManager.findFragmentById(containerId);
+  }
+
+  @Override public Fragment getFragment(String tag) {
+    return fragmentManager.findFragmentByTag(tag);
   }
 
   @Override public void navigateToDialogFragment(DialogFragment fragment) {

--- a/app/src/main/java/cm/aptoide/pt/navigator/FragmentResultNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/navigator/FragmentResultNavigator.java
@@ -95,10 +95,6 @@ public class FragmentResultNavigator implements FragmentNavigator {
     fragmentManager.executePendingTransactions();
   }
 
-  @Override public void cleanBackStackUntil(String fragmentTag) {
-    fragmentManager.popBackStackImmediate(fragmentTag, 0);
-  }
-
   @Override public Fragment peekLast() {
     if (fragmentManager.getBackStackEntryCount() > 0) {
       FragmentManager.BackStackEntry backStackEntry =

--- a/app/src/main/java/cm/aptoide/pt/view/BaseFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/BaseFragment.java
@@ -1,18 +1,44 @@
 package cm.aptoide.pt.view;
 
 import android.app.Activity;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
 import android.view.View;
+import android.view.animation.AlphaAnimation;
+import android.view.animation.Animation;
+import android.view.animation.AnimationUtils;
 import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.FlavourFragmentModule;
 import cm.aptoide.pt.bottomNavigation.BottomNavigationActivity;
+import cm.aptoide.pt.logger.Logger;
 import com.trello.rxlifecycle.components.support.RxFragment;
+import java.lang.reflect.Field;
 
 public abstract class BaseFragment extends RxFragment {
 
   private FragmentComponent fragmentComponent;
   private BottomNavigationActivity bottomNavigationActivity;
+
+  private static long getRemovingParentAnimationDuration(Fragment fragment, long defValue) {
+    try {
+      Field animInfoField = Fragment.class.getDeclaredField("mAnimationInfo");
+      animInfoField.setAccessible(true);
+      Object animationInfo = animInfoField.get(fragment);
+      Field nextAnimField = animationInfo.getClass()
+          .getDeclaredField("mNextAnim");
+      nextAnimField.setAccessible(true);
+      int nextAnimResource = nextAnimField.getInt(animationInfo);
+      Animation nextAnim = AnimationUtils.loadAnimation(fragment.getActivity(), nextAnimResource);
+
+      return (nextAnim == null) ? defValue : nextAnim.getDuration();
+    } catch (NoSuchFieldException | IllegalAccessException | Resources.NotFoundException ex) {
+      Logger.getInstance()
+          .e("BASE FRAGMENT", "Unable to load next animation from parent.", ex);
+      return defValue;
+    }
+  }
 
   @Override public void onAttach(Activity activity) {
     super.onAttach(activity);
@@ -49,5 +75,34 @@ public abstract class BaseFragment extends RxFragment {
               new FlavourFragmentModule());
     }
     return fragmentComponent;
+  }
+
+  @Override public Animation onCreateAnimation(int transit, boolean enter, int nextAnim) {
+    // WORKAROUND FOR NESTED FRAGMENTS DISAPPEARING DURING PARENT ANIMATION
+    // See https://code.google.com/p/android/issues/detail?id=55228
+    /*  find top most parent in my hierarchy that is currently removing */
+    final Fragment removingParent = getRemovingParent(getParentFragment());
+    /*  if its not an enter animation and removing parent was found, otherwise workaround not needed */
+    if (!enter && removingParent != null) {
+      /*  apply stub animation with same duration as the one that will be played for removing parent */
+      Animation doNothingAnim = new AlphaAnimation(1, 1);
+      doNothingAnim.setDuration(getRemovingParentAnimationDuration(removingParent, 300));
+      return doNothingAnim;
+    } else {
+      return super.onCreateAnimation(transit, enter, nextAnim);
+    }
+  }
+
+  private Fragment getRemovingParent(Fragment fragment) {
+    /* if im null, then noone is removing */
+    if (fragment == null) return null;
+    /* get my parent */
+    Fragment parent = fragment.getParentFragment();
+    /* if my parent exists and is removing then continue checking higher in hierarchy */
+    if (parent != null && parent.isRemoving()) return getRemovingParent(parent);
+    /* if my parent doesnt exists or is not removing then check if I am */
+    if (fragment.isRemoving()) return fragment;
+    /* seems like none of my parents is removing, neither am I, so no one really is */
+    return null;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/view/BaseFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/BaseFragment.java
@@ -78,13 +78,9 @@ public abstract class BaseFragment extends RxFragment {
   }
 
   @Override public Animation onCreateAnimation(int transit, boolean enter, int nextAnim) {
-    // WORKAROUND FOR NESTED FRAGMENTS DISAPPEARING DURING PARENT ANIMATION
     // See https://code.google.com/p/android/issues/detail?id=55228
-    /*  find top most parent in my hierarchy that is currently removing */
     final Fragment removingParent = getRemovingParent(getParentFragment());
-    /*  if its not an enter animation and removing parent was found, otherwise workaround not needed */
     if (!enter && removingParent != null) {
-      /*  apply stub animation with same duration as the one that will be played for removing parent */
       Animation doNothingAnim = new AlphaAnimation(1, 1);
       doNothingAnim.setDuration(getRemovingParentAnimationDuration(removingParent, 300));
       return doNothingAnim;
@@ -94,15 +90,10 @@ public abstract class BaseFragment extends RxFragment {
   }
 
   private Fragment getRemovingParent(Fragment fragment) {
-    /* if im null, then noone is removing */
     if (fragment == null) return null;
-    /* get my parent */
     Fragment parent = fragment.getParentFragment();
-    /* if my parent exists and is removing then continue checking higher in hierarchy */
     if (parent != null && parent.isRemoving()) return getRemovingParent(parent);
-    /* if my parent doesnt exists or is not removing then check if I am */
     if (fragment.isRemoving()) return fragment;
-    /* seems like none of my parents is removing, neither am I, so no one really is */
     return null;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -275,8 +275,8 @@ import rx.subscriptions.CompositeSubscription;
   }
 
   @FragmentScope @Provides HomeContainerNavigator providesHomeContainerNavigator(
-      @Named("home-fragment-navigator") FragmentNavigator fragmentNavigator) {
-    return new HomeContainerNavigator(fragmentNavigator);
+      @Named("home-fragment-navigator") FragmentNavigator childFragmentNavigator) {
+    return new HomeContainerNavigator(childFragmentNavigator);
   }
 
   @FragmentScope @Provides Home providesHome(BundlesRepository bundlesRepository,

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -4,7 +4,6 @@ import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
 import android.view.WindowManager;
 import cm.aptoide.accountmanager.AptoideAccountManager;
 import cm.aptoide.analytics.AnalyticsManager;
@@ -189,9 +188,10 @@ import rx.subscriptions.CompositeSubscription;
 
   @FragmentScope @Provides @Named("home-fragment-navigator")
   FragmentNavigator provideHomeFragmentNavigator(Map<Integer, Result> fragmentResultMap,
-      BehaviorRelay<Map<Integer, Result>> fragmentResultRelay, FragmentManager fragmentManager) {
-    return new FragmentResultNavigator(fragmentManager, R.id.main_content, android.R.anim.fade_in,
-        android.R.anim.fade_out, fragmentResultMap, fragmentResultRelay);
+      BehaviorRelay<Map<Integer, Result>> fragmentResultRelay) {
+    return new FragmentResultNavigator(fragment.getChildFragmentManager(),
+        R.id.main_home_container_content, android.R.anim.fade_in, android.R.anim.fade_out,
+        fragmentResultMap, fragmentResultRelay);
   }
 
   @FragmentScope @Provides ImagePickerPresenter provideImagePickerPresenter(

--- a/app/src/main/res/layout/fragment_home_container.xml
+++ b/app/src/main/res/layout/fragment_home_container.xml
@@ -95,7 +95,7 @@
         />
 
     <FrameLayout
-        android:id="@+id/main_content"
+        android:id="@+id/main_home_container_content"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at fixing the navigation in home and keeping the state of all home fragments (games, apps and home). When you navigate to another view and comeback, the previous view should keep its state.

**Database changed?**

 No

**Where should the reviewer start?**

- [ ] HomeContainerNavigator.java

**How should this be manually tested?**

  Open app, scroll down and open an appview. Press the back button and the home fragment should in the same position as before. Also same thing should happen on any of the "chips" fragments

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1654](https://aptoide.atlassian.net/browse/ASV-1654)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass