### PR TITLE
[ASV-1716] - Home BN Item selection flow

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/MoreBundleFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/MoreBundleFragment.java
@@ -3,6 +3,7 @@ package cm.aptoide.pt.app.view;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
+import android.support.annotation.UiThread;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -26,6 +27,7 @@ import cm.aptoide.pt.home.BundlesAdapter;
 import cm.aptoide.pt.home.HomeBundle;
 import cm.aptoide.pt.home.HomeEvent;
 import cm.aptoide.pt.home.ProgressBundle;
+import cm.aptoide.pt.home.ScrollableView;
 import cm.aptoide.pt.store.view.StoreTabGridRecyclerFragment;
 import cm.aptoide.pt.view.Translator;
 import cm.aptoide.pt.view.fragment.NavigationTrackFragment;
@@ -48,7 +50,8 @@ import static android.view.View.GONE;
  * Created by D01 on 04/06/2018.
  */
 
-public class MoreBundleFragment extends NavigationTrackFragment implements MoreBundleView {
+public class MoreBundleFragment extends NavigationTrackFragment
+    implements MoreBundleView, ScrollableView {
 
   private static final String MORE_LIST_STATE_KEY = "cm.aptoide.pt.more.ListState";
   /**
@@ -303,5 +306,19 @@ public class MoreBundleFragment extends NavigationTrackFragment implements MoreB
   private boolean isEndReached() {
     return layoutManager.getItemCount() - layoutManager.findLastVisibleItemPosition()
         <= VISIBLE_THRESHOLD;
+  }
+
+  @UiThread @Override public void scrollToTop() {
+    LinearLayoutManager layoutManager = ((LinearLayoutManager) bundlesList.getLayoutManager());
+    int lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition();
+    if (lastVisibleItemPosition > 10) {
+      bundlesList.scrollToPosition(10);
+    }
+    bundlesList.smoothScrollToPosition(0);
+  }
+
+  @Override public boolean isAtTop() {
+    LinearLayoutManager layoutManager = ((LinearLayoutManager) bundlesList.getLayoutManager());
+    return layoutManager.findFirstVisibleItemPosition() == 0;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/HomeContainerFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeContainerFragment.java
@@ -3,6 +3,7 @@ package cm.aptoide.pt.home;
 import android.app.Activity;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.design.widget.AppBarLayout;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -32,6 +33,7 @@ public class HomeContainerFragment extends NavigationTrackFragment implements Ho
   private BottomNavigationActivity bottomNavigationActivity;
   private CheckBox gamesChip;
   private CheckBox appsChip;
+  private AppBarLayout appBarLayout;
   private ImageView userAvatar;
   private ImageView promotionsIcon;
   private TextView promotionsTicker;
@@ -69,6 +71,7 @@ public class HomeContainerFragment extends NavigationTrackFragment implements Ho
     }
     gamesChip = view.findViewById(R.id.games_chip);
     appsChip = view.findViewById(R.id.apps_chip);
+    appBarLayout = view.findViewById(R.id.app_bar_layout);
 
     gamesChip.setOnCheckedChangeListener((__, isChecked) -> {
       if (isChecked) {
@@ -221,6 +224,15 @@ public class HomeContainerFragment extends NavigationTrackFragment implements Ho
 
   @Override public Observable<ChipsEvents> isChipChecked() {
     return chipCheckedEvent;
+  }
+
+  @Override public void uncheckChips() {
+    gamesChip.setChecked(false);
+    appsChip.setChecked(false);
+  }
+
+  @Override public void expandChips() {
+    appBarLayout.setExpanded(true, true);
   }
 
   public enum ChipsEvents {

--- a/app/src/main/java/cm/aptoide/pt/home/HomeContainerNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeContainerNavigator.java
@@ -6,6 +6,7 @@ import cm.aptoide.pt.R;
 import cm.aptoide.pt.app.view.MoreBundleFragment;
 import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.store.view.StoreTabGridRecyclerFragment;
+import rx.Observable;
 
 public class HomeContainerNavigator {
 
@@ -63,5 +64,19 @@ public class HomeContainerNavigator {
     } else {
       appsTag = childFragmentNavigator.navigateTo(fragment, true);
     }
+  }
+
+  public Observable<Boolean> navigateHome() {
+    Fragment fragment = childFragmentNavigator.getFragment();
+    if (fragment instanceof ScrollableView) {
+      ScrollableView view = (ScrollableView) fragment;
+      if (view.isAtTop()) {
+        if (fragment instanceof MoreBundleFragment) {
+          return Observable.just(true);
+        }
+      }
+      view.scrollToTop();
+    }
+    return Observable.just(false);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/HomeContainerPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeContainerPresenter.java
@@ -100,7 +100,6 @@ public class HomeContainerPresenter implements Presenter {
         });
   }
 
-
   @VisibleForTesting public void loadUserImage() {
     view.getLifecycleEvent()
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))

--- a/app/src/main/java/cm/aptoide/pt/home/HomeContainerPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeContainerPresenter.java
@@ -52,6 +52,7 @@ public class HomeContainerPresenter implements Presenter {
     handleClickOnPrivacyPolicy();
     handleClickOnGamesChip();
     handleClickOnAppsChip();
+    handleBottomNavigationEvents();
   }
 
   @VisibleForTesting public void loadMainHomeContent() {
@@ -77,6 +78,28 @@ public class HomeContainerPresenter implements Presenter {
           throw new OnErrorNotImplementedException(err);
         });
   }
+
+  private void handleBottomNavigationEvents() {
+    view.getLifecycleEvent()
+        .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
+        .flatMap(created -> homeNavigator.bottomNavigation())
+        .observeOn(viewScheduler)
+        .flatMap(__ -> homeContainerNavigator.navigateHome())
+        .doOnNext(shouldGoHome -> {
+          view.expandChips();
+          if (shouldGoHome) {
+            homeContainerNavigator.loadMainHomeContent();
+            chipManager.setCurrentChip(null);
+            view.uncheckChips();
+          }
+        })
+        .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
+        .subscribe(__ -> {
+        }, err -> {
+          throw new OnErrorNotImplementedException(err);
+        });
+  }
+
 
   @VisibleForTesting public void loadUserImage() {
     view.getLifecycleEvent()

--- a/app/src/main/java/cm/aptoide/pt/home/HomeContainerView.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeContainerView.java
@@ -38,4 +38,8 @@ public interface HomeContainerView extends View {
   Observable<Boolean> appsChipClicked();
 
   Observable<HomeContainerFragment.ChipsEvents> isChipChecked();
+
+  void uncheckChips();
+
+  void expandChips();
 }

--- a/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
@@ -47,7 +47,7 @@ import rx.subjects.PublishSubject;
  * Created by jdandrade on 05/03/2018.
  */
 
-public class HomeFragment extends NavigationTrackFragment implements HomeView {
+public class HomeFragment extends NavigationTrackFragment implements HomeView, ScrollableView {
 
   private static final String LIST_STATE_KEY = "cm.aptoide.pt.BottomHomeFragment.ListState";
 
@@ -317,6 +317,11 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView {
       bundlesList.scrollToPosition(10);
     }
     bundlesList.smoothScrollToPosition(0);
+  }
+
+  @Override public boolean isAtTop() {
+    LinearLayoutManager layoutManager = ((LinearLayoutManager) bundlesList.getLayoutManager());
+    return layoutManager.findFirstVisibleItemPosition() == 0;
   }
 
   @Override public void setUserImage(String userAvatarUrl) {

--- a/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
@@ -58,7 +58,7 @@ public class HomePresenter implements Presenter {
 
     handlePullToRefresh();
 
-    handleBottomNavigationEvents();
+    //handleBottomNavigationEvents();
 
     handleRetryClick();
 

--- a/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
@@ -58,8 +58,6 @@ public class HomePresenter implements Presenter {
 
     handlePullToRefresh();
 
-    //handleBottomNavigationEvents();
-
     handleRetryClick();
 
     handleBundleScrolledRight();
@@ -411,17 +409,6 @@ public class HomePresenter implements Presenter {
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(homeClick -> {
         }, crashReporter::log);
-  }
-
-  private void handleBottomNavigationEvents() {
-    view.getLifecycleEvent()
-        .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
-        .flatMap(created -> homeNavigator.bottomNavigation())
-        .observeOn(viewScheduler)
-        .doOnNext(navigated -> view.scrollToTop())
-        .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
-        .subscribe(__ -> {
-        }, throwable -> crashReporter.log(throwable));
   }
 
   @VisibleForTesting public void handleAdClick() {

--- a/app/src/main/java/cm/aptoide/pt/home/ScrollableView.java
+++ b/app/src/main/java/cm/aptoide/pt/home/ScrollableView.java
@@ -1,0 +1,8 @@
+package cm.aptoide.pt.home;
+
+public interface ScrollableView {
+
+  void scrollToTop();
+
+  boolean isAtTop();
+}


### PR DESCRIPTION
**What does this PR do?**

   This PR adds navigation logic to home BN item clicks (in the case where the home item is already selected). The expected flow is described below.

**Database changed?**

   No

**How should this be manually tested?**

  You can test four different flows to see if it's implemented correctly:
  1. In home, without chips selected, scroll down and click Home. It should scroll back up (this was already implemented).
  2. In home, with a chip selected, scroll down and click Home. It should scroll back up and the chip should still be selected.
  3. In home, with a chip selected, scroll down and click Home two times. It should scroll back up and then unselect the chip.
  4. In home, with a chip selected, **don't** scroll down and click Home. It should unselect the chip.

**What are the relevant tickets?**

  [ASV-1716](https://aptoide.atlassian.net/browse/ASV-1716)


**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass