### PR TITLE
[HOTFIX/ASV-1832] Fix resume download

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -371,11 +371,6 @@ public class AppViewManager {
         .toCompletable();
   }
 
-  private void setupDownloadEvents(Download download, long appId,
-      WalletAdsOfferManager.OfferResponseStatus offerResponseStatus) {
-    setupDownloadEvents(download, null, appId, null, null, offerResponseStatus);
-  }
-
   private void setupDownloadEvents(Download download, DownloadModel.Action downloadAction,
       long appId, WalletAdsOfferManager.OfferResponseStatus offerResponseStatus) {
     setupDownloadEvents(download, downloadAction, appId, null, null, offerResponseStatus);
@@ -393,10 +388,6 @@ public class AppViewManager {
         downloadStateParser.getOrigin(download.getAction()), campaignId, abTestGroup,
         downloadAction != null && downloadAction.equals(DownloadModel.Action.MIGRATE),
         download.hasAppc());
-  }
-
-  private boolean isMigration(DownloadModel.Action downloadAction) {
-    return downloadAction != null && downloadAction.equals(DownloadModel.Action.MIGRATE);
   }
 
   public void setupMigratorUninstallEvent(String packageName) {

--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -395,6 +395,10 @@ public class AppViewManager {
         download.hasAppc());
   }
 
+  private boolean isMigration(DownloadModel.Action downloadAction) {
+    return downloadAction != null && downloadAction.equals(DownloadModel.Action.MIGRATE);
+  }
+
   public void setupMigratorUninstallEvent(String packageName) {
     installAnalytics.uninstallStarted(packageName, AnalyticsManager.Action.INSTALL,
         AppContext.APPVIEW);
@@ -415,12 +419,13 @@ public class AppViewManager {
     return Completable.fromAction(() -> installManager.stopInstallation(md5));
   }
 
-  public Completable resumeDownload(String md5, long appId) {
+  public Completable resumeDownload(String md5, long appId, DownloadModel.Action action) {
     return installManager.getDownload(md5)
         .flatMap(download -> moPubAdsManager.getAdsVisibilityStatus()
-            .doOnSuccess(
-                offerResponseStatus -> setupDownloadEvents(download, appId, offerResponseStatus))
+            .doOnSuccess(offerResponseStatus -> setupDownloadEvents(download, action, appId,
+                offerResponseStatus))
             .map(__ -> download))
+        .doOnError(throwable -> throwable.printStackTrace())
         .flatMapCompletable(download -> installManager.install(download));
   }
 

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -1690,8 +1690,9 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     return RxView.clicks(pauseDownload);
   }
 
-  @Override public Observable<Void> resumeDownload() {
-    return RxView.clicks(resumeDownload);
+  @Override public Observable<DownloadModel.Action> resumeDownload() {
+    return RxView.clicks(resumeDownload)
+        .map(__ -> action);
   }
 
   @Override public Observable<Void> cancelDownload() {

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -945,13 +945,14 @@ public class AppViewPresenter implements Presenter {
     view.getLifecycleEvent()
         .filter(lifecycleEvent -> lifecycleEvent == View.LifecycleEvent.CREATE)
         .flatMap(create -> view.resumeDownload()
-            .flatMap(__ -> permissionManager.requestDownloadAccess(permissionService)
+            .flatMap(downloadAction -> permissionManager.requestDownloadAccess(permissionService)
                 .flatMap(success -> permissionManager.requestExternalStoragePermission(
                     permissionService))
                 .flatMapSingle(__1 -> appViewManager.loadAppViewViewModel())
                 .flatMapCompletable(
-                    app -> appViewManager.resumeDownload(app.getMd5(), app.getAppId()))
-                .retry()))
+                    app -> appViewManager.resumeDownload(app.getMd5(), app.getAppId(),
+                        downloadAction)))
+            .retry())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(created -> {
         }, error -> {
@@ -1219,7 +1220,9 @@ public class AppViewPresenter implements Presenter {
                 .flatMap(success -> permissionManager.requestExternalStoragePermission(
                     permissionService))
                 .flatMapCompletable(
-                    __ -> appViewManager.resumeDownload(walletApp.getMd5sum(), walletApp.getId()))
+                    __ -> appViewManager.resumeDownload(walletApp.getMd5sum(), walletApp.getId(),
+                        walletApp.getDownloadModel()
+                            .getAction()))
                 .retry()))
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(created -> {

--- a/app/src/main/java/cm/aptoide/pt/appview/InstallAppView.java
+++ b/app/src/main/java/cm/aptoide/pt/appview/InstallAppView.java
@@ -26,7 +26,7 @@ public interface InstallAppView extends View {
 
   Observable<Void> pauseDownload();
 
-  Observable<Void> resumeDownload();
+  Observable<DownloadModel.Action> resumeDownload();
 
   Observable<Void> cancelDownload();
 

--- a/app/src/test/java/cm/aptoide/pt/app/AppViewManagerTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/AppViewManagerTest.java
@@ -689,7 +689,7 @@ public class AppViewManagerTest {
         Single.just(WalletAdsOfferManager.OfferResponseStatus.ADS_SHOW));
 
     //Then the appViewManager should return a Complete when the request is done
-    appViewManager.resumeDownload("md5", 1)
+    appViewManager.resumeDownload("md5", 1, DownloadModel.Action.INSTALL)
         .test()
         .assertCompleted();
 

--- a/app/src/test/java/cm/aptoide/pt/app/AppViewManagerTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/AppViewManagerTest.java
@@ -697,8 +697,8 @@ public class AppViewManagerTest {
     verify(installManager).getDownload("md5");
     verify(installManager).install(download);
     //And it should set the necessary analytics
-    verify(appViewAnalytics).setupDownloadEvents(download, 2, "aString", null,
-        AnalyticsManager.Action.CLICK, null, null,
+    verify(appViewAnalytics).setupDownloadEvents(download, 2, "aString",
+        DownloadModel.Action.INSTALL, AnalyticsManager.Action.CLICK, null, null,
         WalletAdsOfferManager.OfferResponseStatus.ADS_SHOW);
     verify(installAnalytics).installStarted("packageName", 1, AnalyticsManager.Action.INSTALL,
         AppContext.APPVIEW, downloadStateParser.getOrigin(download.getAction()), 2, "aString",


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at fixing a problem where the user wouldn't be able to resume a paused download.
Note that AppView is being refactored and we will be able to have a single model coming from the manager where we will also have the download model. This was not the best solution but it is a quick temporary one.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppViewAnalytics.java

**How should this be manually tested?**

  Open appview, try to perform a download, pause it and then try to resume it.
It should resume the download and send the download events correctly

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1832](https://aptoide.atlassian.net/browse/ASV-1832)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass