### PR TITLE
[Bugfix/ASV-2114] fix to okhttp cache getting cleared on start

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -281,7 +281,6 @@ import io.fabric.sdk.android.Fabric;
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
 import java.io.File;
-import java.io.IOException;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
@@ -784,13 +783,6 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
     okHttpClientBuilder.writeTimeout(45, TimeUnit.SECONDS);
 
     final Cache cache = new Cache(application.getCacheDir(), 10 * 1024 * 1024);
-    try {
-      // For billing to handle stale data properly the cache should only be stored in memory.
-      // In order to make sure it happens we clean up all data persisted in disk when client
-      // is first created. It only affects API calls with GET verb.
-      cache.evictAll();
-    } catch (IOException ignored) {
-    }
     okHttpClientBuilder.cache(cache); // 10 MiB
     okHttpClientBuilder.addInterceptor(new POSTCacheInterceptor(httpClientCache));
     okHttpClientBuilder.addInterceptor(userAgentInterceptor);
@@ -848,13 +840,6 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
     okHttpClientBuilder.writeTimeout(45, TimeUnit.SECONDS);
 
     final Cache cache = new Cache(application.getCacheDir(), 10 * 1024 * 1024);
-    try {
-      // For billing to handle stale data properly the cache should only be stored in memory.
-      // In order to make sure it happens we clean up all data persisted in disk when client
-      // is first created. It only affects API calls with GET verb.
-      cache.evictAll();
-    } catch (IOException ignored) {
-    }
     okHttpClientBuilder.cache(cache); // 10 MiB
     okHttpClientBuilder.addInterceptor(new POSTCacheInterceptor(httpClientCache));
     okHttpClientBuilder.addInterceptor(userAgentInterceptorV8);

--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -774,23 +774,10 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
     return new OAuthModeProvider();
   }
 
-  @Singleton @Provides @Named("default") OkHttpClient provideOkHttpClient(L2Cache httpClientCache,
-      @Named("user-agent") Interceptor userAgentInterceptor,
-      @Named("default") SharedPreferences sharedPreferences,
-      @Named("retrofit-log") Interceptor retrofitLogInterceptor) {
-    final OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder();
-    okHttpClientBuilder.readTimeout(45, TimeUnit.SECONDS);
-    okHttpClientBuilder.writeTimeout(45, TimeUnit.SECONDS);
-
-    final Cache cache = new Cache(application.getCacheDir(), 10 * 1024 * 1024);
-    okHttpClientBuilder.cache(cache); // 10 MiB
-    okHttpClientBuilder.addInterceptor(new POSTCacheInterceptor(httpClientCache));
+  @Singleton @Provides @Named("default") OkHttpClient provideOkHttpClient(
+      @Named("default") OkHttpClient.Builder okHttpClientBuilder,
+      @Named("user-agent") Interceptor userAgentInterceptor) {
     okHttpClientBuilder.addInterceptor(userAgentInterceptor);
-
-    if (ToolboxManager.isToolboxEnableRetrofitLogs(sharedPreferences)) {
-      okHttpClientBuilder.addInterceptor(retrofitLogInterceptor);
-    }
-
     return okHttpClientBuilder.build();
   }
 
@@ -831,23 +818,27 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
     return okHttpClientBuilder.build();
   }
 
-  @Singleton @Provides @Named("v8") OkHttpClient provideV8OkHttpClient(L2Cache httpClientCache,
-      @Named("user-agent-v8") Interceptor userAgentInterceptorV8,
-      @Named("default") SharedPreferences sharedPreferences,
+  @Singleton @Provides @Named("default") OkHttpClient.Builder providesOkHttpBuilder(
+      L2Cache httpClientCache, @Named("default") SharedPreferences sharedPreferences,
       @Named("retrofit-log") Interceptor retrofitLogInterceptor) {
     final OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder();
     okHttpClientBuilder.readTimeout(45, TimeUnit.SECONDS);
     okHttpClientBuilder.writeTimeout(45, TimeUnit.SECONDS);
-
     final Cache cache = new Cache(application.getCacheDir(), 10 * 1024 * 1024);
     okHttpClientBuilder.cache(cache); // 10 MiB
     okHttpClientBuilder.addInterceptor(new POSTCacheInterceptor(httpClientCache));
-    okHttpClientBuilder.addInterceptor(userAgentInterceptorV8);
 
     if (ToolboxManager.isToolboxEnableRetrofitLogs(sharedPreferences)) {
       okHttpClientBuilder.addInterceptor(retrofitLogInterceptor);
     }
 
+    return okHttpClientBuilder;
+  }
+
+  @Singleton @Provides @Named("v8") OkHttpClient provideV8OkHttpClient(
+      @Named("default") OkHttpClient.Builder okHttpClientBuilder,
+      @Named("user-agent-v8") Interceptor userAgentInterceptorV8) {
+    okHttpClientBuilder.addInterceptor(userAgentInterceptorV8);
     return okHttpClientBuilder.build();
   }
 


### PR DESCRIPTION
**What does this PR do?**

   OkHTTP clients cache GET requests by default. Because we now are migrating some POST requests to GET we surfaced an issue that was intentionally clearing the cache every time app is launched. That logic was because of billing requirements (based on comment), feature that we do not support anymore. So I only removed both method calls and refactored the code a bit to reuse logic.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] ApplicationModule.java

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [ASV-2114](https://aptoide.atlassian.net/browse/ASV-2114)

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-2114](https://aptoide.atlassian.net/browse/ASV-2114)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass