### PR TITLE
[feature/ASV-1755] Support for app source not installed 

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallActivity.kt
+++ b/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallActivity.kt
@@ -26,6 +26,7 @@ class WalletInstallActivity : ActivityView(), WalletInstallView {
     super.onCreate(savedInstanceState)
     activityComponent.inject(this)
     setContentView(R.layout.wallet_install_activity)
+    initStyling()
     attachPresenter(presenter)
   }
 
@@ -36,14 +37,15 @@ class WalletInstallActivity : ActivityView(), WalletInstallView {
     messageTextView.setSubstringTypeface(Pair(walletAppName, Typeface.BOLD))
   }
 
-  override fun showWalletInstallationView(appIcon: String,
+  override fun showWalletInstallationView(appIcon: String?,
                                           walletApp: WalletApp) {
-    initStyling()
     progressView.visibility = View.GONE
     walletInstallSuccessViewGroup.visibility = View.GONE
     walletInstallViewGroup.visibility = View.VISIBLE
 
-    ImageLoader.with(this).load(appIcon, appIconImageView)
+    appIcon?.let {
+      ImageLoader.with(this).load(appIcon, appIconImageView)
+    }
   }
 
   override fun showInstallationSuccessView() {

--- a/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallManager.kt
+++ b/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallManager.kt
@@ -8,7 +8,10 @@ class WalletInstallManager(val configuration: WalletInstallConfiguration,
                            val packageManager: PackageManager) {
 
   fun getAppIcon(): Observable<String> {
-    return Observable.just(AptoideUtils.SystemU.getApkIconPath(
-        packageManager.getPackageInfo(configuration.appPackageName, 0)))
+    return Observable.fromCallable {
+      AptoideUtils.SystemU.getApkIconPath(
+          packageManager.getPackageInfo(configuration.appPackageName, 0))
+    }.onErrorReturn { null }
+
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallPresenter.kt
+++ b/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallPresenter.kt
@@ -1,5 +1,6 @@
 package cm.aptoide.pt.wallet
 
+import android.content.pm.PackageManager
 import cm.aptoide.pt.presenter.Presenter
 import cm.aptoide.pt.presenter.View
 import cm.aptoide.pt.promotions.PromotionsManager
@@ -24,7 +25,7 @@ class WalletInstallPresenter(val view: WalletInstallView,
         .flatMap {
           Observable.zip(walletInstallManager.getAppIcon(),
               promotionsManager.walletApp) { appIcon, walletApp ->
-            Pair<String, WalletApp>(appIcon, walletApp)
+            Pair<String?, WalletApp>(appIcon, walletApp)
           }
         }
         .observeOn(viewScheduler)

--- a/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallView.kt
+++ b/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallView.kt
@@ -6,7 +6,7 @@ import rx.Observable
 
 interface WalletInstallView : View {
 
-  fun showWalletInstallationView(appIcon: String,
+  fun showWalletInstallationView(appIcon: String?,
                                  walletApp: WalletApp)
 
   fun showInstallationSuccessView()

--- a/app/src/main/res/layout/wallet_install_activity.xml
+++ b/app/src/main/res/layout/wallet_install_activity.xml
@@ -16,10 +16,11 @@
       android:layout_height="wrap_content"
       android:scaleType="fitXY"
       android:src="@drawable/ic_wallet_install_header_bg"
-      android:visibility="visible"
+      android:visibility="invisible"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"
+      tools:visibility="visible"
       />
 
   <ImageView
@@ -42,11 +43,13 @@
       android:layout_height="56dp"
       android:layout_below="@id/header_bg"
       android:layout_centerHorizontal="true"
+      android:src="@mipmap/ic_launcher"
+      android:visibility="invisible"
       app:layout_constraintBottom_toBottomOf="@+id/header_bg"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toBottomOf="@+id/header_bg"
-      tools:src="@drawable/appcoins_icon_gradient"
+      tools:visibility="visible"
       />
 
 


### PR DESCRIPTION
Reverted initStyling order because of animations
Added null return on error for app icon

**What does this PR do?**

   This adds support for non-installed app source. It means that if the user does not have the app_source package installed, it should still work and show the Aptoide icon instead. Additionally, it reverses some styling and visibility changes that were done, to have better animations and reduce flickering.

   Just as a note, this ticket was accomplished by deferring the error on getAppIcon() to a null value (which does nothing). We could return the path to the default aptoide icon instead of null, but I think this would be non-trivial, since I'd have to get the actual path of the drawable.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] WalletInstallManager.java

**How should this be manually tested?**

  Send two intents: one where the app_source package is installed, and other that isn't. Both should work, the difference being that if it is installed, it should show the app's icon, otherwise show the Aptoide icon.

As always, use the following intent to test (replace app_source value with your desired package)

`adb shell am start -a "android.intent.action.VIEW" "market://details?id=com.appcoins.wallet\&utm_source=myappcoins\&app_source=com.gtarcade.lod"`

**What are the relevant tickets?**

  [ASV-1755](https://aptoide.atlassian.net/browse/ASV-1755)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass