### PR TITLE
[AN-2046] - get user inner nodes load are now refreshed on pull to refresh

### DIFF
--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/store/GetUserRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/store/GetUserRequest.java
@@ -87,17 +87,17 @@ public class GetUserRequest extends V7<GetStore, GetUserRequest.Body> {
   @Override
   protected Observable<GetStore> loadDataFromNetwork(Interfaces interfaces, boolean bypassCache) {
     return interfaces.getUser(url, body, bypassCache)
-        .flatMap(getStore -> loadGetStoreWidgets(getStore).map(wsWidgets -> getStore));
+        .flatMap(getStore -> loadGetStoreWidgets(getStore, bypassCache).map(wsWidgets -> getStore));
   }
 
-  protected Observable<List<GetStoreWidgets.WSWidget>> loadGetStoreWidgets(
-      GetStore getStoreWidgets) {
+  protected Observable<List<GetStoreWidgets.WSWidget>> loadGetStoreWidgets(GetStore getStoreWidgets,
+      boolean bypassCache) {
     return Observable.from(getStoreWidgets.getNodes()
         .getWidgets()
         .getDataList()
         .getList())
         .observeOn(Schedulers.io())
-        .flatMap(wsWidget -> WSWidgetsUtils.loadWidgetNode(wsWidget, storeCredentials, false,
+        .flatMap(wsWidget -> WSWidgetsUtils.loadWidgetNode(wsWidget, storeCredentials, bypassCache,
             clientUniqueId, isGooglePlayServicesAvailable, partnerId, accountMature,
             ((BodyInterceptor<BaseBody>) bodyInterceptor), httpClient, converterFactory, filters,
             tokenInvalidator, sharedPreferences, resources, windowManager, connectivityManager,


### PR DESCRIPTION
**What does this PR do?**

   Title

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Foo.java
- [ ] Bar.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AN-2046](https://aptoide.atlassian.net/browse/AN-2046)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AN-2046](https://aptoide.atlassian.net/browse/AN-2046)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass