### PR TITLE
[HOTFIX/MOB-646] Install button refresh

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/database/RoomUpdatePersistence.java
+++ b/app/src/main/java/cm/aptoide/pt/database/RoomUpdatePersistence.java
@@ -23,8 +23,9 @@ public class RoomUpdatePersistence implements UpdatePersistence {
     this.updateDao = updateDao;
   }
 
-  public Observable<RoomUpdate> get(String packageName) {
-    return RxJavaInterop.toV1Observable(updateDao.get(packageName), BackpressureStrategy.BUFFER)
+  public Single<RoomUpdate> get(String packageName) {
+    return RxJavaInterop.toV1Single(updateDao.get(packageName))
+        .onErrorReturn(throwable -> null)
         .subscribeOn(Schedulers.io());
   }
 

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
@@ -276,7 +276,8 @@ public class AppsManager {
               return Single.just(value);
             })
             .flatMapCompletable(download -> installManager.install(download))
-            .andThen(aptoideInstallManager.sendConversionEvent()));
+            .andThen(aptoideInstallManager.sendConversionEvent()))
+        .onErrorComplete();
   }
 
   public boolean showWarning() {

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
@@ -276,8 +276,7 @@ public class AppsManager {
               return Single.just(value);
             })
             .flatMapCompletable(download -> installManager.install(download))
-            .andThen(aptoideInstallManager.sendConversionEvent()))
-        .toCompletable();
+            .andThen(aptoideInstallManager.sendConversionEvent()));
   }
 
   public boolean showWarning() {

--- a/app/src/main/java/cm/aptoide/pt/home/apps/UpdatesManager.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/UpdatesManager.java
@@ -67,7 +67,7 @@ public class UpdatesManager {
         .sample(750, TimeUnit.MILLISECONDS);
   }
 
-  public Observable<RoomUpdate> getUpdate(String packageName) {
+  public Single<RoomUpdate> getUpdate(String packageName) {
     return updateRepository.get(packageName);
   }
 
@@ -80,7 +80,7 @@ public class UpdatesManager {
   }
 
   public Completable excludeUpdate(String packageName) {
-    return updateRepository.setExcluded(packageName, true);
+    return updateRepository.setExcluded(packageName);
   }
 
   public Completable refreshUpdates() {

--- a/app/src/main/java/cm/aptoide/pt/install/InstalledIntentService.java
+++ b/app/src/main/java/cm/aptoide/pt/install/InstalledIntentService.java
@@ -15,7 +15,6 @@ import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.database.RoomStoredMinimalAdPersistence;
 import cm.aptoide.pt.database.room.RoomInstalled;
 import cm.aptoide.pt.database.room.RoomStoredMinimalAd;
-import cm.aptoide.pt.database.room.RoomUpdate;
 import cm.aptoide.pt.dataprovider.ads.AdNetworkUtils;
 import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.preferences.managed.ManagerPreferences;
@@ -176,15 +175,6 @@ public class InstalledIntentService extends IntentService {
   }
 
   private PackageInfo databaseOnPackageReplaced(String packageName) {
-    final RoomUpdate update = updatesRepository.get(packageName)
-        .first()
-        .doOnError(throwable -> {
-          CrashReport.getInstance()
-              .log(throwable);
-        })
-        .onErrorReturn(throwable -> null)
-        .toBlocking()
-        .first();
 
     PackageInfo packageInfo = AptoideUtils.SystemU.getPackageInfo(packageName, getPackageManager());
 
@@ -193,7 +183,7 @@ public class InstalledIntentService extends IntentService {
     }
 
     installManager.onUpdateConfirmed(new RoomInstalled(packageInfo, packageManager))
-        .andThen(updatesRepository.remove(update))
+        .andThen(updatesRepository.remove(packageName))
         .subscribe(() -> Logger.getInstance()
                 .d(TAG, "databaseOnPackageReplaced: " + packageName),
             throwable -> CrashReport.getInstance()

--- a/app/src/main/java/cm/aptoide/pt/updates/UpdatePersistence.java
+++ b/app/src/main/java/cm/aptoide/pt/updates/UpdatePersistence.java
@@ -8,7 +8,7 @@ import rx.Single;
 
 public interface UpdatePersistence {
 
-  Observable<RoomUpdate> get(String packageName);
+  Single<RoomUpdate> get(String packageName);
 
   Single<List<RoomUpdate>> getAll(boolean isExcluded);
 

--- a/app/src/main/java/cm/aptoide/pt/updates/UpdateRepository.java
+++ b/app/src/main/java/cm/aptoide/pt/updates/UpdateRepository.java
@@ -161,7 +161,7 @@ public class UpdateRepository {
     return updatePersistence.getAllSorted(isExcluded);
   }
 
-  public Observable<RoomUpdate> get(String packageName) {
+  public Single<RoomUpdate> get(String packageName) {
     return updatePersistence.get(packageName);
   }
 
@@ -177,10 +177,8 @@ public class UpdateRepository {
     return updatePersistence.remove(packageName);
   }
 
-  public Completable setExcluded(String packageName, boolean excluded) {
+  public Completable setExcluded(String packageName) {
     return updatePersistence.get(packageName)
-        .first()
-        .toSingle()
         .flatMap(update -> {
           update.setExcluded(true);
           return Single.just(update);

--- a/aptoide-database/src/main/java/cm/aptoide/pt/database/room/UpdateDao.java
+++ b/aptoide-database/src/main/java/cm/aptoide/pt/database/room/UpdateDao.java
@@ -12,7 +12,7 @@ import static androidx.room.OnConflictStrategy.REPLACE;
 
 @Dao public interface UpdateDao {
 
-  @Query("SELECT * from `update` where packageName = :packageName") Observable<RoomUpdate> get(
+  @Query("SELECT * from `update` where packageName = :packageName") Single<RoomUpdate> get(
       String packageName);
 
   @Query("SELECT * from `update` where excluded = :isExcluded")


### PR DESCRIPTION
**What does this PR do?**

   This pr aims at fixing the button of the install button in appview after updating them. On André's phone, initially, any installation (update, downgrade, whatever) would not update the button, later on it was discovered that it was phone specific. After that i was able to discover that i could reproduce that behavior by downgrading an app and then trying to update it. Then, after the update was installed, the button would not update to open because the update from the db would be removed in the downgrade and then when we would try to get it on the database replaced (update) call, it would not exist so the db would not emit (Room does not reply wiht an empty list like Realm, BUT in case the method is single it will throw an exception that we can map to null).

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] InstalledIntentService.java

**How should this be manually tested?**

Downgrade an app and then try to update it. Check if the button updates well. Also, try to do other type of installations to confirm everything is ok, like update apps, downgrade, install, etc.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-646](https://aptoide.atlassian.net/browse/MOB-646)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass