### PR TITLE
[Bugfix/ASV-2107] Rakam Analytics ab testing similar issue

### DIFF
--- a/app/src/internal/java/cm/aptoide/pt/abtesting/experiments/SimilarAppsExperiment.kt
+++ b/app/src/internal/java/cm/aptoide/pt/abtesting/experiments/SimilarAppsExperiment.kt
@@ -3,6 +3,7 @@ package cm.aptoide.pt.abtesting.experiments
 import cm.aptoide.pt.abtesting.ABTestManager
 import cm.aptoide.pt.abtesting.RakamExperiment
 import cm.aptoide.pt.app.AppViewAnalytics
+import rx.Completable
 import rx.Single
 
 open class SimilarAppsExperiment(private val abTestManager: ABTestManager,

--- a/app/src/leak/java/cm/aptoide/pt/abtesting/experiments/SimilarAppsExperiment.kt
+++ b/app/src/leak/java/cm/aptoide/pt/abtesting/experiments/SimilarAppsExperiment.kt
@@ -3,6 +3,7 @@ package cm.aptoide.pt.abtesting.experiments
 import cm.aptoide.pt.abtesting.ABTestManager
 import cm.aptoide.pt.abtesting.RakamExperiment
 import cm.aptoide.pt.app.AppViewAnalytics
+import rx.Completable
 import rx.Single
 
 open class SimilarAppsExperiment(private val abTestManager: ABTestManager,

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -73,7 +73,8 @@ public class AppViewPresenter implements Presenter {
       AppViewNavigator appViewNavigator, AppViewManager appViewManager,
       AptoideAccountManager accountManager, Scheduler viewScheduler, CrashReport crashReport,
       PermissionManager permissionManager, PermissionService permissionService,
-      PromotionsNavigator promotionsNavigator, SimilarAppsExperiment similarAppsExperiment, ExternalNavigator externalNavigator) {
+      PromotionsNavigator promotionsNavigator, SimilarAppsExperiment similarAppsExperiment,
+      ExternalNavigator externalNavigator) {
     this.view = view;
     this.accountNavigator = accountNavigator;
     this.appViewAnalytics = appViewAnalytics;
@@ -772,7 +773,7 @@ public class AppViewPresenter implements Presenter {
     view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .flatMap(__ -> view.similarAppsVisibility())
-        .doOnNext(__ -> similarAppsExperiment.recordImpression())
+        .flatMapCompletable(__ -> similarAppsExperiment.recordImpression())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {
         }, crashReport::log);
@@ -783,7 +784,7 @@ public class AppViewPresenter implements Presenter {
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .flatMap(__ -> view.installAppClick())
         .flatMap(__ -> view.clickSimilarApp())
-        .doOnNext(__ -> similarAppsExperiment.recordConversion())
+        .flatMapCompletable(__ -> similarAppsExperiment.recordConversion())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {
         }, crashReport::log);

--- a/app/src/monetisation/java/cm/aptoide/pt/abtesting/experiments/SimilarAppsExperiment.kt
+++ b/app/src/monetisation/java/cm/aptoide/pt/abtesting/experiments/SimilarAppsExperiment.kt
@@ -3,6 +3,7 @@ package cm.aptoide.pt.abtesting.experiments
 import cm.aptoide.pt.abtesting.ABTestManager
 import cm.aptoide.pt.abtesting.RakamExperiment
 import cm.aptoide.pt.app.AppViewAnalytics
+import rx.Completable
 import rx.Single
 
 open class SimilarAppsExperiment(private val abTestManager: ABTestManager,

--- a/app/src/prod/java/cm/aptoide/pt/abtesting/experiments/SimilarAppsExperiment.kt
+++ b/app/src/prod/java/cm/aptoide/pt/abtesting/experiments/SimilarAppsExperiment.kt
@@ -4,6 +4,7 @@ import cm.aptoide.pt.abtesting.ABTestManager
 import cm.aptoide.pt.abtesting.RakamExperiment
 import cm.aptoide.pt.app.AppViewAnalytics
 import cm.aptoide.pt.logger.Logger
+import rx.Completable
 import rx.Single
 
 open class SimilarAppsExperiment(private val abTestManager: ABTestManager,
@@ -16,15 +17,17 @@ open class SimilarAppsExperiment(private val abTestManager: ABTestManager,
     return Single.just(true)
   }
 
-  fun recordImpression() {
+  fun recordImpression(): Completable {
     Logger.getInstance()
         .d("SimilarAppsExperiment",
             "similar_apps_impression: $isControlGroup - NOT registering analytics")
+    return Completable.complete()
   }
 
-  fun recordConversion() {
+  fun recordConversion(): Completable {
     Logger.getInstance()
         .d("SimilarAppsExperiment",
             "similar_apps_conversion: $isControlGroup - NOT registering analytics")
+    return Completable.complete()
   }
 }


### PR DESCRIPTION
**What does this PR do?**

   This is an attempt to fix the issue that is going on with the experiment in Rakam. Wasabi numbers are 50/50 but rakam is like 70/30 for the control group. I've separated the default from the control and now added checks for experiment validation in both impression and conversion events.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] SimilarAppsExperiment.kt

**How should this be manually tested?**

  App view > click install > record impression when similar is visible > record conversion when any app in similar is clicked (appc or not)

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-2107](https://aptoide.atlassian.net/browse/ASV-2107)

**Questions:**

   Does this add new dependencies which need to be added? Rakam key if you want to see Charles events.


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass