### PR TITLE
[MOB-218] AutoUpdate dialog darktheme

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/autoupdate/AutoUpdateDialogFragment.kt
+++ b/app/src/main/java/cm/aptoide/pt/autoupdate/AutoUpdateDialogFragment.kt
@@ -25,7 +25,7 @@ class AutoUpdateDialogFragment : BaseDialogView(), AutoUpdateDialogView {
   override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                             savedInstanceState: Bundle?): View? {
     dialog.window?.requestFeature(Window.FEATURE_NO_TITLE)
-    dialog.window.setBackgroundDrawableResource(R.drawable.transparent)
+    dialog.window?.setBackgroundDrawableResource(R.drawable.transparent)
 
     return inflater.inflate(R.layout.auto_update_dialog_fragment, container, false)
   }

--- a/app/src/main/res/layout/auto_update_dialog_fragment.xml
+++ b/app/src/main/res/layout/auto_update_dialog_fragment.xml
@@ -20,6 +20,7 @@
         android:src="@drawable/ic_update_image"
         />
     <androidx.cardview.widget.CardView
+        style="?attr/backgroundCard"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="35dp"
@@ -30,7 +31,6 @@
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginTop="200dp"
-          android:background="@color/white"
           >
 
         <TextView
@@ -78,7 +78,7 @@
 
           <Button
               android:id="@+id/update_button"
-              style="@style/Aptoide.Button.Install"
+              style="@style/Aptoide.Button.Alternative"
               android:layout_width="wrap_content"
               android:layout_marginBottom="25dp"
               android:layout_weight="1"

--- a/app/src/main/res/layout/pushnotificationlayout.xml
+++ b/app/src/main/res/layout/pushnotificationlayout.xml
@@ -9,7 +9,7 @@
       android:id="@+id/icon"
       android:layout_width="45dp"
       android:layout_height="45dp"
-      tools:src="@mipmap/ic_launcher"
+      tools:src="@drawable/ad_icon"
       />
 
   <LinearLayout
@@ -19,43 +19,43 @@
       >
     <TextView
         android:id="@+id/title"
+        style="@style/Aptoide.TextView.Regular.S.Black"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="10dp"
-        android:layout_marginLeft="10dp"
-        android:layout_marginRight="10dp"
         android:layout_marginStart="10dp"
+        android:layout_marginLeft="10dp"
         android:layout_marginTop="5dp"
-        android:textColor="@color/black"
+        android:layout_marginEnd="10dp"
+        android:layout_marginRight="10dp"
         tools:text="teste"
         />
 
     <TextView
         android:id="@+id/description"
+        style="@style/Aptoide.TextView.Regular.S.Black"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:layout_marginBottom="5dp"
-        android:layout_marginEnd="10dp"
-        android:layout_marginLeft="10dp"
-        android:layout_marginRight="10dp"
         android:layout_marginStart="10dp"
+        android:layout_marginLeft="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginRight="10dp"
+        android:layout_marginBottom="5dp"
         android:autoLink="all"
         android:scrollbars="vertical"
-        android:textColor="@color/dark_gray"
         tools:text="description"
         />
 
     <TextView
         android:id="@+id/app_name"
+        style="@style/Aptoide.TextView.Regular.S.Black"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="5dp"
-        android:layout_marginEnd="10dp"
-        android:layout_marginLeft="10dp"
-        android:layout_marginRight="10dp"
         android:layout_marginStart="10dp"
-        android:textColor="@color/dark_gray"
+        android:layout_marginLeft="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginRight="10dp"
+        android:layout_marginBottom="5dp"
         tools:text="app name"
         />
 
@@ -63,8 +63,8 @@
         android:id="@+id/push_notification_graphic"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="10dp"
         android:layout_marginStart="10dp"
+        android:layout_marginLeft="10dp"
         tools:src="@drawable/no_connection_error"
         />
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -56,7 +56,7 @@
   </style>
 
   <style name="AppBaseThemeDark.DialogTheme" parent="Aptoide.DialogTheme">
-    <item name="android:background">@color/grey_900</item>
+    <item name="android:windowBackground">@color/grey_900</item>
   </style>
 
   <style name="AppBaseThemeDark.DialogTheme.Rounded">


### PR DESCRIPTION
**What does this PR do?**

This PR aims at allowing auto update dialog to support dark theme. Also fixed notifications dark theme.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] auto_update_dialog_fragment.xml

**How should this be manually tested?**

Open Aptoide, go through the auto update flow and check the dialog in dark theme. If you need the rewrite let me know.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-218](https://aptoide.atlassian.net/browse/MOB-218)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass