### PR TITLE
[ASV-2004] Created new Root Installer method to allow root installati…

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -180,6 +180,7 @@ import cm.aptoide.pt.install.InstallerFactory;
 import cm.aptoide.pt.install.PackageInstallerManager;
 import cm.aptoide.pt.install.PackageRepository;
 import cm.aptoide.pt.install.RootInstallNotificationEventReceiver;
+import cm.aptoide.pt.install.RootInstallerProvider;
 import cm.aptoide.pt.install.installer.DefaultInstaller;
 import cm.aptoide.pt.install.installer.InstallationProvider;
 import cm.aptoide.pt.install.installer.RootInstallErrorNotificationFactory;
@@ -333,13 +334,19 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
       @Named("cachePath") String cachePath, @Named("apkPath") String apkPath,
       @Named("obbPath") String obbPath, AppInstaller appInstaller,
       AppInstallerStatusReceiver appInstallerStatusReceiver,
-      PackageInstallerManager packageInstallerManager) {
+      PackageInstallerManager packageInstallerManager,
+      RootInstallerProvider rootInstallerProvider) {
     return new InstallManager(application, aptoideDownloadManager,
         new InstallerFactory(new MinimalAdMapper(), installerAnalytics, appInstaller,
-            getInstallingStateTimeout(), appInstallerStatusReceiver).create(application),
-        rootAvailabilityManager, defaultSharedPreferences, secureSharedPreferences,
-        downloadsRepository, installedRepository, cachePath, apkPath, obbPath, new FileUtils(),
-        packageInstallerManager);
+            getInstallingStateTimeout(), appInstallerStatusReceiver, rootInstallerProvider).create(
+            application), rootAvailabilityManager, defaultSharedPreferences,
+        secureSharedPreferences, downloadsRepository, installedRepository, cachePath, apkPath,
+        obbPath, new FileUtils(), packageInstallerManager);
+  }
+
+  @Singleton @Provides RootInstallerProvider providesRootInstallerProvider(
+      InstallerAnalytics installerAnalytics) {
+    return new RootInstallerProvider(installerAnalytics);
   }
 
   @Singleton @Provides InstallerAnalytics providesInstallerAnalytics(
@@ -462,11 +469,13 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
       @Named("default") SharedPreferences sharedPreferences,
       InstalledRepository installedRepository, RootAvailabilityManager rootAvailabilityManager,
       InstallerAnalytics installerAnalytics, AppInstaller appInstaller,
-      AppInstallerStatusReceiver appInstallerStatusReceiver) {
+      AppInstallerStatusReceiver appInstallerStatusReceiver,
+      RootInstallerProvider rootInstallerProvider) {
     return new DefaultInstaller(application.getPackageManager(), installationProvider, appInstaller,
         new FileUtils(), ToolboxManager.isDebug(sharedPreferences) || BuildConfig.DEBUG,
         installedRepository, BuildConfig.ROOT_TIMEOUT, rootAvailabilityManager, sharedPreferences,
-        installerAnalytics, getInstallingStateTimeout(), appInstallerStatusReceiver);
+        installerAnalytics, getInstallingStateTimeout(), appInstallerStatusReceiver,
+        rootInstallerProvider);
   }
 
   private int getInstallingStateTimeout() {

--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -346,7 +346,7 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
 
   @Singleton @Provides RootInstallerProvider providesRootInstallerProvider(
       InstallerAnalytics installerAnalytics) {
-    return new RootInstallerProvider(installerAnalytics);
+    return new RootInstallerProvider(installerAnalytics, getApplicationContext().getPackageName());
   }
 
   @Singleton @Provides InstallerAnalytics providesInstallerAnalytics(

--- a/app/src/main/java/cm/aptoide/pt/install/InstallerFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/install/InstallerFactory.java
@@ -33,15 +33,18 @@ public class InstallerFactory {
   private final AppInstaller appInstaller;
   private final int installingStateTimeout;
   private final AppInstallerStatusReceiver appInstallerStatusReceiver;
+  private final RootInstallerProvider rootInstallerProvider;
 
   public InstallerFactory(MinimalAdMapper adMapper, InstallerAnalytics installerAnalytics,
       AppInstaller appInstaller, int installingStateTimeout,
-      AppInstallerStatusReceiver appInstallerStatusReceiver) {
+      AppInstallerStatusReceiver appInstallerStatusReceiver,
+      RootInstallerProvider rootInstallerProvider) {
     this.adMapper = adMapper;
     this.installerAnalytics = installerAnalytics;
     this.appInstaller = appInstaller;
     this.installingStateTimeout = installingStateTimeout;
     this.appInstallerStatusReceiver = appInstallerStatusReceiver;
+    this.rootInstallerProvider = rootInstallerProvider;
   }
 
   public Installer create(Context context) {
@@ -57,7 +60,8 @@ public class InstallerFactory {
         RepositoryFactory.getInstalledRepository(context.getApplicationContext()), 180000,
         ((AptoideApplication) context.getApplicationContext()).getRootAvailabilityManager(),
         ((AptoideApplication) context.getApplicationContext()).getDefaultSharedPreferences(),
-        installerAnalytics, installingStateTimeout, appInstallerStatusReceiver);
+        installerAnalytics, installingStateTimeout, appInstallerStatusReceiver,
+        rootInstallerProvider);
   }
 
   @NonNull private DownloadInstallationProvider getInstallationProvider(

--- a/app/src/main/java/cm/aptoide/pt/install/RootInstallerProvider.java
+++ b/app/src/main/java/cm/aptoide/pt/install/RootInstallerProvider.java
@@ -19,7 +19,7 @@ public class RootInstallerProvider {
 
   public Observable.OnSubscribe<Void> provideRootInstaller(Installation installation) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      return new RootInstaller(packageName, installation);
+      return new RootInstaller(packageName, installerAnalytics, installation);
     } else {
       return new RootCommandOnSubscribe(installation.getId()
           .hashCode(), getRootInstallCommand(installation), installerAnalytics);

--- a/app/src/main/java/cm/aptoide/pt/install/RootInstallerProvider.java
+++ b/app/src/main/java/cm/aptoide/pt/install/RootInstallerProvider.java
@@ -9,15 +9,17 @@ import rx.Observable;
 
 public class RootInstallerProvider {
 
+  private final String packageName;
   private InstallerAnalytics installerAnalytics;
 
-  public RootInstallerProvider(InstallerAnalytics installerAnalytics) {
+  public RootInstallerProvider(InstallerAnalytics installerAnalytics, String packageName) {
     this.installerAnalytics = installerAnalytics;
+    this.packageName = packageName;
   }
 
   public Observable.OnSubscribe<Void> provideRootInstaller(Installation installation) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      return new RootInstaller(installation);
+      return new RootInstaller(packageName, installation);
     } else {
       return new RootCommandOnSubscribe(installation.getId()
           .hashCode(), getRootInstallCommand(installation), installerAnalytics);

--- a/app/src/main/java/cm/aptoide/pt/install/RootInstallerProvider.java
+++ b/app/src/main/java/cm/aptoide/pt/install/RootInstallerProvider.java
@@ -1,0 +1,34 @@
+package cm.aptoide.pt.install;
+
+import android.os.Build;
+import cm.aptoide.pt.install.installer.Installation;
+import cm.aptoide.pt.install.installer.RootCommandOnSubscribe;
+import cm.aptoide.pt.install.installer.RootInstaller;
+import java.io.File;
+import rx.Observable;
+
+public class RootInstallerProvider {
+
+  private InstallerAnalytics installerAnalytics;
+
+  public RootInstallerProvider(InstallerAnalytics installerAnalytics) {
+    this.installerAnalytics = installerAnalytics;
+  }
+
+  public Observable.OnSubscribe<Void> provideRootInstaller(Installation installation) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      return new RootInstaller(installation);
+    } else {
+      return new RootCommandOnSubscribe(installation.getId()
+          .hashCode(), getRootInstallCommand(installation), installerAnalytics);
+    }
+  }
+
+  private String getRootInstallCommand(Installation installation) {
+    File file = installation.getFile();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      return "cat " + file.getAbsolutePath() + " | pm install -S " + file.length();
+    }
+    return "pm install -r " + file.getAbsolutePath();
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/install/installer/Root.java
+++ b/app/src/main/java/cm/aptoide/pt/install/installer/Root.java
@@ -29,7 +29,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 
 public class Root {
-  private static final String TAG = "SAIRoot";
+  private static final String TAG = "Root";
 
   private Process mSuProcess;
   private boolean mIsAcquired = true;

--- a/app/src/main/java/cm/aptoide/pt/install/installer/Root.java
+++ b/app/src/main/java/cm/aptoide/pt/install/installer/Root.java
@@ -1,0 +1,148 @@
+/*
+ * Aurora Store
+ * Copyright (C) 2019, Rahul Kumar Patel <whyorean@gmail.com>
+ *
+ * Aurora Store is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Aurora Store is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Aurora Store.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package cm.aptoide.pt.install.installer;
+
+import android.util.Log;
+import cm.aptoide.pt.logger.Logger;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class Root {
+  private static final String TAG = "SAIRoot";
+
+  private Process mSuProcess;
+  private boolean mIsAcquired = true;
+  private boolean mIsTerminated;
+
+  private BufferedWriter mWriter;
+  private BufferedReader mReader;
+  private BufferedReader mErrorReader;
+
+  public Root() {
+    try {
+      mSuProcess = Runtime.getRuntime()
+          .exec("su");
+      mWriter = new BufferedWriter(new OutputStreamWriter(mSuProcess.getOutputStream()));
+      mReader = new BufferedReader(new InputStreamReader(mSuProcess.getInputStream()));
+      mErrorReader = new BufferedReader(new InputStreamReader(mSuProcess.getErrorStream()));
+      exec("echo test");
+    } catch (IOException e) {
+      mIsAcquired = false;
+      mIsTerminated = true;
+      Log.w(TAG, "Unable to acquire root access: ");
+      Log.w(TAG, e);
+    }
+  }
+
+  public static boolean requestRoot() {
+    try {
+      Process root = Runtime.getRuntime()
+          .exec("su -c exit");
+      root.waitFor();
+      return root.exitValue() == 0;
+    } catch (Exception e) {
+      Log.w(TAG, "Unable to acquire root access: ");
+      Log.w(TAG, e);
+      return false;
+    }
+  }
+
+  public String exec(String command) {
+    Logger.getInstance()
+        .d("install", "executing command : " + command);
+    try {
+      StringBuilder sb = new StringBuilder();
+      String breaker =
+          "『BREAKER』";//Echoed after main command and used to determine when to stop reading from the stream
+      mWriter.write(command + "\necho " + breaker + "\n");
+      mWriter.flush();
+
+      char[] buffer = new char[256];
+      while (true) {
+        sb.append(buffer, 0, mReader.read(buffer));
+
+        int bi = sb.indexOf(breaker);
+        if (bi != -1) {
+          sb.delete(bi, bi + breaker.length());
+          break;
+        }
+      }
+
+      return sb.toString()
+          .trim();
+    } catch (Exception e) {
+      mIsAcquired = false;
+      mIsTerminated = true;
+      Log.w(TAG, "Unable execute command: ");
+      Log.w(TAG, e);
+    }
+
+    return null;
+  }
+
+  public String readError() {
+    try {
+      StringBuilder sb = new StringBuilder();
+      String breaker = "『BREAKER』";
+      mWriter.write("echo " + breaker + " >&2\n");
+      mWriter.flush();
+
+      char[] buffer = new char[256];
+      while (true) {
+        sb.append(buffer, 0, mErrorReader.read(buffer));
+
+        int bi = sb.indexOf(breaker);
+        if (bi != -1) {
+          sb.delete(bi, bi + breaker.length());
+          break;
+        }
+      }
+
+      return sb.toString()
+          .trim();
+    } catch (Exception e) {
+      mIsAcquired = false;
+      mIsTerminated = true;
+      Log.w(TAG, "Unable execute command: ");
+      Log.w(TAG, e);
+    }
+
+    return null;
+  }
+
+  public void terminate() {
+    if (mIsTerminated) return;
+
+    mIsTerminated = true;
+    mSuProcess.destroy();
+  }
+
+  public boolean isTerminated() {
+    return mIsTerminated;
+  }
+
+  public boolean isAcquired() {
+    return mIsAcquired;
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/install/installer/Root.java
+++ b/app/src/main/java/cm/aptoide/pt/install/installer/Root.java
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Aurora Store.  If not, see <http://www.gnu.org/licenses/>.
  *
+ * taken from https://gitlab.com/AuroraOSS/AuroraStore/blob/master/app/src/main/java/com/aurora/store/utility/Root.java
  *
  */
 

--- a/app/src/main/java/cm/aptoide/pt/install/installer/RootInstaller.java
+++ b/app/src/main/java/cm/aptoide/pt/install/installer/RootInstaller.java
@@ -1,0 +1,94 @@
+package cm.aptoide.pt.install.installer;
+
+import cm.aptoide.pt.database.realm.FileToDownload;
+import cm.aptoide.pt.install.exception.InstallationException;
+import cm.aptoide.pt.logger.Logger;
+import java.io.File;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import rx.Observable;
+import rx.Subscriber;
+
+public class RootInstaller implements Observable.OnSubscribe<Void> {
+
+  private static final String TAG = "RootInstaller";
+
+  private Installation installation;
+  private Root root;
+
+  public RootInstaller(Installation installation) {
+    this.installation = installation;
+    root = new Root();
+  }
+
+  @Override public void call(Subscriber<? super Void> subscriber) {
+    Logger.getInstance()
+        .d(TAG, "call: start with installation package name: " + installation.getPackageName());
+
+    if (root.isTerminated() || !root.isAcquired()) {
+      Root.requestRoot();
+      if (!root.isAcquired()) {
+        Logger.getInstance()
+            .d(TAG, "root is not available");
+        subscriber.onError(new InstallationException("No root permissions"));
+        return;
+      }
+    }
+
+    String commandResult = root.exec(String.format(Locale.getDefault(),
+        "pm install-create -i com.android.vending --user %s -r -S %d", "0",
+        getFilesSize(installation)));
+
+    if (commandResult == null || commandResult.length() == 0) {
+      subscriber.onError(new InstallationException(root.readError()));
+      return;
+    }
+
+    Pattern sessionIdPattern = Pattern.compile("(\\d+)");
+    Matcher sessionIdMatcher = sessionIdPattern.matcher(commandResult);
+    boolean found = sessionIdMatcher.find();
+    int sessionId = Integer.parseInt(sessionIdMatcher.group(1));
+
+    for (FileToDownload apkFile : installation.getFiles()) {
+      Logger.getInstance()
+          .d("install", "started instalation of:" + apkFile.getFileName());
+      File file = new File(apkFile.getPath() + apkFile.getFileName());
+
+      String fileResult = root.exec(
+          String.format(Locale.getDefault(), "cat \"%s\" | pm install-write -S %d %d \"%s\"",
+              file.getAbsolutePath(), file.length(), sessionId, file.getName()));
+      if (fileResult == null || fileResult.length() == 0) {
+        subscriber.onError(new InstallationException(root.readError()));
+        return;
+      }
+    }
+
+    String commitResult =
+        root.exec(String.format(Locale.getDefault(), "pm install-commit %d ", sessionId));
+    if (commitResult == null || commitResult.length() == 0) {
+      subscriber.onError(new InstallationException(root.readError()));
+      return;
+    }
+
+    if (commitResult.toLowerCase()
+        .contains("success")) {
+      if (!subscriber.isUnsubscribed()) {
+        subscriber.onCompleted();
+        return;
+      }
+    } else {
+      subscriber.onError(new InstallationException(root.readError()));
+      return;
+    }
+  }
+
+  private int getFilesSize(Installation installation) {
+    int totalSize = 0;
+    for (FileToDownload apkFile : installation.getFiles()) {
+      File file = new File(apkFile.getPath() + apkFile.getFileName());
+      totalSize += file.length();
+    }
+    return totalSize;
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/install/installer/RootInstaller.java
+++ b/app/src/main/java/cm/aptoide/pt/install/installer/RootInstaller.java
@@ -52,7 +52,7 @@ public class RootInstaller implements Observable.OnSubscribe<Void> {
 
     for (FileToDownload apkFile : installation.getFiles()) {
       Logger.getInstance()
-          .d("install", "started instalation of:" + apkFile.getFileName());
+          .d(TAG, "started instalation of file: " + apkFile.getFileName());
       File file = new File(apkFile.getPath() + apkFile.getFileName());
 
       String fileResult = root.exec(

--- a/app/src/main/java/cm/aptoide/pt/install/installer/RootInstaller.java
+++ b/app/src/main/java/cm/aptoide/pt/install/installer/RootInstaller.java
@@ -13,11 +13,12 @@ import rx.Subscriber;
 public class RootInstaller implements Observable.OnSubscribe<Void> {
 
   private static final String TAG = "RootInstaller";
-
+  private final String packageName;
   private Installation installation;
   private Root root;
 
-  public RootInstaller(Installation installation) {
+  public RootInstaller(String packageName, Installation installation) {
+    this.packageName = packageName;
     this.installation = installation;
     root = new Root();
   }
@@ -37,7 +38,7 @@ public class RootInstaller implements Observable.OnSubscribe<Void> {
     }
 
     String commandResult = root.exec(String.format(Locale.getDefault(),
-        "pm install-create -i com.android.vending --user %s -r -S %d", "0",
+        "pm install-create -i " + packageName + " --user %s -r -S %d", "0",
         getFilesSize(installation)));
 
     if (commandResult == null || commandResult.length() == 0) {
@@ -47,7 +48,7 @@ public class RootInstaller implements Observable.OnSubscribe<Void> {
 
     Pattern sessionIdPattern = Pattern.compile("(\\d+)");
     Matcher sessionIdMatcher = sessionIdPattern.matcher(commandResult);
-    boolean found = sessionIdMatcher.find();
+    sessionIdMatcher.find();
     int sessionId = Integer.parseInt(sessionIdMatcher.group(1));
 
     for (FileToDownload apkFile : installation.getFiles()) {


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at allowing installation of app bundles through root installation.
This new root method is only available for apps above 21, while bellow 21 it uses the old root install method.

**Database changed?**

   No

**Where should the reviewer start?**

- [x] RootInstall.java

**How should this be manually tested?**

  With a device above or equal to 21: install apps with app bundles. Note that in dev, apps with app bundles are not available. To test this, you must go to appbundles availability manager entity and return true on the method that enables app bundles. 
Also, test a root install of an app without appbundles.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-2004](https://aptoide.atlassian.net/browse/ASV-2004)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass