### PR TITLE
[Feature/MOB-118] Support dark-theme in home category chips

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/HomeContainerFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeContainerFragment.java
@@ -93,7 +93,8 @@ public class HomeContainerFragment extends NavigationTrackFragment implements Ho
   }
 
   private void showChipCancelButton(CheckBox chip) {
-    Drawable cancelButton = getResources().getDrawable(R.drawable.ic_cancel_white_24dp);
+    Drawable cancelButton = getResources().getDrawable(
+        themeManager.getAttributeForTheme(R.attr.cancelChipDrawable).resourceId);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
       chip.setCompoundDrawablesRelativeWithIntrinsicBounds(null, null, cancelButton, null);
     } else {
@@ -112,21 +113,16 @@ public class HomeContainerFragment extends NavigationTrackFragment implements Ho
   private void setupChipsListeners() {
     gamesChip.setOnCheckedChangeListener((__, isChecked) -> {
       if (isChecked) {
-        gamesChip.setTextColor(getResources().getColor(R.color.white));
         showChipCancelButton(gamesChip);
       } else {
-        gamesChip.setTextColor(
-            themeManager.getAttributeForTheme(R.attr.colorControlHighlight).data);
         hideChipCancelButton(gamesChip);
       }
     });
 
     appsChip.setOnCheckedChangeListener((__, isChecked) -> {
       if (isChecked) {
-        appsChip.setTextColor(getResources().getColor(R.color.white));
         showChipCancelButton(appsChip);
       } else {
-        appsChip.setTextColor(themeManager.getAttributeForTheme(R.attr.colorControlHighlight).data);
         hideChipCancelButton(appsChip);
       }
     });

--- a/app/src/main/res/drawable/default_home_chips_background_white.xml
+++ b/app/src/main/res/drawable/default_home_chips_background_white.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:exitFadeDuration="@android:integer/config_shortAnimTime">
+  <item
+      android:state_checked="true">
+    <shape android:shape="rectangle">
+      <corners android:radius="35dp"/>
+      <solid
+          android:color="@color/white"/>
+    </shape>
+  </item>
+
+  <item
+      android:state_checked="false">
+    <shape android:shape="rectangle">
+      <corners
+          android:radius="35dp"/>
+      <stroke
+          android:color="@color/grey_700"
+          android:width="1dip"/>
+      <gradient
+          android:endColor="?attr/backgroundMain"
+          android:startColor="?attr/backgroundMain"/>
+    </shape>
+  </item>
+</selector>

--- a/app/src/main/res/drawable/default_home_chips_text_color.xml
+++ b/app/src/main/res/drawable/default_home_chips_text_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:color="#FFFFFF" android:state_checked="true" />
+  <item android:color="?attr/colorPrimaryDark" />
+</selector>

--- a/app/src/main/res/drawable/default_home_chips_text_color_dark_theme.xml
+++ b/app/src/main/res/drawable/default_home_chips_text_color_dark_theme.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:color="#000000" android:state_checked="true" />
+  <item android:color="#FFFFFF" />
+</selector>

--- a/app/src/main/res/drawable/ic_cancel_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_cancel_black_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="18dp"
+    android:tint="#000000"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0"
+    android:width="18dp">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
+</vector>

--- a/app/src/main/res/layout/home_action_bar_chips.xml
+++ b/app/src/main/res/layout/home_action_bar_chips.xml
@@ -7,7 +7,7 @@
     android:fitsSystemWindows="true"
     >
 
-  <androidx.cardview.widget.CardView
+  <FrameLayout
       android:id="@+id/chips_element"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
@@ -15,5 +15,5 @@
       >
 
     <include layout="@layout/view_home_chips" />
-  </androidx.cardview.widget.CardView>
+  </FrameLayout>
 </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/view_home_chips.xml
+++ b/app/src/main/res/layout/view_home_chips.xml
@@ -28,7 +28,7 @@
       android:paddingRight="10dp"
       android:text="@string/home_chip_games"
       android:textAllCaps="true"
-      android:textColor="?attr/colorPrimaryDark"
+      android:textColor="?attr/homeChipsTextColorSelector"
       />
   <CheckBox
       android:id="@+id/apps_chip"
@@ -49,7 +49,7 @@
       android:paddingRight="10dp"
       android:text="@string/home_chip_apps"
       android:textAllCaps="true"
-      android:textColor="?attr/colorPrimaryDark"
+      android:textColor="?attr/homeChipsTextColorSelector"
       />
 
 

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -83,6 +83,8 @@
   <attr name="thumbsDownDrawable" format="reference" />
   <attr name="loggedInIcon" format="reference" />
   <attr name="homeChips" format="reference" />
+  <attr name="homeChipsTextColorSelector" format="reference" />
+  <attr name="cancelChipDrawable" format="reference" />
   <attr name="ratingDrawable" format="reference" />
   <attr name="reactionInputDrawable" format="reference" />
   <attr name="navigationDrawerColor" format="color" />
@@ -159,6 +161,7 @@
   <attr name="preferenceTitleTextSize" format="dimension" />
   <attr name="preferenceSummaryColor" format="color" />
   <attr name="preferenceSummaryTextSize" format="dimension" />
+  <attr name="preferenceTheme" format="reference" />
   <attr name="colorControlHighlight" format="color" />
   <attr name="bnItemColorState" format="color" />
   <attr name="wizardFirstColor" format="color" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -204,6 +204,8 @@
     <item name="android:alertDialogTheme">@style/AlertDialogAptoide</item>
     <item name="loggedInIcon">@drawable/default_ic_logged_in</item>
     <item name="homeChips">@drawable/default_home_chips_background</item>
+    <item name="homeChipsTextColorSelector">@drawable/default_home_chips_text_color</item>
+    <item name="cancelChipDrawable">@drawable/ic_cancel_white_24dp</item>
     <item name="ratingDrawable">@drawable/ic_star_black</item>
     <item name="reactionInputDrawable">@drawable/ic_reaction_emoticon_black</item>
     <item name="ratingBarDrawable">@drawable/dark_progress_bar</item>
@@ -419,7 +421,9 @@
     <item name="icAppviewsPencil">@drawable/ic_edit_black_24dp</item>
     <item name="android:alertDialogTheme">@style/AlertDialogAptoide</item>
     <item name="loggedInIcon">@drawable/default_ic_logged_in</item>
-    <item name="homeChips">@drawable/default_home_chips_background</item>
+    <item name="homeChips">@drawable/default_home_chips_background_white</item>
+    <item name="homeChipsTextColorSelector">@drawable/default_home_chips_text_color_dark_theme</item>
+    <item name="cancelChipDrawable">@drawable/ic_cancel_black_24dp</item>
     <item name="ratingDrawable">@drawable/ic_star_white</item>
     <item name="reactionInputDrawable">@drawable/ic_reaction_emoticon_white</item>
     <item name="ratingBarDrawable">@drawable/light_progress_bar</item>


### PR DESCRIPTION
**What does this PR do?**

   Home Category filter chips now support dark theme.
   Two attrs created, one for the chips background, one for the textcolor, which is orange and white for light theme and white & black for the dark theme, this was achieved with a selector xml.
   Also has a fix for the bug that was showing up 1px dots in the chips layout corners. In light theme this would not be noticeable since its white on white but in dark theme, orange dots would show up. this was achieved by removing the unnecessary card view layout for the chips background. We wanted the cardview because of the elevation, but the app bar layout already gives the behaviour and elevation that we want.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] HomeContainerFragment.java

**How should this be manually tested?**

  Test in both light & dark theme:
  selected and unselected chips, also scroll behaviour.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-118](https://aptoide.atlassian.net/browse/MOB-118)


**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass