### PR TITLE
[MOB-142] Fixed ads super property being set too late;

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
+++ b/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
@@ -290,6 +290,7 @@ public abstract class AptoideApplication extends Application {
      */
     generateAptoideUuid().andThen(initializeRakamSdk())
         .andThen(initializeUXCam())
+        .andThen(setUpAdsUserProperty())
         .andThen(checkAdsUserProperty())
         .andThen(sendAptoideApplicationStartAnalytics(
             uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION))
@@ -347,6 +348,10 @@ public abstract class AptoideApplication extends Application {
 
   private Completable checkAdsUserProperty() {
     return Completable.fromAction(() -> adsUserPropertyManager.start());
+  }
+
+  private Completable setUpAdsUserProperty(){
+    return adsUserPropertyManager.setUp();
   }
 
   private Completable checkApkfyUserProperty() {

--- a/app/src/main/java/cm/aptoide/pt/ads/AdsUserPropertyManager.java
+++ b/app/src/main/java/cm/aptoide/pt/ads/AdsUserPropertyManager.java
@@ -2,6 +2,7 @@ package cm.aptoide.pt.ads;
 
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.install.InstalledRepository;
+import rx.Completable;
 import rx.Scheduler;
 
 public class AdsUserPropertyManager {
@@ -35,5 +36,15 @@ public class AdsUserPropertyManager {
             != WalletAdsOfferManager.OfferResponseStatus.NO_ADS)
         .subscribe(created -> {
         }, error -> crashReport.log(error));
+  }
+
+  public Completable setUp() {
+    return installedRepository.isInstalled(WALLET_PACKAGE)
+        .first()
+        .observeOn(ioScheduler)
+        .distinctUntilChanged()
+        .flatMapSingle(__ -> moPubAdsManager.getAdsVisibilityStatus())
+        .doOnNext(moPubAnalytics::setAdsVisibilityUserProperty)
+        .toCompletable();
   }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR fixes ads super property to Rakam being set too late and not being sent on session_start events;

**Database changed?**

No

**Where should the reviewer start?**

- [x] AptoideApplication.java

**How should this be manually tested?**

From a fresh install check charles and make sure the ads property is being sent on the first _session_start event to Rakam;

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-142](https://aptoide.atlassian.net/browse/MOB-142)

**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass