### PR TITLE
[MOB-45] fix: colors used in some specific store themes

### DIFF
--- a/app/src/main/res/layout/dialog_comment_on_review.xml
+++ b/app/src/main/res/layout/dialog_comment_on_review.xml
@@ -19,7 +19,7 @@
       android:layout_height="wrap_content"
       android:layout_marginBottom="20dp"
       android:gravity="left|center_vertical"
-      android:textColor="?attr/colorPrimary"
+      android:textColor="?attr/colorAccent"
       android:textSize="@dimen/text_size_large"
       android:visibility="gone"
       tools:visibility="visible"
@@ -68,7 +68,7 @@
         android:padding="6dp"
         android:text="@string/dialog_button_comment"
         android:textAllCaps="true"
-        android:textColor="?colorPrimary"
+        android:textColor="?attr/colorAccent"
         android:textSize="@dimen/text_size_medium"
         />
 

--- a/app/src/main/res/layout/fragment_my_account.xml
+++ b/app/src/main/res/layout/fragment_my_account.xml
@@ -124,6 +124,7 @@
         android:id="@+id/settings"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
         android:background="?attr/selectableItemBackground"
         android:clickable="true"
         android:focusable="true"

--- a/app/src/main/res/values/colors_stores_themes.xml
+++ b/app/src/main/res/values/colors_stores_themes.xml
@@ -77,6 +77,8 @@
   <color name="pink_text">@color/pink</color>
   <color name="red_text">@color/red</color>
   <color name="teal_text">@color/teal</color>
+  <color name="deep_purple_light_text">#6D44B8</color>
+
 
 </resources>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -573,6 +573,7 @@
 
   <style name="AptoideThemeDark.Grey" parent="AptoideThemeGrey">
     <item name="themeTextColor">@color/white</item>
+    <item name="colorAccent">@color/grey</item>
   </style>
 
   <style name="AptoideThemeTeal">
@@ -612,6 +613,7 @@
 
   <style name="AptoideThemeDark.Teal" parent="AptoideThemeTeal">
     <item name="themeTextColor">@color/white</item>
+    <item name="colorAccent">@color/teal</item>
   </style>
 
   <style name="AptoideThemeBrown">
@@ -651,6 +653,7 @@
 
   <style name="AptoideThemeDark.Brown" parent="AptoideThemeBrown">
     <item name="themeTextColor">@color/white</item>
+    <item name="colorAccent">@color/brown</item>
   </style>
 
   <style name="AptoideThemeBlueGrey">
@@ -691,6 +694,7 @@
 
   <style name="AptoideThemeDark.BlueGrey" parent="AptoideThemeBlueGrey">
     <item name="themeTextColor">@color/white</item>
+    <item name="colorAccent">@color/grey_fog_dark</item>
   </style>
 
   <style name="AptoideThemeLightGreen">
@@ -963,6 +967,7 @@
 
   <style name="AptoideThemeDark.Indigo" parent="AptoideThemeIndigo">
     <item name="themeTextColor">@color/white</item>
+    <item name="colorAccent">@color/indigo</item>
   </style>
 
   <style name="AptoideThemeRed">
@@ -1080,6 +1085,7 @@
 
   <style name="AptoideThemeDark.DeepPurple" parent="AptoideThemeDeepPurple">
     <item name="themeTextColor">@color/white</item>
+    <item name="colorAccent">@color/deep_purple_light_text</item>
   </style>
 
   <style name="AptoideThemeBlack">
@@ -1118,6 +1124,8 @@
 
   <style name="AptoideThemeDark.Black" parent="AptoideThemeBlack">
     <item name="themeTextColor">@color/white</item>
+    <item name="colorAccent">@color/white</item>
+    <item name="android:statusBarColor" tools:targetApi="lollipop">@color/black</item>
   </style>
 
 </resources>


### PR DESCRIPTION
**What does this PR do?**

   Small specific stores theme color adjustements.
   Fix to the settings button spacing in my account.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] themes.xml
- [ ] fragment_my_account.xml

**How should this be manually tested?**

  validate my account and color changes on both themes.
  Black was the most important one (comment dialog would show text in black)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-45](https://aptoide.atlassian.net/browse/MOB-45)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass