### PR TITLE
[hotfix/MOB-241] Editorial crashing

### DIFF
--- a/app/src/main/res/layout/fragment_appcoins_info.xml
+++ b/app/src/main/res/layout/fragment_appcoins_info.xml
@@ -230,7 +230,7 @@
             <View
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
-                android:background="@color/grey_fog_normal"
+                android:background="?attr/separatorColor"
                 />
 
             <include
@@ -245,7 +245,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:layout_gravity="bottom"
-                android:background="@color/grey_fog_normal"
+                android:background="?attr/separatorColor"
                 />
 
           </FrameLayout>

--- a/aptoide-views/src/main/res/drawable-night/editorial_install_card_background.xml
+++ b/aptoide-views/src/main/res/drawable-night/editorial_install_card_background.xml
@@ -7,7 +7,7 @@
   </item>
   <item android:top="1dp">
     <shape android:shape="rectangle">
-      <solid android:color="?attr/backgroundMain" />
+      <solid android:color="@color/grey_dark" />
     </shape>
   </item>
 </layer-list>

--- a/aptoide-views/src/main/res/drawable/editorial_install_card_background.xml
+++ b/aptoide-views/src/main/res/drawable/editorial_install_card_background.xml
@@ -7,7 +7,7 @@
   </item>
   <item android:top="1dp">
     <shape android:shape="rectangle">
-      <solid android:color="?attr/backgroundMain" />
+      <solid android:color="@color/default_background_color_light" />
     </shape>
   </item>
 </layer-list>


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing the editorial view. Also took the chance to fix a dark theme bug that Luis reported. In the appc info view we are using the wrong separator color

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] editorial_install_card_background.xml

**How should this be manually tested?**

Open editorial fragment on devices above and below android 4.4.2

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-241](https://aptoide.atlassian.net/browse/MOB-241)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass