### PR TITLE
[bugfix/MOB-540] Home Skeleton bug

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/Home.java
+++ b/app/src/main/java/cm/aptoide/pt/home/Home.java
@@ -1,5 +1,6 @@
 package cm.aptoide.pt.home;
 
+import android.util.Log;
 import cm.aptoide.pt.ads.MoPubAdsManager;
 import cm.aptoide.pt.blacklist.BlacklistManager;
 import cm.aptoide.pt.home.bundles.BundlesRepository;
@@ -52,7 +53,7 @@ public class Home {
   public Observable<HomeBundlesModel> loadHomeBundles() {
     return bundlesRepository.loadHomeBundles()
         .flatMap(bundlesModel -> {
-          if (bundlesModel.hasErrors() || bundlesModel.isLoading()) {
+          if (bundlesModel.hasErrors() || bundlesModel.isLoading() || !bundlesModel.isComplete()) {
             return Observable.just(bundlesModel);
           }
           return addAdBundle(bundlesModel);

--- a/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
@@ -370,7 +370,7 @@ public class HomePresenter implements Presenter {
         .doOnNext(view::showBundlesSkeleton)
         .filter(HomeBundlesModel::isComplete)
         .observeOn(viewScheduler)
-        .doOnNext(bundlesModel -> handleBundlesResult(bundlesModel));
+        .doOnNext(this::handleBundlesResult);
   }
 
   private void handleBundlesResult(HomeBundlesModel bundlesModel) {

--- a/app/src/main/java/cm/aptoide/pt/home/bundles/RemoteBundleDataSource.java
+++ b/app/src/main/java/cm/aptoide/pt/home/bundles/RemoteBundleDataSource.java
@@ -142,6 +142,13 @@ public class RemoteBundleDataSource implements BundleDataSource {
                     }))));
   }
 
+  /**
+   * As it was done originally, this method alters the original GetStoreWidgets.WSWidget
+   * for each widget request. This is not great as it can cause concurrency issues (e.g. it may
+   * emit the same WSWidget twice). At the moment this does not cause any actual issue (it doesn't
+   * matter if it emits the same object twice). A refactor could be significant,
+   * so it's not priority, but it's important to note it in case of any requirements change.
+   */
   private Observable<GetStoreWidgets> loadAppsInBundles(boolean adultContentEnabled,
       boolean invalidateHttpCache, List<String> packageNames, GetStoreWidgets getStoreWidgets,
       boolean bypassCache, String id) {


### PR DESCRIPTION
**What does this PR do?**

   This attempts to fix a bug where home wouldn't fully load and remain stuck in skeleton. In reality it actually loaded but then went again to the skeleton state. It seems that the reason was that adding the ads bundle was delaying the emission of HomeBundle and was causing issues. At this point it's not 100% clear that it is fixed but it seems to be.

**Database changed?**

   No

**How should this be manually tested?**

  Simply open home several times (try to clear cache and force stop as well) and check that the skeleton bug doesn't appear again.

**What are the relevant tickets?**

  [MOB-540](https://aptoide.atlassian.net/browse/MOB-540)


**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass