### PR TITLE
[MOB-271] fix: copy amend in wallet install deeplink flow.

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallActivity.kt
+++ b/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallActivity.kt
@@ -105,21 +105,21 @@ class WalletInstallActivity : ActivityView(), WalletInstallView {
   }
 
   override fun showInstallationSuccessView() {
-    showSuccessView(getString(R.string.wallet_install_complete_title),
-        getString(R.string.wallet_install_complete_body))
+    install_complete_message.visibility = View.INVISIBLE
+    showSuccessView(getString(R.string.wallet_install_complete_title))
   }
 
   override fun showWalletInstalledAlreadyView() {
-    showSuccessView(getString(R.string.wallet_install_request_already_installed_title),
-        getString(R.string.wallet_install_request_already_installed_body))
+    install_complete_message.text =
+        getString(R.string.wallet_install_request_already_installed_body)
+    showSuccessView(getString(R.string.wallet_install_request_already_installed_title))
   }
 
-  private fun showSuccessView(title: String, body: String) {
+  private fun showSuccessView(title: String) {
     app_icon_imageview.setImageDrawable(
-        getResources().getDrawable(R.drawable.ic_check_orange_gradient_start))
+        resources.getDrawable(R.drawable.ic_check_orange_gradient_start))
     message_textview.text = title
     message_textview.setSubstringTypeface(Pair(title, Typeface.BOLD))
-    install_complete_message.text = body
     progress_view.visibility = View.GONE
     wallet_install_success_view_group.visibility = View.VISIBLE
     close_button.visibility = View.VISIBLE

--- a/app/src/main/res/layout/wallet_install_activity.xml
+++ b/app/src/main/res/layout/wallet_install_activity.xml
@@ -81,7 +81,7 @@
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toBottomOf="@id/message_textview"
-      tools:text="Just tap to buy again"
+      tools:text="Already installed lorem ipsum"
       />
 
   <Button
@@ -92,7 +92,7 @@
       android:layout_marginEnd="16dp"
       android:layout_marginRight="16dp"
       android:layout_marginBottom="8dp"
-      android:text="@string/got_it_button_text"
+      android:text="@string/continue_button"
       android:visibility="gone"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -712,7 +712,6 @@
   <string name="wallet_install_request_close_button">CLOSE</string>
   <string name="wallet_install_request_install_button">INSTALL WALLET</string>
   <string name="wallet_install_complete_title">Installation Complete</string>
-  <string name="wallet_install_complete_body">Go back to the game to make your purchase!</string>
   <string name="appc_not_supported_body">It seems this device doesn\'t support AppCoins. Try with a different one!</string>
   <string name="wallet_install_request_already_installed_title">AppCoins Wallet Install</string>
   <string name="wallet_install_request_already_installed_body">Enjoy the bonus on every in-app purchase!</string>


### PR DESCRIPTION
**What does this PR do?**

  Because AppCoins sdk changed behaviour, the current copy makes less sence. 
  Changed both wallet install success copy (removed) & Got it button (to continue)

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] WalletInstallActivity.kt

**How should this be manually tested?**

  Deeplink ->  adb shell am start -a "android.intent.action.VIEW" -d "market://details?id=com.appcoins.wallet\&utm_source=appcoinssdk\&app_source=cm.aptoide.pt"

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-271](https://aptoide.atlassian.net/browse/MOB-271)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass