### PR TITLE
[MOB-232] fix: fragment dialogs would lose theme when orientation changes

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/view/fragment/BaseDialogFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/fragment/BaseDialogFragment.java
@@ -1,9 +1,11 @@
 package cm.aptoide.pt.view.fragment;
 
+import android.app.Dialog;
 import android.os.Bundle;
 import android.view.View;
 import android.view.WindowManager;
 import androidx.annotation.AttrRes;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 import cm.aptoide.pt.AptoideApplication;
@@ -26,11 +28,6 @@ public class BaseDialogFragment extends RxDialogFragment {
     super.onCreate(savedInstanceState);
     ((MainActivity) getContext()).getActivityComponent()
         .inject(this);
-
-    if (this.getActivity() != null && shouldUseDefaultDialogStyle()) {
-      setStyle(DialogFragment.STYLE_NO_TITLE,
-          themeManager.getAttributeForTheme(getDialogStyle()).resourceId);
-    }
   }
 
   @Override public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
@@ -42,6 +39,14 @@ public class BaseDialogFragment extends RxDialogFragment {
         .setAttributes(layoutParams);
     getDialog().getWindow()
         .addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
+  }
+
+  @NonNull @Override public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+    if (this.getActivity() != null && shouldUseDefaultDialogStyle()) {
+      setStyle(DialogFragment.STYLE_NO_TITLE,
+          themeManager.getAttributeForTheme(getDialogStyle()).resourceId);
+    }
+    return super.onCreateDialog(savedInstanceState);
   }
 
   public @AttrRes int getDialogStyle() {


### PR DESCRIPTION
**What does this PR do?**

   This would happen because the onCreate of the MainActivity would run after the onCreate of the dialog, which means it would overwrite the style setted for the dialog. By changing the setStyle of the dialog to the onCreateDialog, which runs between the onCreate() and onViewCreated(), we guarantee that the theme is always correctly set for everyone that extends this base dialog fragment.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] BaseDialogFragment.java

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-232](https://aptoide.atlassian.net/browse/MOB-232)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-232](https://aptoide.atlassian.net/browse/MOB-232)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass