### PR TITLE
[MOB-397] enhancement: support aab for newer MIUI devices

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -1579,8 +1579,8 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
 
   @Singleton @Provides AppBundlesVisibilityManager providesAppBundlesVisibilityManager(
       HardwareSpecsFilterPersistence hardwareSpecsFilterPersistence) {
-    return new AppBundlesVisibilityManager(AptoideUtils.isDeviceMIUI(),
-        hardwareSpecsFilterPersistence);
+    return new AppBundlesVisibilityManager(AptoideUtils.isMIUIwithAABFix(),
+        AptoideUtils.isDeviceMIUI(), hardwareSpecsFilterPersistence);
   }
 
   @Singleton @Provides HardwareSpecsFilterPersistence providesHardwareSpecsFilterPersistence(

--- a/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
@@ -545,9 +545,9 @@ public class DeepLinkIntentReceiver extends ActivityView {
             WebService.getDefaultConverter(),
             ((AptoideApplication) getApplicationContext()).getTokenInvalidator(),
             ((AptoideApplication) getApplicationContext()).getDefaultSharedPreferences(),
-            new AppBundlesVisibilityManager(AptoideUtils.isDeviceMIUI(),
-                new HardwareSpecsFilterPersistence(
-                    ((AptoideApplication) getApplicationContext()).getDefaultSharedPreferences())))
+            new AppBundlesVisibilityManager(AptoideUtils.isMIUIwithAABFix(),
+                AptoideUtils.isDeviceMIUI(), new HardwareSpecsFilterPersistence(
+                ((AptoideApplication) getApplicationContext()).getDefaultSharedPreferences())))
             .observe()
             .toBlocking()
             .first();

--- a/app/src/main/java/cm/aptoide/pt/app/view/OtherVersionsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/OtherVersionsFragment.java
@@ -64,7 +64,6 @@ public class OtherVersionsFragment extends AptoideBaseFragment<BaseAdapter> {
    * @param appName
    * @param appImgUrl
    * @param appPackage
-   *
    * @return
    */
   public static OtherVersionsFragment newInstance(String appName, String appImgUrl,
@@ -155,9 +154,9 @@ public class OtherVersionsFragment extends AptoideBaseFragment<BaseAdapter> {
             ((AptoideApplication) getContext().getApplicationContext()).getTokenInvalidator(),
             ((AptoideApplication) getContext().getApplicationContext()).getDefaultSharedPreferences(),
             getContext().getResources(),
-            new AppBundlesVisibilityManager(AptoideUtils.isDeviceMIUI(),
-                new HardwareSpecsFilterPersistence(
-                    ((AptoideApplication) getContext().getApplicationContext()).getDefaultSharedPreferences()))),
+            new AppBundlesVisibilityManager(AptoideUtils.isMIUIwithAABFix(),
+                AptoideUtils.isDeviceMIUI(), new HardwareSpecsFilterPersistence(
+                ((AptoideApplication) getContext().getApplicationContext()).getDefaultSharedPreferences()))),
         otherVersionsSuccessRequestListener, err -> err.printStackTrace());
 
     getRecyclerView().addOnScrollListener(endlessRecyclerOnScrollListener);

--- a/app/src/main/java/cm/aptoide/pt/repository/request/RequestFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/repository/request/RequestFactory.java
@@ -26,7 +26,7 @@ import retrofit2.Converter;
 
 /**
  * Created by neuro on 26-12-2016.
- *
+ * <p>
  * Deprecated since some injected variables such as accountMature are susceptible to change between
  * calls and
  */
@@ -53,8 +53,8 @@ import retrofit2.Converter;
     this.storeCredentialsProvider = storeCredentialsProvider;
     this.googlePlayServicesAvailable = googlePlayServicesAvailable;
     AppBundlesVisibilityManager appBundlesVisibilityManager =
-        new AppBundlesVisibilityManager(AptoideUtils.isDeviceMIUI(),
-            new HardwareSpecsFilterPersistence(sharedPreferences));
+        new AppBundlesVisibilityManager(AptoideUtils.isMIUIwithAABFix(),
+            AptoideUtils.isDeviceMIUI(), new HardwareSpecsFilterPersistence(sharedPreferences));
     listStoresRequestFactory =
         new ListStoresRequestFactory(bodyInterceptor, httpClient, converterFactory,
             tokenInvalidator, sharedPreferences);

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilityManager.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilityManager.java
@@ -1,16 +1,19 @@
 package cm.aptoide.pt.dataprovider.aab;
 
 public class AppBundlesVisibilityManager {
-  private final boolean isDeviceMiui;
+  private final boolean isMIUIWithAABFix;
+  private boolean isDeviceMIUI;
   private final HardwareSpecsFilterProvider hardwareSpecsFilterProvider;
 
-  public AppBundlesVisibilityManager(boolean isDeviceMiui,
+  public AppBundlesVisibilityManager(boolean isMIUIWithAABFix, boolean isDeviceMIUI,
       HardwareSpecsFilterProvider hardwareSpecsFilterProvider) {
-    this.isDeviceMiui = isDeviceMiui;
+    this.isMIUIWithAABFix = isMIUIWithAABFix;
+    this.isDeviceMIUI = isDeviceMIUI;
     this.hardwareSpecsFilterProvider = hardwareSpecsFilterProvider;
   }
 
   public boolean shouldEnableAppBundles() {
-    return !isDeviceMiui || !hardwareSpecsFilterProvider.isOnlyShowCompatibleApps();
+    return !isDeviceMIUI || !hardwareSpecsFilterProvider.isOnlyShowCompatibleApps() || (isDeviceMIUI
+        && isMIUIWithAABFix);
   }
 }

--- a/dataprovider/src/test/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilityManagerTest.java
+++ b/dataprovider/src/test/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilityManagerTest.java
@@ -9,28 +9,28 @@ public class AppBundlesVisibilityManagerTest {
 
   @Test public void shouldEnableAppBundles_MIUI_CompatibleAppsOnly() {
     AppBundlesVisibilityManager appBundlesVisibilityManager =
-        new AppBundlesVisibilityManager(true, () -> true);
+        new AppBundlesVisibilityManager(true, AptoideUtils.isDeviceMIUI(), () -> true);
 
     assertFalse(appBundlesVisibilityManager.shouldEnableAppBundles());
   }
 
   @Test public void shouldEnableAppBundles_MIUI_ShowNonCompatibleApps() {
     AppBundlesVisibilityManager appBundlesVisibilityManager =
-        new AppBundlesVisibilityManager(true, () -> false);
+        new AppBundlesVisibilityManager(true, AptoideUtils.isDeviceMIUI(), () -> false);
 
     assertTrue(appBundlesVisibilityManager.shouldEnableAppBundles());
   }
 
   @Test public void shouldEnableAppBundles_NonMIUI_ShowNonCompatibleApps() {
     AppBundlesVisibilityManager appBundlesVisibilityManager =
-        new AppBundlesVisibilityManager(false, () -> false);
+        new AppBundlesVisibilityManager(false, AptoideUtils.isDeviceMIUI(), () -> false);
 
     assertTrue(appBundlesVisibilityManager.shouldEnableAppBundles());
   }
 
   @Test public void shouldEnableAppBundles_NonMIUI_CompatibleAppsOnly() {
     AppBundlesVisibilityManager appBundlesVisibilityManager =
-        new AppBundlesVisibilityManager(false, () -> true);
+        new AppBundlesVisibilityManager(false, AptoideUtils.isDeviceMIUI(), () -> true);
 
     assertTrue(appBundlesVisibilityManager.shouldEnableAppBundles());
   }

--- a/dataprovider/src/test/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilityManagerTest.java
+++ b/dataprovider/src/test/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilityManagerTest.java
@@ -9,28 +9,28 @@ public class AppBundlesVisibilityManagerTest {
 
   @Test public void shouldEnableAppBundles_MIUI_CompatibleAppsOnly() {
     AppBundlesVisibilityManager appBundlesVisibilityManager =
-        new AppBundlesVisibilityManager(true, AptoideUtils.isDeviceMIUI(), () -> true);
+        new AppBundlesVisibilityManager(false, true, () -> true);
 
     assertFalse(appBundlesVisibilityManager.shouldEnableAppBundles());
   }
 
   @Test public void shouldEnableAppBundles_MIUI_ShowNonCompatibleApps() {
     AppBundlesVisibilityManager appBundlesVisibilityManager =
-        new AppBundlesVisibilityManager(true, AptoideUtils.isDeviceMIUI(), () -> false);
+        new AppBundlesVisibilityManager(false, true, () -> false);
 
     assertTrue(appBundlesVisibilityManager.shouldEnableAppBundles());
   }
 
   @Test public void shouldEnableAppBundles_NonMIUI_ShowNonCompatibleApps() {
     AppBundlesVisibilityManager appBundlesVisibilityManager =
-        new AppBundlesVisibilityManager(false, AptoideUtils.isDeviceMIUI(), () -> false);
+        new AppBundlesVisibilityManager(false, false, () -> false);
 
     assertTrue(appBundlesVisibilityManager.shouldEnableAppBundles());
   }
 
   @Test public void shouldEnableAppBundles_NonMIUI_CompatibleAppsOnly() {
     AppBundlesVisibilityManager appBundlesVisibilityManager =
-        new AppBundlesVisibilityManager(false, AptoideUtils.isDeviceMIUI(), () -> true);
+        new AppBundlesVisibilityManager(false, false, () -> true);
 
     assertTrue(appBundlesVisibilityManager.shouldEnableAppBundles());
   }

--- a/utils/src/main/java/cm/aptoide/pt/utils/AptoideUtils.java
+++ b/utils/src/main/java/cm/aptoide/pt/utils/AptoideUtils.java
@@ -94,6 +94,19 @@ public class AptoideUtils {
     return !TextUtils.isEmpty(getSystemProperty("ro.miui.ui.version.name"));
   }
 
+  public static boolean isMIUIwithAABFix() {
+    String systemProperty = getSystemProperty("ro.miui.version.code_time");
+    boolean versionSupportsAAB = false;
+    if (systemProperty != null) {
+      try {
+        versionSupportsAAB = Long.parseLong(systemProperty)
+            > 1583942400; // this is currently a xiaomi device that we have working with app bundles.
+      } catch (NumberFormatException ignore) {
+      }
+    }
+    return !TextUtils.isEmpty(systemProperty) && versionSupportsAAB;
+  }
+
   @SuppressLint("PrivateApi") private static String getSystemProperty(String key) {
     try {
       return (String) Class.forName("android.os.SystemProperties")
@@ -474,10 +487,9 @@ public class AptoideUtils {
     }
 
     /**
-     * get screen size in "pixels", i.e. touchevent/view units.
-     * on my droid 4, this is 360x640 or 540x960
-     * depending on whether the app is in screen compatibility mode
-     * (i.e. targetSdkVersion<=10 in the manifest) or not.
+     * get screen size in "pixels", i.e. touchevent/view units. on my droid 4, this is 360x640 or
+     * 540x960 depending on whether the app is in screen compatibility mode (i.e.
+     * targetSdkVersion<=10 in the manifest) or not.
      */
     // method deprecated since no usage was found.
     @Deprecated public static String getScreenSizePixels(Resources resources) {
@@ -527,15 +539,12 @@ public class AptoideUtils {
 
     /**
      * <p>Joins the elements of the provided {@code Iterable} into a single String containing the
-     * provided elements.</p> <p> <p>No delimiter is added
-     * before
-     * or after the list. A {@code null} separator is the same as an empty String ("").</p>
+     * provided elements.</p> <p> <p>No delimiter is added before or after the list. A {@code null}
+     * separator is the same as an empty String ("").</p>
      *
-     * @param iterable the {@code Iterable} providing the values to join together, may be null
+     * @param iterable  the {@code Iterable} providing the values to join together, may be null
      * @param separator the separator character to use, null treated as ""
-     *
      * @return the joined String, {@code null} if null iterator input
-     *
      * @since 2.3
      */
     public static String join(final Iterable<?> iterable, final String separator) {
@@ -547,13 +556,11 @@ public class AptoideUtils {
 
     /**
      * <p>Joins the elements of the provided {@code Iterator} into a single String containing the
-     * provided elements.</p> <p> <p>No delimiter is added
-     * before
-     * or after the list. A {@code null} separator is the same as an empty String ("").</p>
+     * provided elements.</p> <p> <p>No delimiter is added before or after the list. A {@code null}
+     * separator is the same as an empty String ("").</p>
      *
-     * @param iterator the {@code Iterator} of values to join together, may be null
+     * @param iterator  the {@code Iterator} of values to join together, may be null
      * @param separator the separator character to use, null treated as ""
-     *
      * @return the joined String, {@code null} if null iterator input
      */
     public static String join(final Iterator<?> iterator, final String separator) {
@@ -617,7 +624,6 @@ public class AptoideUtils {
 
     /**
      * @param bytes file size
-     *
      * @return formatted string for file file showing a Human perceptible file size
      */
     public static String formatBytes(long bytes, boolean speed) {
@@ -893,8 +899,8 @@ public class AptoideUtils {
     }
 
     /**
-     * If you are trying to use this method inside a fragment, the base fragment already has
-     * a copy of it. Use that instead.
+     * If you are trying to use this method inside a fragment, the base fragment already has a copy
+     * of it. Use that instead.
      */
     @Deprecated public static void hideKeyboard(Activity activity) {
       View view = activity.getCurrentFocus();
@@ -935,7 +941,7 @@ public class AptoideUtils {
 
     /**
      * from v7
-     *
+     * <p>
      * Use RootManager or other entity created for this effect in the engine
      */
     @Deprecated public static boolean hasRoot() {
@@ -1090,9 +1096,7 @@ public class AptoideUtils {
      * Singleton constructor, needed to get access to the application context & strings for i18n
      *
      * @param context Context
-     *
      * @return DateTimeUtils singleton instance
-     *
      * @throws Exception
      */
     public static DateTimeU getInstance(Context context) {
@@ -1133,7 +1137,6 @@ public class AptoideUtils {
      * Checks if the given date is yesterday.
      *
      * @param date - Date to check.
-     *
      * @return TRUE if the date is yesterday, FALSE otherwise.
      */
     private static boolean isYesterday(long date) {
@@ -1188,7 +1191,6 @@ public class AptoideUtils {
      * Displays a user-friendly date difference string
      *
      * @param timedate Timestamp to format as date difference from now
-     *
      * @return Friendly-formatted date diff string
      */
     public String getTimeDiffString(Context context, long timedate, Resources resources) {
@@ -1466,7 +1468,6 @@ public class AptoideUtils {
      * filename ends with <b>_icon</b> it is an HD icon.
      *
      * @param iconUrl The String with the URL of the icon
-     *
      * @return A String with
      */
     private static String parseIcon(String iconUrl, Resources resources,
@@ -1583,7 +1584,6 @@ public class AptoideUtils {
      * code from <a href="http://blog.danlew.net/2015/03/02/dont-break-the-chain/">http://blog.danlew.net/2015/03/02/dont-break-the-chain/</a>
      *
      * @param <T> Observable of T
-     *
      * @return original Observable subscribed in an io thread and observed in the main thread
      */
     public static <T> Observable.Transformer<T, T> applySchedulers() {


### PR DESCRIPTION
**What does this PR do?**

   Devices with MIUI 11.2 should technically have a fix that allows the sideload of app with splits without error. This fix is to try to enable, without breaking, newer miui devices that can already do that. More information inside the issue about past investigations.

**Database changed?**

  No

**Where should the reviewer start?**

- [ ] AptoideUtils.java

**How should this be manually tested?**

  This in new MIUI devices (should show aab), old MIUI devices (should not show aab)  and non MIUI devices (should show aab) the installation of an app with app bundles.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-397](https://aptoide.atlassian.net/browse/MOB-397) [MOB-399](https://aptoide.atlassian.net/browse/MOB-399)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass