### PR TITLE
[ASV-1889] fix: disable vector drawable support lib

### DIFF
--- a/aptoide-views/build.gradle
+++ b/aptoide-views/build.gradle
@@ -11,7 +11,6 @@ android {
     targetSdkVersion Integer.parseInt(project.TARGET_SDK_VERSION)
     multiDexEnabled true
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    vectorDrawables.useSupportLibrary = true
   }
 
   compileOptions {


### PR DESCRIPTION
**What does this PR do?**

    since we need to migrate everything to srcCompat, support to drawable support lib is disabled.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] build.gradle

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1889](https://aptoide.atlassian.net/browse/ASV-1889)

https://fabric.io/aptoide2/android/apps/cm.aptoide.pt.dev/issues/cc1b291641763828d6298e380c9fcb3f?time=1565222400000%3A1565308799000

https://fabric.io/aptoide2/android/apps/cm.aptoide.pt.dev/issues/75b825ce18933926652ac1cdb57c868e?time=1565222400000%3A1565308799000

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass