### PR TITLE
[ASV-2100] Fixed bug where action being passed as null in editorial r…

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialDownloadEvent.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialDownloadEvent.java
@@ -90,6 +90,27 @@ public class EditorialDownloadEvent {
     this.storeName = "";
   }
 
+  public EditorialDownloadEvent(Type button, String packageName, String md5, int verCode,
+      long appId, DownloadModel.Action action) {
+    this.button = button;
+    this.appName = "";
+    this.packageName = packageName;
+    this.md5sum = md5;
+    this.icon = "";
+    this.verName = "";
+    this.size = 0;
+    this.verCode = verCode;
+    this.path = "";
+    this.pathAlt = "";
+    this.obb = null;
+    this.appId = appId;
+    this.splits = null;
+    this.requiredSplits = null;
+    this.trustedBadge = "";
+    this.storeName = "";
+    this.action = action;
+  }
+
   public EditorialDownloadEvent(Type button, String appName, String packageName, String md5sum,
       String icon, String verName, int verCode, String path, String pathAlt, Obb obb,
       DownloadModel.Action action, long size, List<Split> splits, List<String> requiredSplits,

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialFragment.java
@@ -427,7 +427,8 @@ public class EditorialFragment extends NavigationTrackFragment
     return RxView.clicks(resumeDownload)
         .map(click -> new EditorialDownloadEvent(EditorialEvent.Type.RESUME,
             editorialViewModel.getBottomCardPackageName(), editorialViewModel.getBottomCardMd5(),
-            editorialViewModel.getBottomCardVersionCode(), editorialViewModel.getBottomCardAppId()))
+            editorialViewModel.getBottomCardVersionCode(), editorialViewModel.getBottomCardAppId(),
+            action))
         .mergeWith(downloadEventListener.filter(editorialEvent -> editorialEvent.getClickType()
             .equals(EditorialEvent.Type.RESUME)));
   }

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialItemsViewHolder.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialItemsViewHolder.java
@@ -379,7 +379,8 @@ class EditorialItemsViewHolder extends RecyclerView.ViewHolder {
             verName, verCode, path, pathAlt, obb, size, splits, requiredSplits)));
     resumeDownload.setOnClickListener(click -> downloadEventListener.onNext(
         new EditorialDownloadEvent(EditorialEvent.Type.RESUME, appName, packageName, md5sum, icon,
-            verName, verCode, path, pathAlt, obb, size, splits, requiredSplits)));
+            verName, verCode, path, pathAlt, obb, action, size, splits, requiredSplits,
+            trustedBadge, storeName)));
     pauseDownload.setOnClickListener(click -> downloadEventListener.onNext(
         new EditorialDownloadEvent(EditorialEvent.Type.PAUSE, appName, packageName, md5sum, icon,
             verName, verCode, path, pathAlt, obb, size, splits, requiredSplits)));


### PR DESCRIPTION
**What does this PR do?**

This PR fixes a bug freezing the app on editorial;

**Database changed?**

No

**Where should the reviewer start?**

- [x] EditorialFragment.java

**How should this be manually tested?**

Start a download in editorial, pause and then resume. The app should not freeze anymore;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-2100](https://aptoide.atlassian.net/browse/ASV-2100)

**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass