### PR TITLE
[MOB-83] Double Search

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/HomeNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeNavigator.java
@@ -74,7 +74,7 @@ public class HomeNavigator {
 
     fragmentNavigator.navigateTo(StoreTabGridRecyclerFragment.newInstance(click.getBundle()
         .getEvent(), click.getType(), click.getBundle()
-        .getTitle(), "default", tag, StoreContext.home), true);
+        .getTitle(), "default", tag, StoreContext.home, true), true);
   }
 
   public void navigateToAppView(String tag, SearchAdResult searchAdResult) {

--- a/app/src/main/java/cm/aptoide/pt/store/view/StoreGridHeaderWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/StoreGridHeaderWidget.java
@@ -26,8 +26,8 @@ public class StoreGridHeaderWidget extends Widget<StoreGridHeaderDisplayable> {
   }
 
   @Override protected void assignViews(View itemView) {
-    title = (TextView) itemView.findViewById(R.id.title);
-    more = (Button) itemView.findViewById(R.id.more);
+    title = itemView.findViewById(R.id.title);
+    more = itemView.findViewById(R.id.more);
   }
 
   @Override public void bindView(StoreGridHeaderDisplayable displayable, int position) {
@@ -66,7 +66,8 @@ public class StoreGridHeaderWidget extends Widget<StoreGridHeaderDisplayable> {
                       storeContext);
             } else {
               displayable.getStoreTabNavigator()
-                  .navigateToStoreTabGridRecyclerView(event, title, storeTheme, tag, storeContext);
+                  .navigateToStoreTabGridRecyclerView(event, title, storeTheme, tag, storeContext,
+                      true);
             }
           }));
     }

--- a/app/src/main/java/cm/aptoide/pt/store/view/StorePagerAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/StorePagerAdapter.java
@@ -123,7 +123,7 @@ public class StorePagerAdapter extends FragmentStatePagerAdapter
   private Fragment caseAPI(GetStoreTabs.Tab tab, boolean addAdultFilter) {
     return AptoideApplication.getFragmentProvider()
         .newStoreTabGridRecyclerFragment(tab.getEvent(), storeTheme, tab.getTag(), storeContext,
-            addAdultFilter);
+            addAdultFilter, false);
   }
 
   private Fragment caseClient(Event event, GetStoreTabs.Tab tab) {

--- a/app/src/main/java/cm/aptoide/pt/store/view/StoreTabGridRecyclerFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/StoreTabGridRecyclerFragment.java
@@ -56,18 +56,19 @@ public abstract class StoreTabGridRecyclerFragment extends GridRecyclerSwipeFrag
   @Inject @Named("marketName") String marketName;
 
   public static Fragment newInstance(Event event, String storeTheme, String tag,
-      StoreContext storeContext) {
-    return newInstance(event, null, storeTheme, tag, storeContext);
+      StoreContext storeContext, boolean shouldShowToolbar) {
+    return newInstance(event, null, storeTheme, tag, storeContext, shouldShowToolbar);
   }
 
   public static Fragment newInstance(Event event, String title, String storeTheme, String tag,
-      StoreContext storeContext) {
-    return newInstance(event, HomeEvent.Type.NO_OP, title, storeTheme, tag, storeContext);
+      StoreContext storeContext, boolean shouldShowToolbar) {
+    return newInstance(event, HomeEvent.Type.NO_OP, title, storeTheme, tag, storeContext,
+        shouldShowToolbar);
   }
 
   public static Fragment newInstance(Event event, HomeEvent.Type type, String title,
-      String storeTheme, String tag, StoreContext storeContext) {
-    Bundle args = buildBundle(event, type, title, storeTheme, tag, storeContext);
+      String storeTheme, String tag, StoreContext storeContext, boolean shouldShowToolbar) {
+    Bundle args = buildBundle(event, type, title, storeTheme, tag, storeContext, shouldShowToolbar);
     Fragment fragment = StoreTabFragmentChooser.choose(event, type);
     Bundle arguments = fragment.getArguments();
     if (arguments != null) {
@@ -79,7 +80,7 @@ public abstract class StoreTabGridRecyclerFragment extends GridRecyclerSwipeFrag
 
   @NonNull
   protected static Bundle buildBundle(Event event, HomeEvent.Type homeEventType, String title,
-      String storeTheme, String tag, StoreContext storeContext) {
+      String storeTheme, String tag, StoreContext storeContext, boolean shouldShowToolbar) {
     Bundle args = new Bundle();
 
     if (homeEventType != null) {
@@ -112,6 +113,7 @@ public abstract class StoreTabGridRecyclerFragment extends GridRecyclerSwipeFrag
     args.putString(BundleCons.ACTION, event.getAction());
     args.putString(BundleCons.STORE_THEME, storeTheme);
     args.putString(BundleCons.TAG, tag);
+    args.putBoolean(BundleCons.TOOLBAR, shouldShowToolbar);
     return args;
   }
 

--- a/app/src/main/java/cm/aptoide/pt/store/view/StoreTabNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/StoreTabNavigator.java
@@ -20,10 +20,10 @@ public class StoreTabNavigator {
   }
 
   public void navigateToStoreTabGridRecyclerView(Event event, String title, String storeTheme,
-      String tag, StoreContext storeContext) {
+      String tag, StoreContext storeContext, boolean shouldShowToolbar) {
     fragmentNavigator.navigateTo(
-        StoreTabGridRecyclerFragment.newInstance(event, title, storeTheme, tag, storeContext),
-        true);
+        StoreTabGridRecyclerFragment.newInstance(event, title, storeTheme, tag, storeContext,
+            shouldShowToolbar), true);
   }
 
   public void navigateToCommentGridRecyclerView(CommentType commentType, String url,

--- a/app/src/main/java/cm/aptoide/pt/store/view/my/MyStoresFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/my/MyStoresFragment.java
@@ -53,7 +53,8 @@ public class MyStoresFragment extends StoreTabWidgetsGridRecyclerFragment implem
   public static MyStoresFragment newInstance(Event event, String storeTheme, String tag,
       StoreContext storeContext) {
     // TODO: 28-12-2016 neuro ia saltando um preguito com este null lolz
-    Bundle args = buildBundle(event, HomeEvent.Type.NO_OP, null, storeTheme, tag, storeContext);
+    Bundle args =
+        buildBundle(event, HomeEvent.Type.NO_OP, null, storeTheme, tag, storeContext, false);
     MyStoresFragment fragment = new MyStoresFragment();
     fragment.setArguments(args);
     return fragment;

--- a/app/src/main/java/cm/aptoide/pt/view/DeepLinkManager.java
+++ b/app/src/main/java/cm/aptoide/pt/view/DeepLinkManager.java
@@ -349,7 +349,7 @@ public class DeepLinkManager {
             .newStoreTabGridRecyclerFragment(event,
                 uri.getQueryParameter(DeepLinkIntentReceiver.DeepLinksKeys.TITLE),
                 uri.getQueryParameter(DeepLinkIntentReceiver.DeepLinksKeys.STORE_THEME),
-                defaultTheme, StoreContext.home, true), true);
+                defaultTheme, StoreContext.home, true, false), true);
       } catch (UnsupportedEncodingException | IllegalArgumentException e) {
         e.printStackTrace();
       }

--- a/app/src/main/java/cm/aptoide/pt/view/DeepLinkManager.java
+++ b/app/src/main/java/cm/aptoide/pt/view/DeepLinkManager.java
@@ -349,7 +349,7 @@ public class DeepLinkManager {
             .newStoreTabGridRecyclerFragment(event,
                 uri.getQueryParameter(DeepLinkIntentReceiver.DeepLinksKeys.TITLE),
                 uri.getQueryParameter(DeepLinkIntentReceiver.DeepLinksKeys.STORE_THEME),
-                defaultTheme, StoreContext.home, true, false), true);
+                defaultTheme, StoreContext.home, true, true), true);
       } catch (UnsupportedEncodingException | IllegalArgumentException e) {
         e.printStackTrace();
       }

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentProvider.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentProvider.java
@@ -41,17 +41,19 @@ public interface FragmentProvider {
    * @param storeContext is needed to give context to fragment ex: store downloads vs global
    * downloads
    * @param addAdultFilter When true, adds adult switch to Fragment's bottom.
+   * @param shouldShowToolbar When true adds toolbar to the fragment.
    */
   @Deprecated Fragment newStoreTabGridRecyclerFragment(Event event, String storeTheme, String tag,
-      StoreContext storeContext, boolean addAdultFilter);
+      StoreContext storeContext, boolean addAdultFilter, boolean shouldShowToolbar);
 
   /**
    * @param storeContext is needed to give context to fragment ex: store downloads vs global
    * downloads
    * @param addAdultFilter When true, adds adult switch to Fragment's bottom.
+   * @param shouldShowToolbar When true adds a toolbar to the fragment.
    */
   @Deprecated Fragment newStoreTabGridRecyclerFragment(Event event, String title, String storeTheme,
-      String tag, StoreContext storeContext, boolean addAdultFilter);
+      String tag, StoreContext storeContext, boolean addAdultFilter, boolean shouldShowToolbar);
 
   @Deprecated Fragment newSubscribedStoresFragment(Event event, String storeTheme, String tag,
       StoreContext storeName);

--- a/app/src/main/java/cm/aptoide/pt/view/configuration/implementation/VanillaFragmentProvider.java
+++ b/app/src/main/java/cm/aptoide/pt/view/configuration/implementation/VanillaFragmentProvider.java
@@ -110,14 +110,16 @@ public class VanillaFragmentProvider implements FragmentProvider {
 
   @Override
   public Fragment newStoreTabGridRecyclerFragment(Event event, String storeTheme, String tag,
-      StoreContext storeContext, boolean addAdultFilter) {
-    return StoreTabGridRecyclerFragment.newInstance(event, storeTheme, tag, storeContext);
+      StoreContext storeContext, boolean addAdultFilter, boolean shouldShowToolbar) {
+    return StoreTabGridRecyclerFragment.newInstance(event, storeTheme, tag, storeContext,
+        shouldShowToolbar);
   }
 
   @Override
   public Fragment newStoreTabGridRecyclerFragment(Event event, String title, String storeTheme,
-      String tag, StoreContext storeContext, boolean addAdultFilter) {
-    return StoreTabGridRecyclerFragment.newInstance(event, title, storeTheme, tag, storeContext);
+      String tag, StoreContext storeContext, boolean addAdultFilter, boolean shouldShowToolbar) {
+    return StoreTabGridRecyclerFragment.newInstance(event, title, storeTheme, tag, storeContext,
+        shouldShowToolbar);
   }
 
   @Override public Fragment newSubscribedStoresFragment(Event event, String storeTheme, String tag,

--- a/app/src/main/java/cm/aptoide/pt/view/recycler/widget/GridDisplayWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/view/recycler/widget/GridDisplayWidget.java
@@ -33,7 +33,7 @@ public class GridDisplayWidget extends Widget<GridDisplayDisplayable> {
   }
 
   @Override protected void assignViews(View itemView) {
-    imageView = (ImageView) itemView.findViewById(R.id.image_category);
+    imageView = itemView.findViewById(R.id.image_category);
   }
 
   @Override public void bindView(GridDisplayDisplayable displayable, int position) {
@@ -48,8 +48,8 @@ public class GridDisplayWidget extends Widget<GridDisplayDisplayable> {
       if (StoreTabFragmentChooser.validateAcceptedName(name)) {
         getFragmentNavigator().navigateTo(
             StoreTabGridRecyclerFragment.newInstance(event, pojo.getLabel(),
-                displayable.getStoreTheme(), displayable.getTag(), displayable.getStoreContext()),
-            true);
+                displayable.getStoreTheme(), displayable.getTag(), displayable.getStoreContext(),
+                false), true);
       } else {
         switch (name) {
           case facebook:


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing a bug where we had double search bars in some views of the stores. This was happening on the tabs that were listApps of type API.

**Database changed?**

 No

**Where should the reviewer start?**

- [x] StoreTabGridRecyclerFragment.java

**How should this be manually tested?**

Open the several grid views in Aptoide. In Home, in stores, navigate through it and check if everything is ok with the toolbars.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-83](https://aptoide.atlassian.net/browse/MOB-83)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass