### PR TITLE
[bugfix/ASV-1879] Negative Progress

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -722,7 +722,7 @@
   <string name="appc_info_view_title_1">Everything You Need to Know About AppCoins</string>
   <string name="appc_info_view_body_1">AppCoins and AppCoins Credits are the currencies for in-app transactions. The best part? You\'ll earn up to <b>30% bonus in all purchases!</b></string>
   <string name="appc_info_view_title_2">First Things First</string>
-  <string name="appc_info_view_body_2">You need to install the AppCoins Wallet to get rewards and process all transactions. Once you install it, it'll do everything for you!</string>
+  <string name="appc_info_view_body_2">You need to install the AppCoins Wallet to get rewards and process all transactions. Once you install it, it\'ll do everything for you!</string>
   <string name="appc_info_view_title_3">Get Rewarded for Installing Apps!</string>
   <string name="appc_info_view_body_3">You\'ll get a reward for installing and spending 2 minutes in the apps with the symbol %s. You can find them all in the bundle "Earn AppCoins Credits" in Aptoide home!</string>
   <string name="appc_info_view_title_4">A Bonus on Every Purchase!</string>

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AppDownloadStatus.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AppDownloadStatus.java
@@ -28,17 +28,16 @@ public class AppDownloadStatus {
 
   public int getOverallProgress() {
     if (downloadSize == 0) {
-
       return calculateProgressByFileNumber(getOverallProgressAsPercentage());
     } else {
       return calculateProgressByFileSize(getOverallProgressAsBytes());
     }
   }
 
-  private int getOverallProgressAsBytes() {
-    int overallProgress = 0;
+  private long getOverallProgressAsBytes() {
+    long overallProgress = 0;
     for (FileDownloadCallback fileDownloadCallback : fileDownloadCallbackList) {
-      overallProgress += (int) fileDownloadCallback.getDownloadProgress()
+      overallProgress += fileDownloadCallback.getDownloadProgress()
           .getDownloadedBytes();
     }
     return overallProgress;
@@ -55,16 +54,14 @@ public class AppDownloadStatus {
   }
 
   private int getFileDownloadProgressAsPercentage(FileDownloadCallback fileDownloadCallback) {
-    return (int) Math.floor((float) fileDownloadCallback.getDownloadProgress()
+    return (int) Math.floor((double) fileDownloadCallback.getDownloadProgress()
         .getDownloadedBytes() / fileDownloadCallback.getDownloadProgress()
         .getTotalFileBytes() * PROGRESS_MAX_VALUE);
   }
 
-  private int calculateProgressByFileSize(int overallProgress) {
-    float result = (float) overallProgress / ((int) downloadSize);
-
-    int progress = (int) (result * 100);
-    return progress;
+  private int calculateProgressByFileSize(long overallProgress) {
+    double result = (double) overallProgress / downloadSize;
+    return (int) (result * 100);
   }
 
   private int calculateProgressByFileNumber(int overallProgress) {


### PR DESCRIPTION
**What does this PR do?**

   This PR fixes a bug where apps with big file sizes would display a negative progress. This was because integer/float was used for interim calculations which probably caused overflow problems. This PR essentially changes it do long / double.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppDownloadStatus.java

**How should this be manually tested?**

  Go to a big app, e.g. Grand Theft Auto San Andreas, and start a download. The progress should display positive values correctly.

**What are the relevant tickets?**

  [ASV-1879](https://aptoide.atlassian.net/browse/ASV-1879)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass