### PR TITLE
[bugfix/ASV-1859] - Fix for Editors Choice Analytics

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppModel.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppModel.java
@@ -422,6 +422,10 @@ public class AppModel {
     return editorsChoice;
   }
 
+  public boolean isFromEditorsChoice() {
+    return !editorsChoice.isEmpty();
+  }
+
   public String getOriginTag() {
     return originTag;
   }

--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -347,7 +347,7 @@ public class AppViewManager {
         .toCompletable();
   }
 
-  public void sendAppViewOpenedFromEvent(String packageName, String publisher, String badge,
+  public void sendAppOpenAnalytics(String packageName, String publisher, String badge,
       boolean hasBilling, boolean hasAdvertising) {
     if (isFirstLoad) {
       appViewAnalytics.sendAppViewOpenedFromEvent(packageName, publisher, badge, hasBilling,
@@ -356,8 +356,14 @@ public class AppViewManager {
     }
   }
 
-  public void sendEditorsChoiceClickEvent(String packageName, String editorsBrickPosition) {
-    appViewAnalytics.sendEditorsChoiceClickEvent(packageName, editorsBrickPosition);
+  public void sendEditorsAppOpenAnalytics(String packageName, String publisher, String badge,
+      boolean hasBilling, boolean hasAdvertising, String editorsBrickPosition) {
+    if (isFirstLoad) {
+      appViewAnalytics.sendAppViewOpenedFromEvent(packageName, publisher, badge, hasBilling,
+          hasAdvertising);
+      appViewAnalytics.sendEditorsChoiceClickEvent(packageName, editorsBrickPosition);
+      isFirstLoad = false;
+    }
   }
 
   public String getMarketName() {

--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -357,10 +357,7 @@ public class AppViewManager {
   }
 
   public void sendEditorsChoiceClickEvent(String packageName, String editorsBrickPosition) {
-    if (isFirstLoad) {
-      appViewAnalytics.sendEditorsChoiceClickEvent(packageName, editorsBrickPosition);
-      isFirstLoad = false;
-    }
+    appViewAnalytics.sendEditorsChoiceClickEvent(packageName, editorsBrickPosition);
   }
 
   public String getMarketName() {

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -179,16 +179,17 @@ public class AppViewPresenter implements Presenter {
 
   private void sendAppViewLoadAnalytics(AppViewModel appViewModel) {
     AppModel appModel = appViewModel.getAppModel();
-    if (!appModel.getEditorsChoice()
-        .isEmpty()) {
-      appViewManager.sendEditorsChoiceClickEvent(appModel.getPackageName(),
-          appModel.getEditorsChoice());
+    if (appModel.isFromEditorsChoice()) {
+      appViewManager.sendEditorsAppOpenAnalytics(appModel.getPackageName(), appModel.getDeveloper()
+          .getName(), appModel.getMalware()
+          .getRank()
+          .name(), appModel.hasBilling(), appModel.hasAdvertising(), appModel.getEditorsChoice());
+    } else {
+      appViewManager.sendAppOpenAnalytics(appModel.getPackageName(), appModel.getDeveloper()
+          .getName(), appModel.getMalware()
+          .getRank()
+          .name(), appModel.hasBilling(), appModel.hasAdvertising());
     }
-    appViewManager.sendAppViewOpenedFromEvent(appModel.getPackageName(), appModel.getDeveloper()
-        .getName(), appModel.getMalware()
-        .getRank()
-        .name(), appModel.hasBilling(), appModel.hasAdvertising());
-
     if (appViewModel.getDownloadModel()
         .getAction()
         .equals(DownloadModel.Action.MIGRATE) && !appViewManager.isMigrationImpressionSent()) {

--- a/app/src/main/java/cm/aptoide/pt/download/DownloadAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/download/DownloadAnalytics.java
@@ -23,7 +23,7 @@ public class DownloadAnalytics implements cm.aptoide.pt.downloadmanager.Analytic
       "Aptoide_Push_Notification_Download_Complete";
   public static final String DOWNLOAD_COMPLETE_EVENT = "Download Complete";
   public static final String EDITORS_CHOICE_DOWNLOAD_COMPLETE_EVENT_NAME =
-      "Editors Choice_Download_Complete";
+      "Editors_Choice_Download_Complete";
   public static final String DOWNLOAD_INTERACT = "Download_Interact";
   private static final String UPDATE_TO_APPC = "UPDATE TO APPC";
   private static final String AB_TEST_GROUP = "ab_test_group";
@@ -176,7 +176,8 @@ public class DownloadAnalytics implements cm.aptoide.pt.downloadmanager.Analytic
     downloadStartEvent(download, 0, null, context, action, isMigration, origin);
   }
 
-  public void downloadStartEvent(Download download, int campaignId, String abTestGroup, AppContext context, AnalyticsManager.Action action, boolean isMigration) {
+  public void downloadStartEvent(Download download, int campaignId, String abTestGroup,
+      AppContext context, AnalyticsManager.Action action, boolean isMigration) {
     downloadStartEvent(download, campaignId, abTestGroup, context, action, isMigration,
         getOrigin(download));
   }
@@ -273,6 +274,8 @@ public class DownloadAnalytics implements cm.aptoide.pt.downloadmanager.Analytic
     updateDownloadEventWithHasProgress(
         download.getPackageName() + download.getVersionCode() + DOWNLOAD_EVENT_NAME);
     updateDownloadEventWithHasProgress(download.getMd5() + DOWNLOAD_COMPLETE_EVENT);
+    updateDownloadEventWithHasProgress(
+        download.getMd5() + EDITORS_CHOICE_DOWNLOAD_COMPLETE_EVENT_NAME);
   }
 
   private void updateDownloadEventWithHasProgress(String key) {

--- a/app/src/test/java/cm/aptoide/pt/app/AppViewPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/AppViewPresenterTest.java
@@ -139,13 +139,11 @@ public class AppViewPresenterTest {
     verify(view).showAppView(appModel);
 
     // Verify analytics
-    verify(appViewManager).sendAppViewOpenedFromEvent(appModel.getPackageName(),
+    verify(appViewManager).sendEditorsAppOpenAnalytics(appModel.getPackageName(),
         appModel.getDeveloper()
             .getName(), appModel.getMalware()
             .getRank()
-            .name(), appModel.hasBilling(), appModel.hasAdvertising());
-    verify(appViewManager).sendEditorsChoiceClickEvent(appModel.getPackageName(),
-        appModel.getEditorsChoice());
+            .name(), appModel.hasBilling(), appModel.hasAdvertising(), appModel.getEditorsChoice());
 
     // Verify our init streams
     verify(presenter).loadAds(appViewModel);
@@ -178,15 +176,12 @@ public class AppViewPresenterTest {
     when(appViewManager.getAppViewModel()).thenReturn(Single.just(appViewModel));
 
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
-    //Then editors choice click event should not be sent
-    verify(appViewManager).sendEditorsChoiceClickEvent(appModel.getPackageName(),
-        appModel.getEditorsChoice());
-    //and app view opened from event should be sent
-    verify(appViewManager).sendAppViewOpenedFromEvent(appModel.getPackageName(),
+    //Then editors choice click event should be sent
+    verify(appViewManager).sendEditorsAppOpenAnalytics(appModel.getPackageName(),
         appModel.getDeveloper()
             .getName(), appModel.getMalware()
             .getRank()
-            .name(), appModel.hasBilling(), appModel.hasAdvertising());
+            .name(), appModel.hasBilling(), appModel.hasAdvertising(), appModel.getEditorsChoice());
   }
 
   @Test public void handleOpenAppViewEventsWithEmptyEditorsChoice() {
@@ -222,10 +217,14 @@ public class AppViewPresenterTest {
 
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
     //Then editors choice click event should not be sent
-    verify(appViewManager, never()).sendEditorsChoiceClickEvent(
-        emptyEditorsChoiceAppModel.getPackageName(), emptyEditorsChoiceAppModel.getEditorsChoice());
+    verify(appViewManager, never()).sendEditorsAppOpenAnalytics(appModel.getPackageName(),
+        appModel.getDeveloper()
+            .getName(), appModel.getMalware()
+            .getRank()
+            .name(), appModel.hasBilling(), appModel.hasAdvertising(),
+        emptyEditorsChoiceAppModel.getEditorsChoice());
     //and app view opened from event should be sent
-    verify(appViewManager).sendAppViewOpenedFromEvent(emptyEditorsChoiceAppModel.getPackageName(),
+    verify(appViewManager).sendAppOpenAnalytics(emptyEditorsChoiceAppModel.getPackageName(),
         emptyEditorsChoiceAppModel.getDeveloper()
             .getName(), emptyEditorsChoiceAppModel.getMalware()
             .getRank()


### PR DESCRIPTION
**What does this PR do?**

   This PR fixes two issues with Editors Choice analytics, namely 'App_Viewed_Open_From' and 'Editors_Choice_Download_Complete'. Please check the ticket for details.

**Database changed?**

   No

**How should this be manually tested?**

   Check if 'App_Viewed_Open_From' and 'Editors_Choice_Download_Complete' is being correctly sent when navigating from an Editors' Choice app.
  

**What are the relevant tickets?**

   [ASV-1859](https://aptoide.atlassian.net/browse/ASV-1859)

**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass