### PR TITLE
[HOTFIX/ASV-2138] Showing interstitial ads in APKFY

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -356,7 +356,7 @@ public class AppViewPresenter implements Presenter {
   private void handleDownloadingSimilarApp() {
     view.getLifecycleEvent()
         .filter(lifecycleEvent -> lifecycleEvent == View.LifecycleEvent.CREATE)
-        .flatMap(__ -> view.installAppClick())
+        .flatMap(__ -> Observable.merge(view.installAppClick(), view.apkfyDialogPositiveClick()))
         .flatMap(__ -> downloadInRange(0, 100))
         .observeOn(viewScheduler)
         .doOnNext(__ -> view.showDownloadingSimilarApps(
@@ -371,7 +371,7 @@ public class AppViewPresenter implements Presenter {
   private void showInterstitial() {
     view.getLifecycleEvent()
         .filter(lifecycleEvent -> lifecycleEvent == View.LifecycleEvent.CREATE)
-        .flatMap(__ -> view.installAppClick())
+        .flatMap(__ -> Observable.merge(view.installAppClick(), view.apkfyDialogPositiveClick()))
         .flatMapSingle(__ -> appViewManager.getAppModel())
         .filter(appModel -> !appModel.isAppCoinApp())
         .flatMap(__ -> Observable.zip(downloadInRange(5, 100), view.interstitialAdLoaded(),


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at fixing the interstitial ads not being shown in AppView through the APKFY flow. This was broken because after a refactor on appview we were only listening to the click on the install button, which does not happen on the APKFY flow.

**Database changed?**

No

**Where should the reviewer start?**

- [x] AppViewPresenter.java

**How should this be manually tested?**

Open app through apkfy flow (replace the app id - instead of it being extracted, change it to a known app id of any app). After opening an apk with this change, it will pop the appview and after accepting permissions (etc) it should start the download and if a network is available to return an add you should be able to see the ad (use vpn if needed)

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-2138](https://aptoide.atlassian.net/browse/ASV-2138)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass