### PR TITLE
[feature/MOB-152] Badge Dialog Dark Theme

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/account/view/store/ManageStoreFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/store/ManageStoreFragment.java
@@ -22,6 +22,7 @@ import androidx.annotation.StringRes;
 import androidx.annotation.StyleRes;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -125,13 +126,14 @@ public class ManageStoreFragment extends BackButtonFragment
     getFragmentComponent(savedInstanceState).inject(this);
     currentModel = Parcels.unwrap(getArguments().getParcelable(EXTRA_STORE_MODEL));
     goToHome = getArguments().getBoolean(EXTRA_GO_TO_HOME, true);
-    dialogFragment =
-        new ImagePickerDialog.Builder(getContext()).setViewRes(ImagePickerDialog.LAYOUT)
-            .setTitle(R.string.upload_dialog_title)
-            .setNegativeButton(R.string.cancel)
-            .setCameraButton(R.id.button_camera)
-            .setGalleryButton(R.id.button_gallery)
-            .build();
+    dialogFragment = new ImagePickerDialog.Builder(new ContextThemeWrapper(getContext(),
+        themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId)).setViewRes(
+        ImagePickerDialog.LAYOUT)
+        .setTitle(R.string.upload_dialog_title)
+        .setNegativeButton(R.string.cancel)
+        .setCameraButton(R.id.button_camera)
+        .setGalleryButton(R.id.button_gallery)
+        .build();
 
     imagePickerErrorHandler = new ImagePickerErrorHandler(getContext());
   }

--- a/app/src/main/java/cm/aptoide/pt/account/view/user/ManageUserFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/user/ManageUserFragment.java
@@ -18,6 +18,7 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.appcompat.widget.Toolbar;
 import cm.aptoide.analytics.implementation.navigation.ScreenTagHistory;
 import cm.aptoide.pt.R;
@@ -111,13 +112,14 @@ public class ManageUserFragment extends BackButtonFragment
     isEditProfile = args != null && args.getBoolean(EXTRA_IS_EDIT, false);
     imagePickerErrorHandler = new ImagePickerErrorHandler(context);
 
-    dialogFragment =
-        new ImagePickerDialog.Builder(getContext()).setViewRes(ImagePickerDialog.LAYOUT)
-            .setTitle(R.string.upload_dialog_title)
-            .setNegativeButton(R.string.cancel)
-            .setCameraButton(R.id.button_camera)
-            .setGalleryButton(R.id.button_gallery)
-            .build();
+    dialogFragment = new ImagePickerDialog.Builder(new ContextThemeWrapper(getContext(),
+        themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId)).setViewRes(
+        ImagePickerDialog.LAYOUT)
+        .setTitle(R.string.upload_dialog_title)
+        .setNegativeButton(R.string.cancel)
+        .setCameraButton(R.id.button_camera)
+        .setGalleryButton(R.id.button_gallery)
+        .build();
 
     uploadWaitDialog = GenericDialogs.createGenericPleaseWaitDialog(context,
         themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId,

--- a/app/src/main/java/cm/aptoide/pt/store/view/BadgeDialogFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/BadgeDialogFactory.java
@@ -9,25 +9,30 @@ import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
+import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.annotation.ColorRes;
 import cm.aptoide.pt.R;
+import cm.aptoide.pt.themes.ThemeManager;
 
 public class BadgeDialogFactory {
   public static final float MEDAL_SCALE = 1.25f;
   private final Context context;
+  private final ThemeManager themeManager;
   private int normalMedalSize;
   private int selectedMedalSize;
 
-  public BadgeDialogFactory(Context context) {
+  public BadgeDialogFactory(Context context, ThemeManager themeManager) {
     this.context = context;
+    this.themeManager = themeManager;
   }
 
   public Dialog create(GridStoreMetaWidget.HomeMeta.Badge badge, boolean storeOwner) {
-    View view = LayoutInflater.from(context)
+    View view = LayoutInflater.from(new ContextThemeWrapper(context,
+        themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId))
         .inflate(R.layout.store_badge_dialog, null);
     ImageView bronzeMedal = ((ImageView) view.findViewById(R.id.bronze_medal));
     normalMedalSize = bronzeMedal.getLayoutParams().width;
@@ -302,7 +307,8 @@ public class BadgeDialogFactory {
       GridStoreMetaWidget.HomeMeta.Badge storeBadge,
       GridStoreMetaWidget.HomeMeta.Badge selectedBadge,
       GridStoreMetaWidget.HomeMeta.Badge currentSetup) {
-    int tinBadgeColor = R.color.progress_bar_color;
+    int tinBadgeColor =
+        themeManager.getAttributeForTheme(R.attr.storeBadgeDialogProgress).resourceId;
     if (currentSetup.ordinal() <= storeBadge.ordinal()
         && currentSetup.ordinal() <= selectedBadge.ordinal()) {
       tinBadgeColor = mainColor;

--- a/app/src/main/java/cm/aptoide/pt/store/view/StoreTabWidgetsGridRecyclerFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/StoreTabWidgetsGridRecyclerFragment.java
@@ -94,7 +94,7 @@ public abstract class StoreTabWidgetsGridRecyclerFragment extends StoreTabGridRe
               storeContext, getContext(), accountManager, storeUtilsProxy,
               (WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE),
               getContext().getResources(), installedRepository, storeAnalytics, storeTabNavigator,
-              navigationTracker, new BadgeDialogFactory(getContext()),
+              navigationTracker, new BadgeDialogFactory(getActivity(), themeManager),
               ((ActivityResultNavigator) getContext()).getFragmentNavigator(),
               AccessorFactory.getAccessorFor(application.getDatabase(), Store.class),
               application.getBodyInterceptorPoolV7(), application.getDefaultClient(),

--- a/app/src/main/res/drawable/ic_edit_white_9dp.xml
+++ b/app/src/main/res/drawable/ic_edit_white_9dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="9dp"
+    android:height="9dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+  <path
+      android:fillColor="#999999"
+      android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z" />
+</vector>

--- a/app/src/main/res/layout/badge_progress_layout.xml
+++ b/app/src/main/res/layout/badge_progress_layout.xml
@@ -8,7 +8,7 @@
       android:id="@+id/progress1"
       android:layout_width="0dp"
       android:layout_height="8dp"
-      android:background="@color/progress_bar_color"
+      android:background="?attr/storeBadgeDialogProgress"
       app:layout_constraintBottom_toBottomOf="@+id/tin_medal_layout"
       app:layout_constraintEnd_toStartOf="@+id/bronze_dummy_view"
       app:layout_constraintLeft_toRightOf="@+id/tin_dummy_view"
@@ -22,6 +22,7 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginTop="36dp"
+      android:background="@color/transparent"
       android:padding="10dp"
       app:layout_constraintEnd_toStartOf="@+id/bronze_medal_layout"
       app:layout_constraintLeft_toLeftOf="parent"
@@ -33,6 +34,7 @@
         android:id="@+id/tin_medal"
         android:layout_width="24dp"
         android:layout_height="wrap_content"
+        android:background="@color/transparent"
         android:src="@drawable/ic_tin_flat_icon"
         />
   </FrameLayout>
@@ -54,7 +56,7 @@
       android:id="@+id/progress2"
       android:layout_width="0dp"
       android:layout_height="8dp"
-      android:background="@color/progress_bar_color"
+      android:background="?attr/storeBadgeDialogProgress"
       app:layout_constraintBottom_toBottomOf="@id/bronze_medal_layout"
       app:layout_constraintEnd_toStartOf="@+id/silver_dummy_view"
       app:layout_constraintLeft_toRightOf="@+id/bronze_dummy_view"
@@ -69,6 +71,7 @@
       android:id="@+id/bronze_medal_layout"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:background="@color/transparent"
       android:padding="10dp"
       app:layout_constraintBottom_toBottomOf="@id/tin_medal_layout"
       app:layout_constraintEnd_toStartOf="@+id/silver_medal_layout"
@@ -81,6 +84,7 @@
         android:id="@+id/bronze_medal"
         android:layout_width="24dp"
         android:layout_height="24dp"
+        android:background="@color/transparent"
         android:src="@drawable/ic_bronze_flat_icon"
         />
   </FrameLayout>
@@ -102,7 +106,7 @@
       android:id="@+id/progress3"
       android:layout_width="0dp"
       android:layout_height="8dp"
-      android:background="@color/progress_bar_color"
+      android:background="?attr/storeBadgeDialogProgress"
       app:layout_constraintBottom_toBottomOf="@id/silver_medal_layout"
       app:layout_constraintEnd_toStartOf="@+id/gold_dummy_view"
       app:layout_constraintLeft_toRightOf="@+id/silver_dummy_view"
@@ -116,6 +120,7 @@
       android:id="@+id/silver_medal_layout"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:background="@color/transparent"
       android:padding="10dp"
       app:layout_constraintBottom_toBottomOf="@id/tin_medal_layout"
       app:layout_constraintEnd_toStartOf="@+id/gold_medal_layout"
@@ -128,6 +133,7 @@
         android:id="@+id/silver_medal"
         android:layout_width="24dp"
         android:layout_height="24dp"
+        android:background="@color/transparent"
         android:src="@drawable/ic_silver_flat_icon"
         />
   </FrameLayout>
@@ -149,7 +155,7 @@
       android:id="@+id/progress4"
       android:layout_width="0dp"
       android:layout_height="8dp"
-      android:background="@color/progress_bar_color"
+      android:background="?attr/storeBadgeDialogProgress"
       app:layout_constraintBottom_toBottomOf="@id/gold_medal_layout"
       app:layout_constraintEnd_toStartOf="@+id/platinum_dummy_view"
       app:layout_constraintLeft_toRightOf="@+id/gold_dummy_view"
@@ -163,6 +169,7 @@
       android:id="@+id/gold_medal_layout"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:background="@color/transparent"
       android:padding="10dp"
       app:layout_constraintBottom_toBottomOf="@id/tin_medal_layout"
       app:layout_constraintEnd_toStartOf="@+id/platinum_medal_layout"
@@ -175,6 +182,7 @@
         android:id="@+id/gold_medal"
         android:layout_width="24dp"
         android:layout_height="24dp"
+        android:background="@color/transparent"
         android:src="@drawable/ic_gold_flat_icon"
         />
   </FrameLayout>
@@ -196,6 +204,7 @@
       android:id="@+id/platinum_medal_layout"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:background="@color/transparent"
       android:padding="10dp"
       app:layout_constraintBottom_toBottomOf="@id/tin_medal_layout"
       app:layout_constraintEnd_toEndOf="parent"
@@ -208,6 +217,7 @@
         android:id="@+id/platinum_medal"
         android:layout_width="24dp"
         android:layout_height="24dp"
+        android:background="@color/transparent"
         android:src="@drawable/ic_platinum_flat_icon"
         />
   </FrameLayout>

--- a/app/src/main/res/layout/displayable_store_meta.xml
+++ b/app/src/main/res/layout/displayable_store_meta.xml
@@ -4,9 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?attr/backgroundCardColor"
     android:orientation="vertical"
     android:padding="16dp"
-    android:background="?attr/backgroundCardColor"
     >
 
   <ImageView
@@ -29,27 +29,27 @@
       />
   <TextView
       android:id="@+id/main_name"
+      style="@style/Aptoide.TextView.Medium.M"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_marginLeft="20dp"
       android:layout_marginStart="20dp"
+      android:layout_marginLeft="20dp"
       app:layout_constraintLeft_toRightOf="@+id/main_icon"
       app:layout_constraintStart_toEndOf="@id/main_icon"
       app:layout_constraintTop_toTopOf="@+id/main_icon"
       tools:text="TextView"
-      style="@style/Aptoide.TextView.Medium.M"
       />
   <TextView
       android:id="@+id/secondary_name"
+      style="@style/Aptoide.TextView.Regular.XS"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_marginLeft="20dp"
       android:layout_marginStart="20dp"
+      android:layout_marginLeft="20dp"
       app:layout_constraintLeft_toRightOf="@+id/main_icon"
       app:layout_constraintStart_toEndOf="@id/main_icon"
       app:layout_constraintTop_toBottomOf="@+id/main_name"
       tools:text="TextView"
-      style="@style/Aptoide.TextView.Regular.XS"
       />
   <FrameLayout
       android:id="@+id/action_button_layout"
@@ -65,25 +65,25 @@
 
     <TextView
         android:id="@+id/edit_store_button"
+        style="text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:drawableLeft="@drawable/ic_edit_black_9dp"
+        android:drawableLeft="?attr/storeEditStoreDrawable"
         android:gravity="center"
-        android:minHeight="24dp"
         android:minWidth="54dp"
-        android:paddingLeft="8dp"
+        android:minHeight="24dp"
         android:paddingStart="8dp"
+        android:paddingLeft="8dp"
         android:text="@string/myaccount_edit_store_button"
         android:textAllCaps="true"
         android:textSize="10sp"
         android:visibility="gone"
-        style="text"
         />
 
     <Button
         android:id="@+id/follow_store_button"
-        android:text="@string/unfollow"
         style="@style/Aptoide.Button.S"
+        android:text="@string/unfollow"
         />
 
   </FrameLayout>
@@ -91,8 +91,8 @@
       android:id="@+id/medal_icon"
       android:layout_width="40dp"
       android:layout_height="40dp"
-      android:layout_marginBottom="8dp"
       android:layout_marginTop="8dp"
+      android:layout_marginBottom="8dp"
       android:padding="8dp"
       app:layout_constraintBottom_toBottomOf="@+id/action_button_layout"
       app:layout_constraintEnd_toStartOf="@id/action_button_layout"
@@ -172,7 +172,7 @@
       app:layout_constraintStart_toEndOf="@+id/apps_text_view"
       app:layout_constraintTop_toBottomOf="@+id/social_separator_container"
       tools:layout_editor_absoluteX="127dp"
-    tools:text="17"
+      tools:text="17"
       />
   <TextView
       android:id="@+id/followers_text_view"
@@ -189,7 +189,7 @@
       app:layout_constraintRight_toRightOf="parent"
       app:layout_constraintStart_toEndOf="@id/following_text_view"
       app:layout_constraintTop_toBottomOf="@+id/social_separator_container"
-    tools:text="100"
+      tools:text="100"
       />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/store_badge_dialog.xml
+++ b/app/src/main/res/layout/store_badge_dialog.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/white"
     android:orientation="vertical"
     >
 
@@ -32,12 +31,14 @@
         android:id="@+id/medal_icon"
         android:layout_width="98dp"
         android:layout_height="98dp"
+        android:background="@color/transparent"
         app:layout_constraintBottom_toBottomOf="@+id/dummy_header"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/dummy_header"
+        tools:background="@drawable/tin_medal_gradient"
         />
     <View
         android:id="@+id/dummy_header"
@@ -49,6 +50,7 @@
 
     <TextView
         android:id="@+id/medal_title"
+        style="@style/Aptoide.TextView.Medium.L"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
@@ -59,18 +61,17 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/medal_icon"
         tools:text="Gold medal"
-        style="@style/Aptoide.TextView.Medium.L"
         />
 
     <TextView
         android:id="@+id/congratulations_message"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginRight="16dp"
         android:layout_marginStart="16dp"
+        android:layout_marginLeft="16dp"
         android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
         android:gravity="center_horizontal"
         android:lines="3"
         android:maxLines="3"
@@ -91,7 +92,7 @@
     <View
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:background="@color/grey_fog_light"
+        android:background="?attr/storeBadgeDialogTextBackground"
         app:layout_constraintBottom_toBottomOf="@+id/uploaded_apps"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
@@ -102,12 +103,14 @@
 
     <TextView
         android:id="@+id/uploaded_apps"
+        style="@style/Aptoide.TextView.Medium.S"
         android:layout_width="wrap_content"
         android:layout_height="32dp"
         android:layout_marginTop="34dp"
+        android:background="@color/transparent"
+        android:drawableStart="@drawable/check"
         android:drawableLeft="@drawable/check"
         android:drawablePadding="16dp"
-        android:drawableStart="@drawable/check"
         android:gravity="center_vertical"
         app:layout_constraintLeft_toRightOf="@id/tin_medal_layout"
         app:layout_constraintStart_toEndOf="@id/tin_medal_layout"
@@ -115,28 +118,28 @@
         app:layout_goneMarginLeft="48dp"
         app:layout_goneMarginStart="48dp"
         tools:text="800 Apps"
-        style="@style/Aptoide.TextView.Medium.S"
         />
     <TextView
         android:id="@+id/downloads"
+        style="@style/Aptoide.TextView.Medium.S"
         android:layout_width="wrap_content"
         android:layout_height="32dp"
+        android:background="@color/transparent"
+        android:drawableStart="@drawable/check"
         android:drawableLeft="@drawable/check"
         android:drawablePadding="16dp"
-        android:drawableStart="@drawable/check"
         android:gravity="center_vertical"
         app:layout_constraintLeft_toLeftOf="@id/uploaded_apps"
         app:layout_constraintStart_toStartOf="@id/uploaded_apps"
         app:layout_constraintTop_toBottomOf="@id/uploaded_apps"
         tools:text="100000 Downloads"
-        style="@style/Aptoide.TextView.Medium.S"
         />
 
     <View
         android:id="@+id/followers_background"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:background="@color/grey_fog_light"
+        android:background="?attr/storeBadgeDialogTextBackground"
         app:layout_constraintBottom_toBottomOf="@+id/followers"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
@@ -147,44 +150,47 @@
 
     <TextView
         android:id="@+id/followers"
+        style="@style/Aptoide.TextView.Medium.S"
         android:layout_width="wrap_content"
         android:layout_height="32dp"
+        android:background="@color/transparent"
+        android:drawableStart="@drawable/check"
         android:drawableLeft="@drawable/check"
         android:drawablePadding="16dp"
-        android:drawableStart="@drawable/check"
         android:gravity="center_vertical"
         app:layout_constraintLeft_toLeftOf="@id/uploaded_apps"
         app:layout_constraintStart_toStartOf="@id/uploaded_apps"
         app:layout_constraintTop_toBottomOf="@id/downloads"
         tools:text="800 Apps"
-        style="@style/Aptoide.TextView.Medium.S"
         />
 
     <TextView
         android:id="@+id/reviews"
+        style="@style/Aptoide.TextView.Medium.S"
         android:layout_width="wrap_content"
         android:layout_height="32dp"
+        android:background="@color/transparent"
+        android:drawableStart="@drawable/check"
         android:drawableLeft="@drawable/check"
         android:drawablePadding="16dp"
-        android:drawableStart="@drawable/check"
         android:gravity="center_vertical"
         app:layout_constraintLeft_toLeftOf="@id/uploaded_apps"
         app:layout_constraintStart_toStartOf="@id/uploaded_apps"
         app:layout_constraintTop_toBottomOf="@id/followers"
         tools:text="7500 Reviews"
-        style="@style/Aptoide.TextView.Medium.S"
         />
     <TextView
         android:id="@+id/ok_button"
+        style="@style/Aptoide.TextView.Medium.S"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="24dp"
+        android:layout_marginTop="28dp"
         android:layout_marginEnd="32dp"
         android:layout_marginRight="32dp"
-        android:layout_marginTop="28dp"
+        android:layout_marginBottom="24dp"
         android:gravity="center"
-        android:minHeight="24dp"
         android:minWidth="54dp"
+        android:minHeight="24dp"
         android:text="@string/got_it_button_text"
         android:textAllCaps="true"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -192,7 +198,6 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/reviews"
         tools:textAllCaps="true"
-        style="@style/Aptoide.TextView.Medium.S"
         />
   </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -194,6 +194,8 @@
   <attr name="roundGradientButtonBackground" format="reference" />
   <attr name="themeSelectorItemBackground" format="reference" />
   <attr name="themeTextColor" format="color|reference" />
+  <attr name="storeBadgeDialogTextBackground" format="color|reference" />
+  <attr name="storeBadgeDialogProgress" format="color|reference" />
 
   <declare-styleable name="CustomTextInputLayout">
     <attr name="helperText" format="string" />

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -196,6 +196,7 @@
   <attr name="themeTextColor" format="color|reference" />
   <attr name="storeBadgeDialogTextBackground" format="color|reference" />
   <attr name="storeBadgeDialogProgress" format="color|reference" />
+  <attr name="storeEditStoreDrawable" format="reference" />
 
   <declare-styleable name="CustomTextInputLayout">
     <attr name="helperText" format="string" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -232,6 +232,7 @@
     <item name="themeTextColor">@color/default_text</item>
     <item name="storeBadgeDialogTextBackground">@color/grey_fog_light</item>
     <item name="storeBadgeDialogProgress">@color/progress_bar_color</item>
+    <item name="storeEditStoreDrawable">@drawable/ic_edit_black_9dp</item>
   </style>
 
 
@@ -465,8 +466,7 @@
     <item name="themeTextColor">@color/white</item>
     <item name="storeBadgeDialogTextBackground">@color/grey_dark</item>
     <item name="storeBadgeDialogProgress">@color/grey_dark</item>
-
-
+    <item name="storeEditStoreDrawable">@drawable/ic_edit_white_9dp</item>
   </style>
 
   <style name="AptoideThemeDark" parent="AppBaseThemeDark" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -230,6 +230,8 @@
     <item name="roundGradientButtonBackground">@drawable/default_search_button_background</item>
     <item name="themeSelectorItemBackground">@drawable/create_store_theme_shape_default</item>
     <item name="themeTextColor">@color/default_text</item>
+    <item name="storeBadgeDialogTextBackground">@color/grey_fog_light</item>
+    <item name="storeBadgeDialogProgress">@color/progress_bar_color</item>
   </style>
 
 
@@ -441,7 +443,8 @@
     <item name="android:alertDialogTheme">@style/AlertDialogAptoide</item>
     <item name="loggedInIcon">@drawable/default_ic_logged_in</item>
     <item name="homeChips">@drawable/default_home_chips_background_white</item>
-    <item name="homeChipsTextColorSelector">@drawable/default_home_chips_text_color_dark_theme</item>
+    <item name="homeChipsTextColorSelector">@drawable/default_home_chips_text_color_dark_theme
+    </item>
     <item name="cancelChipDrawable">@drawable/ic_cancel_black_24dp</item>
     <item name="ratingDrawable">@drawable/ic_star_white</item>
     <item name="reactionInputDrawable">@drawable/ic_reaction_emoticon_white</item>
@@ -460,6 +463,10 @@
     </item>
     <item name="themeSelectorItemBackground">@drawable/create_store_theme_shape_default</item>
     <item name="themeTextColor">@color/white</item>
+    <item name="storeBadgeDialogTextBackground">@color/grey_dark</item>
+    <item name="storeBadgeDialogProgress">@color/grey_dark</item>
+
+
   </style>
 
   <style name="AptoideThemeDark" parent="AppBaseThemeDark" />


### PR DESCRIPTION
**What does this PR do?**

   This PR does 3 things: 
 - Adds dark theme support for badge dialog next to the edit store button;
 - Fixes the edit button color;
 - Edit your store -> Upload photo dialog colors fixed.

**Database changed?**

   No

**How should this be manually tested?**

  Test light/dark theme for 3 things:
 - Badge dialog next to the edit store button;
 - Edit button drawable color;
 - Edit your store -> Upload photo dialog colors.

**What are the relevant tickets?**

  [MOB-152](https://aptoide.atlassian.net/browse/MOB-152)

**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass