### PR TITLE
[bugfix/MOB-273] Search Store Apps fix

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultPresenter.java
@@ -210,8 +210,7 @@ import rx.schedulers.Schedulers;
           if (storeName != null && !storeName.trim()
               .equals("")) {
             return loadDataForSpecificStore(viewModel.getSearchQueryModel()
-                    .getFinalQuery(), storeName, viewModel.getFollowedStoresOffset()).map(
-                    searchResult -> new Pair<>(searchResult, null));
+                .getFinalQuery(), storeName, viewModel.getFollowedStoresOffset());
           }
           return loadDataFromFollowedStores(viewModel.getSearchQueryModel()
               .getFinalQuery(), viewModel.isOnlyTrustedApps(), viewModel.getFollowedStoresOffset());
@@ -222,7 +221,7 @@ import rx.schedulers.Schedulers;
         .doOnNext(data -> {
           final SearchResultView.Model viewModel = view.getViewModel();
           viewModel.incrementOffsetAndCheckIfReachedBottomOfFollowedStores(
-              getItemCount(getResultList((SearchResult) data)));
+              getItemCount(getResultList(data)));
         })
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {


### PR DESCRIPTION
**What does this PR do?**

   This fixes an issue where if searching an app in a specific store resulted in other results (like from apps & catappult store).

**Database changed?**

   No

**How should this be manually tested?**

  Go to stores and follow 'nzxt', then go to the store page and search for an app (e.g. 'tft'), it should only return apps inside that store, and not others.

**What are the relevant tickets?**

  [MOB-273](https://aptoide.atlassian.net/browse/MOB-273)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass