### PR TITLE
[bugfix/MOB-270] No request at PNP endpoint

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/sync/alarm/SyncStorage.java
+++ b/app/src/main/java/cm/aptoide/pt/sync/alarm/SyncStorage.java
@@ -24,9 +24,14 @@ public class SyncStorage {
   }
 
   public Sync get(String syncId) {
-    return persistence.get(syncId)
-        .toBlocking()
-        .first();
+    if (syncId.equals(LocalNotificationSync.APPC_CAMPAIGN_NOTIFICATION) || syncId.equals(
+        LocalNotificationSync.NEW_FEATURE)) {
+      return persistence.get(syncId)
+          .toBlocking()
+          .first();
+    } else {
+      return syncs.get(syncId);
+    }
   }
 
   public List<Sync> getAll() {


### PR DESCRIPTION
**What does this PR do?**

   Fixes a bug where the notifications PNP endpoint was not being called. 

**Database changed?**

   No


**How should this be manually tested?**

  Check that if with the Charles rewrite in the ticket below, a notification appears on launch.

**What are the relevant tickets?**

  [MOB-270](https://aptoide.atlassian.net/browse/MOB-270)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass