### PR TITLE
[MOB-167] fix: app spacing in store grid layouts.

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/store/view/AddStoreDialog.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/AddStoreDialog.java
@@ -350,7 +350,7 @@ public class AddStoreDialog extends BaseDialogFragment {
   }
 
   private void topStoresAction() {
-    navigator.navigateTo(FragmentTopStores.newInstance(), true);
+    navigator.navigateTo(TopStoresFragment.newInstance(), true);
     if (isAdded()) {
       dismiss();
     }

--- a/app/src/main/java/cm/aptoide/pt/store/view/GridStoreMetaDisplayable.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/GridStoreMetaDisplayable.java
@@ -183,6 +183,10 @@ public class GridStoreMetaDisplayable extends DisplayablePojo<GetHomeMeta> {
     return getStore() != null;
   }
 
+  public boolean hasUser() {
+    return getUser() != null;
+  }
+
   public GridStoreMetaWidget.HomeMeta.Badge getBadge() {
     if (hasStore()) {
       switch (getPojo().getData()

--- a/app/src/main/java/cm/aptoide/pt/store/view/GridStoreMetaWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/GridStoreMetaWidget.java
@@ -188,13 +188,13 @@ public class GridStoreMetaWidget extends MetaStoresBaseWidget<GridStoreMetaDispl
     String screenTitle =
         AptoideUtils.StringU.getFormattedString(R.string.social_timeline_followers_fragment_title,
             resources, displayable.getFollowersCount());
-    if (displayable.hasStore()) {
+    if (displayable.hasUser()) {
       fragmentNavigator.navigateTo(
-          TimeLineFollowersFragment.newInstanceUsingStore(displayable.getStoreId(),
+          TimeLineFollowersFragment.newInstanceUsingUser(displayable.getUserId(),
               displayable.getStoreThemeName(), screenTitle, StoreContext.meta), true);
     } else {
       fragmentNavigator.navigateTo(
-          TimeLineFollowersFragment.newInstanceUsingUser(displayable.getUserId(),
+          TimeLineFollowersFragment.newInstanceUsingStore(displayable.getStoreId(),
               displayable.getStoreThemeName(), screenTitle, StoreContext.meta), true);
     }
   }

--- a/app/src/main/java/cm/aptoide/pt/store/view/TopStoresFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/TopStoresFragment.java
@@ -29,11 +29,11 @@ import rx.Observable;
 /**
  * Created by trinkes on 8/25/16.
  */
-public class FragmentTopStores extends GridRecyclerFragmentWithDecorator<BaseAdapter>
+public class TopStoresFragment extends GridRecyclerFragmentWithDecorator<BaseAdapter>
     implements Endless {
 
   public static final int STORES_LIMIT_PER_REQUEST = 10;
-  public static String TAG = FragmentTopStores.class.getSimpleName();
+  public static String TAG = TopStoresFragment.class.getSimpleName();
   @Inject AnalyticsManager analyticsManager;
   @Inject NavigationTracker navigationTracker;
   private int offset = 0;
@@ -46,8 +46,8 @@ public class FragmentTopStores extends GridRecyclerFragmentWithDecorator<BaseAda
                 .log(err);
           });
 
-  public static FragmentTopStores newInstance() {
-    return new FragmentTopStores();
+  public static TopStoresFragment newInstance() {
+    return new TopStoresFragment();
   }
 
   @Override public void onCreate(@Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/cm/aptoide/pt/store/view/TopStoresFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/store/view/TopStoresFragment.java
@@ -16,7 +16,7 @@ import cm.aptoide.pt.dataprovider.model.v7.store.Store;
 import cm.aptoide.pt.dataprovider.ws.v7.Endless;
 import cm.aptoide.pt.dataprovider.ws.v7.store.ListStoresRequest;
 import cm.aptoide.pt.store.StoreAnalytics;
-import cm.aptoide.pt.view.fragment.AptoideBaseFragment;
+import cm.aptoide.pt.view.fragment.GridRecyclerFragmentWithDecorator;
 import cm.aptoide.pt.view.recycler.BaseAdapter;
 import cm.aptoide.pt.view.recycler.EndlessRecyclerOnScrollListener;
 import cm.aptoide.pt.view.recycler.displayable.Displayable;
@@ -29,7 +29,8 @@ import rx.Observable;
 /**
  * Created by trinkes on 8/25/16.
  */
-public class FragmentTopStores extends AptoideBaseFragment<BaseAdapter> implements Endless {
+public class FragmentTopStores extends GridRecyclerFragmentWithDecorator<BaseAdapter>
+    implements Endless {
 
   public static final int STORES_LIMIT_PER_REQUEST = 10;
   public static String TAG = FragmentTopStores.class.getSimpleName();
@@ -75,14 +76,14 @@ public class FragmentTopStores extends AptoideBaseFragment<BaseAdapter> implemen
     return R.layout.fragment_with_toolbar_no_theme;
   }
 
-  @Override public void setupViews() {
-    super.setupViews();
-    setupToolbar();
-  }
-
   @Override public void load(boolean create, boolean refresh, Bundle savedInstanceState) {
     super.load(create, refresh, savedInstanceState);
     fetchStores();
+  }
+
+  @Override public void setupViews() {
+    super.setupViews();
+    setupToolbar();
   }
 
   private void fetchStores() {

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentComponent.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentComponent.java
@@ -25,10 +25,10 @@ import cm.aptoide.pt.promotions.PromotionsFragment;
 import cm.aptoide.pt.reviews.LatestReviewsFragment;
 import cm.aptoide.pt.reviews.RateAndReviewsFragment;
 import cm.aptoide.pt.search.view.SearchResultFragment;
-import cm.aptoide.pt.store.view.FragmentTopStores;
 import cm.aptoide.pt.store.view.ListStoresFragment;
 import cm.aptoide.pt.store.view.StoreFragment;
 import cm.aptoide.pt.store.view.StoreTabWidgetsGridRecyclerFragment;
+import cm.aptoide.pt.store.view.TopStoresFragment;
 import cm.aptoide.pt.store.view.my.MyStoresFragment;
 import cm.aptoide.pt.store.view.my.MyStoresSubscribedFragment;
 import cm.aptoide.pt.timeline.view.follow.TimeLineFollowersFragment;
@@ -58,7 +58,7 @@ public interface FragmentComponent {
 
   void inject(CommentListFragment commentListFragment);
 
-  void inject(FragmentTopStores fragmentTopStores);
+  void inject(TopStoresFragment topStoresFragment);
 
   void inject(LatestReviewsFragment latestReviewsFragment);
 

--- a/app/src/main/res/layout/displayable_grid_app.xml
+++ b/app/src/main/res/layout/displayable_grid_app.xml
@@ -2,7 +2,7 @@
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     style="?attr/backgroundCard"
-    android:layout_width="104dp"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:clickable="true"
     android:focusable="true"


### PR DESCRIPTION
**What does this PR do?**

   Fixes App spacing between items in Stores Grid-like layouts.
   Also fixes the Top Stores Fragment layout, which items are not decorated with spacing between them.
   Also minimizes the issue of navigating to an empty list of followers when you click on the number of followers inside store view.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] displayable_grid_app.xml
- [ ] TopStoresFragment.java
- [ ] GridStoreMetaWidget.java

**How should this be manually tested?**

  Test app items in general, especially where the layout is used (Grid apps/ListStoreApps)
  Test top stores (go to stores > add store > discover top stores)
  Test navigation to followers inside store view (click followers number).

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-167](https://aptoide.atlassian.net/browse/MOB-167)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass