### PR TITLE
[MOB-45] fix: Editorial download buttons & gradient direction fix

### DIFF
--- a/app/src/main/res/drawable/aptoide_gradient.xml
+++ b/app/src/main/res/drawable/aptoide_gradient.xml
@@ -2,6 +2,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
   <gradient
+      android:angle="0"
       android:endColor="#fe6446"
-      android:startColor="#fe9150"/>
+      android:startColor="#fe9150"
+      android:type="linear"/>
 </shape>

--- a/app/src/main/res/drawable/aptoide_gradient.xml
+++ b/app/src/main/res/drawable/aptoide_gradient.xml
@@ -1,9 +1,8 @@
-<shape
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
   <gradient
       android:angle="0"
       android:endColor="#fe6446"
       android:startColor="#fe9150"
-      android:type="linear"/>
+      android:type="linear" />
 </shape>

--- a/app/src/main/res/drawable/aptoide_gradient_rounded.xml
+++ b/app/src/main/res/drawable/aptoide_gradient_rounded.xml
@@ -1,8 +1,9 @@
-<shape
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
   <gradient
+      android:angle="0"
       android:endColor="#fe6446"
-      android:startColor="#fe9150"/>
-  <corners android:radius="4dp"/>
+      android:startColor="#fe9150"
+      android:type="linear" />
+  <corners android:radius="4dp" />
 </shape>

--- a/app/src/main/res/layout/action_bar_stores.xml
+++ b/app/src/main/res/layout/action_bar_stores.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 
-<com.google.android.material.appbar.AppBarLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.appbar.AppBarLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/app_bar_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     >
 
-  <androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto"
+  <androidx.appcompat.widget.Toolbar
       android:id="@+id/toolbar"
       android:layout_width="match_parent"
       android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/app_install_cardview.xml
+++ b/app/src/main/res/layout/app_install_cardview.xml
@@ -147,7 +147,7 @@
           android:contentDescription="@null"
           android:padding="12dp"
           android:scaleType="center"
-          android:src="@drawable/ic_clear_action_black"
+          android:src="?attr/download_progress_cancel"
           android:visibility="gone"
           />
 
@@ -159,7 +159,7 @@
           android:contentDescription="@null"
           android:padding="12dp"
           android:scaleType="fitCenter"
-          android:src="@drawable/ic_play_arrow_action_black"
+          android:src="?attr/download_progress_resume"
           android:visibility="gone"
           />
 
@@ -171,7 +171,7 @@
           android:contentDescription="@null"
           android:padding="12dp"
           android:scaleType="fitCenter"
-          android:src="@drawable/ic_pause_action_black"
+          android:src="?attr/download_progress_pause"
           />
 
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_app_view.xml
+++ b/app/src/main/res/layout/fragment_app_view.xml
@@ -36,12 +36,12 @@
 
       <ProgressBar
           android:id="@+id/appview_progress"
+          style="?android:attr/progressBarStyleLarge"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_gravity="center"
           android:layout_marginTop="150dp"
           android:visibility="gone"
-          style="?android:attr/progressBarStyleLarge"
           />
 
       <cm.aptoide.aptoideviews.errors.ErrorView

--- a/app/src/main/res/layout/fragment_app_view.xml
+++ b/app/src/main/res/layout/fragment_app_view.xml
@@ -36,11 +36,12 @@
 
       <ProgressBar
           android:id="@+id/appview_progress"
-          android:layout_width="100dp"
-          android:layout_height="100dp"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
           android:layout_gravity="center"
           android:layout_marginTop="150dp"
           android:visibility="gone"
+          style="?android:attr/progressBarStyleLarge"
           />
 
       <cm.aptoide.aptoideviews.errors.ErrorView

--- a/app/src/main/res/layout/my_stores.xml
+++ b/app/src/main/res/layout/my_stores.xml
@@ -29,16 +29,6 @@
         android:paddingRight="@dimen/recycler_margin"
         />
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/fabAdd"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="right|end|bottom"
-        android:layout_margin="@dimen/fab_margin"
-        android:src="?attr/addDrawable"
-        android:visibility="gone"
-        />
-
   </cm.aptoide.aptoideviews.swipe.AptoideSwipeRefresh>
 
 


### PR DESCRIPTION
**What does this PR do?**

   Editorial download buttons (app card in bottom, not placeholder)
   Orange gradient direction in Android 10 (both toolbar & install buttons)
   Remove some code not being used (like fab in storesfragment)

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] app_install_cardview.xml
- [ ] aptoide_gradient.xml

**How should this be manually tested?**

  install controls in editorial when app is in the bottom (only 1 app articles) in both light & dark
  Android 10 orange gradient in toolbar  (home & app view & stores for light theme) and orange gradient install buttons (both light and dark theme)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-45](https://aptoide.atlassian.net/browse/MOB-45)
 [MOB-169](https://aptoide.atlassian.net/browse/MOB-169)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass