### PR TITLE
[MOB-555] fix: accept agent as nullable since it is not currently being used.

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/account/AgentPersistence.kt
+++ b/app/src/main/java/cm/aptoide/pt/account/AgentPersistence.kt
@@ -4,7 +4,7 @@ import android.content.SharedPreferences
 
 open class AgentPersistence(private val secureSharedPreferences: SharedPreferences) {
 
-  fun persistAgent(agent: String, state: String, email: String?) {
+  fun persistAgent(agent: String?, state: String, email: String?) {
     secureSharedPreferences.edit().putString("AGENT", agent).putString("STATE", state)
         .putString("EMAIL", email).apply()
   }

--- a/aptoide-authentication-core/src/main/kotlin/com/aptoide/authentication/model/CodeAuth.kt
+++ b/aptoide-authentication-core/src/main/kotlin/com/aptoide/authentication/model/CodeAuth.kt
@@ -3,7 +3,7 @@ package com.aptoide.authentication.model
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-data class CodeAuth(val type: String, val state: String, val agent: String, val signup: Boolean,
+data class CodeAuth(val type: String, val state: String, val agent: String?, val signup: Boolean,
                     val data: Data, var email: String?) {
   @JsonClass(generateAdapter = true)
   data class Data(val type: String, val method: String)


### PR DESCRIPTION
**What does this PR do?**

   According to the API documentation, agent can be null in the first authorize response. This PR makes agent nullable.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] RemoteAuthorizationService.java

**How should this be manually tested?**

  Test the login flow, dev environment is already sending a null agent.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MICRO-850](https://aptoide.atlassian.net/browse/MICRO-850)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass