### PR TITLE
[ASV-1679] Fix bundles inside the chips

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/HomeContainerNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeContainerNavigator.java
@@ -53,7 +53,7 @@ public class HomeContainerNavigator {
         childFragmentNavigator.getFragment()
             .getString(R.string.home_chip_apps));
     args.putString(StoreTabGridRecyclerFragment.BundleCons.ACTION,
-        "https://ws75.aptoide.com/api/7/getStoreWidgets/store_id=15/context=apps/widget=apps_list%3A0%262%3Apdownloads7d");
+        "https://ws75.aptoide.com/api/7/getStoreWidgets/store_id=15/context=apps/widget=apps_list%3A0%261%3Apdownloads7d");
     args.putBoolean(StoreTabGridRecyclerFragment.BundleCons.TOOLBAR, false);
     fragment.setArguments(args);
 


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at fixing the apps chip request. Before, the apps chip was showing games bundles instead of apps.

**NOTE:
Please accept the PR https://github.com/Aptoide/aptoide-client-v8/pull/1020 first, because I checkout from that branch in order to fix this issue.**

**Database changed?**

No

**Where should the reviewer start?**

- [ ] HomeContainerNavigator.java

**How should this be manually tested?**

  Open both chips and check that the bundles are different and now make sense to the chip name.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1679](https://aptoide.atlassian.net/browse/ASV-1679)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass