### PR TITLE
[ASV-1846] fix: similar appc apps impression events 

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppViewAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewAnalytics.java
@@ -418,6 +418,8 @@ public class AppViewAnalytics {
   public void similarAppcAppBundleImpression() {
     Map<String, Object> data = new HashMap<>();
     data.put(IS_AD, false);
+    data.put(ACTION.toLowerCase(), AnalyticsManager.Action.IMPRESSION.name()
+        .toLowerCase());
     analyticsManager.logEvent(data, APPC_SIMILAR_APP_INTERACT, AnalyticsManager.Action.IMPRESSION,
         navigationTracker.getViewName(true));
   }

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -805,7 +805,7 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
         .filter(__ -> isSimilarAppsVisible());
   }
 
-  @Override public Observable<Boolean> similarAppsVisibility() {
+  @Override public Observable<Boolean> similarAppsVisibilityFromInstallClick() {
     return similarAppsVisibilitySubject;
   }
 

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -490,7 +490,6 @@ public class AppViewPresenter implements Presenter {
     view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .flatMap(lifecycleEvent -> Observable.merge(view.scrollVisibleSimilarApps()
-            .takeUntil(__ -> view.isSimilarAppsVisible())
             .map(__ -> true), view.similarAppsVisibilityFromInstallClick()))
         .first()
         .observeOn(Schedulers.io())

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -118,7 +118,6 @@ public class AppViewPresenter implements Presenter {
     handleClickOnToolbar();
     handleClickOnRetry();
     handleClickOnCatappultCard();
-    handleOnScroll();
     handleOnSimilarAppsVisible();
 
     handleInstallButtonClick();
@@ -460,20 +459,6 @@ public class AppViewPresenter implements Presenter {
         }, throwable -> crashReport.log(throwable));
   }
 
-  private void handleOnSimilarAppsVisible() {
-    view.getLifecycleEvent()
-        .filter(event -> event.equals(View.LifecycleEvent.CREATE))
-        .flatMap(__ -> view.similarAppsVisibility())
-        .observeOn(Schedulers.io())
-        .doOnNext(similarAppsVisible -> {
-          sendSimilarAppsAdImpressionEvent(appViewManager.getCachedSimilarAppsViewModel());
-          sendSimilarAppcAppsImpressionEvent(appViewManager.getCachedAppcSimilarAppsViewModel());
-        })
-        .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
-        .subscribe(__ -> {
-        }, throwable -> crashReport.log(throwable));
-  }
-
   private void sendSimilarAppcAppsImpressionEvent(SimilarAppsViewModel appcSimilarAppsViewModel) {
     if (appcSimilarAppsViewModel != null) {
       appViewAnalytics.similarAppcAppBundleImpression();
@@ -501,11 +486,13 @@ public class AppViewPresenter implements Presenter {
         }, throwable -> crashReport.log(throwable));
   }
 
-  private void handleOnScroll() {
+  private void handleOnSimilarAppsVisible() {
     view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
-        .flatMap(lifecycleEvent -> view.scrollVisibleSimilarApps())
-        .takeUntil(__ -> view.isSimilarAppsVisible())
+        .flatMap(lifecycleEvent -> Observable.merge(view.scrollVisibleSimilarApps()
+            .takeUntil(__ -> view.isSimilarAppsVisible())
+            .map(__ -> true), view.similarAppsVisibilityFromInstallClick()))
+        .first()
         .observeOn(Schedulers.io())
         .doOnNext(__ -> {
           sendSimilarAppInteractEvent(appViewManager.getCachedSimilarAppsViewModel());
@@ -808,7 +795,7 @@ public class AppViewPresenter implements Presenter {
   private void handleSimilarAppsABTestingImpression() {
     view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
-        .flatMap(__ -> view.similarAppsVisibility())
+        .flatMap(__ -> view.similarAppsVisibilityFromInstallClick())
         .flatMapCompletable(__ -> similarAppsExperiment.recordImpression())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewView.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewView.java
@@ -59,7 +59,7 @@ public interface AppViewView extends InstallAppView {
 
   Observable<ViewScrollChangeEvent> scrollVisibleSimilarApps();
 
-  Observable<Boolean> similarAppsVisibility();
+  Observable<Boolean> similarAppsVisibilityFromInstallClick();
 
   boolean isSimilarAppsVisible();
 


### PR DESCRIPTION
**What does this PR do?**

   The goal of PR is to solve the issue of "duplicated" impression events of the similar apps bundles in the app view when the user clicks install. What is currently happening in production is that when the user clicks install an app view with similar apps bundles, we send an similar appc and similar apps impression event. Then when the user scrolls down and has both bundles fully visible in the screen it would send a second impression event. 

  With this fix, we either send an event when user clicks install or when the user scrolls down to the fully visible bundle.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppViewFragment.java

**How should this be manually tested?**

  Home > Open an App (with similar apps) > Click install > should send Appc_Similar_App_Interact impression event > scroll down > no more events sent.
  Home > Open an App (with similar apps) > scroll down until both similar apps bundles are fully visible > should send Appc_Similar_App_Interact impression event  (scrolling up and down again should not send)

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-1846](https://aptoide.atlassian.net/browse/ASV-1846)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass