### PR TITLE
[bugfix/MOB-597] Async MD5 Calculation

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -318,13 +318,13 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     super.onViewCreated(view, savedInstanceState);
 
     ViewStub.OnInflateListener installInflateListener = (viewStub, view1) -> {
-      install = ((Button) view1.findViewById(R.id.appview_install_button));
-      downloadInfoLayout = ((LinearLayout) view1.findViewById(R.id.appview_transfer_info));
-      downloadProgressBar = ((ProgressBar) view1.findViewById(R.id.appview_download_progress_bar));
-      downloadProgressValue = (TextView) view1.findViewById(R.id.appview_download_progress_number);
-      cancelDownload = ((ImageView) view1.findViewById(R.id.appview_download_cancel_button));
-      resumeDownload = ((ImageView) view1.findViewById(R.id.appview_download_resume_download));
-      pauseDownload = ((ImageView) view1.findViewById(R.id.appview_download_pause_download));
+      install = view1.findViewById(R.id.appview_install_button);
+      downloadInfoLayout = view1.findViewById(R.id.appview_transfer_info);
+      downloadProgressBar = view1.findViewById(R.id.appview_download_progress_bar);
+      downloadProgressValue = view1.findViewById(R.id.appview_download_progress_number);
+      cancelDownload = view1.findViewById(R.id.appview_download_cancel_button);
+      resumeDownload = view1.findViewById(R.id.appview_download_resume_download);
+      pauseDownload = view1.findViewById(R.id.appview_download_pause_download);
       installStateText = view1.findViewById(R.id.appview_download_download_state);
       downloadControlsLayout = view1.findViewById(R.id.install_controls_layout);
 

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -341,7 +341,7 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     poaInstall.setLayoutResource(R.layout.install_app_view);
     poaInstall.setOnInflateListener(installInflateListener);
 
-    scrollView = (NestedScrollView) view.findViewById(R.id.scroll_view_app);
+    scrollView = view.findViewById(R.id.scroll_view_app);
     errorView = view.findViewById(R.id.error_view);
     reviewsLayout = view.findViewById(R.id.reviews_layout);
     appIcon = view.findViewById(R.id.app_icon);
@@ -366,30 +366,30 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     poaCountdownSeconds = view.findViewById(R.id.seconds);
     iabInfo = view.findViewById(R.id.iap_appc_label);
     versionsLayout = view.findViewById(R.id.versions_layout);
-    latestVersionTitle = (TextView) view.findViewById(R.id.latest_version_title);
+    latestVersionTitle = view.findViewById(R.id.latest_version_title);
     latestVersion = versionsLayout.findViewById(R.id.latest_version);
     rewardAppLatestVersion = view.findViewById(R.id.appview_reward_app_versions_element);
-    otherVersions = (TextView) view.findViewById(R.id.other_versions);
+    otherVersions = view.findViewById(R.id.other_versions);
 
-    screenshots = (RecyclerView) view.findViewById(R.id.screenshots_list);
+    screenshots = view.findViewById(R.id.screenshots_list);
     screenshots.setLayoutManager(
         new LinearLayoutManager(view.getContext(), RecyclerView.HORIZONTAL, false));
     screenshots.setNestedScrollingEnabled(false);
 
-    descriptionText = (TextView) view.findViewById(R.id.description_text);
-    descriptionReadMore = (Button) view.findViewById(R.id.description_see_more);
-    topReviewsProgress = (ContentLoadingProgressBar) view.findViewById(R.id.top_comments_progress);
+    descriptionText = view.findViewById(R.id.description_text);
+    descriptionReadMore = view.findViewById(R.id.description_see_more);
+    topReviewsProgress = view.findViewById(R.id.top_comments_progress);
     ratingLayout = view.findViewById(R.id.rating_layout);
     emptyReviewsLayout = view.findViewById(R.id.empty_reviews_layout);
     topReviewsLayout = view.findViewById(R.id.comments_layout);
-    rateAppButtonLarge = (Button) view.findViewById(R.id.rate_this_button2);
-    emptyReviewTextView = (TextView) view.findViewById(R.id.empty_review_text);
-    reviewUsers = (TextView) view.findViewById(R.id.users_voted);
-    avgReviewScore = (TextView) view.findViewById(R.id.rating_value);
-    avgReviewScoreBar = (RatingBar) view.findViewById(R.id.rating_bar);
-    reviewsView = (RecyclerView) view.findViewById(R.id.top_comments_list);
-    rateAppButton = (Button) view.findViewById(R.id.rate_this_button);
-    showAllReviewsButton = (Button) view.findViewById(R.id.read_all_button);
+    rateAppButtonLarge = view.findViewById(R.id.rate_this_button2);
+    emptyReviewTextView = view.findViewById(R.id.empty_review_text);
+    reviewUsers = view.findViewById(R.id.users_voted);
+    avgReviewScore = view.findViewById(R.id.rating_value);
+    avgReviewScoreBar = view.findViewById(R.id.rating_bar);
+    reviewsView = view.findViewById(R.id.top_comments_list);
+    rateAppButton = view.findViewById(R.id.rate_this_button);
+    showAllReviewsButton = view.findViewById(R.id.read_all_button);
     apkfyElement = view.findViewById(R.id.apkfy_element);
 
     flagThisAppSection = view.findViewById(R.id.flag_this_app_section);

--- a/app/src/main/java/cm/aptoide/pt/download/FileDownloadTask.java
+++ b/app/src/main/java/cm/aptoide/pt/download/FileDownloadTask.java
@@ -52,6 +52,12 @@ public class FileDownloadTask extends FileDownloadLargeFileListener {
 
   @Override protected void completed(BaseDownloadTask baseDownloadTask) {
     new Thread(() -> {
+      FileDownloadTaskStatus fileDownloadTaskStatus1 =
+          new FileDownloadTaskStatus(AppDownloadStatus.AppDownloadState.VERIFYING_FILE_INTEGRITY,
+              new FileDownloadProgressResult(baseDownloadTask.getLargeFileTotalBytes(),
+                  baseDownloadTask.getLargeFileTotalBytes()), md5);
+      downloadStatus.onNext(fileDownloadTaskStatus1);
+
       FileDownloadTaskStatus fileDownloadTaskStatus;
       if (md5Comparator.compareMd5(md5, fileName)) {
         fileDownloadTaskStatus =

--- a/app/src/main/java/cm/aptoide/pt/download/FileDownloadTask.java
+++ b/app/src/main/java/cm/aptoide/pt/download/FileDownloadTask.java
@@ -51,22 +51,24 @@ public class FileDownloadTask extends FileDownloadLargeFileListener {
   }
 
   @Override protected void completed(BaseDownloadTask baseDownloadTask) {
-    FileDownloadTaskStatus fileDownloadTaskStatus;
-    if (md5Comparator.compareMd5(md5, fileName)) {
-      fileDownloadTaskStatus =
-          new FileDownloadTaskStatus(AppDownloadStatus.AppDownloadState.COMPLETED,
-              new FileDownloadProgressResult(baseDownloadTask.getLargeFileTotalBytes(),
-                  baseDownloadTask.getLargeFileTotalBytes()), md5);
-      Logger.getInstance()
-          .d(TAG, " Download completed");
-    } else {
-      Logger.getInstance()
-          .d(TAG, " Download error in md5");
-      fileDownloadTaskStatus =
-          new FileDownloadTaskStatus(AppDownloadStatus.AppDownloadState.ERROR_MD5_DOES_NOT_MATCH,
-              md5, new Md5DownloadComparisonException("md5 does not match"));
-    }
-    downloadStatus.onNext(fileDownloadTaskStatus);
+    new Thread(() -> {
+      FileDownloadTaskStatus fileDownloadTaskStatus;
+      if (md5Comparator.compareMd5(md5, fileName)) {
+        fileDownloadTaskStatus =
+            new FileDownloadTaskStatus(AppDownloadStatus.AppDownloadState.COMPLETED,
+                new FileDownloadProgressResult(baseDownloadTask.getLargeFileTotalBytes(),
+                    baseDownloadTask.getLargeFileTotalBytes()), md5);
+        Logger.getInstance()
+            .d(TAG, " Download completed");
+      } else {
+        Logger.getInstance()
+            .d(TAG, " Download error in md5");
+        fileDownloadTaskStatus =
+            new FileDownloadTaskStatus(AppDownloadStatus.AppDownloadState.ERROR_MD5_DOES_NOT_MATCH,
+                md5, new Md5DownloadComparisonException("md5 does not match"));
+      }
+      downloadStatus.onNext(fileDownloadTaskStatus);
+    }).start();
   }
 
   @Override protected void error(BaseDownloadTask baseDownloadTask, Throwable error) {

--- a/app/src/main/java/cm/aptoide/pt/install/InstallManager.java
+++ b/app/src/main/java/cm/aptoide/pt/install/InstallManager.java
@@ -355,6 +355,7 @@ public class InstallManager {
     if (download != null) {
       switch (download.getOverallDownloadStatus()) {
         case Download.IN_QUEUE:
+        case Download.VERIFYING_FILE_INTEGRITY:
         case Download.WAITING_TO_MOVE_FILES:
           isIndeterminate = true;
           break;

--- a/aptoide-database/src/main/java/cm/aptoide/pt/database/realm/Download.java
+++ b/aptoide-database/src/main/java/cm/aptoide/pt/database/realm/Download.java
@@ -35,6 +35,7 @@ public class Download extends RealmObject {
   public static final int NOT_DOWNLOADED = 12;
   public static final int IN_QUEUE = 13;
   public static final int WAITING_TO_MOVE_FILES = 14;
+  public static final int VERIFYING_FILE_INTEGRITY = 15;
   //errors
   public static final int NO_ERROR = 0;
   public static final int GENERIC_ERROR = 1;

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AppDownloadManager.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AppDownloadManager.java
@@ -108,19 +108,19 @@ public class AppDownloadManager implements AppDownloader {
     return fileDownloader.observeFileDownloadProgress()
         .doOnNext(fileDownloadCallback -> fileDownloadSubject.onNext(fileDownloadCallback))
         .doOnNext(fileDownloadCallback -> {
-          if (fileDownloadCallback.getDownloadState()
-              == AppDownloadStatus.AppDownloadState.COMPLETED) {
-            handleCompletedFileDownload(fileDownloader);
-          } else if (fileDownloadCallback.getDownloadState()
-              == AppDownloadStatus.AppDownloadState.ERROR_FILE_NOT_FOUND
-              || fileDownloadCallback.getDownloadState() == AppDownloadStatus.AppDownloadState.ERROR
-              || fileDownloadCallback.getDownloadState()
-              == AppDownloadStatus.AppDownloadState.ERROR_NOT_ENOUGH_SPACE) {
-            handleErrorFileDownload();
-            if (fileDownloadCallback.hasError()) {
-              downloadAnalytics.onError(app.getPackageName(), app.getVersionCode(), app.getMd5(),
-                  fileDownloadCallback.getError());
-            }
+          switch (fileDownloadCallback.getDownloadState()) {
+            case COMPLETED:
+              handleCompletedFileDownload(fileDownloader);
+              break;
+            case ERROR_FILE_NOT_FOUND:
+            case ERROR:
+            case ERROR_NOT_ENOUGH_SPACE:
+              handleErrorFileDownload();
+              if (fileDownloadCallback.hasError()) {
+                downloadAnalytics.onError(app.getPackageName(), app.getVersionCode(), app.getMd5(),
+                    fileDownloadCallback.getError());
+              }
+              break;
           }
         });
   }

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AppDownloadManager.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AppDownloadManager.java
@@ -108,19 +108,21 @@ public class AppDownloadManager implements AppDownloader {
     return fileDownloader.observeFileDownloadProgress()
         .doOnNext(fileDownloadCallback -> fileDownloadSubject.onNext(fileDownloadCallback))
         .doOnNext(fileDownloadCallback -> {
-          switch (fileDownloadCallback.getDownloadState()) {
-            case COMPLETED:
-              handleCompletedFileDownload(fileDownloader);
-              break;
-            case ERROR_FILE_NOT_FOUND:
-            case ERROR:
-            case ERROR_NOT_ENOUGH_SPACE:
-              handleErrorFileDownload();
-              if (fileDownloadCallback.hasError()) {
-                downloadAnalytics.onError(app.getPackageName(), app.getVersionCode(), app.getMd5(),
-                    fileDownloadCallback.getError());
-              }
-              break;
+          if (fileDownloadCallback.getDownloadState() != null) {
+            switch (fileDownloadCallback.getDownloadState()) {
+              case COMPLETED:
+                handleCompletedFileDownload(fileDownloader);
+                break;
+              case ERROR_FILE_NOT_FOUND:
+              case ERROR:
+              case ERROR_NOT_ENOUGH_SPACE:
+                handleErrorFileDownload();
+                if (fileDownloadCallback.hasError()) {
+                  downloadAnalytics.onError(app.getPackageName(), app.getVersionCode(),
+                      app.getMd5(), fileDownloadCallback.getError());
+                }
+                break;
+            }
           }
         });
   }

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AppDownloadStatus.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AppDownloadStatus.java
@@ -80,45 +80,48 @@ public class AppDownloadStatus {
   private AppDownloadState getAppDownloadState() {
     AppDownloadStatus.AppDownloadState previousState = null;
     for (FileDownloadCallback fileDownloadCallback : fileDownloadCallbackList) {
-      if (fileDownloadCallback.getDownloadState() == AppDownloadStatus.AppDownloadState.ERROR) {
-        return AppDownloadState.ERROR;
-      } else if (fileDownloadCallback.getDownloadState()
-          == AppDownloadState.ERROR_MD5_DOES_NOT_MATCH) {
-        return AppDownloadState.ERROR_MD5_DOES_NOT_MATCH;
-      } else if (fileDownloadCallback.getDownloadState()
-          == AppDownloadStatus.AppDownloadState.ERROR_FILE_NOT_FOUND) {
-        return AppDownloadState.ERROR_FILE_NOT_FOUND;
-      } else if (fileDownloadCallback.getDownloadState()
-          == AppDownloadStatus.AppDownloadState.ERROR_NOT_ENOUGH_SPACE) {
-        return AppDownloadState.ERROR_NOT_ENOUGH_SPACE;
-      } else if (fileDownloadCallback.getDownloadState()
-          == AppDownloadStatus.AppDownloadState.WARN) {
-        return AppDownloadState.WARN;
-      } else if (fileDownloadCallback.getDownloadState()
-          == AppDownloadStatus.AppDownloadState.PAUSED) {
-        return AppDownloadState.PAUSED;
-      } else if (fileDownloadCallback.getDownloadState()
-          == AppDownloadStatus.AppDownloadState.INVALID_STATUS) {
-        return AppDownloadState.INVALID_STATUS;
-      } else if (fileDownloadCallback.getDownloadState()
-          == AppDownloadStatus.AppDownloadState.COMPLETED) {
-        if (previousState != null
-            && previousState != AppDownloadStatus.AppDownloadState.COMPLETED) {
-          return AppDownloadState.PROGRESS;
-        } else if (fileDownloadCallbackList.indexOf(fileDownloadCallback)
-            == fileDownloadCallbackList.size() - 1) {
-          Logger.getInstance()
-              .d("AppDownloadState", "emitting APPDOWNLOADSTATE completed " + md5);
-          return AppDownloadState.COMPLETED;
-        }
-      } else if (fileDownloadCallback.getDownloadState()
-          == AppDownloadStatus.AppDownloadState.PENDING) {
-        if (previousState != null && previousState != AppDownloadStatus.AppDownloadState.PENDING) {
-          return AppDownloadState.PROGRESS;
-        } else if (fileDownloadCallbackList.indexOf(fileDownloadCallback)
-            == fileDownloadCallbackList.size() - 1) {
-          return AppDownloadState.PENDING;
-        }
+      switch (fileDownloadCallback.getDownloadState()) {
+        case ERROR:
+          return AppDownloadState.ERROR;
+        case ERROR_MD5_DOES_NOT_MATCH:
+          return AppDownloadState.ERROR_MD5_DOES_NOT_MATCH;
+        case ERROR_FILE_NOT_FOUND:
+          return AppDownloadState.ERROR_FILE_NOT_FOUND;
+        case ERROR_NOT_ENOUGH_SPACE:
+          return AppDownloadState.ERROR_NOT_ENOUGH_SPACE;
+        case WARN:
+          return AppDownloadState.WARN;
+        case PAUSED:
+          return AppDownloadState.PAUSED;
+        case INVALID_STATUS:
+          return AppDownloadState.INVALID_STATUS;
+        case VERIFYING_FILE_INTEGRITY:
+          if (previousState != null && (previousState
+              != AppDownloadStatus.AppDownloadState.VERIFYING_FILE_INTEGRITY
+              && previousState != AppDownloadState.COMPLETED)) {
+            return AppDownloadState.PROGRESS;
+          } else if (fileDownloadCallbackList.indexOf(fileDownloadCallback)
+              == fileDownloadCallbackList.size() - 1) {
+            return AppDownloadState.VERIFYING_FILE_INTEGRITY;
+          }
+        case COMPLETED:
+          if (previousState != null
+              && previousState != AppDownloadStatus.AppDownloadState.COMPLETED) {
+            return AppDownloadState.PROGRESS;
+          } else if (fileDownloadCallbackList.indexOf(fileDownloadCallback)
+              == fileDownloadCallbackList.size() - 1) {
+            Logger.getInstance()
+                .d("AppDownloadState", "emitting APPDOWNLOADSTATE completed " + md5);
+            return AppDownloadState.COMPLETED;
+          }
+        case PENDING:
+          if (previousState != null
+              && previousState != AppDownloadStatus.AppDownloadState.PENDING) {
+            return AppDownloadState.PROGRESS;
+          } else if (fileDownloadCallbackList.indexOf(fileDownloadCallback)
+              == fileDownloadCallbackList.size() - 1) {
+            return AppDownloadState.PENDING;
+          }
       }
       previousState = fileDownloadCallback.getDownloadState();
     }
@@ -169,6 +172,6 @@ public class AppDownloadStatus {
   }
 
   public enum AppDownloadState {
-    INVALID_STATUS, COMPLETED, PENDING, PAUSED, WARN, ERROR, ERROR_FILE_NOT_FOUND, ERROR_NOT_ENOUGH_SPACE, ERROR_MD5_DOES_NOT_MATCH, PROGRESS, WAITING_TO_MOVE_FILES
+    INVALID_STATUS, COMPLETED, PENDING, PAUSED, WARN, ERROR, ERROR_FILE_NOT_FOUND, ERROR_NOT_ENOUGH_SPACE, ERROR_MD5_DOES_NOT_MATCH, PROGRESS, WAITING_TO_MOVE_FILES, VERIFYING_FILE_INTEGRITY
   }
 }

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AppDownloadStatus.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AppDownloadStatus.java
@@ -80,50 +80,52 @@ public class AppDownloadStatus {
   private AppDownloadState getAppDownloadState() {
     AppDownloadStatus.AppDownloadState previousState = null;
     for (FileDownloadCallback fileDownloadCallback : fileDownloadCallbackList) {
-      switch (fileDownloadCallback.getDownloadState()) {
-        case ERROR:
-          return AppDownloadState.ERROR;
-        case ERROR_MD5_DOES_NOT_MATCH:
-          return AppDownloadState.ERROR_MD5_DOES_NOT_MATCH;
-        case ERROR_FILE_NOT_FOUND:
-          return AppDownloadState.ERROR_FILE_NOT_FOUND;
-        case ERROR_NOT_ENOUGH_SPACE:
-          return AppDownloadState.ERROR_NOT_ENOUGH_SPACE;
-        case WARN:
-          return AppDownloadState.WARN;
-        case PAUSED:
-          return AppDownloadState.PAUSED;
-        case INVALID_STATUS:
-          return AppDownloadState.INVALID_STATUS;
-        case VERIFYING_FILE_INTEGRITY:
-          if (previousState != null && (previousState
-              != AppDownloadStatus.AppDownloadState.VERIFYING_FILE_INTEGRITY
-              && previousState != AppDownloadState.COMPLETED)) {
-            return AppDownloadState.PROGRESS;
-          } else if (fileDownloadCallbackList.indexOf(fileDownloadCallback)
-              == fileDownloadCallbackList.size() - 1) {
-            return AppDownloadState.VERIFYING_FILE_INTEGRITY;
-          }
-        case COMPLETED:
-          if (previousState != null
-              && previousState != AppDownloadStatus.AppDownloadState.COMPLETED) {
-            return AppDownloadState.PROGRESS;
-          } else if (fileDownloadCallbackList.indexOf(fileDownloadCallback)
-              == fileDownloadCallbackList.size() - 1) {
-            Logger.getInstance()
-                .d("AppDownloadState", "emitting APPDOWNLOADSTATE completed " + md5);
-            return AppDownloadState.COMPLETED;
-          }
-        case PENDING:
-          if (previousState != null
-              && previousState != AppDownloadStatus.AppDownloadState.PENDING) {
-            return AppDownloadState.PROGRESS;
-          } else if (fileDownloadCallbackList.indexOf(fileDownloadCallback)
-              == fileDownloadCallbackList.size() - 1) {
-            return AppDownloadState.PENDING;
-          }
+      if (fileDownloadCallback.getDownloadState() != null) {
+        switch (fileDownloadCallback.getDownloadState()) {
+          case ERROR:
+            return AppDownloadState.ERROR;
+          case ERROR_MD5_DOES_NOT_MATCH:
+            return AppDownloadState.ERROR_MD5_DOES_NOT_MATCH;
+          case ERROR_FILE_NOT_FOUND:
+            return AppDownloadState.ERROR_FILE_NOT_FOUND;
+          case ERROR_NOT_ENOUGH_SPACE:
+            return AppDownloadState.ERROR_NOT_ENOUGH_SPACE;
+          case WARN:
+            return AppDownloadState.WARN;
+          case PAUSED:
+            return AppDownloadState.PAUSED;
+          case INVALID_STATUS:
+            return AppDownloadState.INVALID_STATUS;
+          case VERIFYING_FILE_INTEGRITY:
+            if (previousState != null && (previousState
+                != AppDownloadStatus.AppDownloadState.VERIFYING_FILE_INTEGRITY
+                && previousState != AppDownloadState.COMPLETED)) {
+              return AppDownloadState.PROGRESS;
+            } else if (fileDownloadCallbackList.indexOf(fileDownloadCallback)
+                == fileDownloadCallbackList.size() - 1) {
+              return AppDownloadState.VERIFYING_FILE_INTEGRITY;
+            }
+          case COMPLETED:
+            if (previousState != null
+                && previousState != AppDownloadStatus.AppDownloadState.COMPLETED) {
+              return AppDownloadState.PROGRESS;
+            } else if (fileDownloadCallbackList.indexOf(fileDownloadCallback)
+                == fileDownloadCallbackList.size() - 1) {
+              Logger.getInstance()
+                  .d("AppDownloadState", "emitting APPDOWNLOADSTATE completed " + md5);
+              return AppDownloadState.COMPLETED;
+            }
+          case PENDING:
+            if (previousState != null
+                && previousState != AppDownloadStatus.AppDownloadState.PENDING) {
+              return AppDownloadState.PROGRESS;
+            } else if (fileDownloadCallbackList.indexOf(fileDownloadCallback)
+                == fileDownloadCallbackList.size() - 1) {
+              return AppDownloadState.PENDING;
+            }
+        }
+        previousState = fileDownloadCallback.getDownloadState();
       }
-      previousState = fileDownloadCallback.getDownloadState();
     }
     return AppDownloadState.PROGRESS;
   }

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/DownloadStatusMapper.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/DownloadStatusMapper.java
@@ -17,6 +17,9 @@ public class DownloadStatusMapper {
       case INVALID_STATUS:
         downloadState = Download.INVALID_STATUS;
         break;
+      case VERIFYING_FILE_INTEGRITY:
+        downloadState = Download.VERIFYING_FILE_INTEGRITY;
+        break;
       case COMPLETED:
         downloadState = Download.WAITING_TO_MOVE_FILES;
         break;

--- a/utils/src/main/java/cm/aptoide/pt/utils/AptoideUtils.java
+++ b/utils/src/main/java/cm/aptoide/pt/utils/AptoideUtils.java
@@ -227,7 +227,7 @@ public class AptoideUtils {
 
     public static String computeMd5(File f) {
       long time = System.currentTimeMillis();
-      byte[] buffer = new byte[1024];
+      byte[] buffer = new byte[1024 * 1024];
       int read, i;
       String md5hash;
       try {


### PR DESCRIPTION
**What does this PR do?**

   This fixes a bug where file integrity (with a md5 check) was being done in the main thread. It's now in a background thread and this file integrity check now is being represented by a new download status so that the download progress is indeterminate during that time. Also improves md5 check time by increasing the input buffer size.

**Database changed?**

   No

**How should this be manually tested?**

  Check first that downloads are working correctly in general. Then check that big app downloads (with OBB) do not block the main thread at any point during the download (move the screen while downloading, especially at around 99+%). You can also check that the app download status during the integrity check (md5) of the last file is indeterminate (check that the log `V/cm.aptoide.pt.utils.AptoideUtils$AlgorithmU: computeMd5 (...)` appears WHILE the download status is indeterminate)

**What are the relevant tickets?**

  [MOB-597](https://aptoide.atlassian.net/browse/MOB-597)

**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass