### PR TITLE
[ASV-1991] Added logs to home loading start and first bundle loaded;

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
@@ -37,6 +37,7 @@ import cm.aptoide.pt.home.bundles.editorial.EditorialBundleViewHolder;
 import cm.aptoide.pt.home.bundles.editorial.EditorialHomeEvent;
 import cm.aptoide.pt.home.bundles.misc.ErrorHomeBundle;
 import cm.aptoide.pt.home.bundles.misc.ProgressBundle;
+import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.networking.image.ImageLoader;
 import cm.aptoide.pt.promotions.PromotionsHomeDialog;
 import cm.aptoide.pt.reactions.ReactionsHomeEvent;
@@ -195,6 +196,7 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView, S
     bundlesList.setVisibility(View.GONE);
     errorView.setVisibility(View.GONE);
     progressBar.setVisibility(View.VISIBLE);
+    Logger.getInstance().d("HomeTime", "Loading started");
   }
 
   @Override public void hideLoading() {

--- a/app/src/main/java/cm/aptoide/pt/home/bundles/RemoteBundleDataSource.java
+++ b/app/src/main/java/cm/aptoide/pt/home/bundles/RemoteBundleDataSource.java
@@ -23,6 +23,7 @@ import cm.aptoide.pt.dataprovider.ws.v7.store.GetStoreWidgetsRequest;
 import cm.aptoide.pt.dataprovider.ws.v7.store.WidgetsArgs;
 import cm.aptoide.pt.home.bundles.base.HomeBundle;
 import cm.aptoide.pt.install.PackageRepository;
+import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.store.StoreCredentialsProvider;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -197,6 +198,7 @@ public class RemoteBundleDataSource implements BundleDataSource {
           .getList());
       boolean isComplete = isComplete(homeBundles);
       homeBundles = removeEmptyBundles(homeBundles);
+      logFirstLoad(homeBundles);
       int responseBundletotal = homeResponse.getDataList()
           .getTotal();
       total.put(key, responseBundletotal);
@@ -205,6 +207,22 @@ public class RemoteBundleDataSource implements BundleDataSource {
     }
     return Observable.error(
         new IllegalStateException("Could not obtain home bundles from server."));
+  }
+
+  private void logFirstLoad(List<HomeBundle> homeBundles) {
+    int loadCount = 0;
+    for (HomeBundle bundle : homeBundles) {
+      if (bundle.getContent() != null) {
+        loadCount++;
+      }
+      if (loadCount > 1) {
+        return;
+      }
+    }
+    if (loadCount == 1) {
+      Logger.getInstance()
+          .d("HomeTime", "First bundle loaded");
+    }
   }
 
   private boolean isComplete(List<HomeBundle> homeBundles) {


### PR DESCRIPTION
**What does this PR do?**

This PR adds two logs, on home loading start and first bundle loaded, to help benchmark times;

NOTE: The log for first bundle will be resent on every loadMore;

**Database changed?**

No

**Where should the reviewer start?**

- [ ] HomePresenter.java

**How should this be manually tested?**

Open the app and make sure you'll see the two logs. The tag is "HomeTime";

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1991](https://aptoide.atlassian.net/browse/ASV-1991)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass