### PR TITLE
[Hotfix ASV-1980] Editorial fix

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialPresenter.java
@@ -121,6 +121,7 @@ public class EditorialPresenter implements Presenter {
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
         .flatMap(__ -> setUpViewModelOnViewReady())
         .flatMap(view::appCardClicked)
+        .doOnError(throwable -> throwable.printStackTrace())
         .doOnNext(editorialEvent -> {
           editorialNavigator.navigateToAppView(editorialEvent.getId(),
               editorialEvent.getPackageName());
@@ -392,7 +393,8 @@ public class EditorialPresenter implements Presenter {
   private Observable<EditorialViewModel> setUpViewModelOnViewReady() {
     return view.isViewReady()
         .flatMap(__ -> editorialManager.loadEditorialViewModel()
-            .toObservable());
+            .toObservable())
+        .observeOn(viewScheduler);
   }
 
   @VisibleForTesting public void handleReactionButtonClick() {

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialPresenter.java
@@ -121,7 +121,6 @@ public class EditorialPresenter implements Presenter {
         .filter(lifecycleEvent -> lifecycleEvent.equals(View.LifecycleEvent.CREATE))
         .flatMap(__ -> setUpViewModelOnViewReady())
         .flatMap(view::appCardClicked)
-        .doOnError(throwable -> throwable.printStackTrace())
         .doOnNext(editorialEvent -> {
           editorialNavigator.navigateToAppView(editorialEvent.getId(),
               editorialEvent.getPackageName());

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialRepository.kt
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialRepository.kt
@@ -12,17 +12,19 @@ class EditorialRepository(private val editorialService: EditorialService) {
     else
       when (editorialLoadSource) {
         is CardId -> editorialService.loadEditorialViewModel(
-            editorialLoadSource.cardId).map { editorialViewModel ->
+            editorialLoadSource.cardId).doOnError { throwable -> throwable.printStackTrace() }.map { editorialViewModel ->
           saveResponse(editorialViewModel)
         }
         is Slug -> editorialService.loadEditorialViewModelWithSlug(
-            editorialLoadSource.slug).map { editorialViewModel -> saveResponse(editorialViewModel) }
+            editorialLoadSource.slug).doOnError { throwable -> throwable.printStackTrace() }.map { editorialViewModel ->
+          saveResponse(editorialViewModel)
+        }
       }
   }
 
   private fun saveResponse(editorialViewModel: EditorialViewModel): EditorialViewModel {
     if (!editorialViewModel.hasError() && !editorialViewModel.isLoading) {
-      cachedEditorialViewModel = cachedEditorialViewModel
+      cachedEditorialViewModel = editorialViewModel
     }
     return editorialViewModel
   }

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialRepository.kt
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialRepository.kt
@@ -4,7 +4,7 @@ import rx.Single
 
 class EditorialRepository(private val editorialService: EditorialService) {
 
-  private var cachedEditorialViewModel: EditorialViewModel? = null;
+  private var cachedEditorialViewModel: EditorialViewModel? = null
 
   fun loadEditorialViewModel(editorialLoadSource: EditorialLoadSource): Single<EditorialViewModel> {
     return if (cachedEditorialViewModel != null)

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialRepository.kt
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialRepository.kt
@@ -12,11 +12,11 @@ class EditorialRepository(private val editorialService: EditorialService) {
     else
       when (editorialLoadSource) {
         is CardId -> editorialService.loadEditorialViewModel(
-            editorialLoadSource.cardId).doOnError { throwable -> throwable.printStackTrace() }.map { editorialViewModel ->
+            editorialLoadSource.cardId).map { editorialViewModel ->
           saveResponse(editorialViewModel)
         }
         is Slug -> editorialService.loadEditorialViewModelWithSlug(
-            editorialLoadSource.slug).doOnError { throwable -> throwable.printStackTrace() }.map { editorialViewModel ->
+            editorialLoadSource.slug).map { editorialViewModel ->
           saveResponse(editorialViewModel)
         }
       }


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at fixing the Editorial download and open the appview. The request was not being correctly cached which would cause the editorialviewmodel to be wrongly created, meaning that the navigation to appview and download would not work.

**Database changed?**

No

**Where should the reviewer start?**

- [x] EditorialService.java

**How should this be manually tested?**

  Open Editorial and try to download the app and try to navigate to appview.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1980](https://aptoide.atlassian.net/browse/ASV-1980)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass