### PR TITLE
[ASV-1848] hotfix: claim dialog clicks now working.

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -1229,7 +1229,7 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     walletPromotionButtonsLayout.setVisibility(View.GONE);
     walletPromotionClaimLayout.setVisibility(View.VISIBLE);
     walletPromotionClaimButton.setOnClickListener(__ -> promotionAppClick.onNext(
-        new PromotionEvent(promotion, walletApp, getClickType(getState(walletApp)))));
+        new PromotionEvent(promotion, walletApp, PromotionEvent.ClickType.CLAIM)));
     walletPromotionIcon.setVisibility(View.VISIBLE);
   }
 
@@ -1238,56 +1238,6 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
         String.valueOf(promotion.getAppc())));
     walletPromotionMessage.setText(
         String.format(getString(walletMessageStringId), String.valueOf(promotion.getAppc())));
-  }
-
-  private int getState(WalletApp walletApp) {
-    int state;
-    DownloadModel downloadModel = walletApp.getDownloadModel();
-    if (downloadModel.isDownloading()) {
-      return DOWNLOADING;
-    } else {
-      switch (downloadModel.getAction()) {
-        case DOWNGRADE:
-          state = DOWNGRADE;
-          break;
-        case INSTALL:
-          state = INSTALL;
-          break;
-        case OPEN:
-          state = CLAIM;
-          break;
-        case UPDATE:
-          state = UPDATE;
-          break;
-        default:
-          throw new IllegalArgumentException("Invalid type of download action");
-      }
-      return state;
-    }
-  }
-
-  private PromotionEvent.ClickType getClickType(int appState) {
-    PromotionEvent.ClickType clickType;
-    switch (appState) {
-      case DOWNGRADE:
-        clickType = PromotionEvent.ClickType.DOWNGRADE;
-        break;
-      case UPDATE:
-        clickType = PromotionEvent.ClickType.UPDATE;
-        break;
-      case DOWNLOAD:
-        clickType = PromotionEvent.ClickType.DOWNLOAD;
-        break;
-      case INSTALL:
-        clickType = PromotionEvent.ClickType.INSTALL_APP;
-        break;
-      case CLAIM:
-        clickType = PromotionEvent.ClickType.CLAIM;
-        break;
-      default:
-        throw new IllegalArgumentException("Wrong view type of promotions app");
-    }
-    return clickType;
   }
 
   private int getPromotionMessage(DownloadModel appDownloadModel) {

--- a/app/src/main/java/cm/aptoide/pt/promotions/ClaimPromotionDialogFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/ClaimPromotionDialogFragment.java
@@ -82,6 +82,37 @@ public class ClaimPromotionDialogFragment extends BaseDialogView
   private View genericMessageView;
   private View genericErrorView;
 
+  @Override public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+    loading = view.findViewById(R.id.loading);
+    walletAddressEdit = view.findViewById(R.id.wallet_edit);
+    getWalletAddressButton = view.findViewById(R.id.get_wallet_button);
+    walletNextButton = view.findViewById(R.id.wallet_continue_button);
+    walletCancelButton = view.findViewById(R.id.wallet_cancel_button);
+    walletMessageIcon = view.findViewById(R.id.wallet_message_icon);
+    walletErrorView = view.findViewById(R.id.wallet_error_view);
+    captcha = view.findViewById(R.id.captcha_container);
+    captchaEdit = view.findViewById(R.id.captcha_edit);
+    refreshCaptchaButton = view.findViewById(R.id.captcha_refresh);
+    captchaLoading = view.findViewById(R.id.captcha_progress);
+    captchaNextButton = view.findViewById(R.id.captcha_continue_button);
+    captchaCancelButton = view.findViewById(R.id.captcha_cancel_button);
+    captchaErrorView = view.findViewById(R.id.captcha_error_view);
+    genericMessageTitle = view.findViewById(R.id.generic_message_title);
+    genericMessageBody = view.findViewById(R.id.generic_message_body);
+    genericMessageButton = view.findViewById(R.id.generic_message_button);
+    genericErrorOkButton = view.findViewById(R.id.error_ok_button);
+
+    insertWalletView = view.findViewById(R.id.insert_address_view);
+    captchaView = view.findViewById(R.id.captcha_view);
+    genericMessageView = view.findViewById(R.id.generic_message_view);
+    genericErrorView = view.findViewById(R.id.generic_error);
+
+    attachPresenter(presenter);
+
+    handleRestoreViewState(savedInstanceState);
+  }
+
   @Override public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 


### PR DESCRIPTION
**What does this PR do?**

   Fixes the issue with the claim dialog not responding to any clicks. The attachpresenter was not being done because of a merge issue.

**Database changed?**

   No

**Where should the reviewer start?**

- [x] ClaimPromotionDialogFragment.java

**How should this be manually tested?**

  Open the claim dialog and click on get wallet/cancel/next to see if all work. You can see a promotion with a migrated app. Twitch clips is what I use to test. Install Twitch Clips Play version, go to Aptoide apps, follow promotion flow.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1848](https://aptoide.atlassian.net/browse/ASV-1848)

**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass