### PR TITLE
[MOB-137] feature: Support dark-theme in hardware specs dialog.

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
@@ -376,8 +376,8 @@ public class SettingsFragment extends PreferenceFragmentCompat
         getFormattedDensity(AptoideUtils.ScreenU.getDensityDpi(getActivity().getWindowManager()));
 
     hwSpecs.setOnPreferenceClickListener(preference -> {
-      AlertDialog.Builder alertDialogBuilder =
-          new AlertDialog.Builder(context, R.style.AlertDialogAptoide);
+      AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(context,
+          themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId);
       alertDialogBuilder.setTitle(getString(R.string.setting_hwspecstitle));
       alertDialogBuilder.setIcon(android.R.drawable.ic_menu_info_details)
           .setMessage(getString(R.string.setting_sdk_version)


### PR DESCRIPTION
**What does this PR do?**

   Hardware specs dialog theme change

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] SettingsFragment.java

**How should this be manually tested?**

  Test settings > hw specs dialog in both Light and Dark theme

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-137](https://aptoide.atlassian.net/browse/MOB-137)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass