### PR TITLE
[feature/MOB-122] Added support for dark theme in create store widget

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/account/view/user/CreateStoreDisplayable.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/user/CreateStoreDisplayable.java
@@ -1,5 +1,6 @@
 package cm.aptoide.pt.account.view.user;
 
+import androidx.annotation.ColorInt;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.dataprovider.model.v7.TimelineStats;
 import cm.aptoide.pt.store.StoreAnalytics;
@@ -13,13 +14,16 @@ public class CreateStoreDisplayable extends Displayable {
 
   private StoreAnalytics storeAnalytics;
   private TimelineStats timelineStats;
+  private int textAccentColor;
 
   public CreateStoreDisplayable() {
   }
 
-  public CreateStoreDisplayable(StoreAnalytics storeAnalytics, TimelineStats timelineStats) {
+  public CreateStoreDisplayable(StoreAnalytics storeAnalytics, TimelineStats timelineStats,
+      @ColorInt int textAccentColor) {
     this.storeAnalytics = storeAnalytics;
     this.timelineStats = timelineStats;
+    this.textAccentColor = textAccentColor;
   }
 
   @Override protected Configs getConfig() {
@@ -42,5 +46,9 @@ public class CreateStoreDisplayable extends Displayable {
   public long getFollowings() {
     return timelineStats.getData()
         .getFollowing();
+  }
+
+  public int getTextAccentColor() {
+    return textAccentColor;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/store/view/CreateStoreWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/CreateStoreWidget.java
@@ -1,14 +1,11 @@
 package cm.aptoide.pt.store.view;
 
-import android.content.Context;
-import android.os.Build;
 import android.text.ParcelableSpan;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
-import androidx.annotation.ColorInt;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.account.view.store.ManageStoreFragment;
 import cm.aptoide.pt.account.view.store.ManageStoreViewModel;
@@ -47,7 +44,8 @@ public class CreateStoreWidget extends Widget<CreateStoreDisplayable> {
         String.valueOf(displayable.getFollowers()));
 
     ParcelableSpan[] textStyle = {
-        new StyleSpan(android.graphics.Typeface.BOLD), new ForegroundColorSpan(getTextColor())
+        new StyleSpan(android.graphics.Typeface.BOLD),
+        new ForegroundColorSpan(displayable.getTextAccentColor())
     };
     followers.setText(spannableFactory.createMultiSpan(followersText, textStyle,
         String.valueOf(displayable.getFollowers())));
@@ -65,16 +63,5 @@ public class CreateStoreWidget extends Widget<CreateStoreDisplayable> {
             .sendStoreTabInteractEvent("Login", false))
         .subscribe(__ -> {
         }, err -> crashReport.log(err)));
-  }
-
-  private @ColorInt int getTextColor() {
-    Context context = getContext();
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      return context.getResources()
-          .getColor(R.color.default_color, context.getTheme());
-    } else {
-      return context.getResources()
-          .getColor(R.color.default_color);
-    }
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/view/recycler/displayable/DisplayablesFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/view/recycler/displayable/DisplayablesFactory.java
@@ -393,7 +393,8 @@ public class DisplayablesFactory {
             themeManager.getAttributeForTheme(storeTheme, R.attr.themeTextColor).data));
       } else if (accountManager.isLoggedIn()) {
         if (MyStoreManager.shouldShowCreateStore()) {
-          displayables.add(new CreateStoreDisplayable(storeAnalytics, store.getTimelineStats()));
+          displayables.add(new CreateStoreDisplayable(storeAnalytics, store.getTimelineStats(),
+              themeManager.getAttributeForTheme(R.attr.themeTextColor).data));
         }
       } else {
         displayables.add(new LoginDisplayable());

--- a/app/src/main/res/layout/create_store_displayable_layout.xml
+++ b/app/src/main/res/layout/create_store_displayable_layout.xml
@@ -3,15 +3,16 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    app:cardBackgroundColor="?attr/backgroundCardColor"
     >
 
   <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:background="@drawable/white_card"
       >
     <TextView
         android:id="@+id/create_store_message"
+        style="@style/Aptoide.TextView.Regular.S.Black"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="13dp"
@@ -20,21 +21,21 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        style="@style/Aptoide.TextView.Regular.S.Black"
         />
 
     <TextView
         android:id="@+id/following"
+        style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="18dp"
         android:layout_marginTop="20dp"
+        android:layout_marginBottom="18dp"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:gravity="center"
-        android:paddingEnd="16dp"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
         android:paddingStart="16dp"
+        android:paddingLeft="16dp"
+        android:paddingEnd="16dp"
+        android:paddingRight="16dp"
         android:text="@string/storetab_short_followings"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/leftSeparator"
@@ -42,15 +43,14 @@
         app:layout_constraintRight_toLeftOf="@+id/leftSeparator"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/create_store_message"
-        style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
         />
 
     <View
         android:id="@+id/leftSeparator"
         android:layout_width="1dp"
         android:layout_height="36dp"
-        android:layout_marginBottom="18dp"
         android:layout_marginTop="20dp"
+        android:layout_marginBottom="18dp"
         android:background="@color/light_custom_gray"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/followers"
@@ -63,16 +63,17 @@
 
     <TextView
         android:id="@+id/followers"
+        style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="18dp"
         android:layout_marginTop="20dp"
+        android:layout_marginBottom="18dp"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:gravity="center"
-        android:paddingEnd="16dp"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
         android:paddingStart="16dp"
+        android:paddingLeft="16dp"
+        android:paddingEnd="16dp"
+        android:paddingRight="16dp"
         android:text="@string/storetab_short_followers"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/rightSeparator"
@@ -80,15 +81,14 @@
         app:layout_constraintRight_toLeftOf="@+id/rightSeparator"
         app:layout_constraintStart_toEndOf="@+id/leftSeparator"
         app:layout_constraintTop_toBottomOf="@id/create_store_message"
-        style="@style/Aptoide.TextView.Regular.XS.BlackAlpha"
         />
 
     <View
         android:id="@+id/rightSeparator"
         android:layout_width="1dp"
         android:layout_height="36dp"
-        android:layout_marginBottom="18dp"
         android:layout_marginTop="20dp"
+        android:layout_marginBottom="18dp"
         android:background="@color/light_custom_gray"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toRightOf="@id/followers"
@@ -98,17 +98,16 @@
 
     <Button
         android:id="@+id/create_store_action"
+        style="@style/Aptoide.Button.Secondary.S"
         android:layout_width="wrap_content"
-        android:layout_marginBottom="18dp"
+        android:layout_marginTop="20dp"
         android:layout_marginEnd="14dp"
         android:layout_marginRight="14dp"
-        android:layout_marginTop="20dp"
-        android:background="?attr/raisedButtonBackground"
+        android:layout_marginBottom="18dp"
         android:text="@string/create_store_displayable_button"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/create_store_message"
-        style="@style/Aptoide.Button.S"
         />
   </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
**What does this PR do?**

   This adds support for the create store widget in the Stores tab, when the user has no registered store.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Foo.java
- [ ] Bar.kt

**How should this be manually tested?**

  Get an account without store, go to the Stores tab and check if the "Create store" widget looks ok for light and dark theme.

**What are the relevant tickets?**

  [ASV-122](https://aptoide.atlassian.net/browse/ASV-122)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass