### PR TITLE
[HOTFIX/MOB-552] Recommended More Fragment

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/view/FragmentComponent.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentComponent.java
@@ -34,6 +34,7 @@ import cm.aptoide.pt.store.view.StoreTabWidgetsGridRecyclerFragment;
 import cm.aptoide.pt.store.view.TopStoresFragment;
 import cm.aptoide.pt.store.view.my.MyStoresFragment;
 import cm.aptoide.pt.store.view.my.MyStoresSubscribedFragment;
+import cm.aptoide.pt.store.view.recommended.RecommendedStoresFragment;
 import cm.aptoide.pt.themes.NewFeatureDialogFragment;
 import cm.aptoide.pt.timeline.view.follow.TimeLineFollowersFragment;
 import cm.aptoide.pt.timeline.view.follow.TimeLineFollowingFragment;
@@ -73,6 +74,8 @@ public interface FragmentComponent {
   void inject(MyStoresSubscribedFragment myStoresSubscribedFragment);
 
   void inject(StoreTabWidgetsGridRecyclerFragment storeTabWidgetsGridRecyclerFragment);
+
+  void inject(RecommendedStoresFragment recommendedStoresFragment);
 
   void inject(MyStoresFragment myStoresFragment);
 


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at fixing a null pointer exception while opening the recommended stores fragment after pressing the "more" button.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] FragmentComponent.java

**How should this be manually tested?**

Open stores and press the more button from the recommended stores section

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-552](https://aptoide.atlassian.net/browse/MOB-552)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass