### PR TITLE
[Feature/MOB-121] Support dark-theme in Create/Edit Profile flow 

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/account/view/LoginSignUpCredentialsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/LoginSignUpCredentialsFragment.java
@@ -27,6 +27,7 @@ import cm.aptoide.pt.account.AccountAnalytics;
 import cm.aptoide.pt.orientation.ScreenOrientationManager;
 import cm.aptoide.pt.presenter.LoginSignUpCredentialsView;
 import cm.aptoide.pt.presenter.LoginSignupCredentialsFlavorPresenter;
+import cm.aptoide.pt.themes.ThemeManager;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.view.NotBottomNavigationView;
 import cm.aptoide.pt.view.rx.RxAlertDialog;
@@ -50,6 +51,7 @@ public class LoginSignUpCredentialsFragment extends GooglePlayServicesFragment
   @Inject ScreenOrientationManager orientationManager;
   @Inject AccountAnalytics accountAnalytics;
   @Inject @Named("marketName") String marketName;
+  @Inject ThemeManager themeManager;
   private ProgressDialog progressDialog;
   private RxAlertDialog facebookEmailRequiredDialog;
   private Button googleLoginButton;
@@ -448,7 +450,8 @@ public class LoginSignUpCredentialsFragment extends GooglePlayServicesFragment
     termsConditionCheckBox = (CheckBox) view.findViewById(R.id.tc_checkbox);
     termsAndConditions = (TextView) view.findViewById(R.id.terms_and_conditions);
 
-    progressDialog = GenericDialogs.createGenericPleaseWaitDialog(getContext());
+    progressDialog = GenericDialogs.createGenericPleaseWaitDialog(getContext(),
+        themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId);
 
     try {
       bottomSheetBehavior = BottomSheetBehavior.from(view.getRootView()

--- a/app/src/main/java/cm/aptoide/pt/account/view/store/ManageStoreFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/store/ManageStoreFragment.java
@@ -486,6 +486,7 @@ public class ManageStoreFragment extends BackButtonFragment
     youtubeEndRowIcon = view.findViewById(R.id.edit_store_youtube_plus);
 
     waitDialog = GenericDialogs.createGenericPleaseWaitDialog(getActivity(),
+        themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId,
         getActivity().getApplicationContext()
             .getString(R.string.please_wait_upload));
     toolbar = view.findViewById(R.id.toolbar);

--- a/app/src/main/java/cm/aptoide/pt/account/view/user/ManageUserFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/user/ManageUserFragment.java
@@ -120,6 +120,7 @@ public class ManageUserFragment extends BackButtonFragment
             .build();
 
     uploadWaitDialog = GenericDialogs.createGenericPleaseWaitDialog(context,
+        themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId,
         context.getString(R.string.please_wait_upload));
   }
 

--- a/app/src/main/java/cm/aptoide/pt/account/view/user/ProfileStepOneFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/user/ProfileStepOneFragment.java
@@ -18,6 +18,7 @@ import cm.aptoide.pt.account.AccountAnalytics;
 import cm.aptoide.pt.account.view.AccountNavigator;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.orientation.ScreenOrientationManager;
+import cm.aptoide.pt.themes.ThemeManager;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.utils.design.ShowMessage;
 import cm.aptoide.pt.view.NotBottomNavigationView;
@@ -37,6 +38,7 @@ public class ProfileStepOneFragment extends BaseToolbarFragment
   @Inject AccountNavigator accountNavigator;
   @Inject AccountAnalytics accountAnalytics;
   @Inject LoginSignupManager loginSignupManager;
+  @Inject ThemeManager themeManager;
   private Button continueBtn;
   private Button moreInfoBtn;
   private ProgressDialog waitDialog;
@@ -55,6 +57,7 @@ public class ProfileStepOneFragment extends BaseToolbarFragment
     super.onCreate(savedInstanceState);
     getFragmentComponent(savedInstanceState).inject(this);
     waitDialog = GenericDialogs.createGenericPleaseWaitDialog(getContext(),
+        themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId,
         getContext().getString(R.string.please_wait));
   }
 

--- a/app/src/main/java/cm/aptoide/pt/account/view/user/ProfileStepTwoFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/user/ProfileStepTwoFragment.java
@@ -18,6 +18,7 @@ import cm.aptoide.pt.account.AccountAnalytics;
 import cm.aptoide.pt.account.view.AccountNavigator;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.navigator.ActivityResultNavigator;
+import cm.aptoide.pt.themes.ThemeManager;
 import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.utils.design.ShowMessage;
@@ -35,6 +36,7 @@ public class ProfileStepTwoFragment extends BaseToolbarFragment
   @Inject AccountAnalytics accountAnalytics;
   @Inject LoginSignupManager loginSignupManager;
   @Inject MarketResourceFormatter marketResourceFormatter;
+  @Inject ThemeManager themeManager;
   private Button continueBtn;
   private Button privateProfileBtn;
   private TextView createProfileTitle;
@@ -56,6 +58,7 @@ public class ProfileStepTwoFragment extends BaseToolbarFragment
     getFragmentComponent(savedInstanceState).inject(this);
     accountNavigator = ((ActivityResultNavigator) getContext()).getAccountNavigator();
     waitDialog = GenericDialogs.createGenericPleaseWaitDialog(getContext(),
+        themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId,
         getContext().getString(R.string.please_wait));
   }
 

--- a/app/src/main/java/cm/aptoide/pt/store/view/AddStoreDialog.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/AddStoreDialog.java
@@ -42,6 +42,7 @@ import cm.aptoide.pt.store.StoreCredentialsProvider;
 import cm.aptoide.pt.store.StoreCredentialsProviderImpl;
 import cm.aptoide.pt.store.StoreUtils;
 import cm.aptoide.pt.store.StoreUtilsProxy;
+import cm.aptoide.pt.themes.ThemeManager;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.utils.design.ShowMessage;
@@ -91,6 +92,7 @@ public class AddStoreDialog extends BaseDialogFragment {
   private AnalyticsManager analyticsManager;
   private NavigationTracker navigationTracker;
   private ScreenOrientationManager orientationManager;
+  private ThemeManager themeManager;
 
   private SearchSuggestionManager searchSuggestionManager;
   private CompositeSubscription subscriptions;
@@ -114,6 +116,7 @@ public class AddStoreDialog extends BaseDialogFragment {
 
   @Override public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    themeManager = new ThemeManager(getActivity());
     subscriptions = new CompositeSubscription();
 
     tokenInvalidator =
@@ -343,7 +346,8 @@ public class AddStoreDialog extends BaseDialogFragment {
   private void showLoadingDialog() {
 
     if (loadingDialog == null) {
-      loadingDialog = GenericDialogs.createGenericPleaseWaitDialog(getActivity());
+      loadingDialog = GenericDialogs.createGenericPleaseWaitDialog(getActivity(),
+          themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId);
     }
     orientationManager.lock();
     loadingDialog.show();

--- a/app/src/main/java/cm/aptoide/pt/store/view/AddStoreDialog.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/AddStoreDialog.java
@@ -42,7 +42,6 @@ import cm.aptoide.pt.store.StoreCredentialsProvider;
 import cm.aptoide.pt.store.StoreCredentialsProviderImpl;
 import cm.aptoide.pt.store.StoreUtils;
 import cm.aptoide.pt.store.StoreUtilsProxy;
-import cm.aptoide.pt.themes.ThemeManager;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.utils.design.ShowMessage;
@@ -92,7 +91,6 @@ public class AddStoreDialog extends BaseDialogFragment {
   private AnalyticsManager analyticsManager;
   private NavigationTracker navigationTracker;
   private ScreenOrientationManager orientationManager;
-  private ThemeManager themeManager;
 
   private SearchSuggestionManager searchSuggestionManager;
   private CompositeSubscription subscriptions;
@@ -112,35 +110,6 @@ public class AddStoreDialog extends BaseDialogFragment {
       throw exception;
     }
     orientationManager = new ScreenOrientationManager(activity, activity.getWindowManager());
-  }
-
-  @Override public void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    themeManager = new ThemeManager(getActivity());
-    subscriptions = new CompositeSubscription();
-
-    tokenInvalidator =
-        ((AptoideApplication) getContext().getApplicationContext()).getTokenInvalidator();
-    converterFactory = WebService.getDefaultConverter();
-    accountManager =
-        ((AptoideApplication) getContext().getApplicationContext()).getAccountManager();
-    httpClient = ((AptoideApplication) getContext().getApplicationContext()).getDefaultClient();
-    storeCredentialsProvider = new StoreCredentialsProviderImpl(AccessorFactory.getAccessorFor(
-        ((AptoideApplication) getContext().getApplicationContext()
-            .getApplicationContext()).getDatabase(), Store.class));
-    baseBodyBodyInterceptor =
-        ((AptoideApplication) getContext().getApplicationContext()).getAccountSettingsBodyInterceptorPoolV7();
-
-    if (savedInstanceState != null) {
-      storeName = savedInstanceState.getString(BundleArgs.STORE_NAME.name());
-    }
-    final AptoideApplication application =
-        (AptoideApplication) getContext().getApplicationContext();
-    analyticsManager = application.getAnalyticsManager();
-    navigationTracker = application.getNavigationTracker();
-    storeAnalytics = new StoreAnalytics(analyticsManager, navigationTracker);
-
-    searchSuggestionManager = application.getSearchSuggestionManager();
   }
 
   @Override public void onResume() {
@@ -167,6 +136,34 @@ public class AddStoreDialog extends BaseDialogFragment {
       subscriptions.unsubscribe();
     }
     super.onDestroyView();
+  }
+
+  @Override public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    subscriptions = new CompositeSubscription();
+
+    tokenInvalidator =
+        ((AptoideApplication) getContext().getApplicationContext()).getTokenInvalidator();
+    converterFactory = WebService.getDefaultConverter();
+    accountManager =
+        ((AptoideApplication) getContext().getApplicationContext()).getAccountManager();
+    httpClient = ((AptoideApplication) getContext().getApplicationContext()).getDefaultClient();
+    storeCredentialsProvider = new StoreCredentialsProviderImpl(AccessorFactory.getAccessorFor(
+        ((AptoideApplication) getContext().getApplicationContext()
+            .getApplicationContext()).getDatabase(), Store.class));
+    baseBodyBodyInterceptor =
+        ((AptoideApplication) getContext().getApplicationContext()).getAccountSettingsBodyInterceptorPoolV7();
+
+    if (savedInstanceState != null) {
+      storeName = savedInstanceState.getString(BundleArgs.STORE_NAME.name());
+    }
+    final AptoideApplication application =
+        (AptoideApplication) getContext().getApplicationContext();
+    analyticsManager = application.getAnalyticsManager();
+    navigationTracker = application.getNavigationTracker();
+    storeAnalytics = new StoreAnalytics(analyticsManager, navigationTracker);
+
+    searchSuggestionManager = application.getSearchSuggestionManager();
   }
 
   @Override public void onViewCreated(final View view, Bundle savedInstanceState) {

--- a/app/src/main/java/cm/aptoide/pt/store/view/PrivateStoreDialog.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/PrivateStoreDialog.java
@@ -33,7 +33,6 @@ import cm.aptoide.pt.dataprovider.ws.v7.store.GetStoreMetaRequest;
 import cm.aptoide.pt.store.StoreCredentialsProviderImpl;
 import cm.aptoide.pt.store.StoreUtils;
 import cm.aptoide.pt.store.StoreUtilsProxy;
-import cm.aptoide.pt.themes.ThemeManager;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.view.fragment.BaseDialogFragment;
@@ -59,7 +58,6 @@ public class PrivateStoreDialog extends BaseDialogFragment {
   private OkHttpClient httpClient;
   private Converter.Factory converterFactory;
   private TokenInvalidator tokenInvalidator;
-  private ThemeManager themeManager;
 
   public static PrivateStoreDialog newInstance(Fragment returnFragment, int requestCode,
       String storeName, boolean isInsideStore) {
@@ -81,7 +79,6 @@ public class PrivateStoreDialog extends BaseDialogFragment {
 
   @Override public void onCreate(final Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    themeManager = new ThemeManager(getActivity());
     tokenInvalidator =
         ((AptoideApplication) getContext().getApplicationContext()).getTokenInvalidator();
     accountManager =

--- a/app/src/main/java/cm/aptoide/pt/store/view/PrivateStoreDialog.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/PrivateStoreDialog.java
@@ -33,6 +33,7 @@ import cm.aptoide.pt.dataprovider.ws.v7.store.GetStoreMetaRequest;
 import cm.aptoide.pt.store.StoreCredentialsProviderImpl;
 import cm.aptoide.pt.store.StoreUtils;
 import cm.aptoide.pt.store.StoreUtilsProxy;
+import cm.aptoide.pt.themes.ThemeManager;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.view.fragment.BaseDialogFragment;
@@ -58,6 +59,7 @@ public class PrivateStoreDialog extends BaseDialogFragment {
   private OkHttpClient httpClient;
   private Converter.Factory converterFactory;
   private TokenInvalidator tokenInvalidator;
+  private ThemeManager themeManager;
 
   public static PrivateStoreDialog newInstance(Fragment returnFragment, int requestCode,
       String storeName, boolean isInsideStore) {
@@ -79,6 +81,7 @@ public class PrivateStoreDialog extends BaseDialogFragment {
 
   @Override public void onCreate(final Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    themeManager = new ThemeManager(getActivity());
     tokenInvalidator =
         ((AptoideApplication) getContext().getApplicationContext()).getTokenInvalidator();
     accountManager =
@@ -183,7 +186,8 @@ public class PrivateStoreDialog extends BaseDialogFragment {
 
   private void showLoadingDialog() {
     if (loadingDialog == null) {
-      loadingDialog = GenericDialogs.createGenericPleaseWaitDialog(getActivity());
+      loadingDialog = GenericDialogs.createGenericPleaseWaitDialog(getActivity(),
+          themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId);
     }
     loadingDialog.show();
   }

--- a/app/src/main/java/cm/aptoide/pt/view/fragment/BaseDialogFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/fragment/BaseDialogFragment.java
@@ -18,7 +18,7 @@ import javax.inject.Inject;
 
 public class BaseDialogFragment extends RxDialogFragment {
 
-  @Inject ThemeManager themeAttributeProvider;
+  public @Inject ThemeManager themeManager;
   private FragmentComponent fragmentComponent;
 
   @Override public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -28,7 +28,7 @@ public class BaseDialogFragment extends RxDialogFragment {
 
     if (this.getActivity() != null) {
       setStyle(DialogFragment.STYLE_NO_TITLE,
-          themeAttributeProvider.getAttributeForTheme(R.attr.dialogsTheme).resourceId);
+          themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId);
     }
   }
 

--- a/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
@@ -350,7 +350,8 @@ public class SettingsFragment extends PreferenceFragmentCompat
     });
 
     findPreference(SettingsConstants.CLEAR_CACHE).setOnPreferenceClickListener(preference -> {
-      ProgressDialog dialog = GenericDialogs.createGenericPleaseWaitDialog(getContext());
+      ProgressDialog dialog = GenericDialogs.createGenericPleaseWaitDialog(getContext(),
+          themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId);
       subscriptions.add(GenericDialogs.createGenericContinueCancelMessage(getContext(),
           getString(R.string.storage_dialog_title, marketName),
           getString(R.string.clear_cache_dialog_message))

--- a/app/src/main/res/layout/dialog_choose_avatar_source.xml
+++ b/app/src/main/res/layout/dialog_choose_avatar_source.xml
@@ -12,7 +12,7 @@
 
   <TextView
       android:id="@+id/button_camera"
-      style="@style/Aptoide.TextView.Regular.XS"
+      style="@style/Aptoide.TextView.Regular.XS.Primary"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:drawableStart="@drawable/ic_camera"
@@ -24,7 +24,7 @@
 
   <TextView
       android:id="@+id/button_gallery"
-      style="@style/Aptoide.TextView.Regular.XS"
+      style="@style/Aptoide.TextView.Regular.XS.Primary"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginTop="@dimen/padding_medium_small"

--- a/app/src/main/res/layout/dialog_choose_avatar_source.xml
+++ b/app/src/main/res/layout/dialog_choose_avatar_source.xml
@@ -20,8 +20,6 @@
       android:drawableStart="@drawable/ic_camera"
       android:gravity="center_vertical"
       android:text="@string/upload_dialog_photo"
-      android:textColor="@color/create_store_title_color"
-      android:textSize="@dimen/text_size_medium_small"
       style="@style/Aptoide.TextView.Regular.XS"
       />
 
@@ -35,8 +33,6 @@
       android:drawableStart="@drawable/ic_gallery"
       android:gravity="center"
       android:text="@string/upload_dialog_gallery"
-      android:textColor="@color/create_store_title_color"
-      android:textSize="@dimen/text_size_medium_small"
       style="@style/Aptoide.TextView.Regular.XS"
       />
 

--- a/app/src/main/res/layout/dialog_choose_avatar_source.xml
+++ b/app/src/main/res/layout/dialog_choose_avatar_source.xml
@@ -1,39 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingEnd="@dimen/padding_medium_default"
-    android:paddingLeft="@dimen/padding_medium_default"
-    android:paddingRight="@dimen/padding_medium_default"
     android:paddingStart="@dimen/padding_medium_default"
+    android:paddingLeft="@dimen/padding_medium_default"
     android:paddingTop="@dimen/padding_medium_default"
+    android:paddingEnd="@dimen/padding_medium_default"
+    android:paddingRight="@dimen/padding_medium_default"
     >
 
   <TextView
       android:id="@+id/button_camera"
+      style="@style/Aptoide.TextView.Regular.XS"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:drawableStart="@drawable/ic_camera"
       android:drawableLeft="@drawable/ic_camera"
       android:drawablePadding="@dimen/padding_smaller"
-      android:drawableStart="@drawable/ic_camera"
       android:gravity="center_vertical"
       android:text="@string/upload_dialog_photo"
-      style="@style/Aptoide.TextView.Regular.XS"
       />
 
   <TextView
       android:id="@+id/button_gallery"
+      style="@style/Aptoide.TextView.Regular.XS"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginTop="@dimen/padding_medium_small"
+      android:drawableStart="@drawable/ic_gallery"
       android:drawableLeft="@drawable/ic_gallery"
       android:drawablePadding="@dimen/padding_smaller"
-      android:drawableStart="@drawable/ic_gallery"
       android:gravity="center"
       android:text="@string/upload_dialog_gallery"
-      style="@style/Aptoide.TextView.Regular.XS"
       />
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_manage_store.xml
+++ b/app/src/main/res/layout/fragment_manage_store.xml
@@ -100,6 +100,9 @@
               style="@style/Aptoide.TextView.Regular.S.BlackAlpha"
               android:layout_width="match_parent"
               android:hint="@string/create_store_name_inserted"
+              android:inputType="text"
+              android:singleLine="true"
+              android:imeOptions="actionDone"
               />
 
           <EditText
@@ -109,7 +112,7 @@
               android:layout_height="wrap_content"
               android:hint="@string/create_store_description_hint"
               android:visibility="gone"
-              tools:visibility="gone"
+              tools:visibility="visible"
               />
 
           <LinearLayout
@@ -483,7 +486,6 @@
             android:id="@+id/create_store_skip"
             style="@style/Aptoide.Button.Ghost"
             android:layout_width="8dp"
-            android:layout_height="60dp"
             android:layout_marginEnd="@dimen/padding_smaller"
             android:layout_marginRight="@dimen/padding_smaller"
             android:layout_weight="1"

--- a/app/src/main/res/layout/fragment_manage_user.xml
+++ b/app/src/main/res/layout/fragment_manage_user.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -62,7 +61,6 @@
         <Button
             android:id="@+id/create_user_cancel_button"
             android:layout_width="8dp"
-            android:layout_height="60dp"
             android:layout_marginEnd="@dimen/padding_smaller"
             android:layout_marginRight="@dimen/padding_smaller"
             android:layout_weight="1"
@@ -178,6 +176,9 @@
               android:paddingRight="@dimen/padding_smaller"
               android:paddingStart="@dimen/padding_smaller"
               android:paddingTop="@dimen/padding_very_small"
+              android:inputType="text"
+              android:singleLine="true"
+              android:imeOptions="actionDone"
               style="@style/Aptoide.TextView.Regular.S"
               />
 

--- a/app/src/main/res/layout/fragment_manage_user.xml
+++ b/app/src/main/res/layout/fragment_manage_user.xml
@@ -35,11 +35,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
-        android:layout_marginBottom="@dimen/padding_medium_small"
-        android:layout_marginEnd="@dimen/padding_medium_default"
-        android:layout_marginLeft="@dimen/padding_medium_default"
-        android:layout_marginRight="@dimen/padding_medium_default"
         android:layout_marginStart="@dimen/padding_medium_default"
+        android:layout_marginLeft="@dimen/padding_medium_default"
+        android:layout_marginEnd="@dimen/padding_medium_default"
+        android:layout_marginRight="@dimen/padding_medium_default"
+        android:layout_marginBottom="@dimen/padding_medium_small"
         android:gravity="bottom"
         android:orientation="horizontal"
         android:weightSum="2"
@@ -60,6 +60,7 @@
 
         <Button
             android:id="@+id/create_user_cancel_button"
+            style="@style/Aptoide.Button.Ghost"
             android:layout_width="8dp"
             android:layout_marginEnd="@dimen/padding_smaller"
             android:layout_marginRight="@dimen/padding_smaller"
@@ -68,20 +69,19 @@
             android:text="@string/cancel"
             android:visibility="gone"
             tools:visibility="visible"
-            style="@style/Aptoide.Button.Ghost"
             />
 
         <Button
             android:id="@+id/create_user_create_profile"
+            style="@style/Aptoide.Button"
             android:layout_width="0dp"
-            android:layout_marginEnd="5dp"
-            android:layout_marginLeft="@dimen/padding_smaller"
-            android:layout_marginRight="5dp"
             android:layout_marginStart="@dimen/padding_smaller"
+            android:layout_marginLeft="@dimen/padding_smaller"
+            android:layout_marginEnd="5dp"
+            android:layout_marginRight="5dp"
             android:layout_weight="1"
             android:gravity="center"
             android:text="@string/create_user_create_button"
-            style="@style/Aptoide.Button"
             />
       </LinearLayout>
 
@@ -105,11 +105,11 @@
             android:id="@+id/create_user_image_action"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/padding_small"
-            android:layout_marginLeft="@dimen/padding_small"
-            android:layout_marginRight="@dimen/padding_small"
             android:layout_marginStart="@dimen/padding_small"
+            android:layout_marginLeft="@dimen/padding_small"
             android:layout_marginTop="@dimen/padding_medium"
+            android:layout_marginEnd="@dimen/padding_small"
+            android:layout_marginRight="@dimen/padding_small"
             >
 
           <ImageView
@@ -122,24 +122,24 @@
           <ImageView
               android:layout_width="@dimen/select_picture_camera_icon_size"
               android:layout_height="@dimen/select_picture_camera_icon_size"
-              android:layout_alignBottom="@+id/create_user_image"
               android:layout_alignEnd="@+id/create_user_image"
               android:layout_alignRight="@+id/create_user_image"
+              android:layout_alignBottom="@+id/create_user_image"
               android:background="@drawable/create_user_camera_background_shape"
               android:padding="@dimen/padding_very_small"
               android:src="@drawable/create_user_camera"
               />
 
           <TextView
+              style="@style/Aptoide.TextView.Medium"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:layout_centerVertical="true"
-              android:layout_marginLeft="@dimen/padding_medium_default"
               android:layout_marginStart="@dimen/padding_medium_default"
+              android:layout_marginLeft="@dimen/padding_medium_default"
               android:layout_toEndOf="@id/create_user_image"
               android:layout_toRightOf="@id/create_user_image"
               android:text="@string/create_user_take_picture"
-              style="@style/Aptoide.TextView.Medium"
               />
 
         </RelativeLayout>
@@ -147,47 +147,47 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/padding_small"
-            android:layout_marginLeft="@dimen/padding_small"
-            android:layout_marginRight="@dimen/padding_small"
             android:layout_marginStart="@dimen/padding_small"
+            android:layout_marginLeft="@dimen/padding_small"
             android:layout_marginTop="@dimen/padding_medium"
+            android:layout_marginEnd="@dimen/padding_small"
+            android:layout_marginRight="@dimen/padding_small"
             android:orientation="vertical"
             >
 
           <TextView
+              style="@style/Aptoide.TextView.Regular.S"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:text="@string/create_user_choose_username"
-              style="@style/Aptoide.TextView.Regular.S"
               />
 
           <EditText
               android:id="@+id/create_user_username_inserted"
+              style="@style/Aptoide.TextView.Regular.S"
               android:layout_width="match_parent"
               android:layout_height="43dp"
               android:layout_marginTop="@dimen/padding_very_small"
               android:background="@drawable/rounded_corners_white"
               android:hint="@string/create_user_username"
-              android:maxLength="@integer/max_username_char_length"
-              android:paddingBottom="@dimen/padding_very_small"
-              android:paddingEnd="@dimen/padding_smaller"
-              android:paddingLeft="@dimen/padding_smaller"
-              android:paddingRight="@dimen/padding_smaller"
-              android:paddingStart="@dimen/padding_smaller"
-              android:paddingTop="@dimen/padding_very_small"
-              android:inputType="text"
-              android:singleLine="true"
               android:imeOptions="actionDone"
-              style="@style/Aptoide.TextView.Regular.S"
+              android:inputType="text"
+              android:maxLength="@integer/max_username_char_length"
+              android:paddingStart="@dimen/padding_smaller"
+              android:paddingLeft="@dimen/padding_smaller"
+              android:paddingTop="@dimen/padding_very_small"
+              android:paddingEnd="@dimen/padding_smaller"
+              android:paddingRight="@dimen/padding_smaller"
+              android:paddingBottom="@dimen/padding_very_small"
+              android:singleLine="true"
               />
 
           <TextView
+              style="@style/Aptoide.TextView.Regular.XS"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:layout_marginTop="@dimen/padding_very_small"
               android:text="@string/create_user_hint"
-              style="@style/Aptoide.TextView.Regular.XS"
               />
 
         </LinearLayout>
@@ -196,20 +196,20 @@
             android:id="@+id/birthday_layout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/padding_small"
-            android:layout_marginLeft="@dimen/padding_small"
-            android:layout_marginRight="@dimen/padding_small"
             android:layout_marginStart="@dimen/padding_small"
+            android:layout_marginLeft="@dimen/padding_small"
             android:layout_marginTop="22dp"
+            android:layout_marginEnd="@dimen/padding_small"
+            android:layout_marginRight="@dimen/padding_small"
             android:orientation="vertical"
             android:visibility="gone"
             tools:visibility="visible"
             >
           <TextView
+              style="@style/Aptoide.TextView.Regular.M"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:text="@string/createuser_title_date_of_birth"
-              style="@style/Aptoide.TextView.Regular.M"
               />
 
           <RelativeLayout
@@ -227,15 +227,15 @@
                 />
             <TextView
                 android:id="@+id/calendar_date"
+                style="@style/Aptoide.TextView.Medium.S"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="10dp"
                 android:layout_marginStart="10dp"
+                android:layout_marginLeft="10dp"
                 android:layout_toEndOf="@id/calendar"
                 android:layout_toRightOf="@id/calendar"
                 android:text="@string/createuser_title_choose_date"
                 android:textColor="?attr/colorPrimaryDark"
-                style="@style/Aptoide.TextView.Medium.S"
                 />
 
           </RelativeLayout>
@@ -245,8 +245,8 @@
             android:id="@+id/newsletter_layout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="9dp"
             android:layout_marginStart="9dp"
+            android:layout_marginLeft="9dp"
             android:layout_marginTop="30dp"
             android:visibility="gone"
             tools:visibility="visible"
@@ -257,15 +257,15 @@
               android:layout_height="wrap_content"
               />
           <TextView
+              style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:layout_gravity="center"
-              android:layout_marginLeft="6dp"
               android:layout_marginStart="6dp"
+              android:layout_marginLeft="6dp"
               android:gravity="center"
               android:text="@string/createuser_short_subscribe_newsletter"
               android:textAlignment="center"
-              style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
               />
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_profile_step_two.xml
+++ b/app/src/main/res/layout/fragment_profile_step_two.xml
@@ -26,11 +26,11 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_alignParentBottom="true"
-      android:layout_marginBottom="@dimen/padding_medium"
-      android:layout_marginEnd="@dimen/padding_small"
-      android:layout_marginLeft="@dimen/padding_small"
-      android:layout_marginRight="@dimen/padding_small"
       android:layout_marginStart="@dimen/padding_small"
+      android:layout_marginLeft="@dimen/padding_small"
+      android:layout_marginEnd="@dimen/padding_small"
+      android:layout_marginRight="@dimen/padding_small"
+      android:layout_marginBottom="@dimen/padding_medium"
       android:gravity="center|bottom"
       android:orientation="horizontal"
       android:weightSum="2"
@@ -38,26 +38,26 @@
 
     <Button
         android:id="@+id/logged_in_private_button"
+        style="@style/Aptoide.Button.Ghost"
         android:layout_width="8dp"
         android:layout_marginEnd="@dimen/padding_smaller"
         android:layout_marginRight="@dimen/padding_smaller"
         android:layout_weight="1"
         android:text="@string/create_profile_pub_pri_make_priv"
         android:textSize="@dimen/text_size_small"
-        style="@style/Aptoide.Button.Ghost"
         />
 
     <Button
         android:id="@+id/logged_in_continue"
+        style="@style/Aptoide.Button"
         android:layout_width="0dp"
-        android:layout_marginEnd="@dimen/padding_tiny"
-        android:layout_marginLeft="@dimen/padding_smaller"
-        android:layout_marginRight="@dimen/padding_tiny"
         android:layout_marginStart="@dimen/padding_smaller"
+        android:layout_marginLeft="@dimen/padding_smaller"
+        android:layout_marginEnd="@dimen/padding_tiny"
+        android:layout_marginRight="@dimen/padding_tiny"
         android:layout_weight="1"
         android:gravity="center"
         android:text="@string/continue_option"
-        style="@style/Aptoide.Button"
         />
 
   </LinearLayout>
@@ -68,10 +68,10 @@
       android:layout_height="match_parent"
       android:layout_above="@id/bottom_buttons"
       android:layout_marginTop="?android:actionBarSize"
-      android:paddingEnd="@dimen/padding_very_small"
-      android:paddingLeft="@dimen/padding_very_small"
-      android:paddingRight="@dimen/padding_very_small"
       android:paddingStart="@dimen/padding_very_small"
+      android:paddingLeft="@dimen/padding_very_small"
+      android:paddingEnd="@dimen/padding_very_small"
+      android:paddingRight="@dimen/padding_very_small"
       >
 
     <LinearLayout
@@ -85,39 +85,39 @@
 
       <TextView
           android:id="@+id/create_profile_title"
+          style="@style/Aptoide.TextView.Medium.L"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginTop="@dimen/padding_medium_small"
           android:gravity="center_horizontal"
           android:text="@string/create_profile_pub_pri"
-          style="@style/Aptoide.TextView.Medium.L"
           />
 
       <TextView
+          style="@style/Aptoide.TextView.Regular.S"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginTop="@dimen/padding_smaller"
           android:gravity="center_horizontal"
           android:text="@string/create_profile_pub_pri_sub_text_1"
-          style="@style/Aptoide.TextView.Regular.S"
           />
 
       <TextView
+          style="@style/Aptoide.TextView.Regular.S"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginTop="@dimen/padding_smaller"
           android:gravity="center_horizontal"
           android:text="@string/create_profile_pub_pri_sub_text_2"
-          style="@style/Aptoide.TextView.Regular.S"
           />
 
       <TextView
+          style="@style/Aptoide.TextView.Regular.S"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginTop="@dimen/padding_smaller"
           android:gravity="center_horizontal"
           android:text="@string/create_profile_pub_pri_sub_text_3"
-          style="@style/Aptoide.TextView.Regular.S"
           />
 
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_profile_step_two.xml
+++ b/app/src/main/res/layout/fragment_profile_step_two.xml
@@ -85,7 +85,7 @@
 
       <TextView
           android:id="@+id/create_profile_title"
-          style="@style/Aptoide.TextView.Medium.L"
+          style="@style/Aptoide.TextView.Medium.L.Black"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginTop="@dimen/padding_medium_small"
@@ -94,7 +94,7 @@
           />
 
       <TextView
-          style="@style/Aptoide.TextView.Regular.S"
+          style="@style/Aptoide.TextView.Regular.S.Primary"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginTop="@dimen/padding_smaller"
@@ -103,7 +103,7 @@
           />
 
       <TextView
-          style="@style/Aptoide.TextView.Regular.S"
+          style="@style/Aptoide.TextView.Regular.S.Primary"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginTop="@dimen/padding_smaller"
@@ -112,7 +112,7 @@
           />
 
       <TextView
-          style="@style/Aptoide.TextView.Regular.S"
+          style="@style/Aptoide.TextView.Regular.S.Primary"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginTop="@dimen/padding_smaller"

--- a/app/src/main/res/layout/fragment_profile_step_two.xml
+++ b/app/src/main/res/layout/fragment_profile_step_two.xml
@@ -39,7 +39,6 @@
     <Button
         android:id="@+id/logged_in_private_button"
         android:layout_width="8dp"
-        android:layout_height="60dp"
         android:layout_marginEnd="@dimen/padding_smaller"
         android:layout_marginRight="@dimen/padding_smaller"
         android:layout_weight="1"
@@ -91,7 +90,7 @@
           android:layout_marginTop="@dimen/padding_medium_small"
           android:gravity="center_horizontal"
           android:text="@string/create_profile_pub_pri"
-          style="@style/Aptoide.TextView.Medium.L.Theme"
+          style="@style/Aptoide.TextView.Medium.L"
           />
 
       <TextView

--- a/app/src/main/res/values/styles_aptoide_button.xml
+++ b/app/src/main/res/values/styles_aptoide_button.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
   <!--Big buttons-->
   <!--Raised button-->
   <style name="Aptoide.Button" parent="Widget.AppCompat.Button.Colored">
@@ -25,7 +25,7 @@
     <item name="android:textAllCaps">true</item>
     <item name="android:background">?attr/ghostButtonBackground</item>
     <item name="android:textColor">?attr/colorPrimaryDark</item>
-    <item name="android:stateListAnimator">@null</item>
+    <item name="android:stateListAnimator" tools:targetApi="lollipop">@null</item>
   </style>
 
   <!-- Flat Button-->

--- a/app/src/main/res/values/styles_aptoide_text_view.xml
+++ b/app/src/main/res/values/styles_aptoide_text_view.xml
@@ -197,6 +197,10 @@
     <item name="android:textColor">?attr/textColorWhite</item>
   </style>
 
+  <style name="Aptoide.TextView.Regular.XS.Primary">
+    <item name="android:textColor">?android:attr/textColorPrimary</item>
+  </style>
+
   <style name="Aptoide.TextView.Medium.S.White">
     <item name="android:textColor">?attr/textColorWhite</item>
   </style>
@@ -246,6 +250,9 @@
     <item name="android:textColor">?attr/textColorRed700</item>
   </style>
 
+  <style name="Aptoide.TextView.Regular.S.Primary">
+    <item name="android:textColor">?android:attr/textColorPrimary</item>
+  </style>
 
   <style name="Aptoide.TextView.Medium.XXS.Orange">
     <item name="android:textColor">?attr/textColorOrange</item>

--- a/utils/src/main/java/cm/aptoide/pt/utils/GenericDialogs.java
+++ b/utils/src/main/java/cm/aptoide/pt/utils/GenericDialogs.java
@@ -8,6 +8,7 @@ package cm.aptoide.pt.utils;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.graphics.Color;
+import android.view.ContextThemeWrapper;
 import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -21,7 +22,7 @@ import rx.subscriptions.Subscriptions;
 /**
  * Created by trinkes on 5/9/16. <li>{@link #createGenericYesNoCancelMessage(Context, String, *
  * String)}</li> <li>{@link #createGenericOkCancelMessage(Context, String, String)}</li> <li>{@link
- * #createGenericPleaseWaitDialog(Context)}</li>
+ * #createGenericPleaseWaitDialog(Context, int)}</li>
  */
 public class GenericDialogs {
 
@@ -242,8 +243,9 @@ public class GenericDialogs {
    *
    * @return A ProgressDialog with a please wait message
    */
-  public static ProgressDialog createGenericPleaseWaitDialog(Context context) {
-    ProgressDialog progressDialog = new ProgressDialog(context);
+  public static ProgressDialog createGenericPleaseWaitDialog(Context context, int resourceId) {
+    ProgressDialog progressDialog =
+        new ProgressDialog(new ContextThemeWrapper(context, resourceId));
     progressDialog.setMessage(context.getString(R.string.please_wait));
     progressDialog.setCancelable(false);
     return progressDialog;
@@ -252,10 +254,12 @@ public class GenericDialogs {
   /**
    * Creates an endless progressDialog to be shown when user is waiting for something
    *
-   * @return A ProgressDialog with a please wait message
+   * @return A ProgressDialog with a configurable message
    */
-  public static ProgressDialog createGenericPleaseWaitDialog(Context context, String string) {
-    ProgressDialog progressDialog = new ProgressDialog(context);
+  public static ProgressDialog createGenericPleaseWaitDialog(Context context, int resourceId,
+      String string) {
+    ProgressDialog progressDialog =
+        new ProgressDialog(new ContextThemeWrapper(context, resourceId));
     progressDialog.setMessage(string);
     progressDialog.setCancelable(false);
     return progressDialog;


### PR DESCRIPTION
**What does this PR do?**

   This deals with fixes and quality of life improvements.

fixes:
- ProgressDialogs dark theme
- Orange Title

improvement
- Clicking enter in both username and storename fields actually submit field and remove keyboard, instead of a line break.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] LoginSignUpCredentialsFragment.java

**How should this be manually tested?**

  Create accounts in both Light & Dark themes.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-121](https://aptoide.atlassian.net/browse/MOB-121)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass