### PR TITLE
[MOB-413] fix: app view open types now only work once per app view

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -67,6 +67,7 @@ public class AppViewPresenter implements Presenter {
   private final CrashReport crashReport;
   private final ApkfyExperiment apkfyExperiment;
   private final ExternalNavigator externalNavigator;
+  private boolean openTypeAlreadyRegistered = false;
 
   public AppViewPresenter(AppViewView view, AccountNavigator accountNavigator,
       AppViewAnalytics appViewAnalytics, CampaignAnalytics campaignAnalytics,
@@ -310,16 +311,19 @@ public class AppViewPresenter implements Presenter {
   }
 
   private Observable<Boolean> handleOpenAppViewDialogInput(AppModel appModel) {
-    if (appModel.getOpenType() == AppViewFragment.OpenType.OPEN_AND_INSTALL) {
-      return Observable.just(true);
-    } else if (appModel.getOpenType() == AppViewFragment.OpenType.OPEN_WITH_INSTALL_POPUP) {
-      return view.showOpenAndInstallDialog(appModel.getMarketName(), appModel.getAppName())
-          .map(__ -> true);
-    } else if (appModel.getOpenType() == AppViewFragment.OpenType.APK_FY_INSTALL_POPUP) {
-      return view.showOpenAndInstallApkFyDialog(appModel.getMarketName(), appModel.getAppName(),
-          appModel.getAppc(), appModel.getRating()
-              .getAverage(), appModel.getIcon(), appModel.getPackageDownloads())
-          .map(__ -> true);
+    if (!openTypeAlreadyRegistered) {
+      openTypeAlreadyRegistered = true;
+      if (appModel.getOpenType() == AppViewFragment.OpenType.OPEN_AND_INSTALL) {
+        return Observable.just(true);
+      } else if (appModel.getOpenType() == AppViewFragment.OpenType.OPEN_WITH_INSTALL_POPUP) {
+        return view.showOpenAndInstallDialog(appModel.getMarketName(), appModel.getAppName())
+            .map(__ -> true);
+      } else if (appModel.getOpenType() == AppViewFragment.OpenType.APK_FY_INSTALL_POPUP) {
+        return view.showOpenAndInstallApkFyDialog(appModel.getMarketName(), appModel.getAppName(),
+            appModel.getAppc(), appModel.getRating()
+                .getAverage(), appModel.getIcon(), appModel.getPackageDownloads())
+            .map(__ -> true);
+      }
     }
     return Observable.just(false);
   }


### PR DESCRIPTION
**What does this PR do?**

   App View open type behaviour (dialog or auto-download) only fires once per app view instance.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppViewPresenter.java

**How should this be manually tested?**

  Test 3 flows: 

-  apkfy (go to Apkfy.java and replace line 75 with     `return 51150866L; `
- automatic download (go to the reviews, click install in top right, pause download then go to other versions and press back -> it shouldn't start download again.)
- install dialog (deep link from web) - similar to apkfy behaviour

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-413](https://aptoide.atlassian.net/browse/MOB-413)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass