### PR TITLE
[Bugfix/ASV-1722] fix: home adapter notify

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/MoreBundleFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/MoreBundleFragment.java
@@ -19,7 +19,6 @@ import android.widget.ProgressBar;
 import cm.aptoide.analytics.implementation.navigation.ScreenTagHistory;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
-import cm.aptoide.pt.home.AdClick;
 import cm.aptoide.pt.home.AdHomeEvent;
 import cm.aptoide.pt.home.AdsBundlesViewHolderFactory;
 import cm.aptoide.pt.home.AppHomeEvent;
@@ -184,10 +183,6 @@ public class MoreBundleFragment extends NavigationTrackFragment implements MoreB
           .onRestoreInstanceState(listState);
       listState = null;
     }
-  }
-
-  @Override public void addHighlightedAd(AdClick click) {
-    adapter.addHighlightedAd(click);
   }
 
   @Override public void showLoading() {

--- a/app/src/main/java/cm/aptoide/pt/home/BundlesAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/BundlesAdapter.java
@@ -147,8 +147,9 @@ public class BundlesAdapter extends RecyclerView.Adapter<AppBundleViewHolder> {
   }
 
   public void add(List<HomeBundle> bundles) {
+    int initialPosition = this.bundles.size();
     this.bundles.addAll(bundles);
-    notifyDataSetChanged();
+    notifyItemRangeInserted(initialPosition, bundles.size());
   }
 
   public void addLoadMore() {

--- a/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
@@ -184,10 +184,6 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
     }
   }
 
-  @Override public void addHighlightedAd(AdClick click) {
-    adapter.addHighlightedAd(click);
-  }
-
   @Override public void showLoading() {
     bundlesList.setVisibility(View.GONE);
     genericErrorView.setVisibility(View.GONE);

--- a/app/src/main/java/cm/aptoide/pt/home/apps/BundleView.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/BundleView.java
@@ -1,6 +1,5 @@
 package cm.aptoide.pt.home.apps;
 
-import cm.aptoide.pt.home.AdClick;
 import cm.aptoide.pt.home.AdHomeEvent;
 import cm.aptoide.pt.home.AppHomeEvent;
 import cm.aptoide.pt.home.HomeBundle;
@@ -16,8 +15,6 @@ import rx.Observable;
 public interface BundleView extends View {
 
   void showBundles(List<HomeBundle> bundles);
-
-  void addHighlightedAd(AdClick click);
 
   void showLoading();
 


### PR DESCRIPTION
**What does this PR do?**

   Only notify new bundle additions, instead of invalidating every bundle in the adapter. This will prevent the view apps images flicker from happening when user hits load more.
 
**Database changed?**

   No

**Where should the reviewer start?**

- [ ] BundlesAdapter.java

**How should this be manually tested?**

Scroll home, test different bundle management methods (pull to refresh/load more/navigation)

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1722](https://aptoide.atlassian.net/browse/ASV-1722)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass