### PR TITLE
[MOB-806] Fixed login translations

### DIFF
--- a/app/src/main/res/layout/fragment_login_sign_up_credentials.xml
+++ b/app/src/main/res/layout/fragment_login_sign_up_credentials.xml
@@ -46,7 +46,7 @@
       android:layout_marginStart="32dp"
       android:layout_marginTop="24dp"
       android:layout_marginEnd="32dp"
-    android:layout_marginBottom="80dp"
+      android:layout_marginBottom="80dp"
       android:visibility="gone"
       />
 

--- a/app/src/main/res/values-v21/styles_aptoide_button.xml
+++ b/app/src/main/res/values-v21/styles_aptoide_button.xml
@@ -44,7 +44,7 @@
     <item name="android:paddingLeft">50dp</item>
     <item name="android:background">@drawable/google_button_rounded</item>
     <item name="android:drawableLeft">@drawable/google_icon_copy</item>
-    <item name="android:text">@string/connect_google</item>
+    <item name="android:text">@string/connect_with_google</item>
     <item name="android:textColor">@color/google_grey</item>
     <item name="android:contentDescription">@string/google</item>
   </style>

--- a/app/src/main/res/values/strings_appstimeline.xml
+++ b/app/src/main/res/values/strings_appstimeline.xml
@@ -15,7 +15,6 @@
   <string name="private_following_message">you are following %d private users/stores</string>
 
   <string name="google">Google</string>
-  <string name="connect_google">Connect with Google</string>
   <string name="done">Done</string>
 
   <plurals

--- a/app/src/main/res/values/styles_aptoide_button.xml
+++ b/app/src/main/res/values/styles_aptoide_button.xml
@@ -112,7 +112,7 @@
     <item name="android:paddingRight">50dp</item>
     <item name="android:paddingLeft">50dp</item>
     <item name="android:background">?attr/installButtonBackground</item>
-    <item name="android:text">Connect with Email</item>
+    <item name="android:text">@string/login_connect_with_email_button</item>
     <item name="android:textColor">@color/white</item>
   </style>
 
@@ -131,7 +131,7 @@
     <item name="android:paddingLeft">50dp</item>
     <item name="android:background">@drawable/google_button_rounded</item>
     <item name="android:drawableLeft">@drawable/google_icon_copy</item>
-    <item name="android:text">@string/connect_google</item>
+    <item name="android:text">@string/connect_with_google</item>
     <item name="android:textColor">@color/google_grey</item>
     <item name="android:contentDescription">@string/google</item>
   </style>


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing login translations. We were using the wrong string for the connect with google button, which made Portuguese be inconsistent (Connectar while other buttons said entrar). Also removed the other translations. Btw, in BR, the connect with google string is still not correct as all other buttons say connectar and the login with email says entrar.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] styles_aptoide_button.xml

**How should this be manually tested?**
Copy translations from crodwin repo from pt pt and pt br, paste it on your project and confirm that the reported error does not happen anymore.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-806](https://aptoide.atlassian.net/browse/MOB-806)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass