### PR TITLE
Feature/asv 1894 invalidate download on error

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/download/FileDownloadTask.java
+++ b/app/src/main/java/cm/aptoide/pt/download/FileDownloadTask.java
@@ -63,7 +63,7 @@ public class FileDownloadTask extends FileDownloadLargeFileListener {
       Logger.getInstance()
           .d(TAG, " Download error in md5");
       fileDownloadTaskStatus =
-          new FileDownloadTaskStatus(AppDownloadStatus.AppDownloadState.ERROR, md5,
+          new FileDownloadTaskStatus(AppDownloadStatus.AppDownloadState.ERROR_MD5_DOES_NOT_MATCH, md5,
               new Md5DownloadComparisonException("md5 does not match"));
     }
     downloadStatus.onNext(fileDownloadTaskStatus);

--- a/app/src/main/java/cm/aptoide/pt/download/FileDownloadTask.java
+++ b/app/src/main/java/cm/aptoide/pt/download/FileDownloadTask.java
@@ -63,8 +63,8 @@ public class FileDownloadTask extends FileDownloadLargeFileListener {
       Logger.getInstance()
           .d(TAG, " Download error in md5");
       fileDownloadTaskStatus =
-          new FileDownloadTaskStatus(AppDownloadStatus.AppDownloadState.ERROR_MD5_DOES_NOT_MATCH, md5,
-              new Md5DownloadComparisonException("md5 does not match"));
+          new FileDownloadTaskStatus(AppDownloadStatus.AppDownloadState.ERROR_MD5_DOES_NOT_MATCH,
+              md5, new Md5DownloadComparisonException("md5 does not match"));
     }
     downloadStatus.onNext(fileDownloadTaskStatus);
   }

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
@@ -249,7 +249,7 @@ public class AppsPresenter implements Presenter {
     view.getLifecycleEvent()
         .filter(lifecycleEvent -> lifecycleEvent == View.LifecycleEvent.CREATE)
         .observeOn(viewScheduler)
-        .flatMap(created -> Observable.merge(view.resumeUpdate(), view.retryUpdate()))
+        .flatMap(created -> view.resumeUpdate())
         .doOnNext(this::setStandbyState)
         .observeOn(ioScheduler)
         .flatMapCompletable(
@@ -315,7 +315,7 @@ public class AppsPresenter implements Presenter {
     view.getLifecycleEvent()
         .filter(lifecycleEvent -> lifecycleEvent == View.LifecycleEvent.CREATE)
         .observeOn(viewScheduler)
-        .flatMap(created -> view.updateApp()
+        .flatMap(created -> Observable.merge(view.updateApp(), view.retryUpdate())
             .flatMap(appClickEventWrapper -> permissionManager.requestExternalStoragePermission(
                 permissionService)
                 .flatMap(success -> {

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AppDownloadStatus.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AppDownloadStatus.java
@@ -82,6 +82,9 @@ public class AppDownloadStatus {
       if (fileDownloadCallback.getDownloadState() == AppDownloadStatus.AppDownloadState.ERROR) {
         return AppDownloadState.ERROR;
       } else if (fileDownloadCallback.getDownloadState()
+          == AppDownloadState.ERROR_MD5_DOES_NOT_MATCH) {
+        return AppDownloadState.ERROR_MD5_DOES_NOT_MATCH;
+      } else if (fileDownloadCallback.getDownloadState()
           == AppDownloadStatus.AppDownloadState.ERROR_FILE_NOT_FOUND) {
         return AppDownloadState.ERROR_FILE_NOT_FOUND;
       } else if (fileDownloadCallback.getDownloadState()
@@ -163,6 +166,6 @@ public class AppDownloadStatus {
   }
 
   public enum AppDownloadState {
-    INVALID_STATUS, COMPLETED, PENDING, PAUSED, WARN, ERROR, ERROR_FILE_NOT_FOUND, ERROR_NOT_ENOUGH_SPACE, PROGRESS
+    INVALID_STATUS, COMPLETED, PENDING, PAUSED, WARN, ERROR, ERROR_FILE_NOT_FOUND, ERROR_NOT_ENOUGH_SPACE, ERROR_MD5_DOES_NOT_MATCH, PROGRESS
   }
 }

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AptoideDownloadManager.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AptoideDownloadManager.java
@@ -242,7 +242,8 @@ public class AptoideDownloadManager implements DownloadManager {
 
   private Observable<Download> updateDownload(Download download,
       AppDownloadStatus appDownloadStatus) {
-    if(appDownloadStatus.getDownloadStatus().equals(AppDownloadStatus.AppDownloadState.ERROR_MD5_DOES_NOT_MATCH)){
+    if (appDownloadStatus.getDownloadStatus()
+        .equals(AppDownloadStatus.AppDownloadState.ERROR_MD5_DOES_NOT_MATCH)) {
       removeDownloadFiles(download);
     }
     download.setOverallProgress(appDownloadStatus.getOverallProgress());

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AptoideDownloadManager.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AptoideDownloadManager.java
@@ -242,6 +242,9 @@ public class AptoideDownloadManager implements DownloadManager {
 
   private Observable<Download> updateDownload(Download download,
       AppDownloadStatus appDownloadStatus) {
+    if(appDownloadStatus.getDownloadStatus().equals(AppDownloadStatus.AppDownloadState.ERROR_MD5_DOES_NOT_MATCH)){
+      removeDownloadFiles(download);
+    }
     download.setOverallProgress(appDownloadStatus.getOverallProgress());
     download.setOverallDownloadStatus(
         downloadStatusMapper.mapAppDownloadStatus(appDownloadStatus.getDownloadStatus()));

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/DownloadStatusMapper.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/DownloadStatusMapper.java
@@ -30,6 +30,7 @@ public class DownloadStatusMapper {
         downloadState = Download.WARN;
         break;
       case ERROR:
+      case ERROR_MD5_DOES_NOT_MATCH:
       case ERROR_NOT_ENOUGH_SPACE:
       case ERROR_FILE_NOT_FOUND:
         downloadState = Download.ERROR;
@@ -44,6 +45,7 @@ public class DownloadStatusMapper {
     int downloadError;
     switch (appDownloadState) {
       case ERROR:
+      case ERROR_MD5_DOES_NOT_MATCH:
       case ERROR_FILE_NOT_FOUND:
         downloadError = Download.GENERIC_ERROR;
         break;


### PR DESCRIPTION
**What does this PR do?**

This PR fixes two errors related to downloads: On apps fragment, once an error occurred there was no way to recover from it and if the md5 calculation of a file didn't match the server value, there was no way to recover from that error from anywhere in the app;

**Database changed?**

No

**Where should the reviewer start?**

- [ ] FileDownloadTask.java
- [ ] AppsPresenter.java

**How should this be manually tested?**

For the first error, start a download in apps and turn off the internet. You will see an error on that app. If you try to restart it should now work.
For the second error, you can replace the download url of a given app with the url for a different app (so the md5s won't match). After you get the error you should be able to download and install again correctly

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1894](https://aptoide.atlassian.net/browse/ASV-1894)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass