### PR TITLE
[feature/MOB-170] Splash screen dark mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,7 +76,7 @@
 
     <activity
         android:name=".view.MainActivity"
-        android:theme="@style/AppBaseTheme.Splash"
+        android:theme="@style/AppBaseTheme"
         android:windowSoftInputMode="adjustPan">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/res/values/colors_stores_themes.xml
+++ b/app/src/main/res/values/colors_stores_themes.xml
@@ -42,6 +42,8 @@
   <color name="red_gradient_end">#CF382D</color>
   <color name="teal_gradient_end">#00655C</color>
 
+  <color name="status_bar_color">#FE6446</color>
+
 
   <!-- Stores themes - 700 colors -->
   <color name="default_color_700">#bf6113</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -5,9 +5,9 @@
 
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-  <style name="AppBaseTheme" parent="@style/Theme.AppCompat.Light.NoActionBar">
+  <style name="AppBaseTheme" parent="@style/Theme.AppCompat.DayNight.NoActionBar">
 
-    <item name="android:windowBackground">@color/default_background_color_light</item>
+    <item name="android:windowBackground">@drawable/splash_screen</item>
     <item name="android:ratingBarStyle">@style/RatingBarSmall</item>
 
     <item name="colorPrimary">@color/default_orange_gradient_start</item>
@@ -15,7 +15,7 @@
     <item name="colorAccent">@color/aptoide_color_focused</item>
     <item name="customColor">@color/default_orange_gradient_start</item>
     <item name="android:statusBarColor" tools:targetApi="lollipop">
-      @color/default_orange_gradient_end
+      @color/status_bar_color
     </item>
     <item name="widgetBackgroundColorPrimary">@color/white</item>
     <item name="widgetBackgroundColorSecondary">@color/comment_gray</item>
@@ -261,7 +261,7 @@
 
   <style name="AptoideThemeLight" parent="AppBaseTheme" />
 
-  <style name="AppBaseThemeDark" parent="@style/Theme.AppCompat.NoActionBar">
+  <style name="AppBaseThemeDark" parent="@style/Theme.AppCompat.DayNight.NoActionBar">
     <item name="android:windowBackground">@color/default_background_color_dark</item>
     <item name="android:ratingBarStyle">@style/RatingBarSmall</item>
 
@@ -272,7 +272,7 @@
     <item name="colorPrimaryDark">@color/light_grey</item>
     <item name="colorAccent">@color/white</item>
     <item name="customColor">@color/default_orange_gradient_start</item>
-    <item name="android:statusBarColor" tools:targetApi="lollipop">#000000</item>
+    <item name="android:statusBarColor" tools:targetApi="lollipop">@color/status_bar_color</item>
     <item name="widgetBackgroundColorPrimary">@color/default_background_color_dark</item>
     <item name="widgetBackgroundColorSecondary">@color/grey_900</item>
 
@@ -516,10 +516,6 @@
 
   <style name="AppBaseTheme.NoTitle">
     <item name="android:windowNoTitle">true</item>
-  </style>
-
-  <style name="AppBaseTheme.Splash">
-    <item name="android:windowBackground">@drawable/splash_screen</item>
   </style>
 
   <style name="AppBaseTheme.NoTitle.Transparent">

--- a/aptoide-views/src/main/res/drawable-night-v23/splash_screen.xml
+++ b/aptoide-views/src/main/res/drawable-night-v23/splash_screen.xml
@@ -1,9 +1,7 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android"
     android:opacity="opaque">
   <item android:drawable="@color/grey_dark" />
-  <item>
-    <bitmap
-        android:gravity="center"
-        android:src="@drawable/aptoide_icon" />
-  </item>
+  <item
+      android:drawable="@drawable/ic_aptoide_icon"
+      android:gravity="center" />
 </layer-list>

--- a/aptoide-views/src/main/res/drawable-night/splash_screen.xml
+++ b/aptoide-views/src/main/res/drawable-night/splash_screen.xml
@@ -1,0 +1,7 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android"
+    android:opacity="opaque">
+  <item android:drawable="@color/grey_dark" />
+  <item
+      android:drawable="@drawable/ic_aptoide_icon"
+      android:gravity="center" />
+</layer-list>

--- a/aptoide-views/src/main/res/values-night/colors_stores_themes.xml
+++ b/aptoide-views/src/main/res/values-night/colors_stores_themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <color name="status_bar_color">#000000</color>
+</resources>


### PR DESCRIPTION
**What does this PR do?**

   Adds dark mode support for splashscreen in Android 10 devices.

**Database changed?**

   No

**How should this be manually tested?**

  In an Android 10 device, check if light/dark mode shows the correct splash screen.

**What are the relevant tickets?**

  [MOB-170](https://aptoide.atlassian.net/browse/MOB-170)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass