### PR TITLE
[ASV-1685] - Add hostname to launch metrics

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/DeepLinkAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkAnalytics.java
@@ -1,5 +1,6 @@
 package cm.aptoide.pt;
 
+import android.net.Uri;
 import cm.aptoide.analytics.AnalyticsManager;
 import cm.aptoide.analytics.implementation.navigation.NavigationTracker;
 import java.util.HashMap;
@@ -18,6 +19,7 @@ public class DeepLinkAnalytics {
   private static final String NEW_REPO = "New Repository";
   private static final String WEBSITE = "Website";
   private static final String URI = "Uri";
+  private static final String HOSTNAME = "Hostname";
   private static final String SOURCE = "Source";
   private static final String LAUNCHER = "Launcher";
   private static final String SOURCE_GROUP_OPTION_APP_VIEW = "aptoide app view";
@@ -47,6 +49,8 @@ public class DeepLinkAnalytics {
 
     if (uri != null) {
       map.put(URI, uri.substring(0, uri.indexOf(":")));
+      map.put(HOSTNAME, Uri.parse(uri)
+          .getHost());
     }
   }
 


### PR DESCRIPTION
**What does this PR do?**

   This PR does what the title says. It adds a hostname parameter to "Aptoide Launch" event.

**Database changed?**

    No

**How should this be manually tested?**

  Try different deeplinks and check if the hostname is correct

**What are the relevant tickets?**

  [ASV-1685](https://aptoide.atlassian.net/browse/ASV-1685)


**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass