### PR TITLE
[ASV-1744] fix: replace bds-store with catappult

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -1783,7 +1783,7 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
 
   @Singleton @Provides @Named("default-followed-stores")
   List<String> provideDefaultFollowedStores() {
-    return Arrays.asList("apps", "bds-store");
+    return Arrays.asList("apps", "catappult");
   }
 
   @Singleton @Provides AptoideApplicationAnalytics provideAptoideApplicationAnalytics() {

--- a/app/src/main/java/cm/aptoide/pt/view/ActivityModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/ActivityModule.java
@@ -298,9 +298,8 @@ import static android.content.Context.WINDOW_SERVICE;
   }
 
   @ActivityScope @Provides AppCoinsInfoNavigator providesAppCoinsInfoNavigator(
-      @Named("main-fragment-navigator") FragmentNavigator fragmentNavigator,
-      @Named("aptoide-theme") String theme) {
-    return new AppCoinsInfoNavigator(((ActivityNavigator) activity), fragmentNavigator, theme);
+      @Named("main-fragment-navigator") FragmentNavigator fragmentNavigator) {
+    return new AppCoinsInfoNavigator(fragmentNavigator);
   }
 
   @ActivityScope @Provides EditorialNavigator providesEditorialNavigator(AppNavigator appNavigator,

--- a/app/src/main/java/cm/aptoide/pt/view/AppCoinsInfoNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/view/AppCoinsInfoNavigator.java
@@ -36,7 +36,7 @@ public class AppCoinsInfoNavigator {
     AppViewFragment appViewFragment = new AppViewFragment();
     Bundle bundle = new Bundle();
     bundle.putString(AppViewFragment.BundleKeys.PACKAGE_NAME.name(), APPC_WALLET_PACKAGE_NAME);
-    bundle.putString(AppViewFragment.BundleKeys.STORE_NAME.name(), "bds-store");
+    bundle.putString(AppViewFragment.BundleKeys.STORE_NAME.name(), "catappult");
     appViewFragment.setArguments(bundle);
     fragmentNavigator.navigateTo(appViewFragment, true);
   }

--- a/app/src/main/java/cm/aptoide/pt/view/AppCoinsInfoNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/view/AppCoinsInfoNavigator.java
@@ -1,10 +1,7 @@
 package cm.aptoide.pt.view;
 
 import android.os.Bundle;
-import cm.aptoide.pt.R;
 import cm.aptoide.pt.app.view.AppViewFragment;
-import cm.aptoide.pt.link.CustomTabsHelper;
-import cm.aptoide.pt.navigator.ActivityNavigator;
 import cm.aptoide.pt.navigator.FragmentNavigator;
 
 /**
@@ -14,22 +11,10 @@ import cm.aptoide.pt.navigator.FragmentNavigator;
 public class AppCoinsInfoNavigator {
 
   static final String APPC_WALLET_PACKAGE_NAME = "com.appcoins.wallet";
-  private final ActivityNavigator activityNavigator;
   private final FragmentNavigator fragmentNavigator;
-  private final String theme;
 
-  public AppCoinsInfoNavigator(ActivityNavigator activityNavigator,
-      FragmentNavigator fragmentNavigator, String theme) {
-
-    this.activityNavigator = activityNavigator;
+  public AppCoinsInfoNavigator(FragmentNavigator fragmentNavigator) {
     this.fragmentNavigator = fragmentNavigator;
-    this.theme = theme;
-  }
-
-  public void navigateToCoinbaseLink() {
-    CustomTabsHelper.getInstance()
-        .openInChromeCustomTab(activityNavigator.getActivity()
-            .getString(R.string.coinbase_url), activityNavigator.getActivity(), theme);
   }
 
   public void navigateToAppCoinsWallet() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -534,8 +534,6 @@
   <string name="all_url_terms_conditions" translatable="false">https://www.aptoide.com/legal/terms?header=0&amp;menu=0</string>
   <string name="all_url_privacy_policy" translatable="false">https://www.aptoide.com/legal/privacy?header=0&amp;menu=0</string>
   <string name="settings_url_delete_account" translatable="false">https://www.aptoide.com/account/delete?access_token=%1$s</string>
-  <string name="coinbase_url" translatable="false">https://www.coinbase.com</string>
-
 
   <!--APPC-->
   <string name="appc_title_iab">Spend Your AppCoins</string>
@@ -558,8 +556,6 @@
   <!-- Check this code: for the strings with comments: https://gist.github.com/analaragomes/f82de0d3bc26ff15f3a196ce2e20ff1b -->
   <!--This variable is a link to AppCoins wallet app view. The text is AppCoins Wallet. This is done using html-->
   <string name="appc_message_appcoins_section_2a">Get the %s</string>
-  <!--This variable is a link to Coinbase (www.coinbase.com). The text is Coinbase. This is done using html-->
-  <string name="coinbase" translatable="false">Coinbase</string>
   <string name="appc_message_appcoins_section_2b">Open it to get it automatically configured. You\'ll receive your rewards here and it\'ll process all your transactions!</string>
   <string name="appc_message_appcoins_header_3">Get Rewarded!</string>
   <!--This variable is an image with APPC icon followed by id.string=appc_short_get_appc. This is done using html -->


### PR DESCRIPTION
**What does this PR do?**

   Replaces hardcoded references to bds-store to catappult, which is the new AppCoins certified developers store).
  One is the default following stores, the other one is the AppCoins information view to getApp

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppCoinsInfoNavigator.java

**How should this be manually tested?**

  Fresh install to check default following stores (only run at first run)
  Click in the wallet inside the AppCoins information view.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1744](https://aptoide.atlassian.net/browse/ASV-1744)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass