### PR TITLE
[MOB-512] Fixed text getting cut in some translations;

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/bottomNavigation/BottomNavigationActivity.java
+++ b/app/src/main/java/cm/aptoide/pt/bottomNavigation/BottomNavigationActivity.java
@@ -1,14 +1,18 @@
 package cm.aptoide.pt.bottomNavigation;
 
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
+import android.widget.TextView;
 import androidx.fragment.app.Fragment;
 import cm.aptoide.pt.R;
 import cm.aptoide.pt.account.view.LoginBottomSheetActivity;
 import cm.aptoide.pt.home.AptoideBottomNavigator;
 import cm.aptoide.pt.view.NotBottomNavigationView;
+import com.google.android.material.bottomnavigation.BottomNavigationItemView;
+import com.google.android.material.bottomnavigation.BottomNavigationMenuView;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import javax.inject.Inject;
 import rx.Observable;
@@ -101,6 +105,24 @@ public abstract class BottomNavigationActivity extends LoginBottomSheetActivity
     bottomNavigationView.getMenu()
         .getItem(4)
         .setTitle(mapAppsName(name));
+
+    BottomNavigationMenuView menuView =
+        (BottomNavigationMenuView) bottomNavigationView.getChildAt(0);
+    for (int i = 0; i < menuView.getChildCount(); i++) {
+      BottomNavigationItemView item = (BottomNavigationItemView) menuView.getChildAt(i);
+      View largeLabel = item.findViewById(R.id.largeLabel);
+      View smallLabel = item.findViewById(R.id.smallLabel);
+
+      if (largeLabel instanceof TextView) {
+        largeLabel.setPadding(0, 0, 0, 0);
+        ((TextView) largeLabel).setEllipsize(TextUtils.TruncateAt.END);
+      }
+
+      if (smallLabel instanceof TextView) {
+        smallLabel.setPadding(0, 0, 0, 0);
+        ((TextView) smallLabel).setEllipsize(TextUtils.TruncateAt.END);
+      }
+    }
   }
 
   @Override public void onBackPressed() {


### PR DESCRIPTION
**What does this PR do?**

This PR fixes a bug caught in QA for the apps name AB test where some translations would be cut off

**Database changed?**

No

**Where should the reviewer start?**

- [ ] BottomNavigationActivity.java

**How should this be manually tested?**

Check the comment in the ticket for the problem strings. The solution was to ellipsize at the end and was discussed and approved by both Luis and Carlos

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-512](https://aptoide.atlassian.net/browse/MOB-512)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass