### PR TITLE
[MOB-22] feature: Support dark-theme in excluded updates fragment.

### DIFF
--- a/app/src/main/res/layout/fragment_with_toolbar_no_theme.xml
+++ b/app/src/main/res/layout/fragment_with_toolbar_no_theme.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<!--
-  ~ Copyright (c) 2016.
-  ~ Modified on 26/07/2016.
-  -->
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -29,7 +23,7 @@
         android:gravity="center"
         android:minHeight="112dp"
         app:layout_collapseMode="pin"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+        app:popupTheme="@style/PopupMenuStyle"
         />
   </com.google.android.material.appbar.AppBarLayout>
 
@@ -42,7 +36,6 @@
       android:visibility="gone"
       tools:visibility="gone"
       />
-  <!-- is this necessary ?? -->
   <RelativeLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
@@ -78,10 +71,10 @@
       android:layout_height="match_parent"
       android:layout_below="@id/app_bar_layout"
       android:clipToPadding="false"
-      android:paddingEnd="@dimen/recycler_margin"
-      android:paddingLeft="@dimen/recycler_margin"
-      android:paddingRight="@dimen/recycler_margin"
       android:paddingStart="@dimen/recycler_margin"
+      android:paddingLeft="@dimen/recycler_margin"
+      android:paddingEnd="@dimen/recycler_margin"
+      android:paddingRight="@dimen/recycler_margin"
       android:visibility="gone"
       tools:visibility="visible"
       />

--- a/app/src/main/res/layout/row_excluded_update.xml
+++ b/app/src/main/res/layout/row_excluded_update.xml
@@ -1,56 +1,46 @@
-<?xml version="1.0" encoding="UTF-8"?><!--
-  Copyright (c) 2012 tdeus.
-  All rights reserved. This program and the accompanying materials
-  are made available under the terms of the GNU Public License v2.0
-  which accompanies this distribution, and is available at
-  http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
--->
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="UTF-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:foreground="?selectableItemBackground"
     >
-  <!--
-      style="?attr/customRowForeground"
-  -->
   <RelativeLayout
+      style="?attr/backgroundCard"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      style="?attr/backgroundCard"
       >
 
     <ImageView
         android:id="@+id/icon"
         android:layout_width="96dp"
         android:layout_height="96dp"
-        android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
+        android:layout_alignParentLeft="true"
         android:layout_centerVertical="true"
         android:padding="8dp"
-        tools:src="@drawable/com_facebook_profile_picture_blank_square"
+        tools:src="@drawable/ad_icon"
         />
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
-        android:layout_toEndOf="@+id/icon"
-        android:layout_toLeftOf="@+id/is_excluded"
-        android:layout_toRightOf="@+id/icon"
         android:layout_toStartOf="@+id/is_excluded"
+        android:layout_toLeftOf="@+id/is_excluded"
+        android:layout_toEndOf="@+id/icon"
+        android:layout_toRightOf="@+id/icon"
         android:orientation="vertical"
         >
 
       <TextView
           android:id="@+id/name"
+          style="@style/Aptoide.TextView.Regular.L.BlackAlpha"
           android:layout_width="fill_parent"
           android:layout_height="wrap_content"
           android:layout_gravity="center_horizontal"
           android:ellipsize="end"
           android:maxLines="1"
-          android:textAppearance="?android:attr/textAppearanceMedium"
           tools:text="AliExpress"
           />
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -547,6 +547,12 @@
     <item name="android:textColor">?attr/colorPrimary</item>
   </style>
 
+  <style name="PopupMenuStyle" parent="Theme.AppCompat">
+    <item name="android:background">?attr/searchDropdownBackgroundColor</item>
+    <item name="android:textColor">?android:attr/textColorPrimary</item>
+
+  </style>
+
   <style name="AlertDialogAptoide" parent="@style/ThemeOverlay.AppCompat.Dialog.Alert">
     <item name="android:colorAccent">?attr/preferenceTitleColor</item>
     <item name="android:textColorPrimary">@android:color/black</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -549,7 +549,7 @@
 
   <style name="PopupMenuStyle" parent="Theme.AppCompat">
     <item name="android:background">?attr/searchDropdownBackgroundColor</item>
-    <item name="android:textColor">?android:attr/textColorPrimary</item>
+    <item name="android:textColor">?attr/textColorBlackAlpha</item>
 
   </style>
 


### PR DESCRIPTION
**What does this PR do?**

   Excluded updates dark-theme (titles, menu dropdown background)

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] ExcludedUpdatesFragment.java

**How should this be manually tested?**

  Test excluded updates view in both light & dark 

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-22](https://aptoide.atlassian.net/browse/MOB-22)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass