### PR TITLE
[Analytics/ASV-1748] cancel installation event

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/install/InstallAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/install/InstallAnalytics.java
@@ -111,7 +111,7 @@ public class InstallAnalytics {
       boolean aptoideSettings, String packageName, int installingVersion) {
     Map<String, Object> data = installEvent.getData();
     data.put(ROOT, createRoot(isPhoneRoot, aptoideSettings));
-    data.put(RESULT, createFailResult());
+    data.put(RESULT, createResult());
     analyticsManager.logEvent(data, INSTALL_EVENT_NAME, installEvent.getAction(),
         installEvent.getContext());
     cache.remove(getKey(packageName, installingVersion, INSTALL_EVENT_NAME));
@@ -126,7 +126,7 @@ public class InstallAnalytics {
     cache.remove(getKey(packageName, installingVersion, APPLICATION_INSTALL));
   }
 
-  private Map<String, Object> createFailResult() {
+  private Map<String, Object> createResult() {
     Map<String, Object> result = new HashMap<>();
     result.put(STATUS, SUCCESS);
     return result;

--- a/app/src/main/java/cm/aptoide/pt/install/InstallAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/install/InstallAnalytics.java
@@ -38,6 +38,7 @@ public class InstallAnalytics {
   private static final String CAMPAIGN_ID = "campaign_id";
   private static final String EDITORS_CHOICE = "apps-group-editors-choice";
   private static final String FAIL = "FAIL";
+  private static final String CANCEL = "CANCEL";
   private static final String MAIN = "MAIN";
   private static final String MESSAGE = "message";
   private static final String MIGRATOR = "migrator";
@@ -338,6 +339,23 @@ public class InstallAnalytics {
     result.put(TYPE, exception.getClass()
         .getSimpleName());
     result.put(MESSAGE, exception.getMessage());
+    return result;
+  }
+
+  public void logInstallCancelEvent(String packageName, int versionCode) {
+    InstallEvent installEvent = cache.get(getKey(packageName, versionCode, INSTALL_EVENT_NAME));
+    if (installEvent != null) {
+      Map<String, Object> data = installEvent.getData();
+      data.put(RESULT, createCancelResult());
+      analyticsManager.logEvent(data, INSTALL_EVENT_NAME, installEvent.getAction(),
+          installEvent.getContext());
+      cache.remove(getKey(packageName, versionCode, INSTALL_EVENT_NAME));
+    }
+  }
+
+  private Map<String, Object> createCancelResult() {
+    Map<String, Object> result = new HashMap<>();
+    result.put(STATUS, CANCEL);
     return result;
   }
 

--- a/app/src/main/java/cm/aptoide/pt/install/InstallAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/install/InstallAnalytics.java
@@ -111,7 +111,7 @@ public class InstallAnalytics {
       boolean aptoideSettings, String packageName, int installingVersion) {
     Map<String, Object> data = installEvent.getData();
     data.put(ROOT, createRoot(isPhoneRoot, aptoideSettings));
-    data.put(RESULT, createResult());
+    data.put(RESULT, createFailResult());
     analyticsManager.logEvent(data, INSTALL_EVENT_NAME, installEvent.getAction(),
         installEvent.getContext());
     cache.remove(getKey(packageName, installingVersion, INSTALL_EVENT_NAME));
@@ -126,7 +126,7 @@ public class InstallAnalytics {
     cache.remove(getKey(packageName, installingVersion, APPLICATION_INSTALL));
   }
 
-  private Map<String, Object> createResult() {
+  private Map<String, Object> createFailResult() {
     Map<String, Object> result = new HashMap<>();
     result.put(STATUS, SUCCESS);
     return result;
@@ -326,14 +326,14 @@ public class InstallAnalytics {
     if (installEvent != null) {
       Map<String, Object> data = installEvent.getData();
       data.put(ROOT, createRoot(isPhoneRoot, aptoideSettings));
-      data.put(RESULT, createResult(exception));
+      data.put(RESULT, createFailResult(exception));
       analyticsManager.logEvent(data, INSTALL_EVENT_NAME, installEvent.getAction(),
           installEvent.getContext());
       cache.remove(getKey(packageName, versionCode, INSTALL_EVENT_NAME));
     }
   }
 
-  private Map<String, Object> createResult(Exception exception) {
+  private Map<String, Object> createFailResult(Exception exception) {
     Map<String, Object> result = new HashMap<>();
     result.put(STATUS, FAIL);
     result.put(TYPE, exception.getClass()

--- a/app/src/main/java/cm/aptoide/pt/install/InstallEvents.java
+++ b/app/src/main/java/cm/aptoide/pt/install/InstallEvents.java
@@ -89,6 +89,10 @@ public class InstallEvents implements InstallerAnalytics {
             .value(), ManagerPreferences.allowRootInstallation(sharedPreferences));
   }
 
+  @Override public void logInstallCancelEvent(String packageName, int versionCode) {
+    installAnalytics.logInstallCancelEvent(packageName, versionCode);
+  }
+
   @Override public void sendMiuiInstallResultEvent(InstallStatus.Status status) {
     Map<String, Object> parameters = new HashMap<>();
     String key = "successful_installation_type";

--- a/app/src/main/java/cm/aptoide/pt/install/InstallEvents.java
+++ b/app/src/main/java/cm/aptoide/pt/install/InstallEvents.java
@@ -77,7 +77,7 @@ public class InstallEvents implements InstallerAnalytics {
     Map<String, Object> map = new HashMap<>();
     map.put(IS_ROOT, String.valueOf(isRoot));
     map.put(SETTING_ROOT, String.valueOf(isRootAllowed));
-    map.put(CONCAT, String.valueOf(isRootAllowed) + "_" + String.valueOf(isRoot));
+    map.put(CONCAT, isRootAllowed + "_" + isRoot);
     analyticsManager.logEvent(map, IS_INSTALLATION_TYPE_EVENT_NAME, AnalyticsManager.Action.ROOT,
         INSTALLFABRICCONTEXT);
   }

--- a/app/src/main/java/cm/aptoide/pt/install/InstallerAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/install/InstallerAnalytics.java
@@ -21,5 +21,7 @@ public interface InstallerAnalytics {
 
   void logInstallErrorEvent(String packageName, int versionCode, Exception e);
 
+  void logInstallCancelEvent(String packageName, int versionCode);
+
   void sendMiuiInstallResultEvent(InstallStatus.Status status);
 }

--- a/app/src/main/java/cm/aptoide/pt/install/installer/DefaultInstaller.java
+++ b/app/src/main/java/cm/aptoide/pt/install/installer/DefaultInstaller.java
@@ -282,6 +282,12 @@ public class DefaultInstaller implements Installer {
                   }
                   return null;
                 })), appInstallerStatusReceiver.getInstallerInstallStatus()
+                .doOnNext(installStatus -> {
+                  if (InstallStatus.Status.CANCELED.equals(installStatus.getStatus())) {
+                    installerAnalytics.logInstallCancelEvent(installation.getPackageName(),
+                        installation.getVersionCode());
+                  }
+                })
                 .filter(installStatus -> installation.getPackageName()
                     .equalsIgnoreCase(installStatus.getPackageName()))
                 .distinctUntilChanged()

--- a/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
@@ -9,7 +9,6 @@ import android.app.ActivityManager;
 import android.app.ProgressDialog;
 import android.app.Service;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -372,53 +371,41 @@ public class SettingsFragment extends PreferenceFragmentCompat
 
     Preference hwSpecs = findPreference(SettingsConstants.HARDWARE_SPECS);
 
-    hwSpecs.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
-      @Override public boolean onPreferenceClick(Preference preference) {
+    hwSpecs.setOnPreferenceClickListener(preference -> {
+      AlertDialog.Builder alertDialogBuilder =
+          new AlertDialog.Builder(context, R.style.AlertDialogAptoide);
+      alertDialogBuilder.setTitle(getString(R.string.setting_hwspecstitle));
+      alertDialogBuilder.setIcon(android.R.drawable.ic_menu_info_details)
+          .setMessage(getString(R.string.setting_sdk_version)
+              + ": "
+              + AptoideUtils.SystemU.getSdkVer()
+              + "\n"
+              + getString(R.string.setting_screen_size)
+              + ": "
+              + AptoideUtils.ScreenU.getScreenSize(getContext().getResources())
+              + "\n"
+              + getString(R.string.setting_esgl_version)
+              + ": "
+              + AptoideUtils.SystemU.getGlEsVer(
+              ((ActivityManager) getContext().getSystemService(Context.ACTIVITY_SERVICE)))
+              + "\n"
+              + getString(R.string.screenCode)
+              + ": "
+              + AptoideUtils.ScreenU.getNumericScreenSize(getContext().getResources())
+              + "/"
+              + AptoideUtils.ScreenU.getDensityDpi(
+              ((WindowManager) getContext().getSystemService(Service.WINDOW_SERVICE)))
+              + "\n"
+              + getString(R.string.cpuAbi)
+              + ": "
+              + AptoideUtils.SystemU.getAbis())
 
-        AlertDialog.Builder alertDialogBuilder =
-            new AlertDialog.Builder(context, R.style.AlertDialogAptoide);
-        alertDialogBuilder.setTitle(getString(R.string.setting_hwspecstitle));
-        alertDialogBuilder.setIcon(android.R.drawable.ic_menu_info_details)
-            .setMessage(getString(R.string.setting_sdk_version)
-                    + ": "
-                    + AptoideUtils.SystemU.getSdkVer()
-                    + "\n"
-                    + getString(R.string.setting_screen_size)
-                    + ": "
-                    + AptoideUtils.ScreenU.getScreenSize(getContext().getResources())
-                    + "\n"
-                    + getString(R.string.setting_esgl_version)
-                    + ": "
-                    + AptoideUtils.SystemU.getGlEsVer(
-                ((ActivityManager) getContext().getSystemService(Context.ACTIVITY_SERVICE)))
-                    + "\n"
-                    + getString(R.string.screenCode)
-                    + ": "
-                    + AptoideUtils.ScreenU.getNumericScreenSize(getContext().getResources())
-                    + "/"
-                    + AptoideUtils.ScreenU.getDensityDpi(
-                ((WindowManager) getContext().getSystemService(Service.WINDOW_SERVICE)))
-                    + "\n"
-                    + getString(R.string.cpuAbi)
-                    + ": "
-                    + AptoideUtils.SystemU.getAbis()
-                //                            + (ApplicationAptoide.PARTNERID!=null ? "\nPartner ID:"
-                // + ApplicationAptoide.PARTNERID : "")
-            )
-
-            .setCancelable(false)
-            .setNeutralButton(getString(android.R.string.ok),
-                new DialogInterface.OnClickListener() {
-                  public void onClick(DialogInterface dialog, int id) {
-                    //                                FlurryAgent.logEvent
-                    // ("Setting_Opened_Dialog_Hardware_Filters");
-                  }
-                });
-        AlertDialog alertDialog = alertDialogBuilder.create();
-        alertDialog.show();
-
-        return true;
-      }
+          .setCancelable(false)
+          .setNeutralButton(getString(android.R.string.ok), (dialog, id) -> {
+          });
+      AlertDialog alertDialog = alertDialogBuilder.create();
+      alertDialog.show();
+      return true;
     });
 
     EditTextPreference maxFileCache =


### PR DESCRIPTION
**What does this PR do?**

   adds new INSTALL event variation that is sent to the BI. 
   This will be sent everytime an installation cancel happens, which currently can be only known when we use the new installation method from PackageInstaller.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] DefaultInstaller.java
- [ ] InstallAnalytics.java

**How should this be manually tested?**

  Install an APPC app, cancel install wizard. This can only be tested in Cobrand & Nightly (dev)

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1748](https://aptoide.atlassian.net/browse/ASV-1748)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass