### PR TITLE
[MOB-414] fix: show generic error dialog when App validation fails 

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -1709,6 +1709,10 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     return cancelClickSubject;
   }
 
+  public void showGenericErrorDialog() {
+    showErrorDialog("", getContext().getString(R.string.error_occured));
+  }
+
   private void showAppcInfo(boolean hasAdvertising, boolean hasBilling, double appcReward,
       double fiatReward, String fiatCurrency, double appcBudget, String date) {
     if (hasAdvertising) {
@@ -1775,7 +1779,7 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
   private void handleDownloadError(DownloadModel.DownloadState downloadState) {
     switch (downloadState) {
       case ERROR:
-        showErrorDialog("", getContext().getString(R.string.error_occured));
+        showGenericErrorDialog();
         break;
       case NOT_ENOUGH_STORAGE_ERROR:
         showErrorDialog(getContext().getString(R.string.out_of_space_dialog_title),

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -1119,7 +1119,10 @@ public class AppViewPresenter implements Presenter {
               }
               return completable;
             })
-            .doOnError(throwable -> throwable.printStackTrace())
+            .doOnError(throwable -> {
+              crashReport.log(throwable);
+              view.showGenericErrorDialog();
+            })
             .retry())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(created -> {

--- a/app/src/main/java/cm/aptoide/pt/appview/InstallAppView.java
+++ b/app/src/main/java/cm/aptoide/pt/appview/InstallAppView.java
@@ -28,4 +28,6 @@ public interface InstallAppView extends View {
   Observable<DownloadModel.Action> resumeDownload();
 
   Observable<Void> cancelDownload();
+
+  void showGenericErrorDialog();
 }


### PR DESCRIPTION
**What does this PR do?**

   show generic error dialog when App validation fails on download creation. 
   This is only for the app view.

**Database changed?**

  No

**Where should the reviewer start?**

- [ ] AppViewPresenter.java

**How should this be manually tested?**

  You need to start a download on app view of a download that fails AppValidation in AppValidator.kt

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-414](https://aptoide.atlassian.net/browse/MOB-414)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass