### PR TITLE
[ASV-2135] Added q density value to hardware specs in settings;

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
@@ -372,7 +372,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
 
     Preference hwSpecs = findPreference(SettingsConstants.HARDWARE_SPECS);
     String densityValue =
-        getFormatedDensity(AptoideUtils.ScreenU.getDensityDpi(getActivity().getWindowManager()));
+        getFormattedDensity(AptoideUtils.ScreenU.getDensityDpi(getActivity().getWindowManager()));
 
     hwSpecs.setOnPreferenceClickListener(preference -> {
       AlertDialog.Builder alertDialogBuilder =
@@ -479,7 +479,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
     setupAdultContentClickHandlers();
   }
 
-  private String getFormatedDensity(int density) {
+  private String getFormattedDensity(int density) {
     String densityType = "";
     switch (density) {
       case 120:

--- a/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
@@ -371,6 +371,8 @@ public class SettingsFragment extends PreferenceFragmentCompat
     });
 
     Preference hwSpecs = findPreference(SettingsConstants.HARDWARE_SPECS);
+    String densityValue =
+        getFormatedDensity(AptoideUtils.ScreenU.getDensityDpi(getActivity().getWindowManager()));
 
     hwSpecs.setOnPreferenceClickListener(preference -> {
       AlertDialog.Builder alertDialogBuilder =
@@ -399,7 +401,11 @@ public class SettingsFragment extends PreferenceFragmentCompat
               + "\n"
               + getString(R.string.cpuAbi)
               + ": "
-              + AptoideUtils.SystemU.getAbis())
+              + AptoideUtils.SystemU.getAbis()
+              + "\n"
+              + getString(R.string.setting_density)
+              + ": "
+              + densityValue)
 
           .setCancelable(false)
           .setNeutralButton(getString(android.R.string.ok), (dialog, id) -> {
@@ -471,6 +477,36 @@ public class SettingsFragment extends PreferenceFragmentCompat
       }
     });
     setupAdultContentClickHandlers();
+  }
+
+  private String getFormatedDensity(int density) {
+    String densityType = "";
+    switch (density) {
+      case 120:
+        densityType = " ldpi";
+        break;
+      case 160:
+        densityType = " mdpi";
+        break;
+      case 213:
+        densityType = " tvdpi";
+        break;
+      case 240:
+        densityType = " hdpi";
+        break;
+      case 320:
+        densityType = " xhdpi";
+        break;
+      case 480:
+        densityType = " xxhdpi";
+        break;
+      case 640:
+        densityType = " xxxhdpi";
+        break;
+      default:
+        break;
+    }
+    return density + densityType;
   }
 
   private void setupAdultContentClickHandlers() {

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -65,6 +65,7 @@
   <string name="setting_sdk_version">SDK version</string>
   <string name="setting_screen_size">Screen size</string>
   <string name="setting_esgl_version">ESGL version</string>
+  <string name="setting_density">Density</string>
   <string name="screenCode">Screen code</string>
   <string name="cpuAbi">CPU</string>
 


### PR DESCRIPTION
**What does this PR do?**

This PR adds the device's density value to the hardware specs dialog in settings;

**Database changed?**

No

**Where should the reviewer start?**

- [ ] SettingsFragment.java

**How should this be manually tested?**

Go to the hardware specs dialog in settings and make sure everything is showing up according to the ticket;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-2135](https://aptoide.atlassian.net/browse/ASV-2135)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass