### PR TITLE
[MOB-472] Fixed installed with aptoide ab test events

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
@@ -111,9 +111,11 @@ public class AppsManager {
                 return 1;
               }
               return 0;
-            }))
-        .flatMap(list -> aptoideInstallManager.sendImpressionEvent()
-            .andThen(Observable.just(list)));
+            }));
+  }
+
+  public Completable sendInstalledWithAptoideImpression() {
+    return aptoideInstallManager.sendImpressionEvent();
   }
 
   private Observable<List<UpdateApp>> getUpdateDownloadsList() {

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
@@ -75,6 +75,19 @@ public class AppsPresenter implements Presenter {
     handleRefreshApps();
 
     handleAppcoinsMigrationUpgradeClick();
+
+    handleInstalledWithAptoideAbTestImpression();
+  }
+
+  private void handleInstalledWithAptoideAbTestImpression() {
+    view.getLifecycleEvent()
+        .filter(lifecycleEvent -> lifecycleEvent == View.LifecycleEvent.CREATE)
+        .flatMap(__ -> appsManager.getUpdatesList())
+        .first()
+        .flatMapCompletable(__ -> appsManager.sendInstalledWithAptoideImpression())
+        .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
+        .subscribe(created -> {
+        }, error -> crashReport.log(error));
   }
 
   private void handleAppcoinsMigrationUpgradeClick() {


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at fixing the ab test participating event in the installed with aptoide events

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppsPresenter.java

**How should this be manually tested?**

  Open apps, and check that it is only sent 1 event. Also check that contrarily to what was happening before, when you pull to refresh or when you update any app, it does not send any event new participating event.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-472](https://aptoide.atlassian.net/browse/MOB-472)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass