### PR TITLE
[MOB-180] Removed call to identify event, those properties are now be…

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
@@ -14,7 +14,6 @@ import com.flurry.android.FlurryAgent;
 import com.google.android.gms.safetynet.HarmfulAppsData;
 import com.google.android.gms.safetynet.SafetyNetApi;
 import com.google.android.gms.safetynet.SafetyNetClient;
-import io.rakam.api.Identify;
 import io.rakam.api.Rakam;
 import java.io.IOException;
 import java.io.InputStream;
@@ -330,19 +329,23 @@ public class FirstLaunchAnalytics {
 
   private void sendRakamUserProperties(String utmContent, String utmSource, String utmCampaign,
       String utmMedium, String entryPoint, String packageName) {
-    Identify rakamProperties = new Identify();
-
-    rakamProperties.set(GMS_RAKAM, gmsStatusValueProvider.getGmsValue());
-
-    rakamProperties.set(UTM_CONTENT_RAKAM, utmContent)
-        .set(UTM_SOURCE_RAKAM, utmSource)
-        .set(UTM_CAMPAIGN_RAKAM, utmCampaign)
-        .set(UTM_MEDIUM_RAKAM, utmMedium)
-        .set(ENTRY_POINT_RAKAM, entryPoint);
-
-    rakamProperties.set(APTOIDE_PACKAGE, packageName);
-
+    JSONObject superProperties = Rakam.getInstance()
+        .getSuperProperties();
+    if (superProperties == null) {
+      superProperties = new JSONObject();
+    }
+    try {
+      superProperties.put(GMS_RAKAM, gmsStatusValueProvider.getGmsValue());
+      superProperties.put(UTM_CONTENT_RAKAM, utmContent);
+      superProperties.put(UTM_SOURCE_RAKAM, utmSource);
+      superProperties.put(UTM_CAMPAIGN_RAKAM, utmCampaign);
+      superProperties.put(UTM_MEDIUM_RAKAM, utmMedium);
+      superProperties.put(ENTRY_POINT_RAKAM, entryPoint);
+      superProperties.put(APTOIDE_PACKAGE, packageName);
+    } catch (JSONException e) {
+      e.printStackTrace();
+    }
     Rakam.getInstance()
-        .identify(rakamProperties);
+        .setSuperProperties(superProperties);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/navigator/ExternalNavigator.kt
+++ b/app/src/main/java/cm/aptoide/pt/navigator/ExternalNavigator.kt
@@ -9,7 +9,7 @@ open class ExternalNavigator(val context: Context, val themeManager: ThemeManage
 
   fun navigateToCatappultWebsite() {
     CustomTabsHelper.getInstance()
-        .openInChromeCustomTab("https://catappult.io/", context, themeManager.getAttributeForTheme(
+        .openInChromeCustomTab("https://catappult.io/?utm_source=vanilla", context, themeManager.getAttributeForTheme(
             R.attr.colorPrimary).resourceId)
   }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR removes calls to Rakam's identify event and instead sets those properties as super properties;

**Database changed?**

No

**Where should the reviewer start?**

- [x] FirstLaunchAnalytics.java

**How should this be manually tested?**

Make sure identify is no longer sent and that all the properties are now being sent on other events;

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-180](https://aptoide.atlassian.net/browse/MOB-180)

**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass