### PR TITLE
[hotfix/MOB-647] Download stuck on 100%

### DIFF
--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AppDownloadStatus.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AppDownloadStatus.java
@@ -105,6 +105,7 @@ public class AppDownloadStatus {
                 == fileDownloadCallbackList.size() - 1) {
               return AppDownloadState.VERIFYING_FILE_INTEGRITY;
             }
+            break;
           case COMPLETED:
             if (previousState != null
                 && previousState != AppDownloadStatus.AppDownloadState.COMPLETED) {
@@ -115,6 +116,7 @@ public class AppDownloadStatus {
                   .d("AppDownloadState", "emitting APPDOWNLOADSTATE completed " + md5);
               return AppDownloadState.COMPLETED;
             }
+            break;
           case PENDING:
             if (previousState != null
                 && previousState != AppDownloadStatus.AppDownloadState.PENDING) {
@@ -123,6 +125,7 @@ public class AppDownloadStatus {
                 == fileDownloadCallbackList.size() - 1) {
               return AppDownloadState.PENDING;
             }
+            break;
         }
         previousState = fileDownloadCallback.getDownloadState();
       }


### PR DESCRIPTION
**What does this PR do?**

   Fixes an issue where some apps would get stuck on 100%.

**Database changed?**

   No

**How should this be manually tested?**

  Go to "Legends of Runeterra" (either editorial or appview) and check that it downloads correctly and doesn't get stuck on 100% as before.

**What are the relevant tickets?**

  [MOB-647](https://aptoide.atlassian.net/browse/MOB-647)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass