### PR TITLE
[ASV-2022] Editorial now supports embedded videos;

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialItemsViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialItemsViewHolder.java
@@ -4,6 +4,8 @@ import android.graphics.Rect;
 import android.view.View;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
@@ -50,6 +52,7 @@ class EditorialItemsViewHolder extends RecyclerView.ViewHolder {
   private TextView message;
   private View media;
   private ImageView image;
+  private WebView embeddedVideo;
   private ImageView videoThumbnail;
   private FrameLayout videoThumbnailContainer;
   private RecyclerView mediaList;
@@ -78,6 +81,7 @@ class EditorialItemsViewHolder extends RecyclerView.ViewHolder {
     message = (TextView) view.findViewById(R.id.editorial_item_message);
     media = view.findViewById(R.id.editorial_item_media);
     image = (ImageView) view.findViewById(R.id.editorial_image);
+    embeddedVideo = view.findViewById(R.id.embedded_video);
     videoThumbnail = view.findViewById(R.id.editorial_video_thumbnail);
     videoThumbnailContainer = view.findViewById(R.id.editorial_video_thumbnail_container);
     descriptionSwitcher =
@@ -249,6 +253,13 @@ class EditorialItemsViewHolder extends RecyclerView.ViewHolder {
             videoThumbnailContainer.setOnClickListener(v -> uiEventListener.onNext(
                 new EditorialEvent(EditorialEvent.Type.MEDIA, editorialMedia.getUrl())));
           }
+        }
+        if (editorialMedia.isEmbedded()) {
+          embeddedVideo.setWebViewClient(new WebViewClient());
+          embeddedVideo.getSettings()
+              .setJavaScriptEnabled(true);
+          embeddedVideo.loadUrl(editorialMedia.getUrl());
+          embeddedVideo.setVisibility(View.VISIBLE);
         }
       }
     }

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialMedia.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialMedia.java
@@ -34,6 +34,10 @@ class EditorialMedia {
     return hasType() && type.equals("video");
   }
 
+  public boolean isEmbedded() {
+    return hasType() && type.equals("video_webview");
+  }
+
   public String getDescription() {
     return description;
   }

--- a/app/src/main/res/layout/editorial_item_layout.xml
+++ b/app/src/main/res/layout/editorial_item_layout.xml
@@ -107,7 +107,14 @@
           android:src="@drawable/btn_movie_play_normal"
           />
     </FrameLayout>
-
+    <WebView
+        android:id="@+id/embedded_video"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:visibility="gone"
+        tools:ignore="WebViewLayout"
+        tools:visibility="gone"
+        />
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/editoral_image_list"
         android:layout_width="match_parent"


### PR DESCRIPTION
**What does this PR do?**

This PR implements embedded videos on a webvideo in editorials;

**Database changed?**

No

**Where should the reviewer start?**

- [ ] EditorialItemsViewHolder.java


**How should this be manually tested?**

You'll need to rewrite a charles request for an editorial card so as to include a piece of media with type "video-webview" and an embedded youtube link (youtube.com/embed/<videoId>). Check that the video plays correctly on the editorial fragment

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-2022](https://aptoide.atlassian.net/browse/ASV-2022)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass