### PR TITLE
[bugfix/MOB-600] Deeplink install bug

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/AppViewModelManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewModelManager.java
@@ -137,9 +137,7 @@ public class AppViewModelManager {
 
   private Single<AppModel> loadAppModel(String packageName, String storeName) {
     if (cachedApp != null && cachedApp.getPackageName()
-        .equals(packageName) && cachedApp.getStore()
-        .getName()
-        .equals(storeName)) {
+        .equals(packageName)) {
       return Single.just(cachedApp);
     }
     return appCenter.loadDetailedApp(packageName, storeName)


### PR DESCRIPTION
**What does this PR do?**

   Fixes a bug where when an appview opened from a deeplink without store name, the deeplink popup dialog worked fine, but the regular install button in appview did not.

**Database changed?**

   No

**How should this be manually tested?**

  Test that the regular install button coming from a deeplink now works fine. You easily test this by searching for "Crab War" (Crab War : Idle Swarm Evolution), downloading version 3.19.0, or similar. Then open the game and it should ask to update it. Open the deeplink with aptoide and test the flow.
  Also pls try to test if nothing broke with regular install flow in other scenarios (I don't think it's possible though)


**What are the relevant tickets?**

  [MOB-600](https://aptoide.atlassian.net/browse/MOB-600)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass