### PR TITLE
[MOB-199] fix: store view now displays correctly in other versions view

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/widget/OtherVersionWidget.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/widget/OtherVersionWidget.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.annotation.DrawableRes;
+import androidx.appcompat.widget.TooltipCompat;
 import cm.aptoide.pt.AptoideApplication;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.app.view.displayable.OtherVersionDisplayable;
@@ -71,6 +72,9 @@ public class OtherVersionWidget extends Widget<OtherVersionDisplayable>
 
       version.setText(app.getFile()
           .getVername());
+      TooltipCompat.setTooltipText(version, app.getFile()
+          .getVername());
+      version.setOnClickListener(v -> navigateToAppView());
       setBadge(app);
       date.setText(AptoideUtils.DateTimeU.getInstance(getContext())
           .getTimeDiffString(getContext(), app.getModified()
@@ -157,6 +161,10 @@ public class OtherVersionWidget extends Widget<OtherVersionDisplayable>
   }
 
   @Override public void onClick(View v) {
+    navigateToAppView();
+  }
+
+  private void navigateToAppView() {
     Logger.getInstance()
         .d(TAG, "showing other version for app with id = " + appId);
     getFragmentNavigator().navigateTo(AptoideApplication.getFragmentProvider()

--- a/app/src/main/res/layout/other_version_row.xml
+++ b/app/src/main/res/layout/other_version_row.xml
@@ -3,7 +3,8 @@
   ~ Modified on 07/07/2016.
   -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="120dp"
@@ -18,10 +19,16 @@
     >
 
   <LinearLayout
-      android:layout_width="wrap_content"
+      android:id="@+id/version"
+      android:layout_width="0dp"
       android:layout_height="match_parent"
       android:gravity="center_vertical"
       android:orientation="vertical"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toStartOf="@id/store"
+      app:layout_constraintHorizontal_bias="0"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
       tools:background="@android:color/transparent"
       >
     <LinearLayout
@@ -46,11 +53,11 @@
           android:layout_height="@dimen/other_version_icon_size_with_icon"
           android:layout_marginStart="4dp"
           android:layout_marginLeft="4dp"
-          android:ellipsize="end"
+          android:layout_weight="1"
+          android:ellipsize="middle"
           android:fontFamily="@string/font_family_regular"
           android:gravity="center_vertical"
-          android:lines="1"
-          android:maxLines="1"
+          android:singleLine="true"
           android:textStyle="bold"
           tools:text="1.00.258.985lsndakljndanalnalndalnad7"
           />
@@ -95,18 +102,17 @@
   </LinearLayout>
 
   <LinearLayout
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_weight="1"
-      />
-
-
-  <LinearLayout
+      android:id="@+id/store"
       android:layout_width="105dp"
       android:layout_height="match_parent"
       android:gravity="center_vertical"
       android:orientation="vertical"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toEndOf="@id/version"
+      app:layout_constraintTop_toTopOf="parent"
       tools:background="@android:color/transparent"
+
       >
 
     <ImageView
@@ -144,4 +150,4 @@
         />
 
   </LinearLayout>
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**What does this PR do?**

  Store view now displays correctly in other versions view when the version name is very long. Also the version name ellipsize is now in the middle (easier to compare version names) and on long press it shows an Android tooltip with the full version name.


**Database changed?**

   No

**Where should the reviewer start?**

- [ ] OtherVersionsWidget.java
- [ ] other_version_row.xml

**How should this be manually tested?**

  Apps where I tested: Play Games, Netflix, Facebook

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-199](https://aptoide.atlassian.net/browse/MOB-199)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass