### PR TITLE
[MOB-112] Implemented new empty state for search;

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/search/SearchNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/search/SearchNavigator.java
@@ -6,6 +6,7 @@ import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.search.model.SearchAdResult;
 import cm.aptoide.pt.search.model.SearchQueryModel;
 import cm.aptoide.pt.search.view.SearchResultFragment;
+import cm.aptoide.pt.view.settings.SettingsFragment;
 
 public class SearchNavigator {
 
@@ -48,5 +49,9 @@ public class SearchNavigator {
   public void goToSearchFragment(SearchQueryModel searchQueryModel) {
     final Fragment fragment = SearchResultFragment.newInstance(searchQueryModel);
     navigator.navigateTo(fragment, true);
+  }
+
+  public void goToSettings() {
+    navigator.navigateTo(new SettingsFragment(), true);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultFragment.java
@@ -14,8 +14,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AutoCompleteTextView;
 import android.widget.Button;
-import android.widget.EditText;
-import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import androidx.annotation.NonNull;
@@ -98,8 +96,7 @@ public class SearchResultFragment extends BackButtonFragment
   @Inject @Named("aptoide-theme") String theme;
   private DecimalFormat oneDecimalFormatter = new DecimalFormat("#.##");
   private View noSearchLayout;
-  private EditText noSearchLayoutSearchQuery;
-  private ImageView noResultsSearchButton;
+  private Button noSearchSettingsButton;
   private View searchResultsLayout;
   private ProgressBar progressBar;
   private CardView allAndFollowedStoresButtonsLayout;
@@ -194,8 +191,7 @@ public class SearchResultFragment extends BackButtonFragment
     searchResultsLayout = view.findViewById(R.id.fragment_search_result_layout);
 
     noSearchLayout = view.findViewById(R.id.no_search_results_layout);
-    noSearchLayoutSearchQuery = (EditText) view.findViewById(R.id.search_text);
-    noResultsSearchButton = (ImageView) view.findViewById(R.id.ic_search_button);
+    noSearchSettingsButton = view.findViewById(R.id.no_search_settings_button);
     progressBar = (ProgressBar) view.findViewById(R.id.progress_bar);
     toolbar = (Toolbar) view.findViewById(R.id.toolbar);
 
@@ -271,10 +267,8 @@ public class SearchResultFragment extends BackButtonFragment
     return RxView.clicks(allStoresButton);
   }
 
-  @Override public Observable<String> clickNoResultsSearchButton() {
-    return RxView.clicks(noResultsSearchButton)
-        .map(__ -> noSearchLayoutSearchQuery.getText()
-            .toString());
+  @Override public Observable<Void> clickNoResultsSearchButton() {
+    return RxView.clicks(noSearchSettingsButton);
   }
 
   @Override public Observable<Void> retryClicked() {

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultPresenter.java
@@ -294,8 +294,7 @@ import rx.exceptions.OnErrorNotImplementedException;
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .observeOn(viewScheduler)
         .flatMap(__ -> view.clickNoResultsSearchButton())
-        .filter(query -> query.length() > 1)
-        .doOnNext(query -> navigator.goToSearchFragment(new SearchQueryModel(query)))
+        .doOnNext(query -> navigator.goToSettings())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {
         }, e -> crashReport.log(e));

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultView.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultView.java
@@ -22,7 +22,7 @@ public interface SearchResultView extends SearchSuggestionsView {
 
   Observable<Void> clickEverywhereSearchButton();
 
-  Observable<String> clickNoResultsSearchButton();
+  Observable<Void> clickNoResultsSearchButton();
 
   Observable<Void> retryClicked();
 

--- a/app/src/main/res/layout/incl_no_search_results_layout.xml
+++ b/app/src/main/res/layout/incl_no_search_results_layout.xml
@@ -38,43 +38,7 @@
         android:gravity="center"
         android:text="@string/no_search_results_message"
         />
-    <!--
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:background="@drawable/search_background"
-            android:orientation="horizontal"
-            >
-          <EditText
-              android:id="@+id/search_text"
-              android:layout_width="250dp"
-              android:layout_height="50dp"
-              android:layout_marginEnd="5dp"
-              android:layout_marginLeft="5dp"
-              android:layout_marginRight="5dp"
-              android:layout_marginStart="5dp"
-              android:background="@null"
-              android:imeOptions="actionSearch"
-              android:inputType="text"
-              tools:text="search query"
-              />
-
-          <ImageButton
-              android:id="@+id/ic_search_button"
-              android:layout_width="60dp"
-              android:layout_height="50dp"
-              android:background="?attr/raisedButtonBackground"
-              android:paddingEnd="15dp"
-              android:paddingLeft="15dp"
-              android:paddingRight="15dp"
-              android:paddingStart="15dp"
-              android:src="@drawable/ic_search_icon"
-              />
-
-    </LinearLayout>
--->
     <Button
         android:id="@+id/no_search_settings_button"
         style="@style/Aptoide.Button.Ghost"

--- a/app/src/main/res/layout/incl_no_search_results_layout.xml
+++ b/app/src/main/res/layout/incl_no_search_results_layout.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2016.
   ~ Modified by Neurophobic Animal on 07/06/2016.
   -->
@@ -31,50 +30,62 @@
 
 
     <TextView
+        style="@style/Aptoide.TextView.Regular.M"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:layout_margin="20dp"
+        android:layout_margin="32dp"
         android:gravity="center"
         android:text="@string/no_search_results_message"
-        style="@style/Aptoide.TextView.Regular.M"
         />
+    <!--
 
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:background="@drawable/search_background"
-        android:orientation="horizontal"
-        >
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:background="@drawable/search_background"
+            android:orientation="horizontal"
+            >
+          <EditText
+              android:id="@+id/search_text"
+              android:layout_width="250dp"
+              android:layout_height="50dp"
+              android:layout_marginEnd="5dp"
+              android:layout_marginLeft="5dp"
+              android:layout_marginRight="5dp"
+              android:layout_marginStart="5dp"
+              android:background="@null"
+              android:imeOptions="actionSearch"
+              android:inputType="text"
+              tools:text="search query"
+              />
 
-      <EditText
-          android:id="@+id/search_text"
-          android:layout_width="250dp"
-          android:layout_height="50dp"
-          android:layout_marginEnd="5dp"
-          android:layout_marginLeft="5dp"
-          android:layout_marginRight="5dp"
-          android:layout_marginStart="5dp"
-          android:background="@null"
-          android:imeOptions="actionSearch"
-          android:inputType="text"
-          tools:text="search query"
-          />
-
-      <ImageButton
-          android:id="@+id/ic_search_button"
-          android:layout_width="60dp"
-          android:layout_height="50dp"
-          android:background="?attr/raisedButtonBackground"
-          android:paddingEnd="15dp"
-          android:paddingLeft="15dp"
-          android:paddingRight="15dp"
-          android:paddingStart="15dp"
-          android:src="@drawable/ic_search_icon"
-          />
+          <ImageButton
+              android:id="@+id/ic_search_button"
+              android:layout_width="60dp"
+              android:layout_height="50dp"
+              android:background="?attr/raisedButtonBackground"
+              android:paddingEnd="15dp"
+              android:paddingLeft="15dp"
+              android:paddingRight="15dp"
+              android:paddingStart="15dp"
+              android:src="@drawable/ic_search_icon"
+              />
 
     </LinearLayout>
-
+-->
+    <Button
+        android:id="@+id/no_search_settings_button"
+        style="@style/Aptoide.Button.Ghost"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:paddingStart="22dp"
+        android:paddingLeft="22dp"
+        android:paddingEnd="22dp"
+        android:paddingRight="22dp"
+        android:text="@string/settings_title_settings"
+        />
   </LinearLayout>
 </ScrollView>

--- a/app/src/test/java/cm/aptoide/pt/search/SearchResultPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/search/SearchResultPresenterTest.java
@@ -348,14 +348,14 @@ public class SearchResultPresenterTest {
     presenter.handleClickOnNoResultsImage();
 
     //When the search has no results and the user clicks on the image from the no result view
-    when(searchResultView.clickNoResultsSearchButton()).thenReturn(Observable.just("length>1"));
+    when(searchResultView.clickNoResultsSearchButton()).thenReturn(Observable.just(null));
     when(searchResultView.getViewModel()).thenReturn(searchResultModel);
     when(searchResultModel.getStoreName()).thenReturn("random");
 
     lifecycleEvent.onNext(View.LifecycleEvent.CREATE);
 
     //Then it should navigate back to the search view
-    verify(searchNavigator).goToSearchFragment(any(SearchQueryModel.class));
+    verify(searchNavigator).goToSettings();
   }
 
   @Test public void handleAllStoresListReachedBottomTest() {


### PR DESCRIPTION
**What does this PR do?**

This PR implements the new empty state for search;

**Database changed?**

No

**Where should the reviewer start?**

- [ ] SearchResultFragment.java

**How should this be manually tested?**

Make sure you have adult content turned off. Do a search with the word "sex" (or any other adult content related keyword). You should see the new empty state. Press the settings button. Turn on adult content and go back. The search results page should reload with the related results;

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-112](https://aptoide.atlassian.net/browse/MOB-112)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass