### PR TITLE
[ASV-2027] Fixed wizard height

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/view/wizard/WizardPageTwoFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/wizard/WizardPageTwoFragment.java
@@ -59,7 +59,7 @@ public class WizardPageTwoFragment extends BackButtonFragment {
     ((TextView) view.findViewById(R.id.description)).setText(
         marketResourceFormatter.formatString(getContext(),
             R.string.wizard_sub_title_viewpager_two));
-    ((ImageView) view.findViewById(android.R.id.icon)).setImageResource(R.drawable.wizard_2);
+    ((ImageView) view.findViewById(R.id.wizard_icon)).setImageResource(R.drawable.wizard_2);
   }
 
   @Override public void onDestroyView() {

--- a/app/src/main/res/drawable/oval_grey.xml
+++ b/app/src/main/res/drawable/oval_grey.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="oval">
-  <solid android:color="@color/grey_medium"/>
+  android:shape="oval">
+  <solid android:color="@color/fragment_payment_light_gray" />
 </shape>

--- a/app/src/main/res/layout-land/credentials_edit_texts.xml
+++ b/app/src/main/res/layout-land/credentials_edit_texts.xml
@@ -106,8 +106,7 @@
         android:paddingBottom="12dp"
         android:paddingTop="12dp"
         android:text="@string/recover_password"
-        android:textAlignment="center"
-        android:textColor="@color/grey_fog_dark"
+        style="@style/Aptoide.TextView.Regular.XS.ThemeDark"
         />
 
     <Button

--- a/app/src/main/res/layout/credentials_edit_texts.xml
+++ b/app/src/main/res/layout/credentials_edit_texts.xml
@@ -107,8 +107,7 @@
         android:paddingTop="14dp"
         android:text="@string/recover_password"
         android:textAlignment="center"
-        android:textColor="@color/grey_fog_dark"
-        style="@style/Aptoide.TextView.Regular.XS"
+        style="@style/Aptoide.TextView.Regular.XS.ThemeDark"
         />
 
     <Button

--- a/app/src/main/res/layout/fragment_login_signup_wizard_layout.xml
+++ b/app/src/main/res/layout/fragment_login_signup_wizard_layout.xml
@@ -8,7 +8,6 @@ android:fitsSystemWindows="true"
     android:layout_height="match_parent"
     android:background="@color/transparent"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/bottom_skip_bar_height"
     >
 
   <ScrollView
@@ -71,12 +70,12 @@ android:fitsSystemWindows="true"
   <FrameLayout
       android:id="@+id/login_signup_layout"
       android:layout_width="match_parent"
-      android:layout_height="360dp"
+      android:layout_height="wrap_content"
       android:elevation="16dp"
       android:visibility="visible"
       app:behavior_hideable="false"
       app:behavior_peekHeight="315dp"
-    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+      app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
       />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_wizard.xml
+++ b/app/src/main/res/layout/fragment_wizard.xml
@@ -6,8 +6,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/transparent"
+    android:fitsSystemWindows="true"
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
-    >
+  >
 
     <View
         app:layout_constraintTop_toTopOf="parent"
@@ -32,55 +33,49 @@
         tools:background="@color/indigo"
         />
 
-  <androidx.constraintlayout.widget.Group
+  <FrameLayout
       android:id="@+id/skip_next_layout"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintLeft_toLeftOf="parent"
       app:layout_constraintRight_toRightOf="parent"
       app:layout_constraintTop_toBottomOf="@id/view_pager"
+      android:measureWithLargestChild="false"
+      android:minHeight="48dp"
       android:layout_width="0dp"
       android:layout_height="56dp"
-      android:layout_alignParentBottom="true"
       android:background="@color/white"
-      android:measureWithLargestChild="false"
       tools:background="@color/white"
-      tools:visibility="visible"
-      app:constraint_referenced_ids="view_pager_radio_group,skip_text"
-      />
+      android:visibility="visible"
+      >
 
     <RadioGroup
-        app:layout_constraintTop_toTopOf="@id/skip_next_layout"
-        app:layout_constraintRight_toLeftOf="@+id/skip_text"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
         android:id="@+id/view_pager_radio_group"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="30dp"
-        android:layout_gravity="center"
-        android:baselineAligned="false"
-        android:clickable="false"
-        android:gravity="center"
         android:orientation="horizontal"
         tools:background="@color/grey_medium"
-        tools:layout_height="25dp"
+        android:visibility="visible"
+        android:layout_gravity="center"
+        android:gravity="center"
         />
 
     <TextView
         android:id="@+id/skip_text"
-        app:layout_constraintTop_toTopOf="@id/skip_next_layout"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintLeft_toRightOf="@id/view_pager_radio_group"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="30dp"
-        android:gravity="center"
-        android:padding="4dp"
         android:text="@string/skip"
         android:textAllCaps="true"
+        android:layout_gravity="end|center"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="?attr/colorPrimaryDark"
         android:textStyle="bold"
         tools:text="SKIP"
+        android:padding="4dp"
+        android:visibility="visible"
+        android:layout_marginRight="28dp"
+        android:layout_marginEnd="28dp"
         />
+
+  </FrameLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_wizard.xml
+++ b/app/src/main/res/layout/fragment_wizard.xml
@@ -1,61 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/transparent"
-    android:orientation="vertical"
-    android:weightSum="9"
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
     >
 
-  <FrameLayout
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      >
     <View
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="@+id/view_pager"
+        app:layout_constraintRight_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
         android:id="@+id/animated_color_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         />
 
     <cm.aptoide.pt.view.custom.AptoideViewPager
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/skip_next_layout"
+        app:layout_constraintRight_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
         android:id="@+id/view_pager"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         android:background="@color/transparent"
         tools:background="@color/indigo"
         />
-  </FrameLayout>
 
-  <LinearLayout
+  <androidx.constraintlayout.widget.Group
       android:id="@+id/skip_next_layout"
-      android:layout_width="match_parent"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintLeft_toLeftOf="parent"
+      app:layout_constraintRight_toRightOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/view_pager"
+      android:layout_width="0dp"
       android:layout_height="56dp"
       android:layout_alignParentBottom="true"
       android:background="@color/white"
       android:measureWithLargestChild="false"
-      android:minHeight="48dp"
-      android:orientation="horizontal"
-      android:weightSum="4"
       tools:background="@color/white"
       tools:visibility="visible"
-      >
-    <!-- UI element used for padding only -->
-    <View
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        />
+      app:constraint_referenced_ids="view_pager_radio_group,skip_text"
+      />
 
     <RadioGroup
+        app:layout_constraintTop_toTopOf="@id/skip_next_layout"
+        app:layout_constraintRight_toLeftOf="@+id/skip_text"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         android:id="@+id/view_pager_radio_group"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="30dp"
         android:layout_gravity="center"
-        android:layout_weight="2"
         android:baselineAligned="false"
         android:clickable="false"
         android:gravity="center"
@@ -66,9 +67,12 @@
 
     <TextView
         android:id="@+id/skip_text"
+        app:layout_constraintTop_toTopOf="@id/skip_next_layout"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintLeft_toRightOf="@id/view_pager_radio_group"
+        app:layout_constraintBottom_toBottomOf="parent"
         android:layout_width="0dp"
-        android:layout_height="48dp"
-        android:layout_weight="1"
+        android:layout_height="30dp"
         android:gravity="center"
         android:padding="4dp"
         android:text="@string/skip"
@@ -76,10 +80,7 @@
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="?attr/colorPrimaryDark"
         android:textStyle="bold"
-        android:weightSum="1"
         tools:text="SKIP"
         />
 
-  </LinearLayout>
-
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_wizard.xml
+++ b/app/src/main/res/layout/fragment_wizard.xml
@@ -31,7 +31,7 @@
         android:layout_height="0dp"
         android:background="@color/transparent"
         tools:background="@color/indigo"
-        />
+      />
 
   <FrameLayout
       android:id="@+id/skip_next_layout"
@@ -46,7 +46,7 @@
       android:background="@color/white"
       tools:background="@color/white"
       android:visibility="visible"
-      >
+    >
 
     <RadioGroup
         android:id="@+id/view_pager_radio_group"

--- a/app/src/main/res/layout/fragment_wizard_model_page.xml
+++ b/app/src/main/res/layout/fragment_wizard_model_page.xml
@@ -10,14 +10,15 @@
     <ImageView
         android:id="@+id/wizard_icon"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@+id/message_group"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         android:layout_gravity="center"
         android:src="@drawable/wizard_1"
-      app:layout_constraintVertical_chainStyle="spread"
+        app:layout_constraintVertical_chainStyle="spread"
+        app:layout_constraintVertical_weight="6"
 
       />
 
@@ -33,6 +34,7 @@
       android:gravity="center"
       android:layout_marginTop="20dp"
       app:constraint_referenced_ids="title,description"
+    app:layout_constraintVertical_weight="4"
       />
 
     <TextView

--- a/app/src/main/res/layout/fragment_wizard_model_page.xml
+++ b/app/src/main/res/layout/fragment_wizard_model_page.xml
@@ -1,54 +1,72 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:background="@color/transparent"
-    android:gravity="center_horizontal"
-    android:orientation="vertical"
-    android:paddingBottom="56dp"
-    >
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:background="@color/transparent"
+  android:gravity="center_horizontal">
 
-  <LinearLayout
-      android:layout_width="match_parent"
-      android:layout_height="380dp"
-      android:background="@color/transparent"
-      android:gravity="center"
-      >
+
     <ImageView
-        android:id="@android:id/icon"
-        android:layout_width="292dp"
-        android:layout_height="284dp"
+        android:id="@+id/wizard_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/message_group"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
         android:layout_gravity="center"
         android:src="@drawable/wizard_1"
-        />
+      app:layout_constraintVertical_chainStyle="spread"
 
-  </LinearLayout>
-  <LinearLayout
-      android:layout_width="fill_parent"
-      android:layout_height="fill_parent"
+      />
+
+  <androidx.constraintlayout.widget.Group
+      app:layout_constraintTop_toBottomOf="@+id/wizard_icon"
+      app:layout_constraintRight_toRightOf="parent"
+      app:layout_constraintLeft_toLeftOf="parent"
+      app:layout_constraintBottom_toBottomOf="parent"
+      android:id="@+id/message_group"
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
       android:background="@color/white"
       android:gravity="center"
-      android:orientation="vertical"
-      >
+      android:layout_marginTop="20dp"
+      app:constraint_referenced_ids="title,description"
+      />
+
     <TextView
+        app:layout_constraintTop_toTopOf="@id/message_group"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/description"
         android:id="@+id/title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
         android:text="@string/wizard_title_viewpager_one"
+        app:layout_constraintVertical_bias="0.2"
+        app:layout_constraintVertical_chainStyle="packed"
         style="@style/OnBoarding.Title.TextView"
-        />
+      />
 
     <TextView
         android:id="@+id/description"
-        android:layout_width="216dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="14dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginLeft="36dp"
+        android:layout_marginRight="36dp"
+        android:layout_marginStart="36dp"
+        android:layout_marginEnd="36dp"
         android:gravity="center"
         android:text="@string/wizard_sub_title_viewpager_one"
+        app:layout_constraintTop_toBottomOf="@id/title"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/message_group"
         style="@style/OnBoarding.SubTitle.TextView"
-        />
+      />
 
 
-  </LinearLayout>
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/styles_aptoide_text_view.xml
+++ b/app/src/main/res/values/styles_aptoide_text_view.xml
@@ -295,6 +295,10 @@
     <item name="android:textColor">?attr/colorPrimary</item>
   </style>
 
+  <style name="Aptoide.TextView.Regular.XS.ThemeDark">
+    <item name="android:textColor">?attr/colorPrimaryDark</item>
+  </style>
+
   <style name="Aptoide.TextView.Regular.XXS.Theme">
     <item name="android:textColor">?attr/colorPrimary</item>
   </style>


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at changing wizard view to show text on all devices, including the ones with smaller screensizes (ex: 4.0'').
Also took the chance to fix background color from radio buttons and the Recover your password button text color (as requested by Luis).

**Database changed?**

 No

**Where should the reviewer start?**

- [ ] fragment_wizard.xml

**How should this be manually tested?**

Open view on different devices (with different screensizes) and check that everything is visible and that there are no problems.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-2027](https://aptoide.atlassian.net/browse/ASV-2027)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass