### PR TITLE
[bugfix/MOB-618] Poa Campaigns missing AABs

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -1581,9 +1581,10 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
   @Singleton @Provides AppCoinsService providesAppCoinsService(@Named("mature-pool-v7")
       BodyInterceptor<cm.aptoide.pt.dataprovider.ws.v7.BaseBody> bodyInterceptorPoolV7,
       @Named("default") OkHttpClient okHttpClient, TokenInvalidator tokenInvalidator,
-      @Named("default") SharedPreferences sharedPreferences, Converter.Factory converterFactory) {
+      @Named("default") SharedPreferences sharedPreferences, Converter.Factory converterFactory,
+      AppBundlesVisibilityManager appBundlesVisibilityManager) {
     return new AppCoinsService(okHttpClient, tokenInvalidator, sharedPreferences,
-        bodyInterceptorPoolV7, converterFactory);
+        bodyInterceptorPoolV7, converterFactory, appBundlesVisibilityManager);
   }
 
   @Named("remote") @Singleton @Provides BundleDataSource providesRemoteBundleDataSource(

--- a/app/src/main/java/cm/aptoide/pt/app/AppCoinsService.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppCoinsService.java
@@ -1,6 +1,7 @@
 package cm.aptoide.pt.app;
 
 import android.content.SharedPreferences;
+import cm.aptoide.pt.dataprovider.aab.AppBundlesVisibilityManager;
 import cm.aptoide.pt.dataprovider.interfaces.TokenInvalidator;
 import cm.aptoide.pt.dataprovider.model.v7.AppCoinsCampaign;
 import cm.aptoide.pt.dataprovider.model.v7.ListAppCoinsCampaigns;
@@ -18,21 +19,24 @@ public class AppCoinsService {
   private final SharedPreferences preferences;
   private final BodyInterceptor<BaseBody> bodyInterceptor;
   private final Converter.Factory converterFactory;
+  private final AppBundlesVisibilityManager appBundlesVisibilityManager;
 
   public AppCoinsService(OkHttpClient httpClient, TokenInvalidator tokenInvalidator,
       SharedPreferences preferences, BodyInterceptor<BaseBody> bodyInterceptor,
-      Converter.Factory converterFactory) {
+      Converter.Factory converterFactory, AppBundlesVisibilityManager appBundlesVisibilityManager) {
     this.httpClient = httpClient;
     this.tokenInvalidator = tokenInvalidator;
     this.preferences = preferences;
     this.bodyInterceptor = bodyInterceptor;
     this.converterFactory = converterFactory;
+    this.appBundlesVisibilityManager = appBundlesVisibilityManager;
   }
 
   public Single<AppCoinsAdvertisingModel> getValidCampaign(String packageName, int versionCode) {
     return new GetAppCoinsCampaignsRequest(
         new GetAppCoinsCampaignsRequest.Body(packageName, versionCode), httpClient,
-        converterFactory, bodyInterceptor, tokenInvalidator, preferences).observe()
+        converterFactory, bodyInterceptor, tokenInvalidator, preferences,
+        appBundlesVisibilityManager).observe()
         .toSingle()
         .map(listAppCoinsCampaigns -> mapAdvertising(listAppCoinsCampaigns));
   }

--- a/app/src/main/java/cm/aptoide/pt/promotions/PromotionsService.java
+++ b/app/src/main/java/cm/aptoide/pt/promotions/PromotionsService.java
@@ -112,7 +112,7 @@ public class PromotionsService {
 
   public Single<List<PromotionMeta>> getPromotions(String type) {
     return GetPromotionsRequest.of(type, bodyInterceptorPoolV7, okHttpClient, converterFactory,
-        tokenInvalidator, sharedPreferences)
+        tokenInvalidator, sharedPreferences, appBundlesVisibilityManager)
         .observe()
         .map(promotionsResponse -> map(promotionsResponse))
         .toSingle();

--- a/app/src/main/java/cm/aptoide/pt/repository/request/RewardAppCoinsAppsRepository.java
+++ b/app/src/main/java/cm/aptoide/pt/repository/request/RewardAppCoinsAppsRepository.java
@@ -1,6 +1,7 @@
 package cm.aptoide.pt.repository.request;
 
 import android.content.SharedPreferences;
+import cm.aptoide.pt.dataprovider.aab.AppBundlesVisibilityManager;
 import cm.aptoide.pt.dataprovider.interfaces.TokenInvalidator;
 import cm.aptoide.pt.dataprovider.model.v7.AppCoinsCampaign;
 import cm.aptoide.pt.dataprovider.model.v7.DataList;
@@ -23,32 +24,36 @@ import rx.Observable;
 public class RewardAppCoinsAppsRepository {
 
   private static final int APPCOINS_REWARD_LIMIT = 50;
-  
+
   private OkHttpClient httpClient;
   private Converter.Factory converterFactory;
   private BodyInterceptor<BaseBody> bodyInterceptor;
   private TokenInvalidator tokenInvalidator;
   private SharedPreferences sharedPreferences;
   private InstallManager installManager;
+  private AppBundlesVisibilityManager appBundlesVisibilityManager;
 
   private int total = 0;
   private int next = 0;
 
   public RewardAppCoinsAppsRepository(OkHttpClient httpClient, Converter.Factory converterFactory,
       BodyInterceptor<BaseBody> bodyInterceptor, TokenInvalidator tokenInvalidator,
-      SharedPreferences sharedPreferences, InstallManager installManager) {
+      SharedPreferences sharedPreferences, InstallManager installManager,
+      AppBundlesVisibilityManager appBundlesVisibilityManager) {
     this.httpClient = httpClient;
     this.converterFactory = converterFactory;
     this.bodyInterceptor = bodyInterceptor;
     this.tokenInvalidator = tokenInvalidator;
     this.sharedPreferences = sharedPreferences;
     this.installManager = installManager;
+    this.appBundlesVisibilityManager = appBundlesVisibilityManager;
   }
 
   public Observable<List<RewardApp>> getFreshAppCoinsRewardAppsFromHomeMore(String tag) {
     return new GetAppCoinsCampaignsRequest(
         new GetAppCoinsCampaignsRequest.Body(0, APPCOINS_REWARD_LIMIT), httpClient,
-        converterFactory, bodyInterceptor, tokenInvalidator, sharedPreferences).observe(true)
+        converterFactory, bodyInterceptor, tokenInvalidator, sharedPreferences,
+        appBundlesVisibilityManager).observe(true)
         .flatMap(response -> map(response.getDataList(), tag));
   }
 
@@ -58,7 +63,8 @@ public class RewardAppCoinsAppsRepository {
     }
     return new GetAppCoinsCampaignsRequest(
         new GetAppCoinsCampaignsRequest.Body(next, APPCOINS_REWARD_LIMIT), httpClient,
-        converterFactory, bodyInterceptor, tokenInvalidator, sharedPreferences).observe(false)
+        converterFactory, bodyInterceptor, tokenInvalidator, sharedPreferences,
+        appBundlesVisibilityManager).observe(false)
         .flatMap(response -> map(response.getDataList(), tag));
   }
 

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -63,6 +63,7 @@ import cm.aptoide.pt.blacklist.BlacklistManager;
 import cm.aptoide.pt.bottomNavigation.BottomNavigationMapper;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.dataprovider.WebService;
+import cm.aptoide.pt.dataprovider.aab.AppBundlesVisibilityManager;
 import cm.aptoide.pt.dataprovider.interfaces.TokenInvalidator;
 import cm.aptoide.pt.dataprovider.model.v7.Type;
 import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
@@ -642,8 +643,9 @@ import rx.subscriptions.CompositeSubscription;
       @Named("default") OkHttpClient okHttpClient, @Named("mature-pool-v7")
       BodyInterceptor<cm.aptoide.pt.dataprovider.ws.v7.BaseBody> baseBodyBodyInterceptor,
       TokenInvalidator tokenInvalidator, @Named("default") SharedPreferences sharedPreferences,
-      InstallManager installManager) {
+      InstallManager installManager, AppBundlesVisibilityManager appBundlesVisibilityManager) {
     return new RewardAppCoinsAppsRepository(okHttpClient, WebService.getDefaultConverter(),
-        baseBodyBodyInterceptor, tokenInvalidator, sharedPreferences, installManager);
+        baseBodyBodyInterceptor, tokenInvalidator, sharedPreferences, installManager,
+        appBundlesVisibilityManager);
   }
 }

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/GetAppCoinsCampaignsRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/GetAppCoinsCampaignsRequest.java
@@ -3,6 +3,7 @@ package cm.aptoide.pt.dataprovider.ws.v7;
 import android.content.SharedPreferences;
 import androidx.annotation.NonNull;
 import cm.aptoide.pt.dataprovider.BuildConfig;
+import cm.aptoide.pt.dataprovider.aab.AppBundlesVisibilityManager;
 import cm.aptoide.pt.dataprovider.interfaces.TokenInvalidator;
 import cm.aptoide.pt.dataprovider.model.v7.ListAppCoinsCampaigns;
 import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
@@ -18,23 +19,29 @@ import rx.Observable;
 public class GetAppCoinsCampaignsRequest
     extends V7<ListAppCoinsCampaigns, GetAppCoinsCampaignsRequest.Body> {
 
+  private final AppBundlesVisibilityManager appBundlesVisibilityManager;
+
   public GetAppCoinsCampaignsRequest(Body body, OkHttpClient httpClient,
       Converter.Factory converterFactory, BodyInterceptor bodyInterceptor,
-      TokenInvalidator tokenInvalidator, SharedPreferences sharedPreferences) {
+      TokenInvalidator tokenInvalidator, SharedPreferences sharedPreferences,
+      AppBundlesVisibilityManager appBundlesVisibilityManager) {
     super(body, getHost(sharedPreferences), httpClient, converterFactory, bodyInterceptor,
         tokenInvalidator);
+    this.appBundlesVisibilityManager = appBundlesVisibilityManager;
   }
 
   @NonNull public static String getHost(SharedPreferences sharedPreferences) {
     return (ToolboxManager.isToolboxEnableHttpScheme(sharedPreferences) ? "http"
         : BuildConfig.APTOIDE_WEB_SERVICES_SCHEME)
         + "://"
-        + BuildConfig.APTOIDE_WEB_SERVICES_V7_HOST + "/api/7.20191202/";
+        + BuildConfig.APTOIDE_WEB_SERVICES_V7_HOST
+        + "/api/7.20191202/";
   }
 
   @Override protected Observable<ListAppCoinsCampaigns> loadDataFromNetwork(Interfaces interfaces,
       boolean bypassCache) {
-    return interfaces.getAppCoinsAds(body, bypassCache, body.getLimit());
+    return interfaces.getAppCoinsAds(body, bypassCache, body.getLimit(),
+        appBundlesVisibilityManager.shouldEnableAppBundles());
   }
 
   public static class Body extends BaseBody implements Endless {

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/V7.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/V7.java
@@ -451,8 +451,8 @@ public abstract class V7<U, B extends RefreshBody> extends WebService<V7.Interfa
 
     @POST("appcoins/catappult/campaigns/get/limit={limit}")
     Observable<ListAppCoinsCampaigns> getAppCoinsAds(@Body GetAppCoinsCampaignsRequest.Body body,
-        @Header(WebService.BYPASS_HEADER_KEY) boolean bypassCache,
-        @Path(value = "limit") int limit);
+        @Header(WebService.BYPASS_HEADER_KEY) boolean bypassCache, @Path(value = "limit") int limit,
+        @Query("aab") boolean showAabs);
 
     @POST("{url}") Observable<ActionItemResponse> getActionItem(
         @Path(value = "url", encoded = true) String path, @Body GetActionItemRequest.Body body,
@@ -482,7 +482,7 @@ public abstract class V7<U, B extends RefreshBody> extends WebService<V7.Interfa
 
     @POST("appcoins/promotions/get") Observable<GetPromotionsResponse> getPromotions(
         @Body GetPromotionsRequest.Body body,
-        @Header(WebService.BYPASS_HEADER_KEY) boolean bypassCache);
+        @Header(WebService.BYPASS_HEADER_KEY) boolean bypassCache, @Query("aab") boolean showAabs);
   }
 }
 

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/WSWidgetsUtils.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/WSWidgetsUtils.java
@@ -103,8 +103,8 @@ import rx.schedulers.Schedulers;
 
         case APPCOINS_ADS:
           return new GetAppCoinsCampaignsRequest(new GetAppCoinsCampaignsRequest.Body(0, limit),
-              httpClient, converterFactory, bodyInterceptor, tokenInvalidator,
-              sharedPreferences).observe(bypassCache, bypassServerCache)
+              httpClient, converterFactory, bodyInterceptor, tokenInvalidator, sharedPreferences,
+              appBundlesVisibilityManager).observe(bypassCache, bypassServerCache)
               .observeOn(Schedulers.io())
               .doOnNext(obj -> wsWidget.setViewObject(obj))
               .onErrorResumeNext(throwable -> Observable.empty())

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/promotions/GetPromotionsRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/promotions/GetPromotionsRequest.java
@@ -3,6 +3,7 @@ package cm.aptoide.pt.dataprovider.ws.v7.promotions;
 import android.content.SharedPreferences;
 import androidx.annotation.NonNull;
 import cm.aptoide.pt.dataprovider.BuildConfig;
+import cm.aptoide.pt.dataprovider.aab.AppBundlesVisibilityManager;
 import cm.aptoide.pt.dataprovider.interfaces.TokenInvalidator;
 import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
 import cm.aptoide.pt.dataprovider.ws.v7.BaseBody;
@@ -14,11 +15,15 @@ import rx.Observable;
 
 public class GetPromotionsRequest extends V7<GetPromotionsResponse, GetPromotionsRequest.Body> {
 
+  private final AppBundlesVisibilityManager appBundlesVisibilityManager;
+
   public GetPromotionsRequest(Body body, BodyInterceptor<BaseBody> bodyInterceptor,
       OkHttpClient httpClient, Converter.Factory converterFactory,
-      TokenInvalidator tokenInvalidator, SharedPreferences sharedPreferences) {
+      TokenInvalidator tokenInvalidator, SharedPreferences sharedPreferences,
+      AppBundlesVisibilityManager appBundlesVisibilityManager) {
     super(body, getHost(sharedPreferences), httpClient, converterFactory, bodyInterceptor,
         tokenInvalidator);
+    this.appBundlesVisibilityManager = appBundlesVisibilityManager;
   }
 
   @NonNull public static String getHost(SharedPreferences sharedPreferences) {
@@ -31,14 +36,16 @@ public class GetPromotionsRequest extends V7<GetPromotionsResponse, GetPromotion
 
   public static GetPromotionsRequest of(String type, BodyInterceptor<BaseBody> bodyInterceptor,
       OkHttpClient httpClient, Converter.Factory converterFactory,
-      TokenInvalidator tokenInvalidator, SharedPreferences sharedPreferences) {
+      TokenInvalidator tokenInvalidator, SharedPreferences sharedPreferences,
+      AppBundlesVisibilityManager appBundlesVisibilityManager) {
     return new GetPromotionsRequest(new Body(type), bodyInterceptor, httpClient, converterFactory,
-        tokenInvalidator, sharedPreferences);
+        tokenInvalidator, sharedPreferences, appBundlesVisibilityManager);
   }
 
   @Override protected Observable<GetPromotionsResponse> loadDataFromNetwork(Interfaces interfaces,
       boolean bypassCache) {
-    return interfaces.getPromotions(body, bypassCache);
+    return interfaces.getPromotions(body, bypassCache,
+        appBundlesVisibilityManager.shouldEnableAppBundles());
   }
 
   public static class Body extends BaseBody {


### PR DESCRIPTION
**What does this PR do?**

   Adds "aab=true" to promotions WS so that it can return correctly apps with aabs. Right now it isn't implemented in the WS so it can't be tested, but it shouldn't break current function.

**Database changed?**

   No

**How should this be manually tested?**

  As the functionality isn't implemented yet in the WS, for now you can just test that nothing broke and that the 'aab=true' is indeed being sent by checking with Charles on promotions request (like in Earn Appc section).

**What are the relevant tickets?**

  [MOB-618](https://aptoide.atlassian.net/browse/MOB-618)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass