### PR TITLE
[feature/ASV-1710] show background caption color given in the ws

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -156,6 +156,7 @@ import cm.aptoide.pt.downloadmanager.DownloadsRepository;
 import cm.aptoide.pt.downloadmanager.FileDownloaderProvider;
 import cm.aptoide.pt.downloadmanager.RetryFileDownloadManagerProvider;
 import cm.aptoide.pt.downloadmanager.RetryFileDownloaderProvider;
+import cm.aptoide.pt.editorial.CaptionBackgroundPainter;
 import cm.aptoide.pt.editorial.EditorialAnalytics;
 import cm.aptoide.pt.editorial.EditorialService;
 import cm.aptoide.pt.editorialList.EditorialListAnalytics;
@@ -1961,5 +1962,9 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
 
   @Singleton @Provides AppcMigrationAccessor providesAppcMigrationAccessor(Database database) {
     return new AppcMigrationAccessor(database);
+  }
+
+  @Singleton @Provides CaptionBackgroundPainter providesCaptionBackgroundPainter() {
+    return new CaptionBackgroundPainter(getApplicationContext().getResources());
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/app/view/MoreBundleFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/MoreBundleFragment.java
@@ -19,6 +19,7 @@ import android.widget.ProgressBar;
 import cm.aptoide.analytics.implementation.navigation.ScreenTagHistory;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
+import cm.aptoide.pt.editorial.CaptionBackgroundPainter;
 import cm.aptoide.pt.home.AdHomeEvent;
 import cm.aptoide.pt.home.AdsBundlesViewHolderFactory;
 import cm.aptoide.pt.home.AppHomeEvent;
@@ -57,6 +58,7 @@ public class MoreBundleFragment extends NavigationTrackFragment implements MoreB
   private static final int VISIBLE_THRESHOLD = 1;
   @Inject MoreBundlePresenter presenter;
   @Inject @Named("marketName") String marketName;
+  @Inject CaptionBackgroundPainter captionBackgroundPainter;
   private RecyclerView bundlesList;
   private BundlesAdapter adapter;
   private PublishSubject<HomeEvent> uiEventsListener;
@@ -106,7 +108,7 @@ public class MoreBundleFragment extends NavigationTrackFragment implements MoreB
     adapter = new BundlesAdapter(new ArrayList<>(), new ProgressBundle(), uiEventsListener,
         oneDecimalFormatter, marketName,
         new AdsBundlesViewHolderFactory(uiEventsListener, adClickedEvents, oneDecimalFormatter,
-            marketName, false));
+            marketName, false), captionBackgroundPainter);
     layoutManager = new LinearLayoutManager(getContext());
     bundlesList.setLayoutManager(layoutManager);
     bundlesList.setAdapter(adapter);

--- a/app/src/main/java/cm/aptoide/pt/editorial/CaptionBackgroundPainter.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/CaptionBackgroundPainter.java
@@ -1,0 +1,31 @@
+package cm.aptoide.pt.editorial;
+
+import android.content.res.Resources;
+import android.graphics.Color;
+import android.support.v7.widget.CardView;
+import cm.aptoide.pt.R;
+
+public class CaptionBackgroundPainter {
+
+  private final Resources resources;
+
+  public CaptionBackgroundPainter(Resources resources) {
+    this.resources = resources;
+  }
+
+  public void addColorBackgroundToCaption(CardView captionView, String captionColor) {
+    if (captionColor != null && !captionColor.isEmpty()) {
+      try {
+        captionView.setCardBackgroundColor(Color.parseColor(captionColor));
+      } catch (IllegalArgumentException e) {
+        setDefaultBackgroundColor(captionView);
+      }
+    } else {
+      setDefaultBackgroundColor(captionView);
+    }
+  }
+
+  private void setDefaultBackgroundColor(CardView captionView) {
+    captionView.setCardBackgroundColor(this.resources.getColor(R.color.curation_default));
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialFragment.java
@@ -79,6 +79,7 @@ public class EditorialFragment extends NavigationTrackFragment
   @Inject @Named("screenWidth") float screenWidth;
   @Inject @Named("screenHeight") float screenHeight;
   @Inject @Named("aptoide-theme") String theme;
+  @Inject CaptionBackgroundPainter captionBackgroundPainter;
   private Toolbar toolbar;
   private ImageView appImage;
   private TextView itemName;
@@ -617,30 +618,11 @@ public class EditorialFragment extends NavigationTrackFragment
     toolbarTitle.setText(editorialViewModel.getTitle());
     appImage.setVisibility(View.VISIBLE);
     itemName.setText(Translator.translate(caption, getContext(), ""));
-    setCurationCardBubble(caption);
+    captionBackgroundPainter.addColorBackgroundToCaption(actionItemCard,
+        editorialViewModel.getCaptionColor());
     itemName.setVisibility(View.VISIBLE);
     actionItemCard.setVisibility(View.VISIBLE);
     setBottomAppCardInfo(editorialViewModel);
-  }
-
-  public void setCurationCardBubble(String caption) {
-    switch (caption) {
-      case "Game of the Week":
-        actionItemCard.setCardBackgroundColor(getResources().getColor(R.color.curation_grey));
-        break;
-
-      case "App of the Week":
-        actionItemCard.setCardBackgroundColor(getResources().getColor(R.color.curation_blue));
-        break;
-
-      case "Collections":
-        actionItemCard.setCardBackgroundColor(getResources().getColor(R.color.curation_green));
-        break;
-
-      default:
-        actionItemCard.setCardBackgroundColor(getResources().getColor(R.color.curation_default));
-        break;
-    }
   }
 
   private void setBottomAppCardInfo(EditorialViewModel editorialViewModel) {

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialService.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialService.java
@@ -180,6 +180,9 @@ public class EditorialService {
   private EditorialViewModel buildEditorialViewModel(List<EditorialContent> editorialContentList,
       Data card, List<Integer> placeHolderPositions, List<EditorialContent> placeHolderContent,
       EditorialContent bottomCardPlaceHolderContent, String cardId, String groupId) {
+    String captionColor = card.getAppearance() != null ? card.getAppearance()
+        .getCaption()
+        .getTheme() : "";
     if (bottomCardPlaceHolderContent != null) {
       return new EditorialViewModel(editorialContentList, card.getTitle(), card.getCaption(),
           card.getBackground(), placeHolderPositions, placeHolderContent,
@@ -188,9 +191,10 @@ public class EditorialService {
           bottomCardPlaceHolderContent.getMd5sum(), bottomCardPlaceHolderContent.getVerCode(),
           bottomCardPlaceHolderContent.getVerName(), bottomCardPlaceHolderContent.getPath(),
           bottomCardPlaceHolderContent.getPathAlt(), bottomCardPlaceHolderContent.getObb(), true,
-          cardId, groupId, bottomCardPlaceHolderContent.getSize());
+          cardId, groupId, bottomCardPlaceHolderContent.getSize(), captionColor);
     }
     return new EditorialViewModel(editorialContentList, card.getTitle(), card.getCaption(),
-        card.getBackground(), placeHolderPositions, placeHolderContent, false, cardId, groupId);
+        card.getBackground(), placeHolderPositions, placeHolderContent, false, cardId, groupId,
+        captionColor);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialViewModel.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialViewModel.java
@@ -32,11 +32,12 @@ public class EditorialViewModel {
   private final String groupId;
   private final boolean loading;
   private final Error error;
+  private final String captionColor;
 
   public EditorialViewModel(List<EditorialContent> editorialContentList, String title,
       String caption, String background, List<Integer> placeHolderPositions,
       List<EditorialContent> placeHolderContent, boolean shouldHaveAnimation, String cardId,
-      String groupId) {
+      String groupId, String captionColor) {
     contentList = editorialContentList;
     this.title = title;
     this.caption = caption;
@@ -46,6 +47,7 @@ public class EditorialViewModel {
     this.shouldHaveAnimation = shouldHaveAnimation;
     this.cardId = cardId;
     this.groupId = groupId;
+    this.captionColor = captionColor;
     appName = "";
     icon = null;
     id = -1;
@@ -84,6 +86,7 @@ public class EditorialViewModel {
     cardId = "";
     shouldHaveAnimation = false;
     error = null;
+    captionColor = "";
   }
 
   public EditorialViewModel(Error error) {
@@ -109,6 +112,7 @@ public class EditorialViewModel {
     cardId = "";
     obb = null;
     shouldHaveAnimation = false;
+    captionColor = "";
   }
 
   public EditorialViewModel(List<EditorialContent> editorialContentList, String title,
@@ -116,7 +120,7 @@ public class EditorialViewModel {
       List<EditorialContent> placeHolderContent, String appName, String icon, long id,
       String packageName, String md5sum, int versionCode, String versionName, String path,
       String pathAlt, Obb obb, boolean shouldHaveAnimation, String cardId, String groupId,
-      long size) {
+      long size, String captionColor) {
     contentList = editorialContentList;
     this.title = title;
     this.caption = caption;
@@ -137,6 +141,7 @@ public class EditorialViewModel {
     this.shouldHaveAnimation = shouldHaveAnimation;
     this.cardId = cardId;
     this.groupId = groupId;
+    this.captionColor = captionColor;
     error = null;
     loading = false;
   }
@@ -243,6 +248,10 @@ public class EditorialViewModel {
 
   public long getBottomCardSize() {
     return this.size;
+  }
+
+  public String getCaptionColor() {
+    return this.captionColor;
   }
 
   public enum Error {

--- a/app/src/main/java/cm/aptoide/pt/editorialList/CurationCard.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/CurationCard.java
@@ -12,12 +12,13 @@ public class CurationCard {
   private final String views;
   private final String type;
   private final String date;
+  private final String captionColor;
   private List<TopReaction> reactions;
   private String userReaction;
   private int numberOfReactions;
 
   public CurationCard(String id, String subTitle, String icon, String title, String views,
-      String type, String date) {
+      String type, String date, String captionColor) {
     this.id = id;
     this.subTitle = subTitle;
     this.icon = icon;
@@ -25,6 +26,7 @@ public class CurationCard {
     this.views = views;
     this.type = type;
     this.date = date;
+    this.captionColor = captionColor;
     reactions = Collections.emptyList();
     userReaction = "";
     numberOfReactions = -1;
@@ -38,6 +40,7 @@ public class CurationCard {
     views = "";
     type = "";
     date = "";
+    captionColor = "";
   }
 
   public String getId() {
@@ -90,5 +93,9 @@ public class CurationCard {
 
   public void setNumberOfReactions(int numberOfReactions) {
     this.numberOfReactions = numberOfReactions;
+  }
+
+  public String getCaptionColor() {
+    return this.captionColor;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListAdapter.java
@@ -4,6 +4,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 import cm.aptoide.pt.R;
+import cm.aptoide.pt.editorial.CaptionBackgroundPainter;
 import cm.aptoide.pt.home.EditorialBundleViewHolder;
 import cm.aptoide.pt.home.HomeEvent;
 import java.util.List;
@@ -15,22 +16,25 @@ class EditorialListAdapter extends RecyclerView.Adapter<EditorialBundleViewHolde
   private static final int EDITORIAL_CARD = R.layout.editorial_action_item;
   private final ProgressCard progressBundle;
   private final PublishSubject<HomeEvent> uiEventsListener;
+  private final CaptionBackgroundPainter captionBackgroundPainter;
   private List<CurationCard> editorialListItems;
 
   public EditorialListAdapter(List<CurationCard> editorialListItems, ProgressCard progressBundle,
-      PublishSubject<HomeEvent> uiEventsListener) {
+      PublishSubject<HomeEvent> uiEventsListener,
+      CaptionBackgroundPainter captionBackgroundPainter) {
     this.editorialListItems = editorialListItems;
     this.progressBundle = progressBundle;
     this.uiEventsListener = uiEventsListener;
+    this.captionBackgroundPainter = captionBackgroundPainter;
   }
 
   @Override public EditorialBundleViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
     if (viewType == EDITORIAL_CARD) {
       return new EditorialBundleViewHolder(LayoutInflater.from(parent.getContext())
-          .inflate(EDITORIAL_CARD, parent, false), uiEventsListener);
+          .inflate(EDITORIAL_CARD, parent, false), uiEventsListener, captionBackgroundPainter);
     } else {
       return new LoadingViewHolder(LayoutInflater.from(parent.getContext())
-          .inflate(LOADING, parent, false), uiEventsListener);
+          .inflate(LOADING, parent, false), uiEventsListener, captionBackgroundPainter);
     }
   }
 

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListFragment.java
@@ -16,6 +16,7 @@ import cm.aptoide.analytics.implementation.navigation.ScreenTagHistory;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.bottomNavigation.BottomNavigationActivity;
 import cm.aptoide.pt.bottomNavigation.BottomNavigationItem;
+import cm.aptoide.pt.editorial.CaptionBackgroundPainter;
 import cm.aptoide.pt.editorial.EditorialFragment;
 import cm.aptoide.pt.home.EditorialBundleViewHolder;
 import cm.aptoide.pt.home.EditorialHomeEvent;
@@ -44,6 +45,7 @@ public class EditorialListFragment extends NavigationTrackFragment implements Ed
   private static final int VISIBLE_THRESHOLD = 1;
   private static final BottomNavigationItem BOTTOM_NAVIGATION_ITEM = BottomNavigationItem.CURATION;
   @Inject public EditorialListPresenter presenter;
+  @Inject CaptionBackgroundPainter captionBackgroundPainter;
   private BottomNavigationActivity bottomNavigationActivity;
   private RecyclerView editorialList;
   private EditorialListAdapter adapter;
@@ -51,14 +53,12 @@ public class EditorialListFragment extends NavigationTrackFragment implements Ed
   private PublishSubject<Void> snackListener;
   private ScrollControlLinearLayoutManager layoutManager;
   private SwipeRefreshLayout swipeRefreshLayout;
-
   //Error views
   private View genericErrorView;
   private View noNetworkErrorView;
   private ProgressBar progressBar;
   private View noNetworkRetryButton;
   private View retryButton;
-
   private ImageView userAvatar;
 
   @Override public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -75,7 +75,8 @@ public class EditorialListFragment extends NavigationTrackFragment implements Ed
     }
     userAvatar = view.findViewById(R.id.user_actionbar_icon);
     layoutManager = new ScrollControlLinearLayoutManager(getContext());
-    adapter = new EditorialListAdapter(new ArrayList<>(), new ProgressCard(), uiEventsListener);
+    adapter = new EditorialListAdapter(new ArrayList<>(), new ProgressCard(), uiEventsListener,
+        captionBackgroundPainter);
     editorialList = view.findViewById(R.id.editorial_list);
     editorialList.setLayoutManager(layoutManager);
     editorialList.setAdapter(adapter);
@@ -244,10 +245,6 @@ public class EditorialListFragment extends NavigationTrackFragment implements Ed
         .cast(ReactionsHomeEvent.class);
   }
 
-  @Override public void setScrollEnabled(Boolean flag) {
-    layoutManager.setScrollEnabled(flag);
-  }
-
   @Override public Observable<EditorialHomeEvent> reactionButtonLongPress() {
     return uiEventsListener.filter(homeEvent -> homeEvent.getType()
         .equals(HomeEvent.Type.REACT_LONG_PRESS))
@@ -256,12 +253,6 @@ public class EditorialListFragment extends NavigationTrackFragment implements Ed
           setScrollEnabled(false);
           return event;
         });
-  }
-
-  @Override public Observable<EditorialHomeEvent> onPopupDismiss() {
-    return uiEventsListener.filter(homeEvent -> homeEvent.getType()
-        .equals(HomeEvent.Type.POPUP_DISMISS))
-        .cast(EditorialHomeEvent.class);
   }
 
   @Override public void showReactionsPopup(String cardId, String groupId, int bundlePosition) {
@@ -293,6 +284,16 @@ public class EditorialListFragment extends NavigationTrackFragment implements Ed
   @Override public void showNetworkErrorToast() {
     Snackbar.make(getView(), getString(R.string.connection_error), Snackbar.LENGTH_LONG)
         .show();
+  }
+
+  @Override public void setScrollEnabled(Boolean flag) {
+    layoutManager.setScrollEnabled(flag);
+  }
+
+  @Override public Observable<EditorialHomeEvent> onPopupDismiss() {
+    return uiEventsListener.filter(homeEvent -> homeEvent.getType()
+        .equals(HomeEvent.Type.POPUP_DISMISS))
+        .cast(EditorialHomeEvent.class);
   }
 
   private boolean isEndReached() {

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListService.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListService.java
@@ -76,7 +76,10 @@ public class EditorialListService {
       CurationCard curationCard =
           new CurationCard(actionItemData.getId(), actionItemData.getCaption(),
               actionItemData.getIcon(), actionItemData.getTitle(), actionItemData.getViews(),
-              actionItemData.getType(), actionItemData.getDate());
+              actionItemData.getType(), actionItemData.getDate(),
+              actionItemData.getAppearance() != null ? actionItemData.getAppearance()
+                  .getCaption()
+                  .getTheme() : "");
       curationCards.add(curationCard);
     }
     return curationCards;

--- a/app/src/main/java/cm/aptoide/pt/editorialList/LoadingViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/LoadingViewHolder.java
@@ -1,12 +1,14 @@
 package cm.aptoide.pt.editorialList;
 
 import android.view.View;
+import cm.aptoide.pt.editorial.CaptionBackgroundPainter;
 import cm.aptoide.pt.home.EditorialBundleViewHolder;
 import cm.aptoide.pt.home.HomeEvent;
 import rx.subjects.PublishSubject;
 
 class LoadingViewHolder extends EditorialBundleViewHolder {
-  public LoadingViewHolder(View inflate, PublishSubject<HomeEvent> uiEventsListener) {
-    super(inflate, uiEventsListener);
+  public LoadingViewHolder(View inflate, PublishSubject<HomeEvent> uiEventsListener,
+      CaptionBackgroundPainter captionBackgroundPainter) {
+    super(inflate, uiEventsListener, captionBackgroundPainter);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/editorialList/ProgressCard.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/ProgressCard.java
@@ -3,6 +3,6 @@ package cm.aptoide.pt.editorialList;
 public class ProgressCard extends CurationCard {
 
   public ProgressCard() {
-    super("", "", "", "", "", "", "");
+    super("", "", "", "", "", "", "", "");
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/ActionItem.java
+++ b/app/src/main/java/cm/aptoide/pt/home/ActionItem.java
@@ -13,12 +13,13 @@ public class ActionItem {
   private final String url;
   private final String numberOfViews;
   private final String date;
+  private final String captionColor;
   private List<TopReaction> reactionList;
   private int total;
   private String userReaction;
 
   public ActionItem(String cardId, String type, String title, String subTitle, String icon,
-      String url, String numberOfViews, String date) {
+      String url, String numberOfViews, String date, String captionColor) {
     this.cardId = cardId;
     this.type = type;
     this.title = title;
@@ -27,6 +28,7 @@ public class ActionItem {
     this.url = url;
     this.numberOfViews = numberOfViews;
     this.date = date;
+    this.captionColor = captionColor;
     this.reactionList = Collections.emptyList();
     this.total = -1;
     this.userReaction = "";
@@ -86,5 +88,9 @@ public class ActionItem {
 
   public void setUserReaction(String myReaction) {
     this.userReaction = myReaction;
+  }
+
+  public String getCaptionColor() {
+    return captionColor;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/BundlesAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/BundlesAdapter.java
@@ -4,6 +4,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 import cm.aptoide.pt.R;
+import cm.aptoide.pt.editorial.CaptionBackgroundPainter;
 import java.text.DecimalFormat;
 import java.util.List;
 import rx.subjects.PublishSubject;
@@ -28,17 +29,20 @@ public class BundlesAdapter extends RecyclerView.Adapter<AppBundleViewHolder> {
   private final PublishSubject<HomeEvent> uiEventsListener;
   private final String marketName;
   private final AdsBundlesViewHolderFactory adsBundlesViewHolderFactory;
+  private final CaptionBackgroundPainter captionBackgroundPainter;
   private List<HomeBundle> bundles;
 
   public BundlesAdapter(List<HomeBundle> bundles, ProgressBundle homeBundle,
       PublishSubject<HomeEvent> uiEventsListener, DecimalFormat oneDecimalFormatter,
-      String marketName, AdsBundlesViewHolderFactory adsBundlesViewHolderFactory) {
+      String marketName, AdsBundlesViewHolderFactory adsBundlesViewHolderFactory,
+      CaptionBackgroundPainter captionBackgroundPainter) {
     this.bundles = bundles;
     this.progressBundle = homeBundle;
     this.uiEventsListener = uiEventsListener;
     this.oneDecimalFormatter = oneDecimalFormatter;
     this.marketName = marketName;
     this.adsBundlesViewHolderFactory = adsBundlesViewHolderFactory;
+    this.captionBackgroundPainter = captionBackgroundPainter;
   }
 
   @Override public AppBundleViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
@@ -61,7 +65,8 @@ public class BundlesAdapter extends RecyclerView.Adapter<AppBundleViewHolder> {
             .inflate(R.layout.info_action_item, parent, false), uiEventsListener);
       case EDITORIAL:
         return new EditorialBundleViewHolder(LayoutInflater.from(parent.getContext())
-            .inflate(R.layout.editorial_action_item, parent, false), uiEventsListener);
+            .inflate(R.layout.editorial_action_item, parent, false), uiEventsListener,
+            captionBackgroundPainter);
       case LOADING:
         return new LoadingBundleViewHolder(LayoutInflater.from(parent.getContext())
             .inflate(R.layout.progress_item, parent, false));

--- a/app/src/main/java/cm/aptoide/pt/home/BundlesResponseMapper.java
+++ b/app/src/main/java/cm/aptoide/pt/home/BundlesResponseMapper.java
@@ -111,7 +111,9 @@ public class BundlesResponseMapper {
         .get(0);
     return new ActionItem(item.getId(), item.getType() != null ? item.getType() : "",
         item.getTitle(), item.getCaption(), item.getIcon(), item.getUrl(), item.getViews(),
-        item.getDate());
+        item.getDate(), item.getAppearance() != null ? item.getAppearance()
+        .getCaption()
+        .getTheme() : "");
   }
 
   private HomeBundle.BundleType actionItemTypeMapper(Object actionItemData) {

--- a/app/src/main/java/cm/aptoide/pt/home/EditorialBundleViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/home/EditorialBundleViewHolder.java
@@ -7,6 +7,7 @@ import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 import cm.aptoide.pt.R;
+import cm.aptoide.pt.editorial.CaptionBackgroundPainter;
 import cm.aptoide.pt.editorialList.CurationCard;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.reactions.ReactionsHomeEvent;
@@ -36,21 +37,24 @@ public class EditorialBundleViewHolder extends AppBundleViewHolder {
   private final ImageView backgroundImage;
   private final TextView editorialViews;
   private final ImageButton reactButton;
-  private final CardView curationTypeBubble;
-  private final TextView curationTypeBubbleText;
+  private final CardView curationTypeCaption;
+  private final TextView curationTypeCaptionText;
+  private final CaptionBackgroundPainter captionBackgroundPainter;
   private TopReactionsPreview topReactionsPreview;
 
-  public EditorialBundleViewHolder(View view, PublishSubject<HomeEvent> uiEventsListener) {
+  public EditorialBundleViewHolder(View view, PublishSubject<HomeEvent> uiEventsListener,
+      CaptionBackgroundPainter captionBackgroundPainter) {
     super(view);
     this.uiEventsListener = uiEventsListener;
     this.editorialCard = view.findViewById(R.id.editorial_card);
-    this.editorialTitle = (TextView) view.findViewById(R.id.editorial_title);
-    this.editorialDate = (TextView) view.findViewById(R.id.editorial_date);
+    this.editorialTitle = view.findViewById(R.id.editorial_title);
+    this.editorialDate = view.findViewById(R.id.editorial_date);
     this.editorialViews = view.findViewById(R.id.editorial_views);
-    this.backgroundImage = (ImageView) view.findViewById(R.id.background_image);
+    this.backgroundImage = view.findViewById(R.id.background_image);
     this.reactButton = view.findViewById(R.id.add_reactions);
-    this.curationTypeBubble = view.findViewById(R.id.curation_type_bubble);
-    this.curationTypeBubbleText = view.findViewById(R.id.curation_type_bubble_text);
+    this.curationTypeCaption = view.findViewById(R.id.curation_type_bubble);
+    this.curationTypeCaptionText = view.findViewById(R.id.curation_type_bubble_text);
+    this.captionBackgroundPainter = captionBackgroundPainter;
     topReactionsPreview = new TopReactionsPreview();
     topReactionsPreview.initialReactionsSetup(view);
   }
@@ -62,12 +66,13 @@ public class EditorialBundleViewHolder extends AppBundleViewHolder {
     setBundleInformation(actionItem.getIcon(), actionItem.getTitle(), actionItem.getSubTitle(),
         actionItem.getCardId(), actionItem.getNumberOfViews(), actionItem.getType(),
         actionItem.getDate(), getAdapterPosition(), homeBundle, actionItem.getReactionList(),
-        actionItem.getTotal(), actionItem.getUserReaction());
+        actionItem.getTotal(), actionItem.getUserReaction(), actionItem.getCaptionColor());
   }
 
   private void setBundleInformation(String icon, String title, String subTitle, String cardId,
       String numberOfViews, String type, String date, int position, HomeBundle homeBundle,
-      List<TopReaction> reactions, int numberOfReactions, String userReaction) {
+      List<TopReaction> reactions, int numberOfReactions, String userReaction,
+      String captionColor) {
     clearReactions();
     setReactions(reactions, numberOfReactions, userReaction);
     ImageLoader.with(itemView.getContext())
@@ -76,7 +81,8 @@ public class EditorialBundleViewHolder extends AppBundleViewHolder {
     editorialViews.setText(String.format(itemView.getContext()
             .getString(R.string.editorial_card_short_number_views),
         formatNumberOfViews(numberOfViews)));
-    setCurationCardBubble(subTitle);
+    curationTypeCaptionText.setText(subTitle);
+    captionBackgroundPainter.addColorBackgroundToCaption(curationTypeCaption, captionColor);
     setupCalendarDateString(date);
     reactButton.setOnClickListener(view -> uiEventsListener.onNext(
         new EditorialHomeEvent(cardId, type, homeBundle, position,
@@ -120,7 +126,8 @@ public class EditorialBundleViewHolder extends AppBundleViewHolder {
     setBundleInformation(curationCard.getIcon(), curationCard.getTitle(),
         curationCard.getSubTitle(), curationCard.getId(), curationCard.getViews(),
         curationCard.getType(), curationCard.getDate(), position, null, curationCard.getReactions(),
-        curationCard.getNumberOfReactions(), curationCard.getUserReaction());
+        curationCard.getNumberOfReactions(), curationCard.getUserReaction(),
+        curationCard.getCaptionColor());
   }
 
   public void showReactions(String cardId, String groupId, int position) {
@@ -152,34 +159,5 @@ public class EditorialBundleViewHolder extends AppBundleViewHolder {
   private void clearReactions() {
     reactButton.setImageResource(R.drawable.ic_reaction_emoticon);
     topReactionsPreview.clearReactions();
-  }
-
-  private void setCurationCardBubble(String caption) {
-    curationTypeBubbleText.setText(caption);
-    switch (caption) {
-      case "Game of the Week":
-        curationTypeBubble.setCardBackgroundColor(itemView.getContext()
-            .getResources()
-            .getColor(R.color.curation_grey));
-        break;
-
-      case "App of the Week":
-        curationTypeBubble.setCardBackgroundColor(itemView.getContext()
-            .getResources()
-            .getColor(R.color.curation_blue));
-        break;
-
-      case "Collections":
-        curationTypeBubble.setCardBackgroundColor(itemView.getContext()
-            .getResources()
-            .getColor(R.color.curation_green));
-        break;
-
-      default:
-        curationTypeBubble.setCardBackgroundColor(itemView.getContext()
-            .getResources()
-            .getColor(R.color.curation_default));
-        break;
-    }
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
@@ -24,6 +24,7 @@ import cm.aptoide.pt.ads.MoPubConsentDialogView;
 import cm.aptoide.pt.bottomNavigation.BottomNavigationActivity;
 import cm.aptoide.pt.bottomNavigation.BottomNavigationItem;
 import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
+import cm.aptoide.pt.editorial.CaptionBackgroundPainter;
 import cm.aptoide.pt.editorial.EditorialFragment;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.promotions.PromotionsHomeDialog;
@@ -60,6 +61,7 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
   @Inject HomePresenter presenter;
   @Inject @Named("marketName") String marketName;
   @Inject @Named("mopub-consent-dialog-view") MoPubConsentDialogView consentDialogView;
+  @Inject CaptionBackgroundPainter captionBackgroundPainter;
   private RecyclerView bundlesList;
   private BundlesAdapter adapter;
   private PublishSubject<HomeEvent> uiEventsListener;
@@ -342,7 +344,7 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
     adapter = new BundlesAdapter(new ArrayList<>(), new ProgressBundle(), uiEventsListener,
         oneDecimalFormatter, marketName,
         new AdsBundlesViewHolderFactory(uiEventsListener, adClickedEvents, oneDecimalFormatter,
-            marketName, showNatives));
+            marketName, showNatives), captionBackgroundPainter);
     bundlesList.setAdapter(adapter);
   }
 

--- a/app/src/test/java/cm/aptoide/pt/app/view/EditorialPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/view/EditorialPresenterTest.java
@@ -75,7 +75,7 @@ public class EditorialPresenterTest {
             "icon", 1, "packageName", 0, "graphic", null, 1, "storeName", "verName", 0, "path",
             "pathAlt", "md5", "actionTitle", "url", 1));
     editorialViewModel = new EditorialViewModel(editorialContent, "title", "caption", "background",
-        Collections.emptyList(), editorialContent, false, "1", "CURATION_1", captionColor);
+        Collections.emptyList(), editorialContent, false, "1", "CURATION_1", "");
     downloadModel = new EditorialDownloadModel(DownloadModel.Action.INSTALL, 0,
         DownloadModel.DownloadState.ACTIVE, null, 1);
     errorEditorialViewModel = new EditorialViewModel(EditorialViewModel.Error.GENERIC);

--- a/app/src/test/java/cm/aptoide/pt/app/view/EditorialPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/view/EditorialPresenterTest.java
@@ -75,7 +75,7 @@ public class EditorialPresenterTest {
             "icon", 1, "packageName", 0, "graphic", null, 1, "storeName", "verName", 0, "path",
             "pathAlt", "md5", "actionTitle", "url", 1));
     editorialViewModel = new EditorialViewModel(editorialContent, "title", "caption", "background",
-        Collections.emptyList(), editorialContent, false, "1", "CURATION_1");
+        Collections.emptyList(), editorialContent, false, "1", "CURATION_1", captionColor);
     downloadModel = new EditorialDownloadModel(DownloadModel.Action.INSTALL, 0,
         DownloadModel.DownloadState.ACTIVE, null, 1);
     errorEditorialViewModel = new EditorialViewModel(EditorialViewModel.Error.GENERIC);

--- a/app/src/test/java/cm/aptoide/pt/editorialList/EditorialListPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/editorialList/EditorialListPresenterTest.java
@@ -70,8 +70,7 @@ public class EditorialListPresenterTest {
     presenter = new EditorialListPresenter(view, editorialListManager, accountManager,
         editorialListNavigator, editorialListAnalytics, crashReporter, Schedulers.immediate());
     CurationCard curationCard =
-        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56",
-            captionColor);
+        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56", "");
     List<CurationCard> curationCardList = Collections.singletonList(curationCard);
     successEditorialViewModel = new EditorialListViewModel(curationCardList, 0, 0);
     loadingEditorialViewModel = new EditorialListViewModel(true);
@@ -292,8 +291,7 @@ public class EditorialListPresenterTest {
 
   @Test public void handleReactionButtonClickSecondReactionTest() {
     CurationCard curationCard =
-        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56",
-            captionColor);
+        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56", "");
     //Given an initialised presenter
     presenter.handleReactionButtonClick();
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
@@ -328,8 +326,7 @@ public class EditorialListPresenterTest {
 
   @Test public void handleUserReactionTest() {
     CurationCard curationCard =
-        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56",
-            captionColor);
+        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56", "");
     //Given an initialised presenter
     presenter.handleUserReaction();
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
@@ -349,8 +346,7 @@ public class EditorialListPresenterTest {
 
   @Test public void handleUserReactionWithSameReactionTest() {
     CurationCard curationCard =
-        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56",
-            captionColor);
+        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56", "");
     //Given an initialised presenter
     presenter.handleUserReaction();
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);

--- a/app/src/test/java/cm/aptoide/pt/editorialList/EditorialListPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/editorialList/EditorialListPresenterTest.java
@@ -70,7 +70,8 @@ public class EditorialListPresenterTest {
     presenter = new EditorialListPresenter(view, editorialListManager, accountManager,
         editorialListNavigator, editorialListAnalytics, crashReporter, Schedulers.immediate());
     CurationCard curationCard =
-        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56");
+        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56",
+            captionColor);
     List<CurationCard> curationCardList = Collections.singletonList(curationCard);
     successEditorialViewModel = new EditorialListViewModel(curationCardList, 0, 0);
     loadingEditorialViewModel = new EditorialListViewModel(true);
@@ -291,7 +292,8 @@ public class EditorialListPresenterTest {
 
   @Test public void handleReactionButtonClickSecondReactionTest() {
     CurationCard curationCard =
-        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56");
+        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56",
+            captionColor);
     //Given an initialised presenter
     presenter.handleReactionButtonClick();
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
@@ -326,7 +328,8 @@ public class EditorialListPresenterTest {
 
   @Test public void handleUserReactionTest() {
     CurationCard curationCard =
-        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56");
+        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56",
+            captionColor);
     //Given an initialised presenter
     presenter.handleUserReaction();
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
@@ -346,7 +349,8 @@ public class EditorialListPresenterTest {
 
   @Test public void handleUserReactionWithSameReactionTest() {
     CurationCard curationCard =
-        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56");
+        new CurationCard("1", "sub", "icon", "title", "1000", GROUP_ID, "2018-11-29 17:14:56",
+            captionColor);
     //Given an initialised presenter
     presenter.handleUserReaction();
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);

--- a/app/src/test/java/cm/aptoide/pt/navigation/HomePresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/navigation/HomePresenterTest.java
@@ -467,7 +467,7 @@ public class HomePresenterTest {
   @NonNull private ActionBundle getFakeActionBundle() {
     return new ActionBundle("title", HomeBundle.BundleType.INFO_BUNDLE, null, "tag",
         new ActionItem("1", "type", "title", "message", "icon", "url", "1000",
-            "2018-11-29 17:14:56", captionColor));
+            "2018-11-29 17:14:56", "#e3e3e3"));
   }
 
   private AdHomeEvent createAdHomeEvent() {

--- a/app/src/test/java/cm/aptoide/pt/navigation/HomePresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/navigation/HomePresenterTest.java
@@ -467,7 +467,7 @@ public class HomePresenterTest {
   @NonNull private ActionBundle getFakeActionBundle() {
     return new ActionBundle("title", HomeBundle.BundleType.INFO_BUNDLE, null, "tag",
         new ActionItem("1", "type", "title", "message", "icon", "url", "1000",
-            "2018-11-29 17:14:56"));
+            "2018-11-29 17:14:56", captionColor));
   }
 
   private AdHomeEvent createAdHomeEvent() {

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/model/v7/EditorialCard.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/model/v7/EditorialCard.java
@@ -1,6 +1,7 @@
 package cm.aptoide.pt.dataprovider.model.v7;
 
 import cm.aptoide.pt.dataprovider.model.v7.listapp.App;
+import cm.aptoide.pt.dataprovider.ws.v7.home.Appearance;
 import java.util.List;
 
 /**
@@ -32,6 +33,7 @@ public class EditorialCard extends BaseV7Response {
     private String title;
     private String caption;
     private String background;
+    private Appearance appearance;
 
     public Data() {
 
@@ -75,6 +77,14 @@ public class EditorialCard extends BaseV7Response {
 
     public void setTitle(String title) {
       this.title = title;
+    }
+
+    public Appearance getAppearance() {
+      return appearance;
+    }
+
+    public void setAppearance(Appearance appearance) {
+      this.appearance = appearance;
     }
 
     //3rd level

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/EditorialListData.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/EditorialListData.java
@@ -1,6 +1,7 @@
 package cm.aptoide.pt.dataprovider.ws.v7;
 
 import cm.aptoide.pt.dataprovider.model.v7.BaseV7EndlessDataListResponse;
+import cm.aptoide.pt.dataprovider.ws.v7.home.Appearance;
 
 public class EditorialListData extends BaseV7EndlessDataListResponse {
 
@@ -11,6 +12,7 @@ public class EditorialListData extends BaseV7EndlessDataListResponse {
   public String icon;
   public String views;
   public String date;
+  public Appearance appearance;
 
   public EditorialListData() {
 
@@ -42,5 +44,9 @@ public class EditorialListData extends BaseV7EndlessDataListResponse {
 
   public String getDate() {
     return date;
+  }
+
+  public Appearance getAppearance() {
+    return appearance;
   }
 }

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/home/ActionItemData.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/home/ActionItemData.java
@@ -9,6 +9,7 @@ public class ActionItemData {
   private String url;
   private String views;
   private String date;
+  private Appearance appearance;
 
   public String getType() {
     return type;
@@ -72,5 +73,13 @@ public class ActionItemData {
 
   public void setDate(String date) {
     this.date = date;
+  }
+
+  public Appearance getAppearance() {
+    return appearance;
+  }
+
+  public void setAppearance(Appearance appearance) {
+    this.appearance = appearance;
   }
 }

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/home/Appearance.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/home/Appearance.java
@@ -1,0 +1,13 @@
+package cm.aptoide.pt.dataprovider.ws.v7.home;
+
+public class Appearance {
+  private Caption caption;
+
+  public Caption getCaption() {
+    return caption;
+  }
+
+  public void setCaption(Caption caption) {
+    this.caption = caption;
+  }
+}

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/home/Caption.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/home/Caption.java
@@ -1,0 +1,13 @@
+package cm.aptoide.pt.dataprovider.ws.v7.home;
+
+public class Caption {
+  private String theme;
+
+  public String getTheme() {
+    return theme;
+  }
+
+  public void setTheme(String theme) {
+    this.theme = theme;
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

   show background caption color given in the editorial ws response. default is orange

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] CaptionBackgroundPainter.java.java

**How should this be manually tested?**

  Home > check editorial content card caption
  Aptoide > Editorial > check cards caption
  Aptoide > Click an editorial content card > check feature graphic caption 

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1710](https://aptoide.atlassian.net/browse/ASV-1710)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass