### PR TITLE
[feature/ASV-2032] Skeleton one by one

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/Home.java
+++ b/app/src/main/java/cm/aptoide/pt/home/Home.java
@@ -190,7 +190,6 @@ public class Home {
         }
       }
     }
-    bundlesRepository.updateCache(homeBundles);
     return Single.just(homeBundles);
   }
 

--- a/app/src/main/java/cm/aptoide/pt/home/Home.java
+++ b/app/src/main/java/cm/aptoide/pt/home/Home.java
@@ -96,7 +96,7 @@ public class Home {
   }
 
   public Observable<HomeBundlesModel> loadNextHomeBundles() {
-    return bundlesRepository.loadNextHomeBundles()
+    return bundlesRepository.loadNextHomeBundles(false)
         .doOnNext(homeBundlesModel -> {
           if (homeBundlesModel.hasErrors()) {
             setLoadMoreError();
@@ -158,6 +158,15 @@ public class Home {
     return moPubAdsManager.shouldShowConsentDialog();
   }
 
+  public Single<List<HomeBundle>> loadReactionModel(String cardId, String groupId,
+      HomeBundlesModel homeBundlesModel) {
+    return reactionsManager.loadReactionModel(cardId, groupId)
+        .toObservable()
+        .filter(__ -> homeBundlesModel.isComplete())
+        .toSingle()
+        .flatMap(loadReactionModel -> getUpdatedCards(homeBundlesModel, loadReactionModel, cardId));
+  }
+
   public Single<List<HomeBundle>> loadReactionModel(String cardId, String groupId) {
     return reactionsManager.loadReactionModel(cardId, groupId)
         .flatMap(loadReactionModel -> bundlesRepository.loadHomeBundles()
@@ -173,7 +182,7 @@ public class Home {
       if (homeBundle.getType() == HomeBundle.BundleType.EDITORIAL
           && homeBundle instanceof ActionBundle) {
         ActionItem actionBundle = ((ActionBundle) homeBundle).getActionItem();
-        if (actionBundle.getCardId()
+        if (actionBundle != null && actionBundle.getCardId()
             .equals(cardId)) {
           actionBundle.setReactions(loadReactionModel.getTopReactionList());
           actionBundle.setNumberOfReactions(loadReactionModel.getTotal());

--- a/app/src/main/java/cm/aptoide/pt/home/bundles/BundleDataSource.java
+++ b/app/src/main/java/cm/aptoide/pt/home/bundles/BundleDataSource.java
@@ -11,7 +11,8 @@ public interface BundleDataSource {
 
   Observable<HomeBundlesModel> loadFreshHomeBundles(String key);
 
-  Observable<HomeBundlesModel> loadNextHomeBundles(int offset, int limit, String key);
+  Observable<HomeBundlesModel> loadNextHomeBundles(int offset, int limit, String key,
+      boolean skeletonLoad);
 
   boolean hasMore(Integer offset, String title);
 

--- a/app/src/main/java/cm/aptoide/pt/home/bundles/BundlesAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/bundles/BundlesAdapter.java
@@ -239,9 +239,12 @@ public class BundlesAdapter extends RecyclerView.Adapter<AppBundleViewHolder> {
    * @return true if the bundles are fully loaded (i.e. no skeleton layout placeholder)
    */
   public boolean isLoaded() {
-    return bundles != null
-        && !bundles.isEmpty()
-        && bundles.get(0)
-        .getContent() != null;
+    if (bundles == null || bundles.isEmpty()) return false;
+    for (HomeBundle bundle : bundles) {
+      if (bundle.getContent() == null) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/bundles/BundlesRepository.java
+++ b/app/src/main/java/cm/aptoide/pt/home/bundles/BundlesRepository.java
@@ -121,10 +121,6 @@ public class BundlesRepository {
     });
   }
 
-  public void updateCache(List<HomeBundle> homeBundles) {
-    cachedBundles.put(HOME_BUNDLE_KEY, homeBundles);
-  }
-
   public void setHomeLoadMoreError() {
     List<HomeBundle> list = cachedBundles.get(HOME_BUNDLE_KEY);
     if (!list.isEmpty() && !(list.get(list.size() - 1) instanceof ErrorHomeBundle)) {

--- a/app/src/main/java/cm/aptoide/pt/home/bundles/FakeBundleDataSource.java
+++ b/app/src/main/java/cm/aptoide/pt/home/bundles/FakeBundleDataSource.java
@@ -23,7 +23,8 @@ public class FakeBundleDataSource implements BundleDataSource {
   }
 
   @Override
-  public Observable<HomeBundlesModel> loadNextHomeBundles(int offset, int limit, String key) {
+  public Observable<HomeBundlesModel> loadNextHomeBundles(int offset, int limit, String key,
+      boolean skeletonLoad) {
     return loadFreshHomeBundles(key);
   }
 

--- a/app/src/main/java/cm/aptoide/pt/home/bundles/RemoteBundleDataSource.java
+++ b/app/src/main/java/cm/aptoide/pt/home/bundles/RemoteBundleDataSource.java
@@ -24,6 +24,7 @@ import cm.aptoide.pt.dataprovider.ws.v7.store.WidgetsArgs;
 import cm.aptoide.pt.home.bundles.base.HomeBundle;
 import cm.aptoide.pt.install.PackageRepository;
 import cm.aptoide.pt.store.StoreCredentialsProvider;
+import com.google.android.exoplayer2.util.Log;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -104,23 +105,20 @@ public class RemoteBundleDataSource implements BundleDataSource {
   }
 
   private Observable<HomeBundlesModel> getHomeBundles(int offset, int limit,
-      boolean invalidateHttpCache, String key) {
+      boolean invalidateHttpCache, String key, boolean skeletonLoad) {
     if (isLoading(key)) {
       return Observable.just(new HomeBundlesModel(true));
     }
-    final boolean adultContentEnabled = accountManager.enabled()
-        .first()
-        .toSingle()
-        .toBlocking()
-        .value();
 
-    return getPackages().toObservable()
-        .flatMap(
-            packageNames -> GetHomeBundlesRequest.of(limit, offset, okHttpClient, converterFactory,
-                bodyInterceptor, tokenInvalidator, sharedPreferences, widgetsUtils,
-                storeCredentialsProvider.fromUrl(""), clientUniqueId, isGooglePlayServicesAvailable,
-                partnerId, adultContentEnabled, filters, resources, windowManager,
-                connectivityManager, versionCodeProvider, packageNames, appBundlesVisibilityManager)
+    return accountManager.enabled()
+        .first()
+        .flatMap(adultContentEnabled -> getPackages().toObservable()
+            .flatMap(packageNames -> GetHomeBundlesRequest.of(limit, offset, okHttpClient,
+                converterFactory, bodyInterceptor, tokenInvalidator, sharedPreferences,
+                widgetsUtils, storeCredentialsProvider.fromUrl(""), clientUniqueId,
+                isGooglePlayServicesAvailable, partnerId, adultContentEnabled, filters, resources,
+                windowManager, connectivityManager, versionCodeProvider, packageNames,
+                appBundlesVisibilityManager)
                 .observe(invalidateHttpCache, false)
                 .flatMap(widgets -> Observable.merge(Observable.just(widgets),
                     loadAppsInBundles(adultContentEnabled, invalidateHttpCache, packageNames,
@@ -132,11 +130,14 @@ public class RemoteBundleDataSource implements BundleDataSource {
                 .doOnUnsubscribe(() -> loading.put(key, false))
                 .doOnTerminate(() -> loading.put(key, false))
                 .flatMap(homeResponse -> mapHomeResponse(homeResponse, key))
+                .filter(model -> skeletonLoad || model.isComplete())
+                .takeUntil(HomeBundlesModel::isComplete)
                 .onErrorReturn(throwable -> {
                   throwable.printStackTrace();
+                  loading.put(key, false);
                   error.put(key, true);
                   return createErrorAppsList(throwable);
-                }));
+                })));
   }
 
   private Observable<GetStoreWidgets> loadAppsInBundles(boolean adultContentEnabled,
@@ -152,12 +153,8 @@ public class RemoteBundleDataSource implements BundleDataSource {
                 tokenInvalidator, sharedPreferences, resources, windowManager, connectivityManager,
                 versionCodeProvider, bypassCache,
                 Type.ADS.getPerLineCount(resources, windowManager) * 3, packageNames,
-                appBundlesVisibilityManager))
-        .toList()
-        .flatMapIterable(wsWidgets -> getStoreWidgets.getDataList()
-            .getList())
-        .toList()
-        .first()
+                appBundlesVisibilityManager)
+                .map(__ -> wsWidget))
         .map(__ -> getStoreWidgets);
   }
 
@@ -199,30 +196,35 @@ public class RemoteBundleDataSource implements BundleDataSource {
     if (homeResponse.isOk()) {
       List<HomeBundle> homeBundles = mapper.fromWidgetsToBundles(homeResponse.getDataList()
           .getList());
+      boolean isComplete = isComplete(homeBundles);
       homeBundles = removeEmptyBundles(homeBundles);
       int responseBundletotal = homeResponse.getDataList()
           .getTotal();
       total.put(key, responseBundletotal);
       return Observable.just(new HomeBundlesModel(homeBundles, false, homeResponse.getDataList()
-          .getNext(), isComplete(homeBundles)));
+          .getNext(), isComplete));
     }
     return Observable.error(
         new IllegalStateException("Could not obtain home bundles from server."));
   }
 
   private boolean isComplete(List<HomeBundle> homeBundles) {
-    return !homeBundles.isEmpty()
-        && homeBundles.get(0)
-        .getContent() != null;
+    for (HomeBundle bundle : homeBundles) {
+      if (bundle.getContent() == null) {
+        return false;
+      }
+    }
+    return !homeBundles.isEmpty();
   }
 
   @Override public Observable<HomeBundlesModel> loadFreshHomeBundles(String key) {
-    return getHomeBundles(0, limit, true, key);
+    return getHomeBundles(0, limit, true, key, false);
   }
 
   @Override
-  public Observable<HomeBundlesModel> loadNextHomeBundles(int offset, int limit, String key) {
-    return getHomeBundles(offset, limit, false, key);
+  public Observable<HomeBundlesModel> loadNextHomeBundles(int offset, int limit, String key,
+      boolean skeletonLoad) {
+    return getHomeBundles(offset, limit, false, key, skeletonLoad);
   }
 
   @Override public boolean hasMore(Integer offset, String key) {

--- a/app/src/main/java/cm/aptoide/pt/home/bundles/RemoteBundleDataSource.java
+++ b/app/src/main/java/cm/aptoide/pt/home/bundles/RemoteBundleDataSource.java
@@ -24,7 +24,6 @@ import cm.aptoide.pt.dataprovider.ws.v7.store.WidgetsArgs;
 import cm.aptoide.pt.home.bundles.base.HomeBundle;
 import cm.aptoide.pt.install.PackageRepository;
 import cm.aptoide.pt.store.StoreCredentialsProvider;
-import com.google.android.exoplayer2.util.Log;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/app/src/main/java/cm/aptoide/pt/home/bundles/base/ActionBundle.java
+++ b/app/src/main/java/cm/aptoide/pt/home/bundles/base/ActionBundle.java
@@ -25,7 +25,7 @@ public class ActionBundle implements HomeBundle {
   }
 
   @Override public List<?> getContent() {
-    return Collections.emptyList();
+    return actionItem != null ? Collections.emptyList() : null;
   }
 
   @Override public BundleType getType() {

--- a/app/src/test/java/cm/aptoide/pt/home/BundlesRepositoryTest.java
+++ b/app/src/test/java/cm/aptoide/pt/home/BundlesRepositoryTest.java
@@ -39,10 +39,10 @@ public class BundlesRepositoryTest {
 
   @Test public void loadHomeBundlesNoCacheTest() {
     //When the manager asks for bundles and there's no cached bundles, then it should call the bundleDataSource for more apps
-    when(bundleDataSource.loadNextHomeBundles(0, 5, HOME_BUNDLE_KEY, false)).thenReturn(
+    when(bundleDataSource.loadNextHomeBundles(0, 5, HOME_BUNDLE_KEY, true)).thenReturn(
         Observable.just(new HomeBundlesModel(true)));
     bundlesRepository.loadHomeBundles();
-    verify(bundleDataSource).loadNextHomeBundles(0, 5, HOME_BUNDLE_KEY, false);
+    verify(bundleDataSource).loadNextHomeBundles(0, 5, HOME_BUNDLE_KEY, true);
   }
 
   @Test public void loadHomeBundlesWithCacheTest() {

--- a/app/src/test/java/cm/aptoide/pt/home/BundlesRepositoryTest.java
+++ b/app/src/test/java/cm/aptoide/pt/home/BundlesRepositoryTest.java
@@ -39,10 +39,10 @@ public class BundlesRepositoryTest {
 
   @Test public void loadHomeBundlesNoCacheTest() {
     //When the manager asks for bundles and there's no cached bundles, then it should call the bundleDataSource for more apps
-    when(bundleDataSource.loadNextHomeBundles(0, 5, HOME_BUNDLE_KEY)).thenReturn(
+    when(bundleDataSource.loadNextHomeBundles(0, 5, HOME_BUNDLE_KEY, false)).thenReturn(
         Observable.just(new HomeBundlesModel(true)));
     bundlesRepository.loadHomeBundles();
-    verify(bundleDataSource).loadNextHomeBundles(0, 5, HOME_BUNDLE_KEY);
+    verify(bundleDataSource).loadNextHomeBundles(0, 5, HOME_BUNDLE_KEY, false);
   }
 
   @Test public void loadHomeBundlesWithCacheTest() {
@@ -99,10 +99,10 @@ public class BundlesRepositoryTest {
     List<HomeBundle> freshBundles = new ArrayList<>();
     freshBundles.add(freshHomeBundle);
     //When it requests apps to the bundleDataSource then return a list of apps
-    when(bundleDataSource.loadNextHomeBundles(0, 5, HOME_BUNDLE_KEY)).thenReturn(
+    when(bundleDataSource.loadNextHomeBundles(0, 5, HOME_BUNDLE_KEY, false)).thenReturn(
         Observable.just(new HomeBundlesModel(freshBundles, false, 0, true)));
     //Then it should return the requested bundle list
-    bundlesRepository.loadNextHomeBundles()
+    bundlesRepository.loadNextHomeBundles(false)
         .map(HomeBundlesModel::getList)
         .test()
         .assertValue(freshBundles);
@@ -129,10 +129,10 @@ public class BundlesRepositoryTest {
     List<HomeBundle> freshBundles = new ArrayList<>();
     freshBundles.add(freshHomeBundle);
     //When it requests apps to the bundleDataSource then return a list of apps
-    when(bundleDataSource.loadNextHomeBundles(0, 5, HOME_BUNDLE_KEY)).thenReturn(
+    when(bundleDataSource.loadNextHomeBundles(0, 5, HOME_BUNDLE_KEY, false)).thenReturn(
         Observable.just(new HomeBundlesModel(freshBundles, false, 0, true)));
     //Then it should return the requested bundle list
-    bundlesRepository.loadNextHomeBundles()
+    bundlesRepository.loadNextHomeBundles(false)
         .map(HomeBundlesModel::getList)
         .test()
         .assertValue(freshBundles);


### PR DESCRIPTION
**What does this PR do?**

   This PR makes it so that the home bundles are now loaded one by one for skeleton. It also does other minor refactors. 
   Please note that the solution is not 100% ideal. Part of this is because we're manipulating GetStoreWidgets response which causes concurrency issues in certain scenarios (we should only handle immutable data instead).

**Database changed?**

   No

**How should this be manually tested?**

  Test the initial home bundles load (close the app and open it). Each bundle should be loaded separately (only for the first GetStoreWidgets request). Also scroll through home and verify that there's no repeated bundles, and go to other fragments and come back and check if everything's ok. You can also test if it behaves correctly if the requests get cancelled (when the skeleton shows, quickly move to other fragment before loading and go back).

**What are the relevant tickets?**

  [ASV-2032](https://aptoide.atlassian.net/browse/ASV-2032)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass