### PR TITLE
[ASV-1916] fix: null check the drawable.getConstantState 

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/account/view/LoginSignUpCredentialsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/LoginSignUpCredentialsFragment.java
@@ -241,14 +241,16 @@ public class LoginSignUpCredentialsFragment extends GooglePlayServicesFragment
     }
     snackbar.show();
 
-    Drawable replacementDrawable = checkboxDrawable.getConstantState()
-        .newDrawable()
-        .mutate();
+    Drawable.ConstantState constantState = checkboxDrawable.getConstantState();
 
-    replacementDrawable.setColorFilter(getResources().getColor(R.color.red),
-        PorterDuff.Mode.SRC_ATOP);
+    if (constantState != null) {
+      Drawable replacementDrawable = constantState.newDrawable()
+          .mutate();
+      replacementDrawable.setColorFilter(getResources().getColor(R.color.red),
+          PorterDuff.Mode.SRC_ATOP);
+      termsConditionCheckBox.setButtonDrawable(replacementDrawable);
+    }
 
-    termsConditionCheckBox.setButtonDrawable(replacementDrawable);
     termsConditionCheckBox.setOnCheckedChangeListener(
         (buttonView, isChecked) -> termsConditionCheckBox.setButtonDrawable(checkboxDrawable));
   }


### PR DESCRIPTION


**What does this PR do?**

   null check the drawable.getConstantState  which is null in some scenarios and prevents the user from logging in. This solution will prevent the checkbox from becoming red when getConstantState returns null.
   Could only reproduce the null on a Moto G device.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] LoginSignUpCredentialsFragment.java

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [ASV-1916](https://aptoide.atlassian.net/browse/ASV-1916)

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1916](https://aptoide.atlassian.net/browse/ASV-1916)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass