### PR TITLE
[feature/MOB-582] Analytics for NotEnoughSpace error

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppViewAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewAnalytics.java
@@ -540,4 +540,12 @@ public class AppViewAnalytics {
         offerResponseStatus, isMigration, isAppBundle, hasAppc, trustedBadge, storeName, isApkfy,
         throwable);
   }
+
+  public void sendNotEnoughSpaceErrorEvent(String packageName, DownloadModel.Action downloadAction,
+      WalletAdsOfferManager.OfferResponseStatus offerResponseStatus, boolean isMigration,
+      boolean isAppBundle, boolean hasAppc, String trustedBadge, String storeName,
+      boolean isApkfy) {
+    downloadAnalytics.sendNotEnoughSpaceError(packageName, mapDownloadAction(downloadAction),
+        offerResponseStatus, isMigration, isAppBundle, hasAppc, trustedBadge, storeName, isApkfy);
+  }
 }

--- a/app/src/main/java/cm/aptoide/pt/download/DownloadAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/download/DownloadAnalytics.java
@@ -146,6 +146,31 @@ public class DownloadAnalytics implements cm.aptoide.pt.downloadmanager.Download
     }
   }
 
+  public void sendNotEnoughSpaceError(String packageName, InstallType installType,
+      WalletAdsOfferManager.OfferResponseStatus offerResponseStatus, boolean isMigration,
+      boolean isAppBundle, boolean hasAppc, String trustedBadge, String storeName,
+      boolean isApkfy) {
+    String previousContext = navigationTracker.getPreviousViewName();
+    String context = navigationTracker.getCurrentViewName();
+    String tag = navigationTracker.getCurrentScreen() != null ? navigationTracker.getCurrentScreen()
+        .getTag() : "";
+
+    HashMap<String, Object> result =
+        createRakamDownloadEvent(packageName, installType.toString(), offerResponseStatus,
+            isMigration, isAppBundle, hasAppc, trustedBadge, storeName, isApkfy, previousContext,
+            context, tag);
+
+    result.put(STATUS, "incomplete");
+    result.put(ERROR_TYPE, "FileDownloadOutOfSpace");
+
+    DownloadAnalytics.DownloadEvent downloadEvent =
+        new DownloadAnalytics.DownloadEvent(RAKAM_DOWNLOAD_EVENT, result, context,
+            AnalyticsManager.Action.CLICK);
+
+    analyticsManager.logEvent(result, downloadEvent.getEventName(), downloadEvent.getAction(),
+        downloadEvent.getContext());
+  }
+
   public void sendAppNotValidError(String packageName, InstallType installType,
       WalletAdsOfferManager.OfferResponseStatus offerResponseStatus, boolean isMigration,
       boolean isAppBundle, boolean hasAppc, String trustedBadge, String storeName, boolean isApkfy,

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialAnalytics.java
@@ -4,8 +4,10 @@ import cm.aptoide.analytics.AnalyticsManager;
 import cm.aptoide.analytics.implementation.navigation.NavigationTracker;
 import cm.aptoide.pt.ads.WalletAdsOfferManager;
 import cm.aptoide.pt.app.AppViewAnalytics;
+import cm.aptoide.pt.app.DownloadModel;
 import cm.aptoide.pt.database.realm.Download;
 import cm.aptoide.pt.download.DownloadAnalytics;
+import cm.aptoide.pt.download.InstallType;
 import cm.aptoide.pt.install.InstallAnalytics;
 import java.util.HashMap;
 import java.util.Map;
@@ -106,5 +108,33 @@ public class EditorialAnalytics {
     data.put(WHERE, CURATION_DETAIL);
     analyticsManager.logEvent(data, REACTION_INTERACT, AnalyticsManager.Action.CLICK,
         navigationTracker.getViewName(true));
+  }
+
+  public void sendNotEnoughSpaceErrorEvent(String packageName, DownloadModel.Action downloadAction,
+      WalletAdsOfferManager.OfferResponseStatus offerResponseStatus, boolean isMigration,
+      boolean isAppBundle, boolean hasAppc, String trustedBadge, String storeName,
+      boolean isApkfy) {
+    downloadAnalytics.sendNotEnoughSpaceError(packageName, mapDownloadAction(downloadAction),
+        offerResponseStatus, isMigration, isAppBundle, hasAppc, trustedBadge, storeName, isApkfy);
+  }
+
+  private InstallType mapDownloadAction(DownloadModel.Action downloadAction) {
+    InstallType installType = InstallType.INSTALL;
+    switch (downloadAction) {
+      case DOWNGRADE:
+        installType = InstallType.DOWNGRADE;
+        break;
+      case INSTALL:
+        installType = InstallType.INSTALL;
+        break;
+      case UPDATE:
+        installType = InstallType.UPDATE;
+        break;
+      case MIGRATE:
+      case OPEN:
+        throw new IllegalStateException(
+            "Mapping an invalid download action " + downloadAction.name());
+    }
+    return installType;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialPresenter.java
@@ -4,6 +4,7 @@ import androidx.annotation.VisibleForTesting;
 import cm.aptoide.pt.UserFeedbackAnalytics;
 import cm.aptoide.pt.actions.PermissionManager;
 import cm.aptoide.pt.actions.PermissionService;
+import cm.aptoide.pt.ads.MoPubAdsManager;
 import cm.aptoide.pt.app.DownloadModel;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.presenter.Presenter;
@@ -31,11 +32,13 @@ public class EditorialPresenter implements Presenter {
   private final EditorialAnalytics editorialAnalytics;
   private final EditorialNavigator editorialNavigator;
   private final UserFeedbackAnalytics userFeedbackAnalytics;
+  private final MoPubAdsManager moPubAdsManager;
 
   public EditorialPresenter(EditorialView view, EditorialManager editorialManager,
       Scheduler viewScheduler, CrashReport crashReporter, PermissionManager permissionManager,
       PermissionService permissionService, EditorialAnalytics editorialAnalytics,
-      EditorialNavigator editorialNavigator, UserFeedbackAnalytics userFeedbackAnalytics) {
+      EditorialNavigator editorialNavigator, UserFeedbackAnalytics userFeedbackAnalytics,
+      MoPubAdsManager moPubAdsManager) {
     this.view = view;
     this.editorialManager = editorialManager;
     this.viewScheduler = viewScheduler;
@@ -45,6 +48,7 @@ public class EditorialPresenter implements Presenter {
     this.editorialAnalytics = editorialAnalytics;
     this.editorialNavigator = editorialNavigator;
     this.userFeedbackAnalytics = userFeedbackAnalytics;
+    this.moPubAdsManager = moPubAdsManager;
   }
 
   @Override public void present() {
@@ -274,12 +278,33 @@ public class EditorialPresenter implements Presenter {
         .flatMap(
             editorialContent -> editorialManager.loadDownloadModel(editorialContent.getMd5sum(),
                 editorialContent.getPackageName(), editorialContent.getVerCode(),
-                editorialContent.getPosition()))
-        .observeOn(viewScheduler)
-        .doOnNext(view::showDownloadModel)
+                editorialContent.getPosition())
+                .flatMap(editorialDownloadModel -> verifyNotEnoughSpaceError(editorialContent,
+                    editorialDownloadModel))
+                .observeOn(viewScheduler)
+                .doOnNext(view::showDownloadModel))
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(created -> {
         }, crashReporter::log);
+  }
+
+  private Observable<EditorialDownloadModel> verifyNotEnoughSpaceError(
+      EditorialContent editorialContent, EditorialDownloadModel downloadModel) {
+    if (downloadModel.getDownloadState() == DownloadModel.DownloadState.NOT_ENOUGH_STORAGE_ERROR) {
+      return moPubAdsManager.getAdsVisibilityStatus()
+          .doOnSuccess(offerResponseStatus -> {
+            DownloadModel.Action action = downloadModel.getAction();
+            editorialAnalytics.sendNotEnoughSpaceErrorEvent(editorialContent.getPackageName(),
+                downloadModel.getAction(), offerResponseStatus,
+                action != null && action.equals(DownloadModel.Action.MIGRATE),
+                !editorialContent.getSplits()
+                    .isEmpty(), editorialContent.hasAppc(), editorialContent.getRank(),
+                editorialContent.getStoreName(), false);
+          })
+          .toObservable()
+          .map(__ -> downloadModel);
+    }
+    return Observable.just(downloadModel);
   }
 
   @VisibleForTesting public void handlePlaceHolderVisibility() {

--- a/app/src/main/java/cm/aptoide/pt/home/more/appcoins/EarnAppcListAnalytics.kt
+++ b/app/src/main/java/cm/aptoide/pt/home/more/appcoins/EarnAppcListAnalytics.kt
@@ -1,0 +1,32 @@
+package cm.aptoide.pt.home.more.appcoins
+
+import cm.aptoide.pt.ads.WalletAdsOfferManager.OfferResponseStatus
+import cm.aptoide.pt.app.DownloadModel
+import cm.aptoide.pt.download.DownloadAnalytics
+import cm.aptoide.pt.download.InstallType
+
+class EarnAppcListAnalytics(private val downloadAnalytics: DownloadAnalytics) {
+
+  fun sendNotEnoughSpaceErrorEvent(packageName: String?,
+                                   downloadAction: DownloadModel.Action,
+                                   offerResponseStatus: OfferResponseStatus?,
+                                   isMigration: Boolean,
+                                   isAppBundle: Boolean, hasAppc: Boolean,
+                                   trustedBadge: String?, storeName: String?,
+                                   isApkfy: Boolean) {
+    downloadAnalytics.sendNotEnoughSpaceError(packageName, mapDownloadAction(downloadAction),
+        offerResponseStatus, isMigration, isAppBundle, hasAppc, trustedBadge, storeName, isApkfy)
+  }
+
+  private fun mapDownloadAction(downloadAction: DownloadModel.Action): InstallType? {
+    var installType = InstallType.INSTALL
+    installType = when (downloadAction) {
+      DownloadModel.Action.DOWNGRADE -> InstallType.DOWNGRADE
+      DownloadModel.Action.INSTALL -> InstallType.INSTALL
+      DownloadModel.Action.UPDATE -> InstallType.UPDATE
+      DownloadModel.Action.MIGRATE, DownloadModel.Action.OPEN -> throw IllegalStateException(
+          "Mapping an invalid download action " + downloadAction.name)
+    }
+    return installType
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionsAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionsAnalytics.java
@@ -7,6 +7,7 @@ import cm.aptoide.pt.app.AppViewAnalytics;
 import cm.aptoide.pt.app.DownloadModel;
 import cm.aptoide.pt.database.realm.Download;
 import cm.aptoide.pt.download.DownloadAnalytics;
+import cm.aptoide.pt.download.InstallType;
 import cm.aptoide.pt.download.Origin;
 import cm.aptoide.pt.install.InstallAnalytics;
 import java.util.HashMap;
@@ -147,5 +148,33 @@ public class PromotionsAnalytics {
 
     analyticsManager.logEvent(data, VALENTINE_MIGRATOR, AnalyticsManager.Action.CLICK,
         navigationTracker.getViewName(true));
+  }
+
+  public void sendNotEnoughSpaceErrorEvent(String packageName, DownloadModel.Action downloadAction,
+      WalletAdsOfferManager.OfferResponseStatus offerResponseStatus, boolean isMigration,
+      boolean isAppBundle, boolean hasAppc, String trustedBadge, String storeName,
+      boolean isApkfy) {
+    downloadAnalytics.sendNotEnoughSpaceError(packageName, mapDownloadAction(downloadAction),
+        offerResponseStatus, isMigration, isAppBundle, hasAppc, trustedBadge, storeName, isApkfy);
+  }
+
+  private InstallType mapDownloadAction(DownloadModel.Action downloadAction) {
+    InstallType installType = InstallType.INSTALL;
+    switch (downloadAction) {
+      case DOWNGRADE:
+        installType = InstallType.DOWNGRADE;
+        break;
+      case INSTALL:
+        installType = InstallType.INSTALL;
+        break;
+      case UPDATE:
+        installType = InstallType.UPDATE;
+        break;
+      case MIGRATE:
+      case OPEN:
+        throw new IllegalStateException(
+            "Mapping an invalid download action " + downloadAction.name());
+    }
+    return installType;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/view/ActivityModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/ActivityModule.java
@@ -365,10 +365,12 @@ import static android.content.Context.WINDOW_SERVICE;
 
   @ActivityScope @Provides WalletInstallPresenter providesWalletInstallPresenter(
       WalletInstallConfiguration configuration, WalletInstallNavigator walletInstallNavigator,
-      WalletInstallManager walletInstallManager) {
+      WalletInstallManager walletInstallManager, WalletInstallAnalytics walletInstallAnalytics,
+      MoPubAdsManager moPubAdsManager) {
     return new WalletInstallPresenter((WalletInstallView) view, walletInstallManager,
         walletInstallNavigator, new PermissionManager(), ((PermissionService) activity),
-        AndroidSchedulers.mainThread(), Schedulers.io(), configuration);
+        AndroidSchedulers.mainThread(), Schedulers.io(), configuration, walletInstallAnalytics,
+        moPubAdsManager);
   }
 
   @ActivityScope @Provides WalletInstallNavigator providesWalletInstallNavigator(

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -107,6 +107,7 @@ import cm.aptoide.pt.home.apps.UpdatesManager;
 import cm.aptoide.pt.home.bundles.BundlesRepository;
 import cm.aptoide.pt.home.bundles.ads.AdMapper;
 import cm.aptoide.pt.home.bundles.ads.banner.BannerRepository;
+import cm.aptoide.pt.home.more.appcoins.EarnAppcListAnalytics;
 import cm.aptoide.pt.home.more.appcoins.EarnAppcListConfiguration;
 import cm.aptoide.pt.home.more.appcoins.EarnAppcListFragment;
 import cm.aptoide.pt.home.more.appcoins.EarnAppcListManager;
@@ -455,19 +456,21 @@ import rx.subscriptions.CompositeSubscription;
   @FragmentScope @Provides EditorialPresenter providesEditorialPresenter(
       EditorialManager editorialManager, CrashReport crashReport,
       EditorialAnalytics editorialAnalytics, EditorialNavigator editorialNavigator,
-      UserFeedbackAnalytics userFeedbackAnalytics) {
+      UserFeedbackAnalytics userFeedbackAnalytics, MoPubAdsManager moPubAdsManager) {
     return new EditorialPresenter((EditorialView) fragment, editorialManager,
         AndroidSchedulers.mainThread(), crashReport, new PermissionManager(),
         ((PermissionService) fragment.getContext()), editorialAnalytics, editorialNavigator,
-        userFeedbackAnalytics);
+        userFeedbackAnalytics, moPubAdsManager);
   }
 
   @FragmentScope @Provides PromotionsPresenter providesPromotionsPresenter(
       PromotionsManager promotionsManager, PromotionsAnalytics promotionsAnalytics,
-      PromotionsNavigator promotionsNavigator, @Named("homePromotionsId") String promotionsType) {
+      PromotionsNavigator promotionsNavigator, @Named("homePromotionsId") String promotionsType,
+      MoPubAdsManager moPubAdsManager) {
     return new PromotionsPresenter((PromotionsView) fragment, promotionsManager,
         new PermissionManager(), ((PermissionService) fragment.getContext()),
-        AndroidSchedulers.mainThread(), promotionsAnalytics, promotionsNavigator, promotionsType);
+        AndroidSchedulers.mainThread(), promotionsAnalytics, promotionsNavigator, promotionsType,
+        moPubAdsManager);
   }
 
   @FragmentScope @Provides PromotionViewAppMapper providesPromotionViewAppMapper(
@@ -576,12 +579,17 @@ import rx.subscriptions.CompositeSubscription;
   @FragmentScope @Provides EarnAppcListPresenter provideEarnAppCoinsListPresenter(
       CrashReport crashReport, RewardAppCoinsAppsRepository rewardAppCoinsAppsRepository,
       AnalyticsManager analyticsManager, AppNavigator appNavigator,
-      EarnAppcListConfiguration earnAppcListConfiguration,
-      EarnAppcListManager earnAppcListManager) {
+      EarnAppcListConfiguration earnAppcListConfiguration, EarnAppcListManager earnAppcListManager,
+      MoPubAdsManager moPubAdsManager, EarnAppcListAnalytics earnAppcListAnalytics) {
     return new EarnAppcListPresenter((EarnAppcListFragment) fragment,
         AndroidSchedulers.mainThread(), crashReport, rewardAppCoinsAppsRepository, analyticsManager,
         appNavigator, earnAppcListConfiguration, earnAppcListManager, new PermissionManager(),
-        ((PermissionService) fragment.getContext()));
+        ((PermissionService) fragment.getContext()), moPubAdsManager, earnAppcListAnalytics);
+  }
+
+  @FragmentScope @Provides EarnAppcListAnalytics provideEarnAppcListAnalytics(
+      DownloadAnalytics downloadAnalytics) {
+    return new EarnAppcListAnalytics(downloadAnalytics);
   }
 
   @FragmentScope @Provides EarnAppcListManager provideEarnAppcListManager(

--- a/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallAnalytics.kt
+++ b/app/src/main/java/cm/aptoide/pt/wallet/WalletInstallAnalytics.kt
@@ -9,6 +9,7 @@ import cm.aptoide.pt.app.DownloadStateParser
 import cm.aptoide.pt.database.realm.Download
 import cm.aptoide.pt.download.AppContext
 import cm.aptoide.pt.download.DownloadAnalytics
+import cm.aptoide.pt.download.InstallType
 import cm.aptoide.pt.install.InstallAnalytics
 import cm.aptoide.pt.notification.NotificationAnalytics
 import java.util.*
@@ -92,5 +93,28 @@ class WalletInstallAnalytics(val downloadAnalytics: DownloadAnalytics,
 
   private fun getHistoryTracker(): ScreenTagHistory? {
     return ScreenTagHistory.Builder.build(VIEW_CONTEXT)
+  }
+
+  fun sendNotEnoughSpaceErrorEvent(packageName: String?,
+                                   downloadAction: DownloadModel.Action,
+                                   offerResponseStatus: WalletAdsOfferManager.OfferResponseStatus?,
+                                   isMigration: Boolean,
+                                   isAppBundle: Boolean, hasAppc: Boolean,
+                                   trustedBadge: String?, storeName: String?,
+                                   isApkfy: Boolean) {
+    downloadAnalytics.sendNotEnoughSpaceError(packageName, mapDownloadAction(downloadAction),
+        offerResponseStatus, isMigration, isAppBundle, hasAppc, trustedBadge, storeName, isApkfy)
+  }
+
+  private fun mapDownloadAction(downloadAction: DownloadModel.Action): InstallType? {
+    var installType = InstallType.INSTALL
+    installType = when (downloadAction) {
+      DownloadModel.Action.DOWNGRADE -> InstallType.DOWNGRADE
+      DownloadModel.Action.INSTALL -> InstallType.INSTALL
+      DownloadModel.Action.UPDATE -> InstallType.UPDATE
+      DownloadModel.Action.MIGRATE, DownloadModel.Action.OPEN -> throw IllegalStateException(
+          "Mapping an invalid download action " + downloadAction.name)
+    }
+    return installType
   }
 }

--- a/app/src/test/java/cm/aptoide/pt/app/view/EditorialPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/view/EditorialPresenterTest.java
@@ -3,6 +3,7 @@ package cm.aptoide.pt.app.view;
 import cm.aptoide.pt.UserFeedbackAnalytics;
 import cm.aptoide.pt.actions.PermissionManager;
 import cm.aptoide.pt.actions.PermissionService;
+import cm.aptoide.pt.ads.MoPubAdsManager;
 import cm.aptoide.pt.app.DownloadModel;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.editorial.EditorialAnalytics;
@@ -49,6 +50,7 @@ public class EditorialPresenterTest {
   @Mock private EditorialAnalytics editorialAnalytics;
   @Mock private EditorialNavigator editorialNavigator;
   @Mock private UserFeedbackAnalytics userFeedbackAnalytics;
+  @Mock private MoPubAdsManager moPubAdsManager;
 
   private EditorialPresenter presenter;
   private EditorialViewModel editorialViewModel;
@@ -66,7 +68,7 @@ public class EditorialPresenterTest {
     MockitoAnnotations.initMocks(this);
     presenter = new EditorialPresenter(view, editorialManager, Schedulers.immediate(), crashReport,
         permissionManager, permissionService, editorialAnalytics, editorialNavigator,
-        userFeedbackAnalytics);
+        userFeedbackAnalytics, moPubAdsManager);
     lifecycleEvent = PublishSubject.create();
     reactionButtonClickEvent = PublishSubject.create();
     reactionButtonLongPressEvent = PublishSubject.create();


### PR DESCRIPTION
**What does this PR do?**

   It sends analytics for when there is not enough space to install an app. 

**Database changed?**

   No

**How should this be manually tested?**

  Check for every place where there's a download (appview, promotions, earnappclist, editorial) if it sends the correct event when there's no space. Either check this with a device with no space, or go to InstallManager and always set the NOT_ENOUGH_SPACE_ERROR (~line 243)

**What are the relevant tickets?**

  [MOB-582](https://aptoide.atlassian.net/browse/MOB-582)


**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass