### PR TITLE
[Feature/MOB-125] Support dark theme in Apps icons

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
@@ -19,6 +19,7 @@ import cm.aptoide.pt.bottomNavigation.BottomNavigationActivity;
 import cm.aptoide.pt.bottomNavigation.BottomNavigationItem;
 import cm.aptoide.pt.home.apps.list.AppsController;
 import cm.aptoide.pt.networking.image.ImageLoader;
+import cm.aptoide.pt.themes.ThemeManager;
 import cm.aptoide.pt.utils.AptoideUtils;
 import cm.aptoide.pt.utils.GenericDialogs;
 import cm.aptoide.pt.view.fragment.NavigationTrackFragment;
@@ -43,6 +44,7 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
   private static final BottomNavigationItem BOTTOM_NAVIGATION_ITEM = BottomNavigationItem.APPS;
 
   @Inject AppsPresenter appsPresenter;
+  @Inject ThemeManager themeManager;
   private RxAlertDialog ignoreUpdateDialog;
   private ImageView userAvatar;
   private ProgressBar progressBar;
@@ -86,7 +88,7 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
   }
 
   private void setupRecyclerView() {
-    appsController = new AppsController();
+    appsController = new AppsController(themeManager);
     appsRecyclerView.setController(appsController);
     appsController.getAdapter()
         .registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {

--- a/app/src/main/java/cm/aptoide/pt/home/apps/list/AppsController.kt
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/list/AppsController.kt
@@ -7,10 +7,11 @@ import cm.aptoide.pt.home.apps.model.AppcUpdateApp
 import cm.aptoide.pt.home.apps.model.DownloadApp
 import cm.aptoide.pt.home.apps.model.InstalledApp
 import cm.aptoide.pt.home.apps.model.UpdateApp
+import cm.aptoide.pt.themes.ThemeManager
 import com.airbnb.epoxy.Typed4EpoxyController
 import rx.subjects.PublishSubject
 
-class AppsController :
+class AppsController(val themeManager: ThemeManager) :
     Typed4EpoxyController<List<UpdateApp>, List<InstalledApp>, List<AppcUpdateApp>, List<DownloadApp>>() {
 
   val appEventListener: PublishSubject<AppClick> = PublishSubject.create()
@@ -66,6 +67,7 @@ class AppsController :
           .id("updates", update.identifier)
           .application(update)
           .eventSubject(appEventListener)
+          .themeManager(themeManager)
           .addTo(this)
     }
 

--- a/app/src/main/java/cm/aptoide/pt/home/apps/list/models/UpdateCardModel.kt
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/list/models/UpdateCardModel.kt
@@ -1,6 +1,5 @@
 package cm.aptoide.pt.home.apps.list.models
 
-import android.util.Log
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
@@ -11,6 +10,7 @@ import cm.aptoide.pt.home.apps.AppClick
 import cm.aptoide.pt.home.apps.model.StateApp
 import cm.aptoide.pt.home.apps.model.UpdateApp
 import cm.aptoide.pt.networking.image.ImageLoader
+import cm.aptoide.pt.themes.ThemeManager
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModel
 import com.airbnb.epoxy.EpoxyModelClass
@@ -25,6 +25,9 @@ abstract class UpdateCardModel : EpoxyModelWithHolder<UpdateCardModel.CardHolder
 
   @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash)
   var eventSubject: PublishSubject<AppClick>? = null
+
+  @EpoxyAttribute(EpoxyAttribute.Option.DoNotHash)
+  var themeManager: ThemeManager? = null
 
   override fun bind(holder: CardHolder) {
     application?.let { app ->
@@ -120,7 +123,8 @@ abstract class UpdateCardModel : EpoxyModelWithHolder<UpdateCardModel.CardHolder
       holder.secondaryText.setTextAppearance(holder.itemView.context,
           R.style.Aptoide_TextView_Medium_XS_Red700)
     } else {
-      holder.secondaryIcon.setImageResource(R.drawable.ic_refresh_orange)
+      holder.secondaryIcon.setImageResource(
+          themeManager!!.getAttributeForTheme(R.attr.version_refresh_icon).resourceId)
       holder.secondaryText.text = app.version
       holder.secondaryText.setTextAppearance(holder.itemView.context,
           R.style.Aptoide_TextView_Medium_XS_Grey)

--- a/app/src/main/java/cm/aptoide/pt/home/apps/list/models/UpdateCardModel.kt
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/list/models/UpdateCardModel.kt
@@ -123,8 +123,10 @@ abstract class UpdateCardModel : EpoxyModelWithHolder<UpdateCardModel.CardHolder
       holder.secondaryText.setTextAppearance(holder.itemView.context,
           R.style.Aptoide_TextView_Medium_XS_Red700)
     } else {
-      holder.secondaryIcon.setImageResource(
-          themeManager!!.getAttributeForTheme(R.attr.version_refresh_icon).resourceId)
+      themeManager?.getAttributeForTheme(R.attr.version_refresh_icon)?.resourceId?.let {
+        holder.secondaryIcon.setImageResource(
+            it)
+      }
       holder.secondaryText.text = app.version
       holder.secondaryText.setTextAppearance(holder.itemView.context,
           R.style.Aptoide_TextView_Medium_XS_Grey)

--- a/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
@@ -376,8 +376,8 @@ public class SettingsFragment extends PreferenceFragmentCompat
         getFormattedDensity(AptoideUtils.ScreenU.getDensityDpi(getActivity().getWindowManager()));
 
     hwSpecs.setOnPreferenceClickListener(preference -> {
-      AlertDialog.Builder alertDialogBuilder =
-          new AlertDialog.Builder(context, R.style.AlertDialogAptoide);
+      AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(context,
+          themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId);
       alertDialogBuilder.setTitle(getString(R.string.setting_hwspecstitle));
       alertDialogBuilder.setIcon(android.R.drawable.ic_menu_info_details)
           .setMessage(getString(R.string.setting_sdk_version)

--- a/app/src/main/res/drawable/ic_refresh_action_white.xml
+++ b/app/src/main/res/drawable/ic_refresh_action_white.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:autoMirrored="true"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0"
+    android:width="24dp">
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>

--- a/app/src/main/res/layout/apps_header_item.xml
+++ b/app/src/main/res/layout/apps_header_item.xml
@@ -9,7 +9,7 @@
       android:id="@+id/apps_header_title"
       style="@style/Aptoide.TextView.Regular.L.BlackAlpha"
       android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
+      android:layout_height="wrap_content"
       android:layout_alignParentStart="true"
       android:layout_alignParentLeft="true"
       android:layout_centerVertical="true"

--- a/app/src/main/res/layout/apps_update_app_item.xml
+++ b/app/src/main/res/layout/apps_update_app_item.xml
@@ -31,7 +31,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:background="@mipmap/ic_launcher"
+        tools:background="@drawable/ad_icon"
         />
 
     <TextView
@@ -58,7 +58,7 @@
         android:layout_height="12dp"
         android:layout_marginEnd="4dp"
         android:layout_marginRight="4dp"
-        android:src="@drawable/ic_refresh_orange"
+        android:src="?attr/version_refresh_icon"
         android:visibility="visible"
         app:layout_constraintBottom_toBottomOf="@+id/apps_secondary_text"
         app:layout_constraintEnd_toStartOf="@id/apps_secondary_text"
@@ -114,7 +114,7 @@
         android:contentDescription="@null"
         android:padding="12dp"
         android:scaleType="center"
-        android:src="@drawable/ic_refresh_action_black"
+        android:src="?attr/icUpdateDrawable"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -75,6 +75,7 @@
   <attr name="icTimelineDrawable" format="reference" />
   <attr name="icUninstallDrawable" format="reference" />
   <attr name="icUpdateDrawable" format="reference" />
+  <attr name="version_refresh_icon" format="reference" />
   <attr name="icViewMoreComments" format="reference" />
   <attr name="icWebSiteDrawable" format="reference" />
   <attr name="icAppviewsPencil" format="reference" />
@@ -141,6 +142,8 @@
   <attr name="download_progress_resume" format="reference" />
   <attr name="download_progress_pause" format="reference" />
   <attr name="download_progress_cancel" format="reference" />
+  <attr name="resume_to_pause" format="reference" />
+  <attr name="pause_to_resume" format="reference" />
 
   <!--New styles attributes-->
   <attr name="raisedButtonBackground" format="reference" />

--- a/app/src/main/res/values/styles_aptoide_text_view.xml
+++ b/app/src/main/res/values/styles_aptoide_text_view.xml
@@ -368,7 +368,7 @@
   </style>
 
   <style name="Aptoide.TextView.Medium.XS.Theme">
-    <item name="android:textColor">?attr/colorPrimary</item>
+    <item name="android:textColor">?attr/colorPrimaryDark</item>
   </style>
 
   <style name="Aptoide.TextView.Medium.XXS.Theme">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -89,6 +89,8 @@
     <item name="download_progress_resume">@drawable/ic_play_arrow_action_black</item>
     <item name="download_progress_pause">@drawable/ic_pause_action_black</item>
     <item name="download_progress_cancel">@drawable/ic_clear_action_black</item>
+    <item name="resume_to_pause">@drawable/ic_resume_to_pause</item>
+    <item name="pause_to_resume">@drawable/ic_pause_to_resume</item>
 
     <!--account-->
     <item name="login_button_style">@style/Aptoide.Button</item>
@@ -178,7 +180,8 @@
     <item name="icCancelDrawable">@drawable/cross</item>
     <item name="icPlayDrawable">@drawable/media_play</item>
     <item name="icUninstallDrawable">@drawable/ic_action_discard</item>
-    <item name="icUpdateDrawable">@drawable/ic_action_update</item>
+    <item name="icUpdateDrawable">@drawable/ic_refresh_action_black</item>
+    <item name="version_refresh_icon">@drawable/ic_refresh_orange</item>
     <item name="icAboutDrawable">@drawable/ic_action_about</item>
     <item name="icDownloadsDrawable">@drawable/ic_action_download</item>
     <item name="icLikeDrawable">@drawable/thumbs_up_grey</item>
@@ -305,6 +308,8 @@
     <item name="download_progress_resume">@drawable/ic_play_arrow_action_light</item>
     <item name="download_progress_pause">@drawable/ic_pause_action_light</item>
     <item name="download_progress_cancel">@drawable/ic_clear_action_light</item>
+    <item name="resume_to_pause">@drawable/ic_resume_to_pause_white</item>
+    <item name="pause_to_resume">@drawable/ic_pause_to_resume_white</item>
 
     <!--account-->
     <item name="login_button_style">@style/Aptoide.Button</item>
@@ -394,7 +399,8 @@
     <item name="icCancelDrawable">@drawable/ic_action_cancel_dark</item>
     <item name="icPlayDrawable">@drawable/ic_action_play</item>
     <item name="icUninstallDrawable">@drawable/ic_action_discard</item>
-    <item name="icUpdateDrawable">@drawable/ic_action_update</item>
+    <item name="icUpdateDrawable">@drawable/ic_refresh_action_white</item>
+    <item name="version_refresh_icon">@drawable/ic_refresh_action_white</item>
     <item name="icAboutDrawable">@drawable/ic_action_about</item>
     <item name="icDownloadsDrawable">@drawable/ic_action_download</item>
     <item name="icLikeDrawable">@drawable/thumbs_up_grey</item>

--- a/aptoide-views/src/main/res/drawable/ic_pause_to_resume_white.xml
+++ b/aptoide-views/src/main/res/drawable/ic_pause_to_resume_white.xml
@@ -1,0 +1,43 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+  <aapt:attr name="android:drawable">
+    <vector
+        android:name="vector"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24"
+        android:viewportHeight="24">
+      <group
+          android:name="group"
+          android:pivotX="12"
+          android:pivotY="12">
+        <path
+            android:name="path"
+            android:fillColor="#FFFFFF"
+            android:pathData="M 8 12.028 L 19 12 L 19 12 L 19 12 L 8 19 L 8 12.028 M 8 5 L 8 5 L 8 12.028 L 19 12 L 19 12 L 8 5" />
+      </group>
+    </vector>
+  </aapt:attr>
+  <target android:name="path">
+    <aapt:attr name="android:animation">
+      <objectAnimator
+          android:duration="500"
+          android:interpolator="@android:interpolator/fast_out_slow_in"
+          android:propertyName="pathData"
+          android:valueFrom="M 5 14 L 19 14 L 19 14 L 19 18 L 5 18 L 5 14 M 5 6 L 5 6 L 5 10 L 19 10 L 19 6 L 5 6"
+          android:valueTo="M 8 12.028 L 19 12 L 19 12 L 19 12 L 8 19 L 8 12.028 M 8 5 L 8 5 L 8 12.028 L 19 12 L 19 12 L 8 5"
+          android:valueType="pathType" />
+    </aapt:attr>
+  </target>
+  <target android:name="group">
+    <aapt:attr name="android:animation">
+      <objectAnimator
+          android:duration="500"
+          android:interpolator="@android:interpolator/fast_out_slow_in"
+          android:propertyName="rotation"
+          android:valueFrom="90"
+          android:valueTo="0"
+          android:valueType="floatType" />
+    </aapt:attr>
+  </target>
+</animated-vector>

--- a/aptoide-views/src/main/res/drawable/ic_resume_to_pause_white.xml
+++ b/aptoide-views/src/main/res/drawable/ic_resume_to_pause_white.xml
@@ -1,0 +1,43 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+  <aapt:attr name="android:drawable">
+    <vector
+        android:name="vector"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24"
+        android:viewportHeight="24">
+      <group
+          android:name="group"
+          android:pivotX="12"
+          android:pivotY="12">
+        <path
+            android:name="path"
+            android:fillColor="#FFFFFF"
+            android:pathData="M 14 19 L 14 5 L 14 5 L 18 5 L 18 19 L 14 19 L 6 19 L 10 19 L 10 5 L 6 5 L 6 19 Z" />
+      </group>
+    </vector>
+  </aapt:attr>
+  <target android:name="path">
+    <aapt:attr name="android:animation">
+      <objectAnimator
+          android:duration="500"
+          android:interpolator="@android:interpolator/fast_out_slow_in"
+          android:propertyName="pathData"
+          android:valueFrom="M 8 12.028 L 19 12 L 19 12 L 19 12 L 8 19 L 8 12.028 M 8 5 L 8 5 L 8 12.028 L 19 12 L 19 12 L 8 5"
+          android:valueTo="M 5 14 L 19 14 L 19 14 L 19 18 L 5 18 L 5 14 M 5 6 L 5 6 L 5 10 L 19 10 L 19 6 L 5 6"
+          android:valueType="pathType" />
+    </aapt:attr>
+  </target>
+  <target android:name="group">
+    <aapt:attr name="android:animation">
+      <objectAnimator
+          android:duration="500"
+          android:interpolator="@android:interpolator/fast_out_slow_in"
+          android:propertyName="rotation"
+          android:valueFrom="0"
+          android:valueTo="90"
+          android:valueType="floatType" />
+    </aapt:attr>
+  </target>
+</animated-vector>

--- a/aptoide-views/src/main/res/layout/download_progress_view.xml
+++ b/aptoide-views/src/main/res/layout/download_progress_view.xml
@@ -84,8 +84,8 @@
         android:padding="12dp"
         android:scaleType="fitCenter"
         android:visibility="gone"
-        app:animation="@drawable/ic_resume_to_pause"
-        app:reverseAnimation="@drawable/ic_pause_to_resume"
+        app:animation="?attr/resume_to_pause"
+        app:reverseAnimation="?attr/pause_to_resume"
         tools:visibility="visible"
         />
 
@@ -103,7 +103,7 @@
       app:layout_constraintEnd_toStartOf="@+id/frameLayout"
       app:layout_constraintStart_toEndOf="@+id/progressBar"
       app:layout_constraintTop_toTopOf="parent"
-      app:srcCompat="@drawable/ic_clear_action_black"
+      app:srcCompat="?attr/download_progress_cancel"
       tools:visibility="visible"
       />
 


### PR DESCRIPTION
**What does this PR do?**

   Fixes icons and Update all text color to support dark theme in Apps.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppsFragment.java

**How should this be manually tested?**

  Test Apps (download controls) in both light & dark theme.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-125](https://aptoide.atlassian.net/browse/MOB-125)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass