### PR TITLE
[feature/ASV-1734] Dialog Base View for Wallet Install Dialog

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -131,6 +131,14 @@
         android:windowSoftInputMode="adjustPan"></activity>
 
     <activity
+        android:name=".wallet.WalletInstallActivity"
+        android:excludeFromRecents="true"
+        android:noHistory="true"
+        android:taskAffinity=".wallet.WalletInstallActivity"
+        android:theme="@style/Aptoide.DialogTheme"
+        android:windowSoftInputMode="adjustPan"/>
+
+    <activity
         android:name="com.ironsource.sdk.controller.ControllerActivity"
         android:configChanges="orientation|screenSize"
         android:hardwareAccelerated="true"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -262,7 +262,7 @@
     <activity
         android:name=".DeepLinkIntentReceiver"
         android:exported="true"
-        android:taskAffinity=""
+        android:taskAffinity=".DeepLinkIntentReceiver"
         >
       <intent-filter>
         <action android:name="android.intent.action.VIEW"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -262,6 +262,7 @@
     <activity
         android:name=".DeepLinkIntentReceiver"
         android:exported="true"
+        android:taskAffinity=""
         >
       <intent-filter>
         <action android:name="android.intent.action.VIEW"/>

--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -1846,7 +1846,7 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
         PromotionsAnalytics.PROMOTION_DIALOG, PromotionsAnalytics.PROMOTIONS_INTERACT,
         PromotionsAnalytics.VALENTINE_MIGRATOR, AppViewAnalytics.ADS_BLOCK_BY_OFFER,
         AppViewAnalytics.APPC_SIMILAR_APP_INTERACT, AppViewAnalytics.BONUS_MIGRATION_APPVIEW,
-        AppViewAnalytics.BONUS_GAME_WALLET_OFFER_19);
+        AppViewAnalytics.BONUS_GAME_WALLET_OFFER_19, DeepLinkAnalytics.APPCOINS_WALLET_DEEPLINK);
   }
 
   @Singleton @Provides AptoideShortcutManager providesShortcutManager() {

--- a/app/src/main/java/cm/aptoide/pt/DeepLinkAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkAnalytics.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 public class DeepLinkAnalytics {
   public static final String FACEBOOK_APP_LAUNCH = "Aptoide Launch";
+  public static final String APPCOINS_WALLET_DEEPLINK = "AppCoins_Wallet_Deeplink";
   public static final String APP_LAUNCH = "Application Launch";
   private static final String NEW_UPDATES_NOTIFICATION = "New Updates Available";
   private static final String DOWNLOADING_UPDATES = "Downloading Updates";
@@ -108,5 +109,10 @@ public class DeepLinkAnalytics {
 
   private String getViewName(boolean isCurrent) {
     return navigationTracker.getViewName(isCurrent);
+  }
+
+  public void sendWalletDeepLinkEvent(String utmSource) {
+    analyticsManager.logEvent(createMap(SOURCE, utmSource), APPCOINS_WALLET_DEEPLINK,
+        AnalyticsManager.Action.AUTO, getViewName(true));
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
@@ -33,6 +33,7 @@ import cm.aptoide.pt.store.StoreUtils;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.design.ShowMessage;
 import cm.aptoide.pt.view.ActivityView;
+import cm.aptoide.pt.wallet.WalletInstallActivity;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -246,6 +247,10 @@ public class DeepLinkIntentReceiver extends ActivityView {
       } else if (packageName.contains("pub:")) {
         packageName = packageName.substring(4);
       }
+    }
+    String utmSourceParameter = u.getQueryParameter("utm_source");
+    if (utmSourceParameter != null && utmSourceParameter.equals("myappcoins")) {
+      return startWalletInstallIntent();
     }
     return startFromPackageName(packageName);
   }
@@ -471,6 +476,12 @@ public class DeepLinkIntentReceiver extends ActivityView {
       CrashReport.getInstance()
           .log(e);
     }
+  }
+
+  public Intent startWalletInstallIntent() {
+    Intent intent = new Intent(this, WalletInstallActivity.class);
+    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    return intent;
   }
 
   public Intent startFromPackageName(String packageName) {

--- a/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
@@ -249,8 +249,9 @@ public class DeepLinkIntentReceiver extends ActivityView {
       }
     }
     String utmSourceParameter = u.getQueryParameter("utm_source");
-    if (utmSourceParameter != null && utmSourceParameter.equals("myappcoins")) {
-      return startWalletInstallIntent();
+    if (utmSourceParameter != null && (utmSourceParameter.equals("myappcoins")
+        || utmSourceParameter.equals("appcoinssdk"))) {
+      return startWalletInstallIntent(utmSourceParameter);
     }
     return startFromPackageName(packageName);
   }
@@ -478,9 +479,10 @@ public class DeepLinkIntentReceiver extends ActivityView {
     }
   }
 
-  public Intent startWalletInstallIntent() {
+  public Intent startWalletInstallIntent(String utmSource) {
     Intent intent = new Intent(this, WalletInstallActivity.class);
     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    deepLinkAnalytics.sendWalletDeepLinkEvent(utmSource);
     return intent;
   }
 

--- a/app/src/main/java/cm/aptoide/pt/view/ActivityComponent.java
+++ b/app/src/main/java/cm/aptoide/pt/view/ActivityComponent.java
@@ -9,12 +9,15 @@ import cm.aptoide.pt.navigator.ActivityResultNavigator;
 import cm.aptoide.pt.store.view.StoreTabGridRecyclerFragment;
 import cm.aptoide.pt.view.dialog.DialogUtils;
 import cm.aptoide.pt.view.settings.SettingsFragment;
+import cm.aptoide.pt.wallet.WalletInstallActivity;
 import dagger.Subcomponent;
 
 @ActivityScope @Subcomponent(modules = { ActivityModule.class, FlavourActivityModule.class })
 public interface ActivityComponent {
 
   void inject(MainActivity activity);
+
+  void inject(WalletInstallActivity activity);
 
   void inject(ActivityResultNavigator activityResultNavigator);
 

--- a/app/src/main/java/cm/aptoide/pt/view/ActivityModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/ActivityModule.java
@@ -80,6 +80,9 @@ import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.view.app.ListStoreAppsNavigator;
 import cm.aptoide.pt.view.dialog.DialogUtils;
 import cm.aptoide.pt.view.settings.MyAccountNavigator;
+import cm.aptoide.pt.wallet.WalletInstallNavigator;
+import cm.aptoide.pt.wallet.WalletInstallPresenter;
+import cm.aptoide.pt.wallet.WalletInstallView;
 import com.facebook.CallbackManager;
 import com.facebook.login.LoginManager;
 import com.google.android.gms.common.api.GoogleApiClient;
@@ -351,5 +354,15 @@ import static android.content.Context.WINDOW_SERVICE;
   @ActivityScope @Provides PromotionsNavigator providesPromotionsNavigator(
       @Named("main-fragment-navigator") FragmentNavigator fragmentNavigator) {
     return new PromotionsNavigator(fragmentNavigator);
+  }
+
+  @ActivityScope @Provides WalletInstallPresenter providesPromotionsPresenter(
+      WalletInstallNavigator walletInstallNavigator) {
+    return new WalletInstallPresenter((WalletInstallView) view, walletInstallNavigator);
+  }
+
+  @ActivityScope @Provides WalletInstallNavigator providesWalletInstallNavigator(
+      @Named("main-fragment-navigator") FragmentNavigator fragmentNavigator) {
+    return new WalletInstallNavigator(fragmentNavigator);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/view/BackButtonActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/view/BackButtonActivity.java
@@ -5,7 +5,7 @@ import android.support.annotation.Nullable;
 import java.util.HashSet;
 import java.util.Set;
 
-public abstract class BackButtonActivity extends ActivityView implements BackButton {
+public abstract class BackButtonActivity extends ThemedActivityView implements BackButton {
 
   private Set<BackButton.ClickHandler> clickHandlers;
 

--- a/app/src/main/java/cm/aptoide/pt/view/BaseActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/view/BaseActivity.java
@@ -12,7 +12,6 @@ import javax.inject.Named;
 
 public abstract class BaseActivity extends RxAppCompatActivity {
 
-  @Inject @Named("aptoide-theme") String theme;
   private ActivityComponent activityComponent;
   private boolean firstCreated;
 
@@ -20,8 +19,6 @@ public abstract class BaseActivity extends RxAppCompatActivity {
     super.onCreate(savedInstanceState);
     firstCreated = savedInstanceState == null;
     getActivityComponent().inject(this);
-    ThemeUtils.setStatusBarThemeColor(this, theme);
-    ThemeUtils.setAptoideTheme(this, theme);
   }
 
   @Override protected void onDestroy() {

--- a/app/src/main/java/cm/aptoide/pt/view/ThemedActivityView.java
+++ b/app/src/main/java/cm/aptoide/pt/view/ThemedActivityView.java
@@ -4,7 +4,7 @@ import android.os.Bundle;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-public class ThemedActivityView extends ActivityView {
+public abstract class ThemedActivityView extends ActivityView {
   @Inject @Named("aptoide-theme") String theme;
 
   @Override protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/cm/aptoide/pt/view/ThemedActivityView.java
+++ b/app/src/main/java/cm/aptoide/pt/view/ThemedActivityView.java
@@ -1,0 +1,15 @@
+package cm.aptoide.pt.view;
+
+import android.os.Bundle;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+public class ThemedActivityView extends ActivityView {
+  @Inject @Named("aptoide-theme") String theme;
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    ThemeUtils.setStatusBarThemeColor(this, theme);
+    ThemeUtils.setAptoideTheme(this, theme);
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallActivity.kt
+++ b/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallActivity.kt
@@ -1,0 +1,22 @@
+package cm.aptoide.pt.wallet
+
+import android.os.Bundle
+import cm.aptoide.pt.R
+import cm.aptoide.pt.view.ActivityView
+import javax.inject.Inject
+
+
+class WalletInstallActivity : ActivityView(), WalletInstallView {
+
+  @Inject
+  lateinit var presenter: WalletInstallPresenter
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    activityComponent.inject(this)
+
+    setContentView(R.layout.wallet_install_activity)
+    attachPresenter(presenter)
+  }
+
+}

--- a/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallNavigator.kt
+++ b/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallNavigator.kt
@@ -1,0 +1,10 @@
+package cm.aptoide.pt.wallet
+
+import cm.aptoide.pt.navigator.FragmentNavigator
+
+class WalletInstallNavigator(val fragmentNavigator: FragmentNavigator) {
+
+  fun navigateToWalletInstallView() {
+    // TODO
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallPresenter.kt
+++ b/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallPresenter.kt
@@ -12,7 +12,7 @@ class WalletInstallPresenter(val view: WalletInstallView, val navigator: WalletI
   }
 
   private fun showDialog() {
-    view.getLifecycleEvent()
+    view.lifecycleEvent
         .filter { lifecycleEvent -> View.LifecycleEvent.CREATE == lifecycleEvent }
         .doOnNext {
           navigator.navigateToWalletInstallView()

--- a/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallPresenter.kt
+++ b/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallPresenter.kt
@@ -1,0 +1,23 @@
+package cm.aptoide.pt.wallet
+
+import cm.aptoide.pt.presenter.Presenter
+import cm.aptoide.pt.presenter.View
+import rx.exceptions.OnErrorNotImplementedException
+
+class WalletInstallPresenter(val view: WalletInstallView, val navigator: WalletInstallNavigator) :
+    Presenter {
+
+  override fun present() {
+    showDialog()
+  }
+
+  private fun showDialog() {
+    view.getLifecycleEvent()
+        .filter { lifecycleEvent -> View.LifecycleEvent.CREATE == lifecycleEvent }
+        .doOnNext {
+          navigator.navigateToWalletInstallView()
+        }
+        .compose(view.bindUntilEvent<View.LifecycleEvent>(View.LifecycleEvent.DESTROY))
+        .subscribe({}, { throwable -> throw OnErrorNotImplementedException(throwable) })
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallView.kt
+++ b/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallView.kt
@@ -1,0 +1,6 @@
+package cm.aptoide.pt.wallet
+
+import cm.aptoide.pt.presenter.View
+
+interface WalletInstallView : View {
+}

--- a/app/src/main/res/layout/wallet_install_activity.xml
+++ b/app/src/main/res/layout/wallet_install_activity.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@android:color/white"
+    >
+
+
+  <FrameLayout
+      android:id="@+id/main_container"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      />
+
+</LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,6 +9,52 @@
     <item name="android:windowAnimationStyle">@android:style/Animation</item>
   </style>
 
+  <style name="Theme.AppCompat.Transparent" parent="Theme.AppCompat">
+    <item name="android:windowIsTranslucent">true</item>
+    <item name="android:windowContentOverlay">@null</item>
+    <item name="windowActionBar">false</item>
+    <item name="windowNoTitle">true</item>
+    <item name="android:windowNoTitle">true</item>
+    <item name="android:windowBackground">@android:color/transparent</item>
+    <item name="android:windowIsFloating">true</item>
+    <item name="android:backgroundDimEnabled">true</item>
+    <item name="android:fitsSystemWindows">true</item>
+    <item name="listPreferredItemPaddingLeft">24dip</item>
+    <item name="listPreferredItemPaddingRight">24dip</item>
+  </style>
+
+  <style name="Aptoide.DialogTheme" parent="Theme.AppCompat">
+    <item name="android:colorBackgroundCacheHint">@null</item>
+    <item name="android:windowIsTranslucent">true</item>
+    <item name="windowNoTitle">true</item>
+    <item name="android:windowNoTitle">true</item>
+    <item name="android:windowFrame">@null</item>
+    <item name="android:fitsSystemWindows">true</item>
+    <item name="android:windowTitleStyle">@style/RtlOverlay.DialogWindowTitle.AppCompat</item>
+    <item name="android:windowTitleBackgroundStyle">
+      @style/Base.DialogWindowTitleBackground.AppCompat
+    </item>
+    <item name="android:windowBackground">@drawable/abc_dialog_material_background</item>
+    <item name="android:windowIsFloating">true</item>
+    <item name="android:backgroundDimEnabled">true</item>
+    <item name="android:windowContentOverlay">@null</item>
+    <item name="android:windowAnimationStyle">@style/Animation.AppCompat.Dialog</item>
+    <item name="android:windowSoftInputMode">stateUnspecified|adjustPan</item>
+
+    <item name="windowActionBar">false</item>
+    <item name="windowActionModeOverlay">true</item>
+
+    <item name="listPreferredItemPaddingLeft">24dip</item>
+    <item name="listPreferredItemPaddingRight">24dip</item>
+
+    <item name="android:listDivider">@null</item>
+
+    <item name="android:buttonBarStyle">@style/Widget.AppCompat.ButtonBar.AlertDialog</item>
+    <item name="android:borderlessButtonStyle">@style/Widget.AppCompat.Button.Borderless</item>
+    <item name="android:windowCloseOnTouchOutside">true</item>
+  </style>
+
+
   <style name="Widget.Aptoide.Card" parent="">
     <item name="cardCornerRadius">8.3dp</item>
     <item name="cardBackgroundColor">?attr/backgroundCardColor</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -23,7 +23,7 @@
     <item name="listPreferredItemPaddingRight">24dip</item>
   </style>
 
-  <style name="Aptoide.DialogTheme" parent="Theme.AppCompat">
+  <style name="Aptoide.DialogTheme" parent="Theme.AppCompat.Dialog">
     <item name="android:colorBackgroundCacheHint">@null</item>
     <item name="android:windowIsTranslucent">true</item>
     <item name="windowNoTitle">true</item>
@@ -34,12 +34,14 @@
     <item name="android:windowTitleBackgroundStyle">
       @style/Base.DialogWindowTitleBackground.AppCompat
     </item>
-    <item name="android:windowBackground">@drawable/abc_dialog_material_background</item>
+    <item name="android:windowBackground">@drawable/dialog_bg</item>
     <item name="android:windowIsFloating">true</item>
     <item name="android:backgroundDimEnabled">true</item>
     <item name="android:windowContentOverlay">@null</item>
     <item name="android:windowAnimationStyle">@style/Animation.AppCompat.Dialog</item>
     <item name="android:windowSoftInputMode">stateUnspecified|adjustPan</item>
+    <item name="android:windowMinWidthMajor">67%</item>
+    <item name="android:windowMinWidthMinor">90%</item>
 
     <item name="windowActionBar">false</item>
     <item name="windowActionModeOverlay">true</item>


### PR DESCRIPTION
**What does this PR do?**

   This PR creates a base activity for the wallet install dialog. The way it's setup, there's a main container in the activity layout used to inflate the actual content of the view (similar to MainActivity). 

This activity uses a specific custom dialog theme ('Aptoide.DialogTheme'). This theme defines several aspects of the dialog, namely: the minimum width in portrait/landscape mode (%) according to Zeplin, the dialog background with rounded edges etc.

Finally, this activity is launched as a new task, and 'taskAffinity', 'noHistory' and 'excludeFromRecents' are used in combination to properly use this activity independently from Aptoide task itself. DeepLinkIntentReceiver, which launches the dialog activity also needs a custom 'taskAffinity'.

Relevant analytics were also implemented.

**Database changed?**

   No

**Where should the reviewer start?**

- [x] AndroidManifest.xml
- [x] styles.xml
- [x] cm.aptoide.pt.wallet package

**How should this be manually tested?**

  Call the relevant intent from anywhere (and with Aptoide both active and stopped), and check if the dialog behaves as expected (i.e. if it's independent from Aptoide and doesn't leave any trace in the phone's 'Recent'). Also because taskAffinity for DeepLinkIntentReceiver was changed, please check if no other activity launched from this one was broken (i.e. check other intents).

To test the deeplink use:

adb shell am start -a "android.intent.action.VIEW" "market://details?id=com.appcoins.wallet\&utm_source=myappcoins"

There’s a backslash before '&' to escape the character.

**What are the relevant tickets?**

  [ASV-1734](https://aptoide.atlassian.net/browse/ASV-1734)


**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass