### PR TITLE
[bugfix/ASV-1847] Release set as debuggable

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,13 @@ buildscript {
 android {
 
   configurations.all {
-    resolutionStrategy.force 'com.google.code.findbugs:jsr305:1.3.9'
+    resolutionStrategy{
+      force "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
+      force "com.android.support:support-v4:${SUPPORT_LIB_VERSION}"
+      force "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
+      force "com.android.support:animated-vector-drawable:${SUPPORT_LIB_VERSION}"
+      force "com.android.support:design:${SUPPORT_LIB_VERSION}"
+    }
   }
   // Websockets
   useLibrary 'org.apache.http.legacy'
@@ -131,7 +137,6 @@ android {
     }
 
     release {
-      testCoverageEnabled = true
       buildConfigField "boolean", "CRASH_REPORTS_DISABLED", "false"
       zipAlignEnabled true
       minifyEnabled true
@@ -363,38 +368,26 @@ dependencies {
   testImplementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
 
   // Force usage of support annotations in the test app, since it is internally used by the runner module.
-  androidTestImplementation("com.android.support.test:runner:${RUNNER_VERSION}") {
-    exclude group: "com.android.support", module: "support-annotations"
-  }
+  androidTestImplementation("com.android.support.test:runner:${RUNNER_VERSION}")
   androidTestImplementation "com.android.support.test:rules:${RULES_VERSION}"
-  androidTestImplementation("com.android.support:multidex-instrumentation:${MULTIDEX_VERSION}") {
-    exclude group: "com.android.support", module: "support-annotations"
-  }
+  androidTestImplementation("com.android.support:multidex-instrumentation:${MULTIDEX_VERSION}")
   androidTestImplementation "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
 
   androidTestImplementation "io.reactivex:rxjava:${RXJAVA_VERSION}"
   implementation "io.reactivex:rxjava:${RXJAVA_VERSION}"
   implementation "com.squareup.retrofit2:adapter-rxjava:${RETROFIT_VERSION}"
 
-  androidTestImplementation("com.android.support:multidex:${MULTIDEX_VERSION}") {
-    exclude group: "com.android.support", module: "support-annotations"
-  }
+  androidTestImplementation("com.android.support:multidex:${MULTIDEX_VERSION}")
 
-  implementation("com.android.support:multidex:${MULTIDEX_VERSION}") {
-    exclude group: "com.android.support", module: "support-annotations"
-  }
+  implementation("com.android.support:multidex:${MULTIDEX_VERSION}")
 
   testImplementation "junit:junit:${JUNIT_VERSION}"
   testImplementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
   // Force usage of support annotations in the test app, since it is internally used by the runner module.
   androidTestImplementation "junit:junit:${JUNIT_VERSION}"
-  androidTestImplementation("com.android.support.test:runner:${RUNNER_VERSION}") {
-    exclude group: "com.android.support", module: "support-annotations"
-  }
+  androidTestImplementation("com.android.support.test:runner:${RUNNER_VERSION}")
   androidTestImplementation "com.android.support.test:rules:${RULES_VERSION}"
-  androidTestImplementation("com.android.support:multidex-instrumentation:${MULTIDEX_VERSION}") {
-    exclude group: "com.android.support", module: "support-annotations"
-  }
+  androidTestImplementation("com.android.support:multidex-instrumentation:${MULTIDEX_VERSION}")
   //dependencies needed for UITests
   androidTestImplementation "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
   androidTestImplementation "com.android.support.test.espresso:espresso-core:${ESPRESSO_VERSION}"
@@ -447,8 +440,6 @@ dependencies {
     transitive = true
     exclude module: 'moat-mobile-app-kit'
     exclude group: "com.android.support"
-    exclude module: "support-annotations"
-    exclude module: "support-v4"
   }
 
   // AppLovin
@@ -465,9 +456,6 @@ dependencies {
   // Vungle
   implementation("com.github.vungle:vungle-android-sdk:${VUNGLE_SDK_VERSION}") {
     transitive = true
-    exclude group: "com.android.support"
-    exclude module: "support-annotations"
-    exclude module: "support-v4"
   }
   implementation "com.mopub.mediation:vungle:${MOPUB_MEDIATION_VUNGLE_VERSION}"
 
@@ -526,9 +514,7 @@ dependencies {
   //Color Palette
   implementation "com.android.support:palette-v7:${SUPPORT_LIB_VERSION}"
 
-  implementation("com.github.bumptech.glide:glide:${GLIDE_VERSION}") {
-    exclude group: "com.android.support"
-  }
+  implementation("com.github.bumptech.glide:glide:${GLIDE_VERSION}")
 
   annotationProcessor "com.github.bumptech.glide:compiler:${GLIDE_VERSION}"
 

--- a/aptoide-views/build.gradle
+++ b/aptoide-views/build.gradle
@@ -6,12 +6,21 @@ android {
   compileSdkVersion Integer.parseInt(project.COMPILE_SDK_VERSION)
   buildToolsVersion BUILD_TOOLS_VERSION
 
+  configurations.all {
+    resolutionStrategy{
+      force "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
+      force "com.android.support:support-v4:${SUPPORT_LIB_VERSION}"
+      force "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
+      force "com.android.support:animated-vector-drawable:${SUPPORT_LIB_VERSION}"
+      force "com.android.support:design:${SUPPORT_LIB_VERSION}"
+    }
+  }
+
   defaultConfig {
     minSdkVersion project.LIB_MINIMUM_SDK_VERSION
     targetSdkVersion Integer.parseInt(project.TARGET_SDK_VERSION)
     multiDexEnabled true
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    vectorDrawables.useSupportLibrary = true
   }
 
   compileOptions {
@@ -73,7 +82,6 @@ dependencies {
   androidTestImplementation "com.android.support.test:rules:${RULES_VERSION}"
   androidTestImplementation "org.mockito:mockito-android:${MOCKITO_CORE_ANDROID_VERSION}"
 
-
   // These are just for styling compatibility when we run instrumentation tests.
   // This essentially means that we are directly dependent on these libraries for resources.
   androidTestImplementation project(path: ':utils')
@@ -82,7 +90,5 @@ dependencies {
   androidTestImplementation "com.facebook.android:facebook-core:${FACEBOOK_ANDROID_SDK_VERSION}"
   androidTestImplementation "com.facebook.android:facebook-login:${FACEBOOK_ANDROID_SDK_VERSION}"
   androidTestImplementation "com.adyen.checkout:ui:${ADYEN_VERSION}"
-  androidTestImplementation("com.android.support:multidex:${MULTIDEX_VERSION}") {
-    exclude group: "com.android.support", module: "support-annotations"
-  }
+  androidTestImplementation("com.android.support:multidex:${MULTIDEX_VERSION}")
 }


### PR DESCRIPTION
**What does this PR do?**

   This PR removes a testCoverage command in release that was causing the release to be set as debuggable. It also improves the resolution strategy for different versions of certain dependencies (e.g. support libraries), so that we don't have to put exclude in every dependency.
   This fix for release also has the positive side effect that now launch times are a lot faster.

**Database changed?**

   No

**How should this be manually tested?**

  Check if the release variant now isn't debuggable... I think you can check this in the manifest of the apk, but I generally check the generated BuildConfig after gradle sync.

**What are the relevant tickets?**

  [ASV-1847](https://aptoide.atlassian.net/browse/ASV-1847)

**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass