### PR TITLE
[MOB-757] fix: aptoideinstall:// not showing Aptoide issue

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -213,14 +213,20 @@
         <data android:scheme="aptoidexml" />
         <data android:scheme="aptoideinstall" />
         <data android:scheme="aptoideauth" />
-        <data
-            android:host="app.aptoide.com"
-            android:scheme="https" />
         <data android:scheme="aptoidesearch" />
         <data android:scheme="aptword" />
         <data android:scheme="aptoidefeature" />
       </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
 
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <data
+            android:host="app.aptoide.com"
+            android:scheme="https" />
+      </intent-filter>
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
 


### PR DESCRIPTION
**What does this PR do?**

   fix: separting the app.aptoide intent from the other ones seems to fix the aptoideinstall:// issue

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Foo.java
- [ ] Bar.kt

**How should this be manually tested?**

  adb shell am start -a "android.intent.action.VIEW" -d "aptoideinstall://package=com.tencent.tmgp.sskeus\&store=catappult\&show_install_popup=false"

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-757](https://aptoide.atlassian.net/browse/MOB-757)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass