### PR TITLE
[MOB-770] fix: home visual flicker in navigation

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/MoreBundlePresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/MoreBundlePresenter.java
@@ -95,8 +95,8 @@ public class MoreBundlePresenter implements Presenter {
           if (bundlesModel.hasErrors()) {
             handleError(bundlesModel.getError());
           } else if (!bundlesModel.isLoading()) {
-            view.hideLoading();
             view.showBundles(bundlesModel.getList());
+            view.hideLoading();
           }
         });
   }

--- a/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomeFragment.java
@@ -419,8 +419,13 @@ public class HomeFragment extends NavigationTrackFragment implements HomeView, S
   }
 
   @Override public void showBundlesSkeleton(HomeBundlesModel homeBundles) {
-    hideLoading();
     adapter.update(homeBundles.getList());
+    if (listState != null) {
+      bundlesList.getLayoutManager()
+          .onRestoreInstanceState(listState);
+      listState = null;
+    }
+    hideLoading();
   }
 
   @Override public boolean isAtTop() {

--- a/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/HomePresenter.java
@@ -377,8 +377,8 @@ public class HomePresenter implements Presenter {
     if (bundlesModel.hasErrors()) {
       handleError(bundlesModel.getError());
     } else if (!bundlesModel.isLoading()) {
-      view.hideLoading();
       view.showBundles(bundlesModel.getList());
+      view.hideLoading();
     }
   }
 


### PR DESCRIPTION
**What does this PR do?**

   restore scroll state when showing skeleton views, so it doesn't do the visual flicker while navigating back to it.
   change hide loading method calls to after show so we don't end with an empty screen between those two operations.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] HomeFragment.java
- [ ] HomePresenter.java

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-770](https://aptoide.atlassian.net/browse/MOB-770)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-770](https://aptoide.atlassian.net/browse/MOB-770)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass