### PR TITLE
[ASV-1721] Search RV now using getAdapterPosition() in items;

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultAdapter.java
@@ -61,7 +61,7 @@ public class SearchResultAdapter extends RecyclerView.Adapter<SearchResultItemVi
   @SuppressWarnings("unchecked") @Override
   public void onBindViewHolder(SearchResultItemView holder, int position) {
     try {
-      holder.setup(getItem(position), position);
+      holder.setup(getItem(position));
     } catch (ClassCastException e) {
       crashReport.log(e);
     }

--- a/app/src/main/java/cm/aptoide/pt/search/view/item/SearchResultAdViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/item/SearchResultAdViewHolder.java
@@ -23,7 +23,6 @@ public class SearchResultAdViewHolder extends SearchResultItemView<SearchAdResul
   private TextView downloadsTextView;
   private TextView ratingBar;
   private SearchAdResult adResult;
-  private int position;
 
   public SearchResultAdViewHolder(View itemView,
       PublishRelay<SearchAdResultWrapper> onItemViewClickRelay) {
@@ -39,14 +38,14 @@ public class SearchResultAdViewHolder extends SearchResultItemView<SearchAdResul
     ratingBar = (TextView) itemView.findViewById(R.id.rating);
     RxView.clicks(itemView)
         .map(__ -> adResult)
-        .subscribe(data -> onItemViewClickRelay.call(new SearchAdResultWrapper(data, position)));
+        .subscribe(data -> onItemViewClickRelay.call(
+            new SearchAdResultWrapper(data, getAdapterPosition())));
   }
 
-  @Override public void setup(SearchAdResult searchAd, int position) {
+  @Override public void setup(SearchAdResult searchAd) {
     final Context context = itemView.getContext();
     final Resources resources = itemView.getResources();
     this.adResult = searchAd;
-    this.position = position;
     setName(searchAd);
     setIcon(searchAd, context);
     setDownloadsCount(searchAd, resources);

--- a/app/src/main/java/cm/aptoide/pt/search/view/item/SearchResultItemView.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/item/SearchResultItemView.java
@@ -9,7 +9,7 @@ public abstract class SearchResultItemView<T> extends RecyclerView.ViewHolder {
     super(itemView);
   }
 
-  public void setup(T item, int position) {
+  public void setup(T item) {
   }
 
   public void prepareToRecycle() {

--- a/app/src/main/java/cm/aptoide/pt/search/view/item/SearchResultViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/item/SearchResultViewHolder.java
@@ -28,7 +28,6 @@ public class SearchResultViewHolder extends SearchResultItemView<SearchAppResult
   private TextView storeTextView;
   private View bottomView;
   private SearchAppResult searchApp;
-  private int position;
   private CompositeSubscription subscriptions;
 
   public SearchResultViewHolder(View itemView, PublishRelay<SearchAppResultWrapper> onItemViewClick,
@@ -41,9 +40,8 @@ public class SearchResultViewHolder extends SearchResultItemView<SearchAppResult
     bindViews(itemView);
   }
 
-  @Override public void setup(SearchAppResult result, int position) {
+  @Override public void setup(SearchAppResult result) {
     this.searchApp = result;
-    this.position = position;
     appInfoViewHolder.setInfo(result.hasAppcBilling(), result.getAverageRating(), false, false);
     setAppName();
     setDownloadCount();
@@ -99,7 +97,7 @@ public class SearchResultViewHolder extends SearchResultItemView<SearchAppResult
 
     subscriptions.add(RxView.clicks(itemView)
         .map(__ -> searchApp)
-        .subscribe(
-            data -> onItemViewClick.call(new SearchAppResultWrapper(query, data, position))));
+        .subscribe(data -> onItemViewClick.call(
+            new SearchAppResultWrapper(query, data, getAdapterPosition()))));
   }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR aims to change the way we pass viewholder positions to search results. Instead of using the position provided when onBind is called, we now call getAdapterPosition inside the viewHolder

**Database changed?**

No

**Where should the reviewer start?**

- [ ] SearchResultAdapter.java

**How should this be manually tested?**

Check if the position is being correctly passed;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1721](https://aptoide.atlassian.net/browse/ASV-1721)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass