### PR TITLE
[ASV-2036] task: enable app bundles everywhere but Apps

### DIFF
--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilityManager.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilityManager.java
@@ -8,6 +8,6 @@ public class AppBundlesVisibilityManager {
   }
 
   public boolean shouldEnableAppBundles() {
-    return false;
+    return !isDeviceMiui;
   }
 }

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/V7.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/V7.java
@@ -261,7 +261,7 @@ public abstract class V7<U, B extends RefreshBody> extends WebService<V7.Interfa
 
     @POST("listAppsUpdates") Observable<ListAppsUpdates> listAppsUpdates(
         @Body ListAppsUpdatesRequest.Body body,
-        @Header(WebService.BYPASS_HEADER_KEY) boolean bypassCache, @Query("aab") boolean showAabs);
+        @Header(WebService.BYPASS_HEADER_KEY) boolean bypassCache);
 
     @POST("listAppcAppsUpgrades") Observable<ListAppsUpdates> listAppcAppssUpgrades(
         @Body ListAppcAppsUpgradesRequest.Body body,

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/listapps/ListAppsUpdatesRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/listapps/ListAppsUpdatesRequest.java
@@ -113,8 +113,7 @@ public class ListAppsUpdatesRequest extends V7<ListAppsUpdates, ListAppsUpdatesR
                 .observeOn(Schedulers.io())
                 // map bodies to request with bodies
                 //.map(body -> fetchDataUsingBodyWithRetry(interfaces, body, bypassCache, 3))
-                .map(body -> interfaces.listAppsUpdates(body, bypassCache,
-                    appBundlesVisibilityManager.shouldEnableAppBundles()))
+                .map(body -> interfaces.listAppsUpdates(body, bypassCache))
                 // wait for all requests to be ready and return a list of requests
                 .toList()
                 // subscribe to all observables (list of observables<request>) at the same time using merge
@@ -136,8 +135,7 @@ public class ListAppsUpdatesRequest extends V7<ListAppsUpdates, ListAppsUpdatesR
                   return resultListAppsUpdates;
                 });
           }
-          return interfaces.listAppsUpdates(body, bypassCache,
-              appBundlesVisibilityManager.shouldEnableAppBundles());
+          return interfaces.listAppsUpdates(body, bypassCache);
         });
   }
 


### PR DESCRIPTION
**What does this PR do?**

   This ticket enables aabs everywhere but in Apps.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] v7.java
- [ ] AppBundlesVisibilityManager.java

**How should this be manually tested?**

  Check if search shows apps with splits (airbnb - split store)
  Check if apps does not show apps with splits (install 2nd latest linkedin, force Apps request and check if there is no updates to do)

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-2036](https://aptoide.atlassian.net/browse/ASV-2036)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass