### PR TITLE
[MOB-615] Remove buffer space in download

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/install/InstallAppSizeValidator.kt
+++ b/app/src/main/java/cm/aptoide/pt/install/InstallAppSizeValidator.kt
@@ -3,15 +3,12 @@ package cm.aptoide.pt.install
 import android.os.Build
 import android.os.Environment
 import android.os.StatFs
-import kotlin.math.roundToLong
 
 class InstallAppSizeValidator {
 
   fun hasEnoughSpaceToInstallApp(downloadSize: Long): Boolean {
-    val bufferedAppSize = getBufferedAppSize(downloadSize)
     val availableSpace = getAvailableSpace()
-
-    return bufferedAppSize < availableSpace
+    return downloadSize <= availableSpace
   }
 
   private fun getAvailableSpace(): Long {
@@ -23,8 +20,4 @@ class InstallAppSizeValidator {
     }
   }
 
-  private fun getBufferedAppSize(appSize: Long): Long {
-    val sizePercentage = (appSize * 0.20).roundToLong()
-    return appSize + sizePercentage
-  }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR aims at removing a buffer from the download available space check

**Database changed?**

 No

**Where should the reviewer start?**

- [x] InstallAppSizeValidator.kt

**How should this be manually tested?**

In a device low on storage try download apps and check that it is coherent.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-615](https://aptoide.atlassian.net/browse/MOB-615)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass