### PR TITLE
[MOB-496] New error message for app not valid

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppViewAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewAnalytics.java
@@ -540,4 +540,13 @@ public class AppViewAnalytics {
     data.put("group", assignment);
     return data;
   }
+
+  public void sendInvalidAppEventError(String packageName, DownloadModel.Action downloadAction,
+      WalletAdsOfferManager.OfferResponseStatus offerResponseStatus, boolean isMigration,
+      boolean isAppBundle, boolean hasAppc, String trustedBadge, String storeName, boolean isApkfy,
+      Throwable throwable) {
+    downloadAnalytics.sendAppNotValidError(packageName, mapDownloadAction(downloadAction),
+        offerResponseStatus, isMigration, isAppBundle, hasAppc, trustedBadge, storeName, isApkfy,
+        throwable);
+  }
 }

--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -10,6 +10,7 @@ import cm.aptoide.pt.app.view.donations.Donation;
 import cm.aptoide.pt.database.realm.Download;
 import cm.aptoide.pt.download.AppContext;
 import cm.aptoide.pt.download.DownloadFactory;
+import cm.aptoide.pt.download.InvalidAppException;
 import cm.aptoide.pt.install.InstallAnalytics;
 import cm.aptoide.pt.install.InstallManager;
 import cm.aptoide.pt.notification.AppcPromotionNotificationStringProvider;
@@ -214,15 +215,27 @@ public class AppViewManager {
   public Completable downloadApp(DownloadModel.Action downloadAction, long appId,
       String trustedValue, String editorsChoicePosition,
       WalletAdsOfferManager.OfferResponseStatus status, boolean isApkfy) {
-    return getAppModel().flatMapObservable(app -> Observable.just(
-        downloadFactory.create(downloadStateParser.parseDownloadAction(downloadAction),
-            app.getAppName(), app.getPackageName(), app.getMd5(), app.getIcon(),
-            app.getVersionName(), app.getVersionCode(), app.getPath(), app.getPathAlt(),
-            app.getObb(), app.hasAdvertising() || app.hasBilling(), app.getSize(), app.getSplits(),
-            app.getRequiredSplits(), app.getMalware()
-                .getRank()
-                .toString(), app.getStore()
-                .getName())))
+    return getAppModel().flatMapObservable(app -> Observable.just(app)
+        .flatMap(__ -> Observable.just(
+            downloadFactory.create(downloadStateParser.parseDownloadAction(downloadAction),
+                app.getAppName(), app.getPackageName(), app.getMd5(), app.getIcon(),
+                app.getVersionName(), app.getVersionCode(), app.getPath(), app.getPathAlt(),
+                app.getObb(), app.hasAdvertising() || app.hasBilling(), app.getSize(),
+                app.getSplits(), app.getRequiredSplits(), app.getMalware()
+                    .getRank()
+                    .toString(), app.getStore()
+                    .getName())))
+        .doOnError(throwable -> {
+          if (throwable instanceof InvalidAppException) {
+            appViewAnalytics.sendInvalidAppEventError(app.getPackageName(), downloadAction, status,
+                downloadAction != null && downloadAction.equals(DownloadModel.Action.MIGRATE),
+                !app.getSplits()
+                    .isEmpty(), app.hasAdvertising() || app.hasBilling(), app.getMalware()
+                    .getRank()
+                    .toString(), app.getStore()
+                    .getName(), isApkfy, throwable);
+          }
+        }))
         .doOnNext(download -> {
           setupDownloadEvents(download, downloadAction, appId, trustedValue, editorsChoicePosition,
               status, download.getStoreName(), isApkfy);
@@ -480,9 +493,11 @@ public class AppViewManager {
         String.format(appcPromotionNotificationStringProvider.getNotificationTitle(), appcValue),
         appcPromotionNotificationStringProvider.getNotificationBody(), image,
         R.string.promo_update2appc_notification_claim_button, "aptoideinstall://package="
-            + packageName + "&store=" + storeName + "&show_install_popup=false",
-        LocalNotificationSync.APPC_CAMPAIGN_NOTIFICATION, AptoideNotification.APPC_PROMOTION,
-        LocalNotificationSyncManager.FIVE_MINUTES);
+            + packageName
+            + "&store="
+            + storeName
+            + "&show_install_popup=false", LocalNotificationSync.APPC_CAMPAIGN_NOTIFICATION,
+        AptoideNotification.APPC_PROMOTION, LocalNotificationSyncManager.FIVE_MINUTES);
   }
 
   public void unscheduleNotificationSync() {

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -1713,6 +1713,10 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     showErrorDialog("", getContext().getString(R.string.error_occured));
   }
 
+  @Override public void showInvalidAppInfoErrorDialog() {
+    showErrorDialog("", getContext().getString(R.string.appview_download_error_missing_splits));
+  }
+
   private void showAppcInfo(boolean hasAdvertising, boolean hasBilling, double appcReward,
       double fiatReward, String fiatCurrency, double appcBudget, String date) {
     if (hasAdvertising) {

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -305,6 +305,8 @@ public class AppViewPresenter implements Presenter {
                 throwable -> {
                   if (throwable instanceof InvalidAppException) {
                     view.showInvalidAppInfoErrorDialog();
+                  } else {
+                    view.showGenericErrorDialog();
                   }
                 })
                 .onErrorComplete()))

--- a/app/src/main/java/cm/aptoide/pt/appview/InstallAppView.java
+++ b/app/src/main/java/cm/aptoide/pt/appview/InstallAppView.java
@@ -30,4 +30,6 @@ public interface InstallAppView extends View {
   Observable<Void> cancelDownload();
 
   void showGenericErrorDialog();
+
+  void showInvalidAppInfoErrorDialog();
 }

--- a/app/src/main/java/cm/aptoide/pt/download/DownloadFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/download/DownloadFactory.java
@@ -129,7 +129,7 @@ public class DownloadFactory {
       download.setSize(update.getSize());
       return download;
     } else {
-      throw new IllegalArgumentException(validationResult.getMessage());
+      throw new InvalidAppException(validationResult.getMessage());
     }
   }
 
@@ -205,7 +205,7 @@ public class DownloadFactory {
 
       return download;
     } else {
-      throw new IllegalArgumentException(validationResult.getMessage());
+      throw new InvalidAppException(validationResult.getMessage());
     }
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/download/InvalidAppException.java
+++ b/app/src/main/java/cm/aptoide/pt/download/InvalidAppException.java
@@ -1,0 +1,10 @@
+package cm.aptoide.pt.download;
+
+import cm.aptoide.pt.utils.BaseException;
+
+public class InvalidAppException extends BaseException {
+
+  public InvalidAppException(String detailMessage) {
+    super(detailMessage);
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

This PR aims at changing the message that is shown when the app is not valid (meaning that something important is missing on the webservice response, like md5, path to download, etc). 
**PS:** This error is only being mapped in AppView as the errors for the other views where we have downloads were not thought yet.

**Database changed?**

 No

**Where should the reviewer start?**

- [ ] AppViewPresenter.java

**How should this be manually tested?**

Change on download factory, instead of returning the download, just throw an InvalidAppException. Either that or just make a rewrite where you put one of the important fields as empty.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-496](https://aptoide.atlassian.net/browse/MOB-496)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass