### PR TITLE
[MOB-625] Remove Permissions from social login

### DIFF
--- a/app/src/androidTest/java/cm/aptoide/pt/MockApplicationModule.java
+++ b/app/src/androidTest/java/cm/aptoide/pt/MockApplicationModule.java
@@ -170,8 +170,7 @@ public class MockApplicationModule extends ApplicationModule {
         return Single.just(account);
       }
 
-      @Override public Single<Account> createAccount(String email, String metadata, String name,
-          String type) {
+      @Override public Single<Account> createAccount(String email, String metadata, String type) {
         return Single.just(account);
       }
 

--- a/app/src/cobrand/java/cm/aptoide/pt/presenter/LoginSignupCredentialsFlavorPresenter.java
+++ b/app/src/cobrand/java/cm/aptoide/pt/presenter/LoginSignupCredentialsFlavorPresenter.java
@@ -19,10 +19,9 @@ public class LoginSignupCredentialsFlavorPresenter extends LoginSignUpCredential
       AptoideAccountManager accountManager, CrashReport crashReport,
       boolean dismissToNavigateToMainView, boolean navigateToHome,
       AccountNavigator accountNavigator, Collection<String> permissions,
-      Collection<String> requiredPermissions, ThrowableToStringMapper errorMapper,
-      AccountAnalytics accountAnalytics) {
+      ThrowableToStringMapper errorMapper, AccountAnalytics accountAnalytics) {
     super(view, accountManager, crashReport, dismissToNavigateToMainView, navigateToHome,
-        accountNavigator, permissions, requiredPermissions, errorMapper, accountAnalytics);
+        accountNavigator, permissions, errorMapper, accountAnalytics);
     this.view = view;
     this.errorMapper = errorMapper;
     this.crashReport = crashReport;

--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -282,9 +282,7 @@ import com.facebook.login.LoginManager;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
-import com.google.android.gms.common.Scopes;
 import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.android.gms.common.api.Scope;
 import com.google.android.gms.safetynet.SafetyNet;
 import com.google.android.gms.safetynet.SafetyNetClient;
 import com.jakewharton.rxrelay.BehaviorRelay;
@@ -717,8 +715,6 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
   @Singleton @Provides GoogleApiClient provideGoogleApiClient() {
     return new GoogleApiClient.Builder(application).addApi(GOOGLE_SIGN_IN_API,
         new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN).requestEmail()
-            .requestScopes(new Scope("https://www.googleapis.com/auth/contacts.readonly"))
-            .requestScopes(new Scope(Scopes.PROFILE))
             .requestServerAuthCode(BuildConfig.GMS_SERVER_ID)
             .build())
         .build();

--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -129,7 +129,6 @@ import cm.aptoide.pt.database.RoomNotificationPersistence;
 import cm.aptoide.pt.database.RoomStorePersistence;
 import cm.aptoide.pt.database.RoomStoredMinimalAdPersistence;
 import cm.aptoide.pt.database.RoomUpdatePersistence;
-
 import cm.aptoide.pt.database.accessors.Database;
 import cm.aptoide.pt.database.accessors.RealmToRealmDatabaseMigration;
 import cm.aptoide.pt.database.accessors.StoreAccessor;
@@ -303,6 +302,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -724,9 +724,15 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
         .build();
   }
 
+  @Singleton @Provides @Named("facebookLoginPermissions")
+  List<String> providesFacebookLoginPermissions() {
+    return Collections.singletonList("email");
+  }
+
   @Singleton @Provides AptoideAccountManager provideAptoideAccountManager(AdultContent adultContent,
       GoogleApiClient googleApiClient, StoreManager storeManager, AccountService accountService,
-      LoginPreferences loginPreferences, AccountPersistence accountPersistence) {
+      LoginPreferences loginPreferences, AccountPersistence accountPersistence,
+      @Named("facebookLoginPermissions") List<String> facebookPermissions) {
     FacebookSdk.sdkInitialize(application);
 
     return new AptoideAccountManager.Builder().setAccountPersistence(
@@ -736,7 +742,7 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
         .registerSignUpAdapter(GoogleSignUpAdapter.TYPE,
             new GoogleSignUpAdapter(googleApiClient, loginPreferences))
         .registerSignUpAdapter(FacebookSignUpAdapter.TYPE,
-            new FacebookSignUpAdapter(Arrays.asList("email"), LoginManager.getInstance(),
+            new FacebookSignUpAdapter(facebookPermissions, LoginManager.getInstance(),
                 loginPreferences))
         .setStoreManager(storeManager)
         .build();

--- a/app/src/main/java/cm/aptoide/pt/account/AccountServiceV3.java
+++ b/app/src/main/java/cm/aptoide/pt/account/AccountServiceV3.java
@@ -92,15 +92,13 @@ public class AccountServiceV3 implements AccountService {
   }
 
   @Override public Single<Account> getAccount(String email, String password) {
-    return createAccount(email.toLowerCase(), password, null,
-        AptoideAccountManager.APTOIDE_SIGN_UP_TYPE);
+    return createAccount(email.toLowerCase(), password, AptoideAccountManager.APTOIDE_SIGN_UP_TYPE);
   }
 
-  @Override
-  public Single<Account> createAccount(String email, String metadata, String name, String type) {
-    return OAuth2AuthenticationRequest.of(email, metadata, type, null,
-        v3NoAuthorizationBodyInterceptor, httpClient, converterFactory, tokenInvalidator,
-        sharedPreferences, extraId, oAuthModeProvider.getAuthMode(type))
+  @Override public Single<Account> createAccount(String email, String metadata, String type) {
+    return OAuth2AuthenticationRequest.of(email, metadata, type, v3NoAuthorizationBodyInterceptor,
+        httpClient, converterFactory, tokenInvalidator, sharedPreferences, extraId,
+        oAuthModeProvider.getAuthMode(type))
         .observe()
         .toSingle()
         .flatMap(oAuth -> {

--- a/app/src/main/java/cm/aptoide/pt/account/FacebookSignUpAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/account/FacebookSignUpAdapter.java
@@ -56,7 +56,7 @@ public class FacebookSignUpAdapter implements SignUpAdapter<FacebookLoginResult>
     return getFacebookEmail(result.getResult()
         .getAccessToken()).flatMap(email -> service.createAccount(email, result.getResult()
         .getAccessToken()
-        .getToken(), null, TYPE));
+        .getToken(), TYPE));
   }
 
   @Override public Completable logout() {

--- a/app/src/main/java/cm/aptoide/pt/account/GoogleSignUpAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/account/GoogleSignUpAdapter.java
@@ -31,8 +31,7 @@ public class GoogleSignUpAdapter implements SignUpAdapter<GoogleSignInResult> {
 
     final GoogleSignInAccount account = result.getSignInAccount();
     if (result.isSuccess() && account != null) {
-      return service.createAccount(account.getEmail(), account.getServerAuthCode(),
-          account.getDisplayName(), "GOOGLE");
+      return service.createAccount(account.getEmail(), account.getServerAuthCode(), "GOOGLE");
     } else {
       return Single.error(new GoogleSignUpException(GoogleSignInStatusCodes.getStatusCodeString(
           result.getStatus()

--- a/app/src/main/java/cm/aptoide/pt/presenter/LoginSignUpCredentialsPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/presenter/LoginSignUpCredentialsPresenter.java
@@ -29,7 +29,6 @@ public abstract class LoginSignUpCredentialsPresenter
   private final boolean navigateToHome;
   private final AccountNavigator accountNavigator;
   private final Collection<String> permissions;
-  private final Collection<String> requiredPermissions;
   private final ThrowableToStringMapper errorMapper;
   private final AccountAnalytics accountAnalytics;
   private boolean dismissToNavigateToMainView;
@@ -38,8 +37,7 @@ public abstract class LoginSignUpCredentialsPresenter
       AptoideAccountManager accountManager, CrashReport crashReport,
       boolean dismissToNavigateToMainView, boolean navigateToHome,
       AccountNavigator accountNavigator, Collection<String> permissions,
-      Collection<String> requiredPermissions, ThrowableToStringMapper errorMapper,
-      AccountAnalytics accountAnalytics) {
+      ThrowableToStringMapper errorMapper, AccountAnalytics accountAnalytics) {
     this.view = view;
     this.accountManager = accountManager;
     this.crashReport = crashReport;
@@ -47,7 +45,6 @@ public abstract class LoginSignUpCredentialsPresenter
     this.navigateToHome = navigateToHome;
     this.accountNavigator = accountNavigator;
     this.permissions = permissions;
-    this.requiredPermissions = requiredPermissions;
     this.errorMapper = errorMapper;
     this.accountAnalytics = accountAnalytics;
   }
@@ -255,7 +252,7 @@ public abstract class LoginSignUpCredentialsPresenter
         .flatMap(__ -> view.facebookSignUpWithRequiredPermissionsInEvent())
         .doOnNext(event -> {
           view.showLoading();
-          accountNavigator.navigateToFacebookSignUpForResult(requiredPermissions);
+          accountNavigator.navigateToFacebookSignUpForResult(permissions);
         })
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -169,7 +169,7 @@ import cm.aptoide.pt.wallet.WalletInstallManager;
 import com.jakewharton.rxrelay.BehaviorRelay;
 import dagger.Module;
 import dagger.Provides;
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import javax.inject.Named;
 import okhttp3.OkHttpClient;
@@ -197,13 +197,13 @@ import rx.subscriptions.CompositeSubscription;
 
   @FragmentScope @Provides LoginSignupCredentialsFlavorPresenter provideLoginSignUpPresenter(
       AptoideAccountManager accountManager, AccountNavigator accountNavigator,
-      AccountErrorMapper errorMapper, AccountAnalytics accountAnalytics) {
+      AccountErrorMapper errorMapper, AccountAnalytics accountAnalytics,
+      @Named("facebookLoginPermissions") List<String> facebookPermissions) {
     return new LoginSignupCredentialsFlavorPresenter((LoginSignUpCredentialsView) fragment,
         accountManager, CrashReport.getInstance(),
         arguments.getBoolean("dismiss_to_navigate_to_main_view"),
-        arguments.getBoolean("clean_back_stack"), accountNavigator,
-        Arrays.asList("email", "user_friends"), Arrays.asList("email"), errorMapper,
-        accountAnalytics);
+        arguments.getBoolean("clean_back_stack"), accountNavigator, facebookPermissions,
+        errorMapper, accountAnalytics);
   }
 
   @FragmentScope @Provides @Named("home-fragment-navigator")

--- a/app/src/vanilla/java/cm/aptoide/pt/presenter/LoginSignupCredentialsFlavorPresenter.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/presenter/LoginSignupCredentialsFlavorPresenter.java
@@ -20,10 +20,9 @@ public class LoginSignupCredentialsFlavorPresenter extends LoginSignUpCredential
       AptoideAccountManager accountManager, CrashReport crashReport,
       boolean dismissToNavigateToMainView, boolean navigateToHome,
       AccountNavigator accountNavigator, Collection<String> permissions,
-      Collection<String> requiredPermissions, ThrowableToStringMapper errorMapper,
-      AccountAnalytics accountAnalytics) {
+      ThrowableToStringMapper errorMapper, AccountAnalytics accountAnalytics) {
     super(view, accountManager, crashReport, dismissToNavigateToMainView, navigateToHome,
-        accountNavigator, permissions, requiredPermissions, errorMapper, accountAnalytics);
+        accountNavigator, permissions, errorMapper, accountAnalytics);
     this.view = view;
     this.errorMapper = errorMapper;
     this.crashReport = crashReport;

--- a/aptoide-account-manager/src/main/java/cm/aptoide/accountmanager/AccountService.java
+++ b/aptoide-account-manager/src/main/java/cm/aptoide/accountmanager/AccountService.java
@@ -7,7 +7,7 @@ public interface AccountService {
 
   Single<Account> getAccount(String email, String password);
 
-  Single<Account> createAccount(String email, String metadata, String name, String type);
+  Single<Account> createAccount(String email, String metadata, String type);
 
   Single<Account> createAccount(String email, String password);
 

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v3/OAuth2AuthenticationRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v3/OAuth2AuthenticationRequest.java
@@ -7,7 +7,6 @@ package cm.aptoide.pt.dataprovider.ws.v3;
 
 import android.content.SharedPreferences;
 import android.text.TextUtils;
-import androidx.annotation.Nullable;
 import cm.aptoide.pt.dataprovider.interfaces.TokenInvalidator;
 import cm.aptoide.pt.dataprovider.model.v3.OAuth;
 import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
@@ -28,10 +27,9 @@ public class OAuth2AuthenticationRequest extends V3<OAuth> {
   }
 
   public static OAuth2AuthenticationRequest of(String username, String password, String mode,
-      @Nullable String nameForGoogle, BodyInterceptor<BaseBody> bodyInterceptor,
-      OkHttpClient httpClient, Converter.Factory converterFactory,
-      TokenInvalidator tokenInvalidator, SharedPreferences sharedPreferences, String extraId,
-      String authMode) {
+      BodyInterceptor<BaseBody> bodyInterceptor, OkHttpClient httpClient,
+      Converter.Factory converterFactory, TokenInvalidator tokenInvalidator,
+      SharedPreferences sharedPreferences, String extraId, String authMode) {
 
     final BaseBody body = new BaseBody();
 
@@ -46,10 +44,6 @@ public class OAuth2AuthenticationRequest extends V3<OAuth> {
           body.put("password", password);
           break;
         case "GOOGLE":
-          body.put("authMode", authMode);
-          body.put("oauthUserName", nameForGoogle);
-          body.put("oauthToken", password);
-          break;
         case "FACEBOOK":
           body.put("authMode", authMode);
           body.put("oauthToken", password);
@@ -58,7 +52,6 @@ public class OAuth2AuthenticationRequest extends V3<OAuth> {
           body.put("oauthUserName", username);
           body.put("oauthToken", password);
           body.put("authMode", authMode);
-          body.put("oauthUser", nameForGoogle);
           break;
       }
     }


### PR DESCRIPTION
**What does this PR do?**

This PR aims at removing not needed permissions form social login. Also removed a field that was always being sent as null.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] ApplicationModule.java

**How should this be manually tested?**

Perform both google sign in and facebook sign in. Don't forget to remove aptoide access on the accounts of those social platforms that you will use, so that you can check the login permissions dialog in both scenarios.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-625](https://aptoide.atlassian.net/browse/MOB-625)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass