### PR TITLE
[ASV-1774] Uniformization of card backgrounds in home and apps;

### DIFF
--- a/app/src/main/res/layout/app_home_item.xml
+++ b/app/src/main/res/layout/app_home_item.xml
@@ -1,78 +1,86 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
-  style="?attr/selectableItemBackground"
-  android:layout_width="104dp"
-  android:layout_height="165dp"
-  android:clickable="true"
-  android:focusable="true"
-  app:cardCornerRadius="4dp">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="?attr/backgroundCard"
+    android:layout_width="104dp"
+    android:layout_height="165dp"
+    android:clickable="true"
+    android:focusable="true"
+    app:cardCornerRadius="4dp"
+    >
 
   <LinearLayout
-    style="?attr/backgroundCard"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingTop="8dp"
-    android:paddingBottom="5dp">
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:orientation="vertical"
+      android:paddingTop="8dp"
+      android:paddingBottom="5dp"
+      >
 
     <ImageView
-      android:id="@+id/icon"
-      android:layout_width="match_parent"
-      android:layout_height="0dp"
-      android:layout_marginStart="8dp"
-      android:layout_marginEnd="8dp"
-      android:layout_weight="0.5"
-      android:contentDescription="@null"
-      android:scaleType="centerInside" />
+        android:id="@+id/icon"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_weight="0.5"
+        android:contentDescription="@null"
+        android:scaleType="centerInside"
+        />
 
     <LinearLayout
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="8dp"
-      android:layout_marginLeft="8dp"
-      android:layout_marginTop="4dp"
-      android:layout_marginEnd="8dp"
-      android:layout_marginRight="8dp"
-      android:layout_marginBottom="5dp"
-      android:layout_weight="0"
-      android:orientation="vertical">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginBottom="5dp"
+        android:layout_weight="0"
+        android:orientation="vertical"
+        >
 
       <TextView
-        android:id="@+id/name"
-        style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        tools:text="Twitch Clips"
-        android:lines="2" />
-
-      <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="6dp">
-
-        <include
-          layout="@layout/rating_label"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginStart="1dp"
-          android:layout_marginLeft="1dp" />
-
-        <include
-          layout="@layout/appc_label"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content" />
-
-        <TextView
-          android:id="@+id/ad_label"
-          style="@style/Aptoide.TextView.Regular.XXS.Black"
+          android:id="@+id/name"
+          style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:gravity="end"
-          android:text="@string/all_title_ad"
-          android:visibility="gone"
-          tools:ignore="SmallSp" />
+          android:lines="2"
+          tools:text="Twitch Clips"
+          />
+
+      <FrameLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="6dp"
+          >
+
+        <include
+            layout="@layout/rating_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="1dp"
+            android:layout_marginLeft="1dp"
+            />
+
+        <include
+            layout="@layout/appc_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            />
+
+        <TextView
+            android:id="@+id/ad_label"
+            style="@style/Aptoide.TextView.Regular.XXS.Black"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="end"
+            android:text="@string/all_title_ad"
+            android:visibility="gone"
+            tools:ignore="SmallSp"
+            />
       </FrameLayout>
 
     </LinearLayout>

--- a/app/src/main/res/layout/apps_appc_promotion_upgrade_app_item.xml
+++ b/app/src/main/res/layout/apps_appc_promotion_upgrade_app_item.xml
@@ -2,6 +2,7 @@
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    style="?attr/backgroundCard"
     android:layout_width="match_parent"
     android:layout_height="72dp"
     android:layout_marginLeft="8dp"

--- a/app/src/main/res/layout/apps_installed_app_item.xml
+++ b/app/src/main/res/layout/apps_installed_app_item.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    style="?attr/backgroundCard"
     android:layout_width="match_parent"
     android:layout_height="72dp"
-    android:layout_marginBottom="8dp"
     android:layout_marginLeft="8dp"
     android:layout_marginRight="8dp"
+    android:layout_marginBottom="8dp"
     app:cardCornerRadius="4dp"
     >
 
   <RelativeLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_alignParentLeft="true"
       android:layout_alignParentStart="true"
+      android:layout_alignParentLeft="true"
       >
 
     <ImageView
@@ -42,22 +42,22 @@
 
       <TextView
           android:id="@+id/apps_installed_app_name"
+          style="@style/Aptoide.TextView.Regular.M.BlackAlpha"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:ellipsize="end"
           android:maxLines="1"
           tools:text="Aptoide"
-          style="@style/Aptoide.TextView.Regular.M.BlackAlpha"
           />
 
       <TextView
           android:id="@+id/apps_installed_app_version"
+          style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:ellipsize="end"
           android:maxLines="1"
           tools:text="1994"
-          style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
           />
 
 

--- a/app/src/main/res/layout/apps_update_app_item.xml
+++ b/app/src/main/res/layout/apps_update_app_item.xml
@@ -2,6 +2,7 @@
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    style="?attr/backgroundCard"
     android:layout_width="match_parent"
     android:layout_height="72dp"
     android:layout_marginLeft="8dp"

--- a/app/src/main/res/layout/displayable_grid_ad.xml
+++ b/app/src/main/res/layout/displayable_grid_ad.xml
@@ -2,15 +2,14 @@
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    style="?attr/backgroundCard"
     android:layout_width="104dp"
     android:layout_height="wrap_content"
     android:clickable="true"
-    android:foreground="?selectableItemBackground"
     app:cardCornerRadius="4dp"
     >
 
   <RelativeLayout
-      style="?attr/backgroundCard"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:orientation="vertical"

--- a/app/src/main/res/layout/editorial_action_item.xml
+++ b/app/src/main/res/layout/editorial_action_item.xml
@@ -77,7 +77,7 @@
         android:layout_width="match_parent"
         android:layout_height="40dp"
         android:layout_alignBottom="@id/background_image"
-        android:background="?attr/backgroundSecondary"
+        android:background="?attr/backgroundCardColor"
         android:paddingTop="7dp"
         android:paddingBottom="2dp"
         >

--- a/app/src/main/res/layout/editorial_action_item.xml
+++ b/app/src/main/res/layout/editorial_action_item.xml
@@ -2,15 +2,16 @@
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-  android:id="@+id/root_cardview"
+    android:id="@+id/root_cardview"
+    style="?attr/backgroundCard"
     android:layout_width="match_parent"
     android:layout_height="240dp"
-    android:layout_marginBottom="5dp"
-    android:layout_marginEnd="8dp"
-    android:layout_marginLeft="8dp"
-    android:layout_marginRight="8dp"
     android:layout_marginStart="8dp"
+    android:layout_marginLeft="8dp"
     android:layout_marginTop="15dp"
+    android:layout_marginEnd="8dp"
+    android:layout_marginRight="8dp"
+    android:layout_marginBottom="5dp"
     app:cardCornerRadius="4dp"
     >
 
@@ -38,13 +39,14 @@
 
     <TextView
         android:id="@+id/editorial_title"
+        style="@style/Aptoide.TextView.Medium"
         android:layout_width="290dp"
         android:layout_height="168dp"
         android:layout_above="@id/editorial_date"
-        android:layout_marginEnd="13dp"
-        android:layout_marginLeft="13dp"
-        android:layout_marginRight="13dp"
         android:layout_marginStart="13dp"
+        android:layout_marginLeft="13dp"
+        android:layout_marginEnd="13dp"
+        android:layout_marginRight="13dp"
         android:gravity="bottom"
         android:shadowColor="#80000000"
         android:shadowDy="1"
@@ -53,45 +55,44 @@
         android:textSize="29sp"
         android:textStyle="bold"
         tools:text="Game of the week"
-        style="@style/Aptoide.TextView.Medium"
         />
 
     <TextView
         android:id="@+id/editorial_date"
+        style="@style/Aptoide.TextView.Medium.XS.White"
         android:layout_width="match_parent"
         android:layout_height="24dp"
         android:layout_alignBottom="@id/background_image"
-        android:layout_marginBottom="42dp"
-        android:layout_marginEnd="15dp"
-        android:layout_marginLeft="15dp"
-        android:layout_marginRight="15dp"
         android:layout_marginStart="15dp"
+        android:layout_marginLeft="15dp"
+        android:layout_marginEnd="15dp"
+        android:layout_marginRight="15dp"
+        android:layout_marginBottom="42dp"
         android:ellipsize="end"
         android:maxLines="1"
         tools:text="TESTING SOME STUFF"
-        style="@style/Aptoide.TextView.Medium.XS.White"
         />
 
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="40dp"
         android:layout_alignBottom="@id/background_image"
-        android:background="?attr/backgroundCardColor"
-        android:paddingBottom="2dp"
+        android:background="?attr/backgroundSecondary"
         android:paddingTop="7dp"
+        android:paddingBottom="2dp"
         >
 
       <include
           layout="@layout/reactions_layout_white"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginLeft="16dp"
           android:layout_marginStart="16dp"
+          android:layout_marginLeft="16dp"
           />
 
       <include
-          layout="@layout/views_layout"
           android:id="@+id/views_layout"
+          layout="@layout/views_layout"
 
           />
     </RelativeLayout>
@@ -108,8 +109,8 @@
         android:id="@+id/curation_type_bubble"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="8dp"
         android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
         android:layout_marginTop="8dp"
         app:cardBackgroundColor="#3c3c3c"
         app:cardCornerRadius="12dp"
@@ -117,20 +118,20 @@
         >
       <TextView
           android:id="@+id/curation_type_bubble_text"
+          style="@style/Aptoide.TextView.Regular.XXS"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_gravity="center"
-          android:paddingBottom="5dp"
-          android:paddingEnd="10dp"
-          android:paddingLeft="10dp"
-          android:paddingRight="10dp"
           android:paddingStart="10dp"
+          android:paddingLeft="10dp"
           android:paddingTop="5dp"
+          android:paddingEnd="10dp"
+          android:paddingRight="10dp"
+          android:paddingBottom="5dp"
           android:textAllCaps="true"
           android:textColor="@color/white"
           android:textStyle="bold"
           tools:text="Game of the Week"
-          style="@style/Aptoide.TextView.Regular.XXS"
           />
     </androidx.cardview.widget.CardView>
   </LinearLayout>

--- a/app/src/main/res/layout/feature_graphic_home_item.xml
+++ b/app/src/main/res/layout/feature_graphic_home_item.xml
@@ -12,7 +12,7 @@
   <ImageView
       android:id="@+id/featured_graphic"
       android:layout_width="match_parent"
-    android:layout_height="144dp"
+      android:layout_height="144dp"
       android:adjustViewBounds="true"
       android:contentDescription="@null"
       android:scaleType="fitXY"
@@ -28,27 +28,27 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="40dp"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentBottom="true"
         android:layout_centerVertical="true"
-        android:background="?attr/backgroundCardColor"
+        android:background="?attr/backgroundSecondary"
         android:orientation="horizontal"
         >
 
       <TextView
           android:id="@+id/app_name"
+          style="@style/Aptoide.TextView.Medium.S.BlackAlpha"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_centerVertical="true"
-          android:layout_marginEnd="55dp"
-          android:layout_marginLeft="55dp"
-          android:layout_marginRight="55dp"
           android:layout_marginStart="55dp"
+          android:layout_marginLeft="55dp"
+          android:layout_marginEnd="55dp"
+          android:layout_marginRight="55dp"
           android:ellipsize="end"
           android:maxLines="1"
           tools:text="Little Commander world world II"
-          style="@style/Aptoide.TextView.Medium.S.BlackAlpha"
           />
 
       <ImageView
@@ -56,26 +56,26 @@
           android:layout_width="12dp"
           android:layout_height="12dp"
           android:layout_centerVertical="true"
-          android:layout_toLeftOf="@+id/rating_label"
           android:layout_toStartOf="@+id/rating_label"
+          android:layout_toLeftOf="@+id/rating_label"
           android:adjustViewBounds="true"
           android:src="?attr/ratingDrawable"
           />
 
       <TextView
           android:id="@+id/rating_label"
+          style="@style/Aptoide.TextView.Medium.XS.Black"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_alignParentEnd="true"
           android:layout_alignParentRight="true"
           android:layout_centerVertical="true"
-          android:layout_marginEnd="12dp"
-          android:layout_marginLeft="5dp"
-          android:layout_marginRight="12dp"
           android:layout_marginStart="5dp"
+          android:layout_marginLeft="5dp"
+          android:layout_marginEnd="12dp"
+          android:layout_marginRight="12dp"
           tools:ignore="SmallSp"
           tools:text="2.3"
-          style="@style/Aptoide.TextView.Medium.XS.Black"
           />
     </RelativeLayout>
 
@@ -84,8 +84,8 @@
         android:layout_width="40dp"
         android:layout_height="40dp"
         android:layout_marginLeft="8dp"
-        android:layout_marginRight="8dp"
         android:layout_marginTop="52dp"
+        android:layout_marginRight="8dp"
         tools:src="@color/red"
         />
   </RelativeLayout>

--- a/app/src/main/res/layout/feature_graphic_home_item.xml
+++ b/app/src/main/res/layout/feature_graphic_home_item.xml
@@ -32,7 +32,7 @@
         android:layout_alignParentLeft="true"
         android:layout_alignParentBottom="true"
         android:layout_centerVertical="true"
-        android:background="?attr/backgroundSecondary"
+        android:background="?attr/backgroundCardColor"
         android:orientation="horizontal"
         >
 

--- a/app/src/main/res/layout/frame_layout.xml
+++ b/app/src/main/res/layout/frame_layout.xml
@@ -25,7 +25,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_alignParentBottom="true"
-      android:background="?attr/backgroundSecondary"
+      android:background="?attr/backgroundCardColor"
       app:itemIconTint="?attr/bnItemColorState"
       app:itemTextColor="?attr/bnItemColorState"
       app:labelVisibilityMode="labeled"

--- a/app/src/main/res/layout/frame_layout.xml
+++ b/app/src/main/res/layout/frame_layout.xml
@@ -25,7 +25,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_alignParentBottom="true"
-      android:background="?attr/backgroundCardColor"
+      android:background="?attr/backgroundSecondary"
       app:itemIconTint="?attr/bnItemColorState"
       app:itemTextColor="?attr/bnItemColorState"
       app:labelVisibilityMode="labeled"

--- a/app/src/main/res/layout/reward_app_home_item.xml
+++ b/app/src/main/res/layout/reward_app_home_item.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    style="?attr/backgroundCard"
     android:layout_width="104dp"
     android:layout_height="wrap_content"
     android:clickable="true"
     android:focusable="true"
-    android:foreground="?selectableItemBackground"
     app:cardCornerRadius="4dp"
     >
 
@@ -15,9 +14,8 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:orientation="vertical"
-      android:paddingBottom="5dp"
       android:paddingTop="8dp"
-      style="?attr/backgroundCard"
+      android:paddingBottom="5dp"
       >
 
     <ImageView
@@ -33,21 +31,21 @@
         android:layout_width="107dp"
         android:layout_height="wrap_content"
         android:layout_below="@+id/icon"
-        android:layout_marginBottom="5dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginLeft="8dp"
-        android:layout_marginRight="8dp"
         android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
         android:layout_marginTop="4dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginBottom="5dp"
         android:orientation="vertical"
         >
 
       <TextView
           android:id="@+id/name"
+          style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:lines="2"
-          style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
           />
 
 
@@ -63,15 +61,15 @@
             android:layout_height="16dp"
             android:layout_marginEnd="5dp"
             android:layout_marginRight="5dp"
-          android:src="@drawable/ic_get_appc"
+            android:src="@drawable/ic_get_appc"
             />
 
         <TextView
             android:id="@+id/appc_text"
+            style="@style/Aptoide.TextView.Medium.XXS.CurationGold"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             tools:text="0.056 APPC"
-            style="@style/Aptoide.TextView.Medium.XXS.CurationGold"
             />
 
       </LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -125,7 +125,8 @@
   </style>
 
   <style name="backgroundCardStyleLight">
-    <item name="android:background">?attr/backgroundCardColor</item>
+    <item name="android:foreground">?selectableItemBackground</item>
+    <item name="cardBackgroundColor">?attr/backgroundCardColor</item>
   </style>
 
   <style name="WidgetButtonCustomAptoide" parent="WidgetButtonCustom">
@@ -161,7 +162,7 @@
 
   <style name="backgroundCardStyleDark">
     <item name="android:foreground">?selectableItemBackground</item>
-    <item name="cardBackgroundColor">?attr/backgroundSecondary</item>
+    <item name="cardBackgroundColor">?attr/backgroundCardColor</item>
   </style>
 
   <style name="headerSeparatorButtonStyle">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -125,7 +125,7 @@
   </style>
 
   <style name="backgroundCardStyleLight">
-    <item name="android:background">@drawable/white_card</item>
+    <item name="android:background">?attr/backgroundCardColor</item>
   </style>
 
   <style name="WidgetButtonCustomAptoide" parent="WidgetButtonCustom">
@@ -160,7 +160,8 @@
   </style>
 
   <style name="backgroundCardStyleDark">
-    <item name="android:background">@drawable/dark_card</item>
+    <item name="android:foreground">?selectableItemBackground</item>
+    <item name="cardBackgroundColor">?attr/backgroundSecondary</item>
   </style>
 
   <style name="headerSeparatorButtonStyle">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -215,7 +215,7 @@
 
     <!--background-->
     <item name="backgroundMain">@color/black</item>
-    <item name="backgroundSecondary">@color/dark_gray</item>
+    <item name="backgroundSecondary">@color/grey_900</item>
     <item name="backgroundInverse">@android:color/white</item>
     <item name="backgroundTabs">@color/dark_gray</item>
     <item name="backgroundWidgetSecondary">@android:color/transparent</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -220,7 +220,7 @@
     <item name="backgroundTabs">@color/dark_gray</item>
     <item name="backgroundWidgetSecondary">@android:color/transparent</item>
     <item name="backgroundCard">@style/backgroundCardStyleDark</item>
-    <item name="backgroundCardColor">@color/black</item>
+    <item name="backgroundCardColor">@color/grey_900</item>
     <item name="appviewRatingCardBarckground">@drawable/dark_card</item>
     <item name="backgroundHomeSeparator">@color/background_window</item>
     <item name="backgroundAddStoreButton">@android:color/white</item>

--- a/aptoide-views/src/main/res/layout/apps_app_card_item.xml
+++ b/aptoide-views/src/main/res/layout/apps_app_card_item.xml
@@ -2,6 +2,7 @@
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    style="?attr/backgroundCard"
     android:layout_width="match_parent"
     android:layout_height="72dp"
     android:layout_marginLeft="8dp"

--- a/aptoide-views/src/main/res/layout/apps_download_app_item.xml
+++ b/aptoide-views/src/main/res/layout/apps_download_app_item.xml
@@ -2,6 +2,7 @@
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    style="?attr/backgroundCard"
     android:layout_width="match_parent"
     android:layout_height="72dp"
     android:layout_marginLeft="8dp"

--- a/aptoide-views/src/main/res/layout/editorial_action_item_skeleton.xml
+++ b/aptoide-views/src/main/res/layout/editorial_action_item_skeleton.xml
@@ -1,73 +1,82 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="?attr/backgroundCard"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
 
 
   <cm.aptoide.aptoideviews.skeleton.SkeletonView
-    android:id="@+id/background_image_sk"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+      android:id="@+id/background_image_sk"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      />
 
   <RelativeLayout
-    android:layout_width="match_parent"
-    android:layout_height="40dp"
-    android:layout_alignBottom="@id/background_image_sk"
-    android:background="@color/white"
-    android:paddingTop="7dp"
-    android:paddingBottom="2dp">
+      android:layout_width="match_parent"
+      android:layout_height="40dp"
+      android:layout_alignBottom="@id/background_image_sk"
+      android:background="@color/white"
+      android:paddingTop="7dp"
+      android:paddingBottom="2dp"
+      >
 
     <cm.aptoide.aptoideviews.skeleton.SkeletonView
-      android:id="@+id/sk1"
-      android:layout_width="32dp"
-      android:layout_height="24dp"
-      android:layout_centerVertical="true"
-      android:layout_marginStart="16dp"
-      android:layout_marginLeft="16dp"
-      app:skeleton_corner_radius="12dp" />
+        android:id="@+id/sk1"
+        android:layout_width="32dp"
+        android:layout_height="24dp"
+        android:layout_centerVertical="true"
+        android:layout_marginStart="16dp"
+        android:layout_marginLeft="16dp"
+        app:skeleton_corner_radius="12dp"
+        />
 
     <cm.aptoide.aptoideviews.skeleton.SkeletonView
-      android:layout_width="23dp"
-      android:layout_height="23dp"
-      android:layout_centerVertical="true"
-      android:layout_marginLeft="-10dp"
-      android:layout_toRightOf="@id/sk3"
-      android:cropToPadding="true"
-      app:skeleton_border_thickness="2dp"
-      app:skeleton_corner_radius="12dp" />
+        android:layout_width="23dp"
+        android:layout_height="23dp"
+        android:layout_centerVertical="true"
+        android:layout_marginLeft="-10dp"
+        android:layout_toRightOf="@id/sk3"
+        android:cropToPadding="true"
+        app:skeleton_border_thickness="2dp"
+        app:skeleton_corner_radius="12dp"
+        />
 
     <cm.aptoide.aptoideviews.skeleton.SkeletonView
-      android:id="@+id/sk3"
-      android:layout_width="23dp"
-      android:layout_height="23dp"
-      android:layout_centerVertical="true"
-      android:layout_marginLeft="-10dp"
-      android:layout_toRightOf="@id/sk2"
-      app:skeleton_border_thickness="2dp"
-      app:skeleton_corner_radius="12dp" />
+        android:id="@+id/sk3"
+        android:layout_width="23dp"
+        android:layout_height="23dp"
+        android:layout_centerVertical="true"
+        android:layout_marginLeft="-10dp"
+        android:layout_toRightOf="@id/sk2"
+        app:skeleton_border_thickness="2dp"
+        app:skeleton_corner_radius="12dp"
+        />
 
     <cm.aptoide.aptoideviews.skeleton.SkeletonView
-      android:id="@+id/sk2"
-      android:layout_width="23dp"
-      android:layout_height="23dp"
-      android:layout_centerVertical="true"
-      android:layout_marginStart="9dp"
-      android:layout_marginLeft="9dp"
-      android:layout_toRightOf="@id/sk1"
-      app:skeleton_border_thickness="2dp"
-      app:skeleton_corner_radius="12dp" />
+        android:id="@+id/sk2"
+        android:layout_width="23dp"
+        android:layout_height="23dp"
+        android:layout_centerVertical="true"
+        android:layout_marginStart="9dp"
+        android:layout_marginLeft="9dp"
+        android:layout_toRightOf="@id/sk1"
+        app:skeleton_border_thickness="2dp"
+        app:skeleton_corner_radius="12dp"
+        />
 
 
     <cm.aptoide.aptoideviews.skeleton.SkeletonView
-      android:layout_width="82dp"
-      android:layout_height="19dp"
-      android:layout_alignParentEnd="true"
-      android:layout_alignParentRight="true"
-      android:layout_centerVertical="true"
-      android:layout_marginEnd="16dp"
-      android:layout_marginRight="16dp"
-      app:skeleton_corner_radius="2dp" />
+        android:layout_width="82dp"
+        android:layout_height="19dp"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        app:skeleton_corner_radius="2dp"
+        />
 
   </RelativeLayout>
 </RelativeLayout>


### PR DESCRIPTION
**What does this PR do?**

This PR tries to uniformize cards in home and apps. Due to the StoreThemes class and how it's being used, I left store cards out of this ticket until we decide what to do with it

**Database changed?**

No

**How should this be manually tested?**

Make sure apps and home cards have the same background are are being set in the same way;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1774](https://aptoide.atlassian.net/browse/ASV-1774)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass