### PR TITLE
[MOB-22] fix: catapput developer card now navigates correctly to the web page.

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/account/view/AccountNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/AccountNavigator.java
@@ -159,13 +159,13 @@ public class AccountNavigator {
     CustomTabsHelper.getInstance()
         .openInChromeCustomTab(activityNavigator.getActivity()
                 .getString(R.string.all_url_terms_conditions), activityNavigator.getActivity(),
-            themeManager.getAttributeForTheme(R.attr.colorPrimary).data);
+            themeManager.getAttributeForTheme(R.attr.colorPrimary).resourceId);
   }
 
   public void navigateToPrivacyPolicy() {
     CustomTabsHelper.getInstance()
         .openInChromeCustomTab(activityNavigator.getActivity()
                 .getString(R.string.all_url_privacy_policy), activityNavigator.getActivity(),
-            themeManager.getAttributeForTheme(R.attr.colorPrimary).data);
+            themeManager.getAttributeForTheme(R.attr.colorPrimary).resourceId);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/HomeNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeNavigator.java
@@ -109,14 +109,14 @@ public class HomeNavigator {
     CustomTabsHelper.getInstance()
         .openInChromeCustomTab(activityNavigator.getActivity()
                 .getString(R.string.all_url_terms_conditions), activityNavigator.getActivity(),
-            themeManager.getAttributeForTheme(R.attr.colorPrimary).data);
+            themeManager.getAttributeForTheme(R.attr.colorPrimary).resourceId);
   }
 
   public void navigateToPrivacyPolicy() {
     CustomTabsHelper.getInstance()
         .openInChromeCustomTab(activityNavigator.getActivity()
                 .getString(R.string.all_url_privacy_policy), activityNavigator.getActivity(),
-            themeManager.getAttributeForTheme(R.attr.colorPrimary).data);
+            themeManager.getAttributeForTheme(R.attr.colorPrimary).resourceId);
   }
 
   public void navigateToPromotions() {

--- a/app/src/main/java/cm/aptoide/pt/navigator/ExternalNavigator.kt
+++ b/app/src/main/java/cm/aptoide/pt/navigator/ExternalNavigator.kt
@@ -10,6 +10,6 @@ open class ExternalNavigator(val context: Context, val themeManager: ThemeManage
   fun navigateToCatappultWebsite() {
     CustomTabsHelper.getInstance()
         .openInChromeCustomTab("https://catappult.io/", context, themeManager.getAttributeForTheme(
-            R.attr.colorPrimary).data)
+            R.attr.colorPrimary).resourceId)
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/view/settings/MyAccountFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/MyAccountFragment.java
@@ -267,7 +267,7 @@ public class MyAccountFragment extends BackButtonFragment
   @Override public void startAptoideTvWebView() {
     CustomTabsHelper.getInstance()
         .openInChromeCustomTab("https://blog.aptoide.com/what-is-aptoidetv/", getContext(),
-            themeManager.getAttributeForTheme(R.attr.colorPrimary).data);
+            themeManager.getAttributeForTheme(R.attr.colorPrimary).resourceId);
   }
 
   @Override public void refreshUI(Store store) {

--- a/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
@@ -325,12 +325,12 @@ public class SettingsFragment extends PreferenceFragmentCompat
       subscriptions.add(RxPreference.clicks(termsAndConditions)
           .subscribe(clicked -> CustomTabsHelper.getInstance()
               .openInChromeCustomTab(getString(R.string.all_url_terms_conditions), getContext(),
-                  themeManager.getAttributeForTheme(R.attr.colorPrimary).data)));
+                  themeManager.getAttributeForTheme(R.attr.colorPrimary).resourceId)));
 
       subscriptions.add(RxPreference.clicks(privacyPolicy)
           .subscribe(clicked -> CustomTabsHelper.getInstance()
               .openInChromeCustomTab(getString(R.string.all_url_privacy_policy), getContext(),
-                  themeManager.getAttributeForTheme(R.attr.colorPrimary).data)));
+                  themeManager.getAttributeForTheme(R.attr.colorPrimary).resourceId)));
     }
 
     findPreference(SettingsConstants.FILTER_APPS).setOnPreferenceClickListener(preference -> {
@@ -640,7 +640,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
   private void openDeleteAccountView(String accessToken) {
     CustomTabsHelper.getInstance()
         .openInChromeCustomTab(getString(R.string.settings_url_delete_account, accessToken),
-            getContext(), themeManager.getAttributeForTheme(R.attr.colorPrimary).data);
+            getContext(), themeManager.getAttributeForTheme(R.attr.colorPrimary).resourceId);
   }
 
   private void handleSocialNotifications(Boolean isChecked) {


### PR DESCRIPTION
**What does this PR do?**

   Fixes the click on developer catappult card. we were passing the color data instead of res id.
   Also fixes other custom chrome tab navigations like Terms and Conditions and Privacy Policy.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] ExternalNavigator.java

**How should this be manually tested?**

  Click on developer card in app view.

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass