### PR TITLE
[ASV-2075] Fix timed out installations

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/view/ActivityModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/ActivityModule.java
@@ -74,6 +74,7 @@ import cm.aptoide.pt.presenter.View;
 import cm.aptoide.pt.promotions.ClaimPromotionsNavigator;
 import cm.aptoide.pt.promotions.PromotionsNavigator;
 import cm.aptoide.pt.repository.StoreRepository;
+import cm.aptoide.pt.root.RootAvailabilityManager;
 import cm.aptoide.pt.search.SearchNavigator;
 import cm.aptoide.pt.search.analytics.SearchAnalytics;
 import cm.aptoide.pt.store.StoreAnalytics;
@@ -184,14 +185,15 @@ import static android.content.Context.WINDOW_SERVICE;
       @Named("secureShared") SharedPreferences secureSharedPreferences,
       @Named("main-fragment-navigator") FragmentNavigator fragmentNavigator,
       DeepLinkManager deepLinkManager, BottomNavigationNavigator bottomNavigationNavigator,
-      UpdatesManager updatesManager, AutoUpdateManager autoUpdateManager) {
+      UpdatesManager updatesManager, AutoUpdateManager autoUpdateManager,
+      RootAvailabilityManager rootAvailabilityManager) {
     return new MainPresenter((MainView) view, installManager, rootInstallationRetryHandler,
         CrashReport.getInstance(), apkFy, new ContentPuller(activity), notificationSyncScheduler,
         new InstallCompletedNotifier(PublishRelay.create(), installManager,
             CrashReport.getInstance()), sharedPreferences, secureSharedPreferences,
         fragmentNavigator, deepLinkManager, firstCreated, (AptoideBottomNavigator) activity,
         AndroidSchedulers.mainThread(), Schedulers.io(), bottomNavigationNavigator, updatesManager,
-        autoUpdateManager);
+        autoUpdateManager, rootAvailabilityManager);
   }
 
   @ActivityScope @Provides AccountNavigator provideAccountNavigator(

--- a/app/src/test/java/cm/aptoide/pt/navigation/BottomNavigationPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/navigation/BottomNavigationPresenterTest.java
@@ -14,6 +14,7 @@ import cm.aptoide.pt.notification.ContentPuller;
 import cm.aptoide.pt.notification.NotificationSyncScheduler;
 import cm.aptoide.pt.presenter.MainPresenter;
 import cm.aptoide.pt.presenter.View;
+import cm.aptoide.pt.root.RootAvailabilityManager;
 import cm.aptoide.pt.util.ApkFy;
 import cm.aptoide.pt.view.DeepLinkManager;
 import cm.aptoide.pt.view.MainActivity;
@@ -48,6 +49,7 @@ public class BottomNavigationPresenterTest {
   @Mock private BottomNavigationNavigator bottomNavigationNavigator;
   @Mock private UpdatesManager updatesManager;
   @Mock private AutoUpdateManager autoUpdateManager;
+  @Mock private RootAvailabilityManager rootAvailabilityManager;
   private MainPresenter presenter;
   private PublishSubject<View.LifecycleEvent> lifecycleEvent;
   private PublishSubject<Integer> navigationEvent;
@@ -62,7 +64,7 @@ public class BottomNavigationPresenterTest {
         CrashReport.getInstance(), apkFy, contentPuller, notificationSyncScheduler,
         installCompletedNotifier, sharedPreferences, sharedPreferences, fragmentNavigator,
         deepLinkManager, true, bottomNavigationActivity, Schedulers.immediate(), Schedulers.io(),
-        bottomNavigationNavigator, updatesManager, autoUpdateManager);
+        bottomNavigationNavigator, updatesManager, autoUpdateManager, rootAvailabilityManager);
 
     //simulate view lifecycle event
     when(mainView.getLifecycleEvent()).thenReturn(lifecycleEvent);


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at improving downloads performance. After the spike in https://aptoide.atlassian.net/browse/ASV-2064 we discovered that one of the main problems related with the downloads performance is the fact that the getInstall() method is being subscribed multiple times, which leads to multiple emissions (as it has several subscriptions). As some of these subscriptions were not necessary for all users (for example, the ones that were related with root installation timeouts, which were fixed here).

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] MainPresenter.java

**How should this be manually tested?**

  Do several downloads on a rooted device and check that it installs normally. You may try to reproduce a timeout but I could not force it.

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-2075](https://aptoide.atlassian.net/browse/ASV-2075)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass