### PR TITLE
[ASV-1453] - Add deeplink for appc info view

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
@@ -177,7 +177,8 @@ public class DeepLinkIntentReceiver extends ActivityView {
       return startFromPickApp();
     } else if ("promotions".equals(u.getQueryParameter("name"))) {
       return startFromPromotions();
-    } else if ("CURATION_1".equals(u.getQueryParameter("name")) && u.getQueryParameter("id") != null) {
+    } else if ("CURATION_1".equals(u.getQueryParameter("name"))
+        && u.getQueryParameter("id") != null) {
       return startFromEditorialCard(u.getQueryParameter("id"));
     } else if ("appc_info_view".equals(u.getQueryParameter("name"))) {
       return startAppcInfoView();

--- a/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
@@ -177,9 +177,10 @@ public class DeepLinkIntentReceiver extends ActivityView {
       return startFromPickApp();
     } else if ("promotions".equals(u.getQueryParameter("name"))) {
       return startFromPromotions();
-    } else if ("CURATION_1".equals(u.getQueryParameter("name"))
-        && u.getQueryParameter("id") != null) {
+    } else if ("CURATION_1".equals(u.getQueryParameter("name")) && u.getQueryParameter("id") != null) {
       return startFromEditorialCard(u.getQueryParameter("id"));
+    } else if ("appc_info_view".equals(u.getQueryParameter("name"))) {
+      return startAppcInfoView();
     } else if (sURIMatcher.match(u) == DEEPLINK_ID) {
       return startGenericDeepLink(u);
     }
@@ -575,6 +576,12 @@ public class DeepLinkIntentReceiver extends ActivityView {
     return intent;
   }
 
+  private Intent startAppcInfoView() {
+    Intent intent = new Intent(this, startClass);
+    intent.putExtra(DeepLinksTargets.APPC_INFO_VIEW, true);
+    return intent;
+  }
+
   public Intent startFromAppView(String packageName) {
     Intent intent = new Intent(this, startClass);
     intent.putExtra(DeepLinksTargets.APP_VIEW_FRAGMENT, true);
@@ -702,6 +709,7 @@ public class DeepLinkIntentReceiver extends ActivityView {
     public static final String PICK_APP_DEEPLINK = "pick_app_deeplink";
     public static final String PROMOTIONS_DEEPLINK = "promotions";
     public static final String EDITORIAL_DEEPLINK = "editorial";
+    public static final String APPC_INFO_VIEW = "appc_info_view";
   }
 
   public static class DeepLinksKeys {

--- a/app/src/main/java/cm/aptoide/pt/view/DeepLinkManager.java
+++ b/app/src/main/java/cm/aptoide/pt/view/DeepLinkManager.java
@@ -18,6 +18,7 @@ import cm.aptoide.pt.account.view.store.ManageStoreFragment;
 import cm.aptoide.pt.account.view.store.ManageStoreViewModel;
 import cm.aptoide.pt.ads.AdsRepository;
 import cm.aptoide.pt.app.AppNavigator;
+import cm.aptoide.pt.app.view.AppCoinsInfoFragment;
 import cm.aptoide.pt.app.view.AppViewFragment;
 import cm.aptoide.pt.bottomNavigation.BottomNavigationNavigator;
 import cm.aptoide.pt.crashreports.CrashReport;
@@ -150,6 +151,8 @@ public class DeepLinkManager {
       promotionsDeepLink();
     } else if (intent.hasExtra(DeepLinkIntentReceiver.DeepLinksTargets.EDITORIAL_DEEPLINK)) {
       editorialDeepLink(intent.getStringExtra(DeepLinkIntentReceiver.DeepLinksKeys.CARD_ID));
+    } else if (intent.hasExtra(DeepLinkIntentReceiver.DeepLinksTargets.APPC_INFO_VIEW)) {
+      appcInfoDeepLink();
     } else {
       deepLinkAnalytics.launcher();
       return false;
@@ -165,6 +168,10 @@ public class DeepLinkManager {
       navigationTracker.registerScreen(ScreenTagHistory.Builder.build(DEEPLINK_KEY));
     }
     return true;
+  }
+
+  private void appcInfoDeepLink() {
+    fragmentNavigator.navigateTo(new AppCoinsInfoFragment(), true);
   }
 
   private void editorialDeepLink(String cardId) {


### PR DESCRIPTION
**What does this PR do?**

   As the title says, this PR adds deeplink support for the appc info view (the view that pops up if you click the PoA view in an appc compatible app). 

**Database changed?**

   No

**How should this be manually tested?**

  Test the new deeplink to check if it goes to the appc info view as expected.

  Deeplink: `adb shell am start -a "android.intent.action.VIEW" -d "aptoide://cm.aptoide.pt/deeplink?name=appc_info_view"`


**What are the relevant tickets?**

  [ASV-1453](https://aptoide.atlassian.net/browse/ASV-1453)

**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass