### PR TITLE
[ASV-2201] Sending "empty" on all properties related to empty searchs

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/search/analytics/SearchAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/search/analytics/SearchAnalytics.java
@@ -20,6 +20,7 @@ public class SearchAnalytics {
   public static final String SEARCH_START = "Search_Start";
   public static final String AB_SEARCH_ACTION = "AB_Search_Action";
   public static final String AB_SEARCH_IMPRESSION = "AB_Search_Impression";
+  private static final String EMPTY = "empty";
   private final AnalyticsManager analyticsManager;
   private final NavigationTracker navigationTracker;
 
@@ -87,7 +88,10 @@ public class SearchAnalytics {
       map.put(AttributeKey.IS_AD, isAd);
       map.put(AttributeKey.IS_APPC, isAppc);
     } else {
-      map.put(AttributeKey.POSITION, "empty");
+      map.put(AttributeKey.PACKAGE_NAME, EMPTY);
+      map.put(AttributeKey.POSITION, EMPTY);
+      map.put(AttributeKey.IS_AD, EMPTY);
+      map.put(AttributeKey.IS_APPC, EMPTY);
     }
     analyticsManager.logEvent(map, SEARCH_RESULT_CLICK, AnalyticsManager.Action.CLICK,
         getViewName(true));


### PR DESCRIPTION
**What does this PR do?**

This PR changes the search_result_clicked event for empty searches. Before, when this happened, position was being filled with empty and everything else was not being filled at all. Since this creates null properties in rakam that make very little sense, we're now sending empty on all the properties for that event to make it clear what is going on;

**Database changed?**

No

**Where should the reviewer start?**

- [x] SearchAnalytics.java

**How should this be manually tested?**

Do a search that returns no results and make sure the properties to rakam are being filled with empty in charles;

**What are the relevant tickets?**

  Tickets related to this pull-request: [ASV-2201](https://aptoide.atlassian.net/browse/ASV-2201)

**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass