### PR TITLE
[ASV-1778] AdView Controler bug

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/AdsBundlesViewHolderFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/home/AdsBundlesViewHolderFactory.java
@@ -29,7 +29,7 @@ public class AdsBundlesViewHolderFactory {
   public AppBundleViewHolder createViewHolder(ViewGroup parent) {
     if (Build.VERSION.SDK_INT >= 21 && showNatives) {
       return new AdsWithMoPubBundleViewHolder(LayoutInflater.from(parent.getContext())
-          .inflate(ADS, parent, false), uiEventsListener, oneDecimalFormatter, adClickedEvents,
+          .inflate(ADS, null, false), uiEventsListener, oneDecimalFormatter, adClickedEvents,
           marketName);
     } else {
       return new AdsBundleViewHolder(LayoutInflater.from(parent.getContext())

--- a/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
@@ -321,11 +321,6 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView, S
     bundlesList.smoothScrollToPosition(0);
   }
 
-  @Override public boolean isAtTop() {
-    LinearLayoutManager layoutManager = ((LinearLayoutManager) bundlesList.getLayoutManager());
-    return layoutManager.findFirstVisibleItemPosition() == 0;
-  }
-
   @Override public void setUserImage(String userAvatarUrl) {
     ImageLoader.with(getContext())
         .loadWithShadowCircleTransformWithPlaceholder(userAvatarUrl, userAvatar,
@@ -405,6 +400,11 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView, S
   @Override public void showNetworkErrorToast() {
     Snackbar.make(getView(), getString(R.string.connection_error), Snackbar.LENGTH_LONG)
         .show();
+  }
+
+  @Override public boolean isAtTop() {
+    LinearLayoutManager layoutManager = ((LinearLayoutManager) bundlesList.getLayoutManager());
+    return layoutManager.findFirstVisibleItemPosition() == 0;
   }
 
   private boolean isEndReached() {


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at fixing a problem reported in fabric (link in the ticket) related with the ads. Since the crash happens on MoPub's code and we could not reproduce it is not possible to know if this solution actually fixes the problem reported.



**Database changed?**

No

**Where should the reviewer start?**

- [ ] AdsBundleViewHolderFactory.java

**How should this be manually tested?**

Since we can not reproduce this issue and it is in MoPub's code this is unreproducible. According to João we applied this fix (searched this solution online) and we will see if the issue on fabric resurfaces.
  

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1778](https://aptoide.atlassian.net/browse/ASV-1778)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass