### PR TITLE
[ASV-1814] Fix download at 100%

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/download/DownloadAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/download/DownloadAnalytics.java
@@ -8,6 +8,7 @@ import cm.aptoide.analytics.implementation.navigation.NavigationTracker;
 import cm.aptoide.analytics.implementation.navigation.ScreenTagHistory;
 import cm.aptoide.pt.ads.WalletAdsOfferManager;
 import cm.aptoide.pt.database.realm.Download;
+import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.view.DeepLinkManager;
 import java.util.ArrayList;
@@ -256,10 +257,19 @@ public class DownloadAnalytics implements cm.aptoide.pt.downloadmanager.Analytic
   }
 
   public void startProgress(Download download) {
-    cache.get(download.getPackageName() + download.getVersionCode() + DOWNLOAD_EVENT_NAME)
-        .setHadProgress(true);
-    cache.get(download.getMd5() + DOWNLOAD_COMPLETE_EVENT)
-        .setHadProgress(true);
+    DownloadEvent downloadEvent =
+        cache.get(download.getPackageName() + download.getVersionCode() + DOWNLOAD_EVENT_NAME);
+    if (downloadEvent != null) {
+      downloadEvent.setHadProgress(true);
+    } else {
+      Logger.getInstance()
+          .d("DownloadAnalytics", "tried to update download");
+    }
+
+    DownloadEvent downloadCompleteEvent = cache.get(download.getMd5() + DOWNLOAD_COMPLETE_EVENT);
+    if (downloadCompleteEvent != null) {
+      downloadCompleteEvent.setHadProgress(true);
+    }
   }
 
   public void installClicked(String md5, String packageName, String trustedValue,

--- a/app/src/main/java/cm/aptoide/pt/download/DownloadAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/download/DownloadAnalytics.java
@@ -257,12 +257,12 @@ public class DownloadAnalytics implements cm.aptoide.pt.downloadmanager.Analytic
   }
 
   public void startProgress(Download download) {
-    startProgressOnDownloadEvent(
+    updateDownloadEventWithHasProgress(
         download.getPackageName() + download.getVersionCode() + DOWNLOAD_EVENT_NAME);
-    startProgressOnDownloadEvent(download.getMd5() + DOWNLOAD_COMPLETE_EVENT);
+    updateDownloadEventWithHasProgress(download.getMd5() + DOWNLOAD_COMPLETE_EVENT);
   }
 
-  private void startProgressOnDownloadEvent(String key) {
+  private void updateDownloadEventWithHasProgress(String key) {
     DownloadEvent event = cache.get(key);
     if (event != null) {
       event.setHadProgress(true);

--- a/app/src/main/java/cm/aptoide/pt/download/DownloadAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/download/DownloadAnalytics.java
@@ -257,18 +257,18 @@ public class DownloadAnalytics implements cm.aptoide.pt.downloadmanager.Analytic
   }
 
   public void startProgress(Download download) {
-    DownloadEvent downloadEvent =
-        cache.get(download.getPackageName() + download.getVersionCode() + DOWNLOAD_EVENT_NAME);
-    if (downloadEvent != null) {
-      downloadEvent.setHadProgress(true);
+    startProgressOnDownloadEvent(
+        download.getPackageName() + download.getVersionCode() + DOWNLOAD_EVENT_NAME);
+    startProgressOnDownloadEvent(download.getMd5() + DOWNLOAD_COMPLETE_EVENT);
+  }
+
+  private void startProgressOnDownloadEvent(String key) {
+    DownloadEvent event = cache.get(key);
+    if (event != null) {
+      event.setHadProgress(true);
     } else {
       Logger.getInstance()
-          .d("DownloadAnalytics", "tried to update download");
-    }
-
-    DownloadEvent downloadCompleteEvent = cache.get(download.getMd5() + DOWNLOAD_COMPLETE_EVENT);
-    if (downloadCompleteEvent != null) {
-      downloadCompleteEvent.setHadProgress(true);
+          .d("DownloadAnalytics", "Tried setting progress on an event that was not setup " + key);
     }
   }
 

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialAnalytics.java
@@ -2,6 +2,7 @@ package cm.aptoide.pt.editorial;
 
 import cm.aptoide.analytics.AnalyticsManager;
 import cm.aptoide.analytics.implementation.navigation.NavigationTracker;
+import cm.aptoide.pt.ads.WalletAdsOfferManager;
 import cm.aptoide.pt.database.realm.Download;
 import cm.aptoide.pt.download.DownloadAnalytics;
 import java.util.HashMap;
@@ -36,7 +37,11 @@ public class EditorialAnalytics {
   }
 
   public void setupDownloadEvents(Download download, int campaignId, String abTestGroup,
-      AnalyticsManager.Action action) {
+      AnalyticsManager.Action action,
+      WalletAdsOfferManager.OfferResponseStatus offerResponseStatus) {
+    downloadAnalytics.installClicked(download.getMd5(), download.getPackageName(), action,
+        offerResponseStatus, false, download.hasAppc());
+
     downloadAnalytics.downloadStartEvent(download, campaignId, abTestGroup,
         DownloadAnalytics.AppContext.EDITORIAL, action, false);
   }

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -422,11 +422,12 @@ import rx.subscriptions.CompositeSubscription;
       EditorialRepository editorialRepository, InstallManager installManager,
       DownloadFactory downloadFactory, DownloadStateParser downloadStateParser,
       NotificationAnalytics notificationAnalytics, InstallAnalytics installAnalytics,
-      EditorialAnalytics editorialAnalytics, ReactionsManager reactionsManager) {
+      EditorialAnalytics editorialAnalytics, ReactionsManager reactionsManager,
+      MoPubAdsManager moPubAdsManager) {
     return new EditorialManager(editorialRepository,
         arguments.getString(EditorialFragment.CARD_ID, ""), installManager, downloadFactory,
         downloadStateParser, notificationAnalytics, installAnalytics, editorialAnalytics,
-        reactionsManager);
+        reactionsManager, moPubAdsManager);
   }
 
   @FragmentScope @Provides EditorialRepository providesEditorialRepository(


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing the problem related with a download being stuck at 100% on editorial.
This fix could also avoid it from happening on other views.

**Database changed?**

   No

**Where should the reviewer start?**

- [x] EditorialAnalytics.java

**How should this be manually tested?**

  Perform download on all views where you can do downloads and check that there is a notification and that there when the download finishes, the android install dialog pops up.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1814](https://aptoide.atlassian.net/browse/ASV-1814)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass