### PR TITLE
[ASV-1757] Fix navigation flow

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
@@ -250,11 +250,19 @@ public class DeepLinkIntentReceiver extends ActivityView {
     }
     String utmSourceParameter = u.getQueryParameter("utm_source");
     String appSourceParameter = u.getQueryParameter("app_source");
-    if (utmSourceParameter != null && (utmSourceParameter.equals("myappcoins")
-        || utmSourceParameter.equals("appcoinssdk")) && "com.appcoins.wallet".equals(packageName)) {
-      return startWalletInstallIntent(packageName, utmSourceParameter, appSourceParameter);
+    if (utmSourceParameter != null
+        && isFromAppCoins(utmSourceParameter)
+        && "com.appcoins.wallet".equals(packageName)) {
+      deepLinkAnalytics.sendWalletDeepLinkEvent(utmSourceParameter);
+      if (utmSourceParameter.equals("appcoinssdk")) {
+        return startWalletInstallIntent(packageName, utmSourceParameter, appSourceParameter);
+      }
     }
     return startFromPackageName(packageName);
+  }
+
+  private boolean isFromAppCoins(String utmSourceParameter) {
+    return utmSourceParameter.equals("myappcoins") || utmSourceParameter.equals("appcoinssdk");
   }
 
   private Intent dealWithAptoideXml(String uri) {
@@ -486,7 +494,6 @@ public class DeepLinkIntentReceiver extends ActivityView {
     intent.putExtra(DeepLinksKeys.WALLET_PACKAGE_NAME_KEY, packageName);
     intent.putExtra(DeepLinksKeys.PACKAGE_NAME_KEY, appPackageName);
     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-    deepLinkAnalytics.sendWalletDeepLinkEvent(utmSourceParameter);
     return intent;
   }
 


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at fixing navigation when sending the helping appcoins wallet installation deeplinks. 
If the utm source is myappcoins we should navigate to appview. If the utmsource is appcoinssdk we should navigate to the new dialog.
In both cases we should send the deeplink event.
 
**Database changed?**

 No

**Where should the reviewer start?**

- [ ] DeeplinkIntentReceiver.java

**How should this be manually tested?**

  Send both deeplinks and check that the event is being sent on both cases and that we are navigating the correct places: 
If the utm source is myappcoins we should navigate to appview. If the utmsource is appcoinssdk we should navigate to the new dialog.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1757](https://aptoide.atlassian.net/browse/ASV-1757)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass