### PR TITLE
[HOTFIX/ASV-1807] Fixed load more inflate error

### DIFF
--- a/app/src/main/res/layout/load_more_error.xml
+++ b/app/src/main/res/layout/load_more_error.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -42,7 +42,6 @@
       style="@style/Aptoide.TextView.Regular.XS.GreyMedium"
       />
 
-
   <Button
       android:id="@+id/load_more_retry_button"
       android:layout_width="wrap_content"
@@ -58,4 +57,4 @@
       style="@style/Aptoide.Button.GreyFogLight"
       />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at fixing the load more error view inflating. Due to the change to androidx and the fact that this view was still using the support constraint layout, it was crashing.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] load_more_error.xml

**How should this be manually tested?**

  Open home, turn off internet, scroll and check that the load more error shows correctly

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1807](https://aptoide.atlassian.net/browse/ASV-1807)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass