### PR TITLE
[ASV-1984] Implemented skeleton for editorial;

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListFragment.java
@@ -137,12 +137,10 @@ public class EditorialListFragment extends NavigationTrackFragment implements Ed
   @Override public void showLoading() {
     errorView.setVisibility(View.GONE);
     skeleton.showSkeleton();
-    //progressBar.setVisibility(View.VISIBLE);
   }
 
   @Override public void hideLoading() {
     errorView.setVisibility(View.GONE);
-    //progressBar.setVisibility(View.GONE);
     skeleton.showOriginal();
     swipeRefreshLayout.setVisibility(View.VISIBLE);
   }

--- a/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/editorialList/EditorialListFragment.java
@@ -13,6 +13,8 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import cm.aptoide.analytics.implementation.navigation.ScreenTagHistory;
 import cm.aptoide.aptoideviews.errors.ErrorView;
+import cm.aptoide.aptoideviews.skeleton.Skeleton;
+import cm.aptoide.aptoideviews.skeleton.SkeletonUtils;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.bottomNavigation.BottomNavigationActivity;
 import cm.aptoide.pt.bottomNavigation.BottomNavigationItem;
@@ -59,6 +61,8 @@ public class EditorialListFragment extends NavigationTrackFragment implements Ed
   private ProgressBar progressBar;
   private ImageView userAvatar;
 
+  private Skeleton skeleton;
+
   @Override public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     getFragmentComponent(savedInstanceState).inject(this);
@@ -87,6 +91,9 @@ public class EditorialListFragment extends NavigationTrackFragment implements Ed
 
     errorView = view.findViewById(R.id.error_view);
     progressBar = view.findViewById(R.id.progress_bar);
+
+    skeleton =
+        SkeletonUtils.applySkeleton(editorialList, R.layout.editorial_list_action_item_skeleton, 4);
     attachPresenter(presenter);
   }
 
@@ -129,12 +136,14 @@ public class EditorialListFragment extends NavigationTrackFragment implements Ed
 
   @Override public void showLoading() {
     errorView.setVisibility(View.GONE);
-    progressBar.setVisibility(View.VISIBLE);
+    skeleton.showSkeleton();
+    //progressBar.setVisibility(View.VISIBLE);
   }
 
   @Override public void hideLoading() {
     errorView.setVisibility(View.GONE);
-    progressBar.setVisibility(View.GONE);
+    //progressBar.setVisibility(View.GONE);
+    skeleton.showOriginal();
     swipeRefreshLayout.setVisibility(View.VISIBLE);
   }
 

--- a/aptoide-views/src/main/res/layout/editorial_list_action_item_skeleton.xml
+++ b/aptoide-views/src/main/res/layout/editorial_list_action_item_skeleton.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/root_cardview"
+    android:layout_width="match_parent"
+    android:layout_height="240dp"
+    android:layout_marginBottom="5dp"
+    android:layout_marginEnd="8dp"
+    android:layout_marginLeft="8dp"
+    android:layout_marginRight="8dp"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="15dp"
+    app:cardCornerRadius="4dp"
+    >
+
+  <include layout="@layout/editorial_action_item_skeleton"/>
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
**What does this PR do?**

This PR implements the skeleton view on editorial;

**Database changed?**

No

**Where should the reviewer start?**

- [ ] EditorialListFragment.java

**How should this be manually tested?**

Check that the editorial fragment shows the skeleton while loading;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1984](https://aptoide.atlassian.net/browse/ASV-1984)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass