### PR TITLE
[MOB-555] fix: show pp & tc error 

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/account/view/LoginSignUpCredentialsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/account/view/LoginSignUpCredentialsFragment.java
@@ -187,8 +187,9 @@ public class LoginSignUpCredentialsFragment extends GooglePlayServicesFragment
         .map(event -> termsConditionCheckBox.isChecked());
   }
 
-  @Override public Observable<Void> googleSignUpEvent() {
+  @Override public Observable<Boolean> googleSignUpEvent() {
     return RxView.clicks(googleLoginButton)
+        .map(event -> termsConditionCheckBox.isChecked())
         .doOnNext(__ -> accountAnalytics.clickIn(AccountAnalytics.StartupClick.CONNECT_GOOGLE,
             getStartupClickOrigin()));
   }
@@ -198,8 +199,9 @@ public class LoginSignUpCredentialsFragment extends GooglePlayServicesFragment
         .map(dialog -> null);
   }
 
-  @Override public Observable<Void> facebookSignUpEvent() {
+  @Override public Observable<Boolean> facebookSignUpEvent() {
     return RxView.clicks(facebookLoginButton)
+        .map(event -> termsConditionCheckBox.isChecked())
         .doOnNext(__ -> accountAnalytics.clickIn(AccountAnalytics.StartupClick.CONNECT_FACEBOOK,
             getStartupClickOrigin()));
   }

--- a/app/src/main/java/cm/aptoide/pt/presenter/LoginSignUpCredentialsPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/presenter/LoginSignUpCredentialsPresenter.java
@@ -90,11 +90,20 @@ public abstract class LoginSignUpCredentialsPresenter
             .log(err));
   }
 
+  void showNotCheckedMessage(boolean checked) {
+    if (!checked) {
+      view.showTermsConditionError();
+    }
+  }
+
   private void handleGoogleSignUpEvent() {
     view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .doOnNext(__ -> showOrHideGoogleSignUp())
-        .flatMap(__ -> view.googleSignUpEvent())
+        .flatMap(__ -> view.googleSignUpEvent()
+            .doOnNext(this::showNotCheckedMessage)
+            .filter(event -> event)
+            .retry())
         .doOnNext(event -> {
           view.showLoading();
           accountAnalytics.sendGoogleLoginButtonPressed();
@@ -143,7 +152,10 @@ public abstract class LoginSignUpCredentialsPresenter
     view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .doOnNext(__ -> showOrHideFacebookSignUp())
-        .flatMap(__ -> view.facebookSignUpEvent())
+        .flatMap(__ -> view.facebookSignUpEvent()
+            .doOnNext(this::showNotCheckedMessage)
+            .filter(event -> event)
+            .retry())
         .doOnNext(event -> {
           view.showLoading();
           accountAnalytics.sendFacebookLoginButtonPressed();

--- a/app/src/main/java/cm/aptoide/pt/presenter/LoginSignUpCredentialsView.java
+++ b/app/src/main/java/cm/aptoide/pt/presenter/LoginSignUpCredentialsView.java
@@ -13,11 +13,11 @@ public interface LoginSignUpCredentialsView extends GooglePlayServicesView {
 
   Observable<Boolean> showAptoideLoginAreaClick();
 
-  Observable<Void> googleSignUpEvent();
+  Observable<Boolean> googleSignUpEvent();
 
   Observable<Void> facebookSignUpWithRequiredPermissionsInEvent();
 
-  Observable<Void> facebookSignUpEvent();
+  Observable<Boolean> facebookSignUpEvent();
 
   Observable<Void> termsAndConditionsClickEvent();
 

--- a/app/src/vanilla/java/cm/aptoide/pt/presenter/LoginSignupCredentialsFlavorPresenter.java
+++ b/app/src/vanilla/java/cm/aptoide/pt/presenter/LoginSignupCredentialsFlavorPresenter.java
@@ -81,12 +81,6 @@ public class LoginSignupCredentialsFlavorPresenter extends LoginSignUpCredential
         });
   }
 
-  private void showNotCheckedMessage(boolean checked) {
-    if (!checked) {
-      view.showTermsConditionError();
-    }
-  }
-
   @Override public boolean handle() {
     return view.tryCloseLoginBottomSheet(true);
   }


### PR DESCRIPTION
**What does this PR do?**

    show pp & tc error  if user tries to login with fb/google without accepting the pp & tc

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] LoginSignUpCredentialsFragment.java

**How should this be manually tested?**

  Try to login with google/fb without accepting the terms and conditions

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-555](https://aptoide.atlassian.net/browse/MOB-555)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass