### PR TITLE
[ASV-1772] Added background color for reactions pop up with dark theme;

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/reactions/ui/ReactionsPopup.java
+++ b/app/src/main/java/cm/aptoide/pt/reactions/ui/ReactionsPopup.java
@@ -8,6 +8,7 @@ import android.view.WindowManager;
 import android.widget.PopupWindow;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.reactions.data.ReactionType;
 
@@ -41,8 +42,8 @@ public class ReactionsPopup {
     popup.setContentView(reactionsView);
     popup.setFocusable(true);
     popup.setClippingEnabled(true);
-    popup.setBackgroundDrawable(context.getResources()
-        .getDrawable(R.drawable.rounded_corners_white));
+    popup.setBackgroundDrawable(
+        ContextCompat.getDrawable(context, R.drawable.rounded_corners_white));
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       popup.setElevation(10);
     }

--- a/app/src/main/res/drawable/rounded_corners_white.xml
+++ b/app/src/main/res/drawable/rounded_corners_white.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-  <solid android:color="#FFFFFF"/>
+  <solid android:color="?attr/reactionsPopUpBackgroundColor"/>
   <corners android:radius="40dp"/>
 </shape>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -127,6 +127,7 @@
   <attr format="color" name="colorControlHighlight"/>
   <attr format="color" name="bnItemColorState"/>
   <attr format="color" name="wizard3Color"/>
+  <attr format="color" name="reactionsPopUpBackgroundColor"/>
 
   <declare-styleable name="CustomTextInputLayout">
     <attr format="string" name="helperText"/>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -55,6 +55,7 @@
     <item name="backgroundAddStoreButton">@android:color/white</item>
     <item name="appManualReviewedMessageBackground">@drawable/shape_gray_border</item>
     <item name="wizard3Color">@color/wizard_color_3_orange</item>
+    <item name="reactionsPopUpBackgroundColor">@color/white</item>
 
     <!--text-->
     <item name="defaultTextStyle">@style/Widget.Aptoide.defaultColorText</item>
@@ -226,6 +227,7 @@
     <item name="backgroundAddStoreButton">@android:color/white</item>
     <item name="appManualReviewedMessageBackground">@drawable/shape_gray_border</item>
     <item name="wizard3Color">@color/wizard_color_3_orange</item>
+    <item name="reactionsPopUpBackgroundColor">@color/grey_900</item>
 
     <!--text-->
     <item name="android:textColorPrimary">@android:color/primary_text_dark</item>


### PR DESCRIPTION
**What does this PR do?**

This PR adds a new color for the reactions popup background with dark theme;

**Database changed?**

No

**How should this be manually tested?**

Make sure the color is working on dark theme;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1772](https://aptoide.atlassian.net/browse/ASV-1772)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass