### PR TITLE
[bugfix/MOB-601] Out of space error bug

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -318,13 +318,13 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     super.onViewCreated(view, savedInstanceState);
 
     ViewStub.OnInflateListener installInflateListener = (viewStub, view1) -> {
-      install = ((Button) view1.findViewById(R.id.appview_install_button));
-      downloadInfoLayout = ((LinearLayout) view1.findViewById(R.id.appview_transfer_info));
-      downloadProgressBar = ((ProgressBar) view1.findViewById(R.id.appview_download_progress_bar));
-      downloadProgressValue = (TextView) view1.findViewById(R.id.appview_download_progress_number);
-      cancelDownload = ((ImageView) view1.findViewById(R.id.appview_download_cancel_button));
-      resumeDownload = ((ImageView) view1.findViewById(R.id.appview_download_resume_download));
-      pauseDownload = ((ImageView) view1.findViewById(R.id.appview_download_pause_download));
+      install = view1.findViewById(R.id.appview_install_button);
+      downloadInfoLayout = view1.findViewById(R.id.appview_transfer_info);
+      downloadProgressBar = view1.findViewById(R.id.appview_download_progress_bar);
+      downloadProgressValue = view1.findViewById(R.id.appview_download_progress_number);
+      cancelDownload = view1.findViewById(R.id.appview_download_cancel_button);
+      resumeDownload = view1.findViewById(R.id.appview_download_resume_download);
+      pauseDownload = view1.findViewById(R.id.appview_download_pause_download);
       installStateText = view1.findViewById(R.id.appview_download_download_state);
       downloadControlsLayout = view1.findViewById(R.id.install_controls_layout);
 
@@ -341,7 +341,7 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     poaInstall.setLayoutResource(R.layout.install_app_view);
     poaInstall.setOnInflateListener(installInflateListener);
 
-    scrollView = (NestedScrollView) view.findViewById(R.id.scroll_view_app);
+    scrollView = view.findViewById(R.id.scroll_view_app);
     errorView = view.findViewById(R.id.error_view);
     reviewsLayout = view.findViewById(R.id.reviews_layout);
     appIcon = view.findViewById(R.id.app_icon);
@@ -366,30 +366,30 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     poaCountdownSeconds = view.findViewById(R.id.seconds);
     iabInfo = view.findViewById(R.id.iap_appc_label);
     versionsLayout = view.findViewById(R.id.versions_layout);
-    latestVersionTitle = (TextView) view.findViewById(R.id.latest_version_title);
+    latestVersionTitle = view.findViewById(R.id.latest_version_title);
     latestVersion = versionsLayout.findViewById(R.id.latest_version);
     rewardAppLatestVersion = view.findViewById(R.id.appview_reward_app_versions_element);
-    otherVersions = (TextView) view.findViewById(R.id.other_versions);
+    otherVersions = view.findViewById(R.id.other_versions);
 
-    screenshots = (RecyclerView) view.findViewById(R.id.screenshots_list);
+    screenshots = view.findViewById(R.id.screenshots_list);
     screenshots.setLayoutManager(
         new LinearLayoutManager(view.getContext(), RecyclerView.HORIZONTAL, false));
     screenshots.setNestedScrollingEnabled(false);
 
-    descriptionText = (TextView) view.findViewById(R.id.description_text);
-    descriptionReadMore = (Button) view.findViewById(R.id.description_see_more);
-    topReviewsProgress = (ContentLoadingProgressBar) view.findViewById(R.id.top_comments_progress);
+    descriptionText = view.findViewById(R.id.description_text);
+    descriptionReadMore = view.findViewById(R.id.description_see_more);
+    topReviewsProgress = view.findViewById(R.id.top_comments_progress);
     ratingLayout = view.findViewById(R.id.rating_layout);
     emptyReviewsLayout = view.findViewById(R.id.empty_reviews_layout);
     topReviewsLayout = view.findViewById(R.id.comments_layout);
-    rateAppButtonLarge = (Button) view.findViewById(R.id.rate_this_button2);
-    emptyReviewTextView = (TextView) view.findViewById(R.id.empty_review_text);
-    reviewUsers = (TextView) view.findViewById(R.id.users_voted);
-    avgReviewScore = (TextView) view.findViewById(R.id.rating_value);
-    avgReviewScoreBar = (RatingBar) view.findViewById(R.id.rating_bar);
-    reviewsView = (RecyclerView) view.findViewById(R.id.top_comments_list);
-    rateAppButton = (Button) view.findViewById(R.id.rate_this_button);
-    showAllReviewsButton = (Button) view.findViewById(R.id.read_all_button);
+    rateAppButtonLarge = view.findViewById(R.id.rate_this_button2);
+    emptyReviewTextView = view.findViewById(R.id.empty_review_text);
+    reviewUsers = view.findViewById(R.id.users_voted);
+    avgReviewScore = view.findViewById(R.id.rating_value);
+    avgReviewScoreBar = view.findViewById(R.id.rating_bar);
+    reviewsView = view.findViewById(R.id.top_comments_list);
+    rateAppButton = view.findViewById(R.id.rate_this_button);
+    showAllReviewsButton = view.findViewById(R.id.read_all_button);
     apkfyElement = view.findViewById(R.id.apkfy_element);
 
     flagThisAppSection = view.findViewById(R.id.flag_this_app_section);
@@ -408,28 +408,28 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     LinearLayoutManager linearLayoutManager = new LinearLayoutManager(getContext());
     donationsList.setLayoutManager(linearLayoutManager);
 
-    workingWellText = (TextView) view.findViewById(R.id.working_well_count);
-    needsLicenceText = (TextView) view.findViewById(R.id.needs_licence_count);
-    fakeAppText = (TextView) view.findViewById(R.id.fake_app_count);
-    virusText = (TextView) view.findViewById(R.id.virus_count);
+    workingWellText = view.findViewById(R.id.working_well_count);
+    needsLicenceText = view.findViewById(R.id.needs_licence_count);
+    fakeAppText = view.findViewById(R.id.fake_app_count);
+    virusText = view.findViewById(R.id.virus_count);
     storeLayout = view.findViewById(R.id.store_uploaded_layout);
-    storeIcon = (ImageView) view.findViewById(R.id.store_icon);
-    storeName = (TextView) view.findViewById(R.id.store_name);
-    storeFollowers = (TextView) view.findViewById(R.id.user_count);
-    storeDownloads = (TextView) view.findViewById(R.id.download_count);
-    storeFollow = (Button) view.findViewById(R.id.follow_button);
+    storeIcon = view.findViewById(R.id.store_icon);
+    storeName = view.findViewById(R.id.store_name);
+    storeFollowers = view.findViewById(R.id.user_count);
+    storeDownloads = view.findViewById(R.id.download_count);
+    storeFollow = view.findViewById(R.id.follow_button);
     similarListRecyclerView = view.findViewById(R.id.similar_list);
-    similarDownloadPlaceholder = (View) view.findViewById(R.id.similar_download_placeholder);
-    similarBottomPlaceholder = (View) view.findViewById(R.id.similar_bottom_placeholder);
+    similarDownloadPlaceholder = view.findViewById(R.id.similar_download_placeholder);
+    similarBottomPlaceholder = view.findViewById(R.id.similar_bottom_placeholder);
     infoWebsite = view.findViewById(R.id.website_label);
     infoEmail = view.findViewById(R.id.email_label);
     infoPrivacy = view.findViewById(R.id.privacy_policy_label);
     infoPermissions = view.findViewById(R.id.permissions_label);
     catappultCard = view.findViewById(R.id.catappult_card);
 
-    viewProgress = (ProgressBar) view.findViewById(R.id.appview_progress);
+    viewProgress = view.findViewById(R.id.appview_progress);
     appview = view.findViewById(R.id.appview_full);
-    toolbar = (Toolbar) view.findViewById(R.id.toolbar);
+    toolbar = view.findViewById(R.id.toolbar);
     collapsingAppcBackground = view.findViewById(R.id.collapsing_appc_coins_background);
 
     promotionView = view.findViewById(R.id.wallet_install_promotion);
@@ -501,8 +501,7 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
       scrollViewY = savedInstanceState.getInt(KEY_SCROLL_Y, 0);
     }
 
-    collapsingToolbarLayout =
-        ((CollapsingToolbarLayout) view.findViewById(R.id.collapsing_toolbar_layout));
+    collapsingToolbarLayout = view.findViewById(R.id.collapsing_toolbar_layout);
     collapsingToolbarLayout.setExpandedTitleColor(
         getResources().getColor(android.R.color.transparent));
 
@@ -1336,8 +1335,8 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
         downloadWalletProgressBar.setIndeterminate(false);
         downloadWalletProgressBar.setProgress(walletApp.getDownloadModel()
             .getProgress());
-        downloadWalletProgressValue.setText(String.valueOf(walletApp.getDownloadModel()
-            .getProgress()) + "%");
+        downloadWalletProgressValue.setText(walletApp.getDownloadModel()
+            .getProgress() + "%");
         pauseWalletDownload.setVisibility(View.VISIBLE);
         pauseWalletDownload.setOnClickListener(__ -> promotionAppClick.onNext(
             new PromotionEvent(promotion, walletApp, PromotionEvent.ClickType.PAUSE_DOWNLOAD)));
@@ -1358,8 +1357,8 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
         downloadWalletProgressBar.setIndeterminate(false);
         downloadWalletProgressBar.setProgress(walletApp.getDownloadModel()
             .getProgress());
-        downloadWalletProgressValue.setText(String.valueOf(walletApp.getDownloadModel()
-            .getProgress()) + "%");
+        downloadWalletProgressValue.setText(walletApp.getDownloadModel()
+            .getProgress() + "%");
         pauseWalletDownload.setVisibility(View.GONE);
         cancelWalletDownload.setVisibility(View.VISIBLE);
         cancelWalletDownload.setOnClickListener(__ -> promotionAppClick.onNext(
@@ -1674,9 +1673,12 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
       downloadInfoLayout.setVisibility(View.GONE);
       install.setVisibility(View.VISIBLE);
       setButtonText(downloadModel);
-      if (downloadModel.hasError()) {
-        handleDownloadError(downloadModel.getDownloadState());
-      }
+    }
+  }
+
+  @Override public void showDownloadError(DownloadModel downloadModel) {
+    if (downloadModel.hasError()) {
+      handleDownloadError(downloadModel.getDownloadState());
     }
   }
 
@@ -1855,13 +1857,6 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
         resumeDownload.setVisibility(View.GONE);
         downloadControlsLayout.setVisibility(View.GONE);
         installStateText.setText(getString(R.string.appview_short_installing));
-        break;
-      case ERROR:
-        showErrorDialog("", getContext().getString(R.string.error_occured));
-        break;
-      case NOT_ENOUGH_STORAGE_ERROR:
-        showErrorDialog(getContext().getString(R.string.out_of_space_dialog_title),
-            getContext().getString(R.string.out_of_space_dialog_message));
         break;
     }
   }

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -149,7 +149,8 @@ public class AppViewPresenter implements Presenter {
             .hasError())
         .flatMap(appViewModel -> Observable.mergeDelayError(loadAds(appViewModel),
             handleAppViewOpenOptions(appViewModel), loadAppcPromotion(appViewModel),
-            loadTopDonations(appViewModel), observeDownloadApp(),
+            observePromotionDownloadErrors(appViewModel), loadTopDonations(appViewModel),
+            observeDownloadApp(), observeDownloadErrors(),
             loadOtherAppViewComponents(appViewModel)));
   }
 
@@ -375,12 +376,39 @@ public class AppViewPresenter implements Presenter {
         });
   }
 
+  public Observable<AppViewModel> observePromotionDownloadErrors(AppViewModel appViewModel) {
+    return Observable.merge(view.resumePromotionDownload(), view.installWalletButtonClick())
+        .flatMap(__ -> Observable.just(appViewModel.getAppModel()))
+        .filter(appModel -> appModel.hasBilling() || appModel.hasAdvertising())
+        .flatMap(__ -> appViewManager.loadPromotionViewModel()
+            .filter(promotionViewModel -> promotionViewModel.getWalletApp()
+                .getDownloadModel() != null && promotionViewModel.getWalletApp()
+                .getDownloadModel()
+                .hasError())
+            .first())
+        .doOnNext(promotionViewModel -> view.showDownloadError(promotionViewModel.getWalletApp()
+            .getDownloadModel()))
+        .flatMap(this::verifyNotEnoughSpaceError)
+        .map(__ -> appViewModel)
+        .retry();
+  }
+
   public Observable<AppViewModel> observeDownloadApp() {
     return appViewManager.observeAppViewModel()
         .observeOn(viewScheduler)
         .doOnNext(model -> view.showDownloadAppModel(model.getDownloadModel(),
-            model.getAppCoinsViewModel()))
-        .flatMap(this::verifyNotEnoughSpaceError);
+            model.getAppCoinsViewModel()));
+  }
+
+  private Observable<AppViewModel> observeDownloadErrors() {
+    return Observable.merge(view.installAppClick(), view.resumeDownload())
+        .flatMap(__ -> appViewManager.observeAppViewModel()
+            .filter(appViewModel -> appViewModel.getDownloadModel()
+                .hasError())
+            .first())
+        .doOnNext(appViewModel -> view.showDownloadError(appViewModel.getDownloadModel()))
+        .flatMap(this::verifyNotEnoughSpaceError)
+        .retry();
   }
 
   private Observable<AppViewModel> verifyNotEnoughSpaceError(AppViewModel appViewModel) {

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewView.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewView.java
@@ -187,4 +187,6 @@ public interface AppViewView extends InstallAppView {
   void showConsentDialog();
 
   void setInstallButton(AppCoinsViewModel appCoinsViewModel);
+
+  void showDownloadError(DownloadModel downloadModel);
 }

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialFragment.java
@@ -390,9 +390,12 @@ public class EditorialFragment extends NavigationTrackFragment
             getResources().getString(R.string.appview_button_open),
             getResources().getString(R.string.appview_button_downgrade));
       }
-      if (downloadModel.hasError()) {
-        handleDownloadError(downloadModel.getDownloadState());
-      }
+    }
+  }
+
+  @Override public void showDownloadError(EditorialDownloadModel downloadModel) {
+    if (downloadModel.hasError()) {
+      handleDownloadError(downloadModel.getDownloadState());
     }
   }
 

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialView.java
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialView.java
@@ -28,6 +28,8 @@ public interface EditorialView extends View {
 
   void showDownloadModel(EditorialDownloadModel model);
 
+  void showDownloadError(EditorialDownloadModel editorialDownloadModel);
+
   Observable<Boolean> showRootInstallWarningPopup();
 
   void openApp(String packageName);

--- a/app/src/main/java/cm/aptoide/pt/home/more/appcoins/EarnAppcListFragment.kt
+++ b/app/src/main/java/cm/aptoide/pt/home/more/appcoins/EarnAppcListFragment.kt
@@ -102,9 +102,14 @@ class EarnAppcListFragment : ListAppsFragment<RewardApp, EarnAppcListViewHolder>
       } else if (!walletApp.isInstalled) {
         appview_transfer_info.visibility = View.GONE
         install_group.visibility = View.VISIBLE
-        if (downloadModel.hasError()) {
-          handleDownloadError(downloadModel.downloadState)
-        }
+      }
+    }
+  }
+
+  override fun showDownloadError(walletApp: WalletApp) {
+    walletApp.downloadModel?.also { downloadModel ->
+      if (downloadModel.hasError()) {
+        handleDownloadError(downloadModel.downloadState)
       }
     }
   }

--- a/app/src/main/java/cm/aptoide/pt/home/more/appcoins/EarnAppcListView.kt
+++ b/app/src/main/java/cm/aptoide/pt/home/more/appcoins/EarnAppcListView.kt
@@ -14,4 +14,5 @@ interface EarnAppcListView : ListAppsView<RewardApp> {
   fun cancelDownload(): Observable<Void>
   fun updateState(walletApp: WalletApp)
   fun hideWalletArea()
+  fun showDownloadError(walletApp: WalletApp)
 }

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionsFragment.java
@@ -221,17 +221,20 @@ public class PromotionsFragment extends NavigationTrackFragment implements Promo
       showWallet(promotionViewApp, isWalletInstalled);
       setWalletItemClickListener(promotionViewApp);
     } else {
-      if (promotionViewApp.getDownloadModel()
-          .hasError()) {
-        handleDownloadError(promotionViewApp.getDownloadModel()
-            .getDownloadState());
-      }
       promotionsAdapter.setPromotionApp(promotionViewApp);
     }
     loading.setVisibility(View.GONE);
     toolbarImagePlaceholder.setVisibility(View.GONE);
     toolbarImage.setVisibility(View.VISIBLE);
     promotionsView.setVisibility(View.VISIBLE);
+  }
+
+  @Override public void showDownloadError(PromotionViewApp promotionViewApp) {
+    if (promotionViewApp.getDownloadModel()
+        .hasError()) {
+      handleDownloadError(promotionViewApp.getDownloadModel()
+          .getDownloadState());
+    }
   }
 
   @Override public Observable<PromotionViewApp> installButtonClick() {

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionsView.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionsView.java
@@ -40,4 +40,6 @@ public interface PromotionsView extends View {
   void showPromotionFeatureGraphic(String background);
 
   Observable<PromotionAppClick> appCardClick();
+
+  void showDownloadError(PromotionViewApp promotioViewApp);
 }


### PR DESCRIPTION
**What does this PR do?**

   Fixes a bug where if an user clicked install and an out of space error occured and then the user went back and re-entered the download view, the out of space error would appear without the user even clicking install.

   I'm not very much a fan of how it was eventually done, but my LOGAF is pretty low for this :) I think when we isolate downloads in general we can maybe think of a better solution. 

**Database changed?**

   No

**How should this be manually tested?**

  Ideally every fragment where there's downloads should be checked for the bugs presence. This is: app view, promotions view, editorial view, wallet install view, earn appc list view.

**What are the relevant tickets?**

  [MOB-601](https://aptoide.atlassian.net/browse/MOB-601)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass