### PR TITLE
[MOB-246] fix: show app bundles if 'Show compatible apps only' is disabled

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -1484,7 +1484,8 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
 
   @Singleton @Provides @Named("rakamEvents") Collection<String> providesRakamEvents() {
     return Arrays.asList(InstallAnalytics.CLICK_ON_INSTALL, DownloadAnalytics.RAKAM_DOWNLOAD_EVENT,
-        InstallAnalytics.RAKAM_INSTALL_EVENT, AppViewAnalytics.ASV_2053_SIMILAR_APPS_PARTICIPATING_EVENT_NAME,
+        InstallAnalytics.RAKAM_INSTALL_EVENT,
+        AppViewAnalytics.ASV_2053_SIMILAR_APPS_PARTICIPATING_EVENT_NAME,
         AppViewAnalytics.ASV_2053_SIMILAR_APPS_CONVERTING_EVENT_NAME, SearchAnalytics.SEARCH,
         SearchAnalytics.SEARCH_RESULT_CLICK,
         AppViewAnalytics.ASV_2119_APKFY_ADS_PARTICIPATING_EVENT_NAME,
@@ -1526,8 +1527,9 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
         appBundlesVisibilityManager);
   }
 
-  @Singleton @Provides AppBundlesVisibilityManager providesAppBundlesVisibilityManager() {
-    return new AppBundlesVisibilityManager(AptoideUtils.isDeviceMIUI());
+  @Singleton @Provides AppBundlesVisibilityManager providesAppBundlesVisibilityManager(
+      @Named("default") SharedPreferences sharedPreferences) {
+    return new AppBundlesVisibilityManager(AptoideUtils.isDeviceMIUI(), sharedPreferences);
   }
 
   @Singleton @Provides AppCenterRepository providesAppCenterRepository(AppService appService) {

--- a/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
@@ -559,7 +559,8 @@ public class DeepLinkIntentReceiver extends ActivityView {
             WebService.getDefaultConverter(),
             ((AptoideApplication) getApplicationContext()).getTokenInvalidator(),
             ((AptoideApplication) getApplicationContext()).getDefaultSharedPreferences(),
-            new AppBundlesVisibilityManager(AptoideUtils.isDeviceMIUI()))
+            new AppBundlesVisibilityManager(AptoideUtils.isDeviceMIUI(),
+                ((AptoideApplication) getApplicationContext()).getDefaultSharedPreferences()))
             .observe()
             .toBlocking()
             .first();

--- a/app/src/main/java/cm/aptoide/pt/app/view/OtherVersionsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/OtherVersionsFragment.java
@@ -157,7 +157,8 @@ public class OtherVersionsFragment extends AptoideBaseFragment<BaseAdapter> {
             ((AptoideApplication) getContext().getApplicationContext()).getTokenInvalidator(),
             ((AptoideApplication) getContext().getApplicationContext()).getDefaultSharedPreferences(),
             getContext().getResources(),
-            new AppBundlesVisibilityManager(AptoideUtils.isDeviceMIUI())),
+            new AppBundlesVisibilityManager(AptoideUtils.isDeviceMIUI(),
+                ((AptoideApplication) getContext().getApplicationContext()).getDefaultSharedPreferences())),
         otherVersionsSuccessRequestListener, err -> err.printStackTrace());
 
     getRecyclerView().addOnScrollListener(endlessRecyclerOnScrollListener);

--- a/app/src/main/java/cm/aptoide/pt/repository/RepositoryFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/repository/RepositoryFactory.java
@@ -36,7 +36,7 @@ public final class RepositoryFactory {
             .getApplicationContext()).getDatabase(), Store.class), getIdsRepository(context),
         getBaseBodyInterceptorV7(context), getHttpClient(context), WebService.getDefaultConverter(),
         getTokenInvalidator(context), sharedPreferences, context.getPackageManager(),
-        new AppBundlesVisibilityManager(AptoideUtils.isDeviceMIUI()));
+        new AppBundlesVisibilityManager(AptoideUtils.isDeviceMIUI(), sharedPreferences));
   }
 
   private static IdsRepository getIdsRepository(Context context) {

--- a/app/src/main/java/cm/aptoide/pt/repository/request/RequestFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/repository/request/RequestFactory.java
@@ -41,8 +41,6 @@ import retrofit2.Converter;
   private final GetStoreRecommendedRequestFactory getStoreRecommendedRequestFactory;
   private final GetRecommendedRequestFactory getRecommendedRequestFactory;
   private final boolean googlePlayServicesAvailable;
-  private final AppBundlesVisibilityManager appBundlesVisibilityManager =
-      new AppBundlesVisibilityManager(AptoideUtils.isDeviceMIUI());
 
   public RequestFactory(StoreCredentialsProvider storeCredentialsProvider,
       BodyInterceptor<BaseBody> bodyInterceptor, OkHttpClient httpClient,
@@ -53,6 +51,8 @@ import retrofit2.Converter;
       AdsApplicationVersionCodeProvider versionCodeProvider, boolean googlePlayServicesAvailable) {
     this.storeCredentialsProvider = storeCredentialsProvider;
     this.googlePlayServicesAvailable = googlePlayServicesAvailable;
+    AppBundlesVisibilityManager appBundlesVisibilityManager =
+        new AppBundlesVisibilityManager(AptoideUtils.isDeviceMIUI(), sharedPreferences);
     listStoresRequestFactory =
         new ListStoresRequestFactory(bodyInterceptor, httpClient, converterFactory,
             tokenInvalidator, sharedPreferences);

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilityManager.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilityManager.java
@@ -1,13 +1,19 @@
 package cm.aptoide.pt.dataprovider.aab;
 
+import android.content.SharedPreferences;
+import cm.aptoide.pt.preferences.managed.ManagedKeys;
+
 public class AppBundlesVisibilityManager {
   private final boolean isDeviceMiui;
+  private final SharedPreferences sharedPreferences;
 
-  public AppBundlesVisibilityManager(boolean isDeviceMiui) {
+  public AppBundlesVisibilityManager(boolean isDeviceMiui, SharedPreferences sharedPreferences) {
     this.isDeviceMiui = isDeviceMiui;
+    this.sharedPreferences = sharedPreferences;
   }
 
   public boolean shouldEnableAppBundles() {
-    return !isDeviceMiui;
+    boolean showCompatibleAppsOnly = sharedPreferences.getBoolean(ManagedKeys.HWSPECS_FILTER, true);
+    return !isDeviceMiui || !showCompatibleAppsOnly;
   }
 }


### PR DESCRIPTION
**What does this PR do?**

   Shows app bundles to users that disable the "Show compatible apps only" setting, even if its a MIUI rom.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppBundlesVisibilityManager.java

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-246](https://aptoide.atlassian.net/browse/MOB-246)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-246](https://aptoide.atlassian.net/browse/MOB-246)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass