### PR TITLE
[feature/MOB-849] Support for apkfy oem_id

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,9 @@ android {
   }
 
   signingConfigs {
+    debug {
+      v2SigningEnabled = false
+    }
     release {
       storeFile = file(project.STORE_FILE_VANILLA)
       storePassword = project.STORE_PASSWORD_VANILLA

--- a/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
@@ -704,7 +704,7 @@ public class DeepLinkIntentReceiver extends ActivityView {
 
       FileOutputStream saveit = new FileOutputStream(TMP_MYAPP_FILE);
       BufferedOutputStream bout = new BufferedOutputStream(saveit, 1024);
-      byte data[] = new byte[1024];
+      byte[] data = new byte[1024];
 
       int readed = getit.read(data, 0, 1024);
       while (readed != -1) {
@@ -771,6 +771,7 @@ public class DeepLinkIntentReceiver extends ActivityView {
 
     public static final String APP_MD5_KEY = "md5";
     public static final String APP_ID_KEY = "appId";
+    public static final String OEM_ID_KEY = "oemId";
     public static final String PACKAGE_NAME_KEY = "packageName";
     public static final String UNAME = "uname";
     public static final String STORENAME_KEY = "storeName";

--- a/app/src/main/java/cm/aptoide/pt/app/AppModel.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppModel.java
@@ -70,6 +70,7 @@ public class AppModel {
   private List<String> bdsFlags;
   private String campaignUrl;
   private String signature;
+  private String oemId;
 
   public AppModel(long appId, String appName, Store store, String storeTheme, boolean isGoodApp,
       Malware malware, AppFlags appFlags, List<String> tags, List<String> usedFeatures,
@@ -81,7 +82,7 @@ public class AppModel {
       double appc, SearchAdResult minimalAd, String editorsChoice, String originTag,
       boolean isStoreFollowed, String marketName, boolean hasBilling, boolean hasAdvertising,
       List<String> bdsFlags, String campaignUrl, String signature, boolean isMature,
-      List<Split> splits, List<String> requiredSplits) {
+      List<Split> splits, List<String> requiredSplits, String oemId) {
     this.appId = appId;
     this.appName = appName;
     this.store = store;
@@ -131,6 +132,7 @@ public class AppModel {
     this.requiredSplits = requiredSplits;
     this.loading = false;
     this.error = null;
+    this.oemId = oemId;
   }
 
   public AppModel(boolean loading) {
@@ -183,6 +185,7 @@ public class AppModel {
     this.campaignUrl = "";
     this.splits = null;
     this.requiredSplits = null;
+    this.oemId = null;
   }
 
   public AppModel(DetailedAppRequestResult.Error error) {
@@ -236,6 +239,7 @@ public class AppModel {
     this.campaignUrl = "";
     this.splits = null;
     this.requiredSplits = null;
+    this.oemId = null;
   }
 
   public boolean isMature() {
@@ -459,5 +463,9 @@ public class AppModel {
 
   public List<String> getRequiredSplits() {
     return requiredSplits;
+  }
+
+  public String getOemId() {
+    return oemId;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/app/AppNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppNavigator.java
@@ -56,11 +56,19 @@ public class AppNavigator {
 
   public void navigateWithAppId(long appId, String packageName, AppViewFragment.OpenType openType,
       String tag) {
+    navigateWithAppId(appId, packageName, openType, tag, null);
+  }
+
+  public void navigateWithAppId(long appId, String packageName, AppViewFragment.OpenType openType,
+      String tag, String oemId) {
     Bundle bundle = new Bundle();
     bundle.putString(AppViewFragment.BundleKeys.ORIGIN_TAG.name(), tag);
     bundle.putLong(AppViewFragment.BundleKeys.APP_ID.name(), appId);
     bundle.putString(AppViewFragment.BundleKeys.PACKAGE_NAME.name(), packageName);
     bundle.putSerializable(AppViewFragment.BundleKeys.SHOULD_INSTALL.name(), openType);
+    if (openType == AppViewFragment.OpenType.APK_FY_INSTALL_POPUP && oemId != null) {
+      bundle.putString(AppViewFragment.BundleKeys.OEM_ID.name(), oemId);
+    }
     AppViewFragment fragment = new AppViewFragment();
     fragment.setArguments(bundle);
     fragmentNavigator.navigateTo(fragment, true);

--- a/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewManager.java
@@ -215,7 +215,7 @@ public class AppViewManager {
                 app.getSplits(), app.getRequiredSplits(), app.getMalware()
                     .getRank()
                     .toString(), app.getStore()
-                    .getName())))
+                    .getName(), app.getOemId())))
         .doOnError(throwable -> {
           if (throwable instanceof InvalidAppException) {
             appViewAnalytics.sendInvalidAppEventError(app.getPackageName(), downloadAction, status,

--- a/app/src/main/java/cm/aptoide/pt/app/AppViewModelManager.java
+++ b/app/src/main/java/cm/aptoide/pt/app/AppViewModelManager.java
@@ -198,7 +198,7 @@ public class AppViewModelManager {
             appViewConfiguration.getEditorsChoice(), appViewConfiguration.getOriginTag(),
             isStoreFollowed, marketName, app.hasBilling(), app.hasAdvertising(), app.getBdsFlags(),
             appViewConfiguration.getCampaignUrl(), app.getSignature(), app.isMature(),
-            app.getSplits(), app.getRequiredSplits()));
+            app.getSplits(), app.getRequiredSplits(), appViewConfiguration.getOemId()));
   }
 
   private Single<Boolean> isStoreFollowed(long storeId) {

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewFragment.java
@@ -1280,7 +1280,7 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
     setupWalletPromotionText(promotion, stringId);
     walletPromotionInstallDisableButton.setText(
         String.format(getString(R.string.wallet_promotion_button_install_disabled),
-            String.valueOf(promotion.getAppc())));
+            promotion.getAppc()));
     walletPromotionInstallDisableLayout.setVisibility(View.VISIBLE);
     walletPromotionDownloadLayout.setVisibility(View.GONE);
     walletPromotionButtonsLayout.setVisibility(View.GONE);
@@ -1291,8 +1291,7 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
   private void setupClaimWalletPromotion(Promotion promotion, WalletApp walletApp) {
     setupWalletPromotionText(promotion, R.string.wallet_promotion_wallet_claim_message);
     walletPromotionClaimButton.setText(
-        String.format(getString(R.string.wallet_promotion_button_claim),
-            String.valueOf(promotion.getAppc())));
+        String.format(getString(R.string.wallet_promotion_button_claim), promotion.getAppc()));
     walletPromotionDownloadLayout.setVisibility(View.GONE);
     walletPromotionInstallDisableLayout.setVisibility(View.GONE);
     walletPromotionButtonsLayout.setVisibility(View.GONE);
@@ -1304,9 +1303,9 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
 
   private void setupWalletPromotionText(Promotion promotion, @StringRes int walletMessageStringId) {
     walletPromotionTitle.setText(String.format(getString(R.string.wallet_promotion_title),
-        String.valueOf(promotion.getAppc())));
+        promotion.getAppc()));
     walletPromotionMessage.setText(
-        String.format(getString(walletMessageStringId), String.valueOf(promotion.getAppc())));
+        String.format(getString(walletMessageStringId), promotion.getAppc()));
   }
 
   private int getPromotionMessage(DownloadModel appDownloadModel) {
@@ -1745,8 +1744,7 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
       String formatedFiatCurrency = fiatCurrency + poaFiatDecimalFormat.format(fiatReward);
       appcInfoView.setVisibility(View.VISIBLE);
       poaOfferValue.setText(
-          String.format(getResources().getString(R.string.poa_app_view_card_body_2),
-              String.valueOf(appcReward), formatedFiatCurrency));
+          String.format(getResources().getString(R.string.poa_app_view_card_body_2), appcReward, formatedFiatCurrency));
       if (!date.equals("")) {
         poaCountdownMessage.setVisibility(View.VISIBLE);
         setCountdownTimer(date);
@@ -1754,8 +1752,7 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
         int transactionsLeft = (int) (appcBudget / appcReward);
         poaBudgetElement.setVisibility(View.VISIBLE);
         poaBudgetMessage.setText(
-            String.format(getResources().getString(R.string.poa_APPCC_left_body),
-                String.valueOf(transactionsLeft)));
+            String.format(getResources().getString(R.string.poa_APPCC_left_body), transactionsLeft));
       }
       if (hasBilling) poaIabInfo.setVisibility(View.VISIBLE);
     } else {
@@ -1966,7 +1963,7 @@ public class AppViewFragment extends NavigationTrackFragment implements AppViewV
   }
 
   public enum BundleKeys {
-    APP_ID, STORE_NAME, STORE_THEME, MINIMAL_AD, PACKAGE_NAME, SHOULD_INSTALL, MD5, UNAME, DOWNLOAD_CONVERSION_URL, APPC, EDITORS_CHOICE_POSITION, ORIGIN_TAG,
+    APP_ID, STORE_NAME, STORE_THEME, MINIMAL_AD, PACKAGE_NAME, SHOULD_INSTALL, MD5, UNAME, DOWNLOAD_CONVERSION_URL, APPC, EDITORS_CHOICE_POSITION, ORIGIN_TAG, OEM_ID
   }
 
   public enum OpenType {

--- a/app/src/main/java/cm/aptoide/pt/download/DownloadApkPathsProvider.java
+++ b/app/src/main/java/cm/aptoide/pt/download/DownloadApkPathsProvider.java
@@ -15,7 +15,11 @@ public class DownloadApkPathsProvider {
   }
 
   public ApkPaths getDownloadPaths(int downloadAction, String path, String altPath) {
-    String oemid = getOemidQueryString();
+    return getDownloadPaths(downloadAction, path, altPath, null);
+  }
+
+  public ApkPaths getDownloadPaths(int downloadAction, String path, String altPath, String oemId) {
+    String oemid = getOemidQueryString(oemId);
     switch (downloadAction) {
       case RoomDownload.ACTION_INSTALL:
         path += INSTALL_ACTION + oemid;
@@ -33,12 +37,13 @@ public class DownloadApkPathsProvider {
     return new ApkPaths(path, altPath);
   }
 
-  private String getOemidQueryString() {
-    String oemid = oemidProvider.getOemid();
-    if (oemid.isEmpty()) {
-      return "";
-    } else {
-      return OEMID_QUERY + oemid;
+  private String getOemidQueryString(String downloadOemId) {
+    String oemId =
+        (downloadOemId == null || downloadOemId.isEmpty()) ? "" : OEMID_QUERY + downloadOemId;
+    if (oemId.isEmpty()) {
+      String providerOemId = oemidProvider.getOemid();
+      oemId = providerOemId.isEmpty() ? "" : OEMID_QUERY + providerOemId;
     }
+    return oemId;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/download/DownloadFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/download/DownloadFactory.java
@@ -169,6 +169,15 @@ public class DownloadFactory {
       String icon, String versionName, int versionCode, String appPath, String appPathAlt, Obb obb,
       boolean hasAppc, long size, List<Split> splits, List<String> requiredSplits,
       String trustedBadge, String storeName) {
+    return create(downloadAction, appName, packageName, md5, icon, versionName, versionCode,
+        appPath, appPathAlt, obb, hasAppc, size, splits, requiredSplits, trustedBadge, storeName,
+        null);
+  }
+
+  public RoomDownload create(int downloadAction, String appName, String packageName, String md5,
+      String icon, String versionName, int versionCode, String appPath, String appPathAlt, Obb obb,
+      boolean hasAppc, long size, List<Split> splits, List<String> requiredSplits,
+      String trustedBadge, String storeName, String oemId) {
 
     AppValidator.AppValidationResult validationResult =
         appValidator.validateApp(md5, obb, packageName, appName, appPath, appPathAlt, splits,
@@ -177,7 +186,7 @@ public class DownloadFactory {
     if (validationResult == AppValidator.AppValidationResult.VALID_APP) {
 
       ApkPaths downloadPaths =
-          downloadApkPathsProvider.getDownloadPaths(downloadAction, appPath, appPathAlt);
+          downloadApkPathsProvider.getDownloadPaths(downloadAction, appPath, appPathAlt, oemId);
 
       RoomDownload download = new RoomDownload();
       download.setMd5(md5);

--- a/app/src/main/java/cm/aptoide/pt/presenter/MainPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/presenter/MainPresenter.java
@@ -30,7 +30,7 @@ import cm.aptoide.pt.notification.NotificationSyncScheduler;
 import cm.aptoide.pt.preferences.managed.ManagerPreferences;
 import cm.aptoide.pt.preferences.secure.SecurePreferences;
 import cm.aptoide.pt.root.RootAvailabilityManager;
-import cm.aptoide.pt.util.ApkFy;
+import cm.aptoide.pt.util.ApkFyManager;
 import cm.aptoide.pt.view.DeepLinkManager;
 import cm.aptoide.pt.view.wizard.WizardFragment;
 import com.aptoide.authentication.AuthenticationException;
@@ -55,7 +55,7 @@ public class MainPresenter implements Presenter {
   private final DeepLinkManager deepLinkManager;
   private final NotificationSyncScheduler notificationSyncScheduler;
   private final InstallCompletedNotifier installCompletedNotifier;
-  private final ApkFy apkFy;
+  private final ApkFyManager apkFyManager;
   private final boolean firstCreated;
   private final AptoideBottomNavigator aptoideBottomNavigator;
   private final Scheduler viewScheduler;
@@ -73,7 +73,8 @@ public class MainPresenter implements Presenter {
 
   public MainPresenter(MainView view, InstallManager installManager,
       RootInstallationRetryHandler rootInstallationRetryHandler, CrashReport crashReport,
-      ApkFy apkFy, ContentPuller contentPuller, NotificationSyncScheduler notificationSyncScheduler,
+      ApkFyManager apkFyManager, ContentPuller contentPuller,
+      NotificationSyncScheduler notificationSyncScheduler,
       InstallCompletedNotifier installCompletedNotifier, SharedPreferences sharedPreferences,
       SharedPreferences securePreferences, FragmentNavigator fragmentNavigator,
       DeepLinkManager deepLinkManager, boolean firstCreated,
@@ -87,7 +88,7 @@ public class MainPresenter implements Presenter {
     this.installManager = installManager;
     this.rootInstallationRetryHandler = rootInstallationRetryHandler;
     this.crashReport = crashReport;
-    this.apkFy = apkFy;
+    this.apkFyManager = apkFyManager;
     this.contentPuller = contentPuller;
     this.notificationSyncScheduler = notificationSyncScheduler;
     this.installCompletedNotifier = installCompletedNotifier;
@@ -123,7 +124,7 @@ public class MainPresenter implements Presenter {
 
     view.getLifecycleEvent()
         .filter(event -> View.LifecycleEvent.CREATE.equals(event))
-        .doOnNext(created -> apkFy.run())
+        .doOnNext(created -> apkFyManager.run())
         .filter(created -> firstCreated)
         .doOnNext(created -> notificationSyncScheduler.forceSync())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))

--- a/app/src/main/java/cm/aptoide/pt/util/ApkfyParameters.kt
+++ b/app/src/main/java/cm/aptoide/pt/util/ApkfyParameters.kt
@@ -1,0 +1,3 @@
+package cm.aptoide.pt.util
+
+data class ApkfyParameters(val appId: Long?, val oemId: String?)

--- a/app/src/main/java/cm/aptoide/pt/view/ActivityModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/ActivityModule.java
@@ -87,7 +87,7 @@ import cm.aptoide.pt.store.StoreUtilsProxy;
 import cm.aptoide.pt.themes.NewFeature;
 import cm.aptoide.pt.themes.ThemeAnalytics;
 import cm.aptoide.pt.themes.ThemeManager;
-import cm.aptoide.pt.util.ApkFy;
+import cm.aptoide.pt.util.ApkFyManager;
 import cm.aptoide.pt.util.MarketResourceFormatter;
 import cm.aptoide.pt.view.app.ListStoreAppsNavigator;
 import cm.aptoide.pt.view.dialog.DialogUtils;
@@ -135,9 +135,9 @@ import static android.content.Context.WINDOW_SERVICE;
     this.fileProviderAuthority = fileProviderAuthority;
   }
 
-  @ActivityScope @Provides ApkFy provideApkFy(
+  @ActivityScope @Provides ApkFyManager provideApkFy(
       @Named("secureShared") SharedPreferences securePreferences) {
-    return new ApkFy(activity, intent, securePreferences);
+    return new ApkFyManager(activity, intent, securePreferences);
   }
 
   @ActivityScope @Provides AutoUpdateService providesAutoUpdateService(Service service,
@@ -187,7 +187,7 @@ import static android.content.Context.WINDOW_SERVICE;
   }
 
   @ActivityScope @Provides Presenter provideMainPresenter(
-      RootInstallationRetryHandler rootInstallationRetryHandler, ApkFy apkFy,
+      RootInstallationRetryHandler rootInstallationRetryHandler, ApkFyManager apkFyManager,
       InstallManager installManager, @Named("default") SharedPreferences sharedPreferences,
       @Named("secureShared") SharedPreferences secureSharedPreferences,
       @Named("main-fragment-navigator") FragmentNavigator fragmentNavigator,
@@ -197,7 +197,8 @@ import static android.content.Context.WINDOW_SERVICE;
       BottomNavigationMapper bottomNavigationMapper, AptoideAccountManager accountManager,
       AccountNavigator accountNavigator, AgentPersistence agentPersistence) {
     return new MainPresenter((MainView) view, installManager, rootInstallationRetryHandler,
-        CrashReport.getInstance(), apkFy, new ContentPuller(activity), notificationSyncScheduler,
+        CrashReport.getInstance(), apkFyManager, new ContentPuller(activity),
+        notificationSyncScheduler,
         new InstallCompletedNotifier(PublishRelay.create(), installManager,
             CrashReport.getInstance()), sharedPreferences, secureSharedPreferences,
         fragmentNavigator, deepLinkManager, firstCreated, (AptoideBottomNavigator) activity,

--- a/app/src/main/java/cm/aptoide/pt/view/AppViewConfiguration.java
+++ b/app/src/main/java/cm/aptoide/pt/view/AppViewConfiguration.java
@@ -21,10 +21,11 @@ public class AppViewConfiguration {
   private final String editorsChoice;
   private final String originTag;
   private final String campaignUrl;
+  private final String oemId;
 
   public AppViewConfiguration(long appId, String packageName, String storeName, String storeTheme,
       SearchAdResult minimalAd, OpenType shouldInstall, String md5, String uniqueName, double appc,
-      String editorsChoice, String originTag, String campaignUrl) {
+      String editorsChoice, String originTag, String campaignUrl, String oemId) {
     this.appId = appId;
     this.packageName = packageName;
     this.storeName = storeName;
@@ -37,6 +38,7 @@ public class AppViewConfiguration {
     this.editorsChoice = editorsChoice;
     this.originTag = originTag;
     this.campaignUrl = campaignUrl;
+    this.oemId = oemId;
   }
 
   public long getAppId() {
@@ -93,5 +95,9 @@ public class AppViewConfiguration {
 
   public String getCampaignUrl() {
     return campaignUrl;
+  }
+
+  public String getOemId() {
+    return oemId;
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/view/DeepLinkManager.java
+++ b/app/src/main/java/cm/aptoide/pt/view/DeepLinkManager.java
@@ -126,7 +126,8 @@ public class DeepLinkManager {
       } else if (intent.hasExtra(DeepLinkIntentReceiver.DeepLinksKeys.APP_ID_KEY)) {
         appViewDeepLink(intent.getLongExtra(DeepLinkIntentReceiver.DeepLinksKeys.APP_ID_KEY, -1),
             intent.getStringExtra(DeepLinkIntentReceiver.DeepLinksKeys.PACKAGE_NAME_KEY), true,
-            intent.getBooleanExtra(DeepLinkIntentReceiver.DeepLinksKeys.APK_FY, false));
+            intent.getBooleanExtra(DeepLinkIntentReceiver.DeepLinksKeys.APK_FY, false),
+            intent.getStringExtra(DeepLinkIntentReceiver.DeepLinksKeys.OEM_ID_KEY));
       } else if (intent.hasExtra(DeepLinkIntentReceiver.DeepLinksKeys.PACKAGE_NAME_KEY)) {
         appViewDeepLink(
             intent.getStringExtra(DeepLinkIntentReceiver.DeepLinksKeys.PACKAGE_NAME_KEY),
@@ -249,7 +250,8 @@ public class DeepLinkManager {
     appNavigator.navigateWithMd5(md5);
   }
 
-  private void appViewDeepLink(long appId, String packageName, boolean showPopup, boolean isApkfy) {
+  private void appViewDeepLink(long appId, String packageName, boolean showPopup, boolean isApkfy,
+      String oemId) {
     AppViewFragment.OpenType openType;
     if (isApkfy) {
       openType = AppViewFragment.OpenType.APK_FY_INSTALL_POPUP;
@@ -258,7 +260,7 @@ public class DeepLinkManager {
           : AppViewFragment.OpenType.OPEN_ONLY;
     }
 
-    appNavigator.navigateWithAppId(appId, packageName, openType, "");
+    appNavigator.navigateWithAppId(appId, packageName, openType, "", oemId);
   }
 
   private void appViewDeepLink(String packageName, String storeName, boolean showPopup) {
@@ -408,7 +410,7 @@ public class DeepLinkManager {
 
   private void pickAppDeeplink() {
     subscriptions.add(adsRepository.getAdForShortcut()
-        .subscribe(ad -> appViewDeepLink(ad.getAppId(), ad.getPackageName(), false, false),
+        .subscribe(ad -> appViewDeepLink(ad.getAppId(), ad.getPackageName(), false, false, null),
             throwable -> Logger.getInstance()
                 .e(TAG, "pickAppDeepLink: " + throwable)));
   }

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -436,7 +436,8 @@ import rx.subscriptions.CompositeSubscription;
         arguments.getDouble(BundleKeys.APPC.name(), -1),
         arguments.getString(BundleKeys.EDITORS_CHOICE_POSITION.name(), ""),
         arguments.getString(BundleKeys.ORIGIN_TAG.name(), ""),
-        arguments.getString(BundleKeys.DOWNLOAD_CONVERSION_URL.name(), ""));
+        arguments.getString(BundleKeys.DOWNLOAD_CONVERSION_URL.name(), ""),
+        arguments.getString(BundleKeys.OEM_ID.name(), null));
   }
 
   @FragmentScope @Provides MoreBundlePresenter providesGetStoreWidgetsPresenter(

--- a/app/src/test/java/cm/aptoide/pt/app/AppViewManagerTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/AppViewManagerTest.java
@@ -104,7 +104,7 @@ public class AppViewManagerTest {
             Collections.emptyList(), Collections.emptyList()), "modified", "app added", null,
             "weburls", true, "aptoide", AppViewFragment.OpenType.OPEN_ONLY, 0, null,
             "editorsChoice", "origin", false, "marketName", false, false, bdsFlags, "", "", false,
-            null, null);
+            null, null, null);
     AppViewModel exampleAppViewModel = new AppViewModel(appModel, null, null, null);
 
     appViewManager =
@@ -222,7 +222,7 @@ public class AppViewManagerTest {
             Collections.emptyList(), Collections.emptyList()), "modified", "app added", null,
             "weburls", true, "aptoide", AppViewFragment.OpenType.OPEN_ONLY, 0, null,
             "editorsChoice", "origin", false, "marketName", false, false, bdsFlags, "", "", false,
-            null, null);
+            null, null, null);
 
     MinimalAd minimalAd =
         new MinimalAd("anyString", (long) 1, "", "", "", (long) 1, (long) 1, "", "", "", "", 1, 1,
@@ -331,7 +331,7 @@ public class AppViewManagerTest {
             Collections.emptyList(), Collections.emptyList()), "modified", "app added", null,
             "weburls", true, "aptoide", AppViewFragment.OpenType.OPEN_ONLY, 0, null,
             "editorsChoice", "origin", false, "marketName", false, false, bdsFlags, "", "", false,
-            null, null);
+            null, null, null);
 
     appViewManager =
         new AppViewManager(appViewModelManager, installManager, downloadFactory, appCenter,
@@ -360,7 +360,7 @@ public class AppViewManagerTest {
         null, null, appModel.getMalware()
             .getRank()
             .toString(), appModel.getStore()
-            .getName())).thenReturn(download);
+            .getName(), null)).thenReturn(download);
     when(installManager.install(download)).thenReturn(Completable.complete());
     when(notificationAnalytics.getCampaignId("packageName", (long) 1)).thenReturn(2);
     when(notificationAnalytics.getAbTestingGroup("packageName", (long) 1)).thenReturn("aString");

--- a/app/src/test/java/cm/aptoide/pt/app/AppViewModelManagerTest.kt
+++ b/app/src/test/java/cm/aptoide/pt/app/AppViewModelManagerTest.kt
@@ -24,15 +24,20 @@ class AppViewModelManagerTest {
   @Mock
   private lateinit var storeManager: StoreManager
   private lateinit var marketName: String
+
   @Mock
   private lateinit var appCenter: AppCenter
   private lateinit var downloadStateParser: DownloadStateParser
+
   @Mock
   private lateinit var installManager: InstallManager
+
   @Mock
   private lateinit var appcMigrationManager: AppcMigrationManager
+
   @Mock
   private lateinit var appCoinsManager: AppCoinsManager
+
   @Mock
   private lateinit var store: Store
 
@@ -58,7 +63,7 @@ class AppViewModelManagerTest {
     val detailedAppRequestResult = DetailedAppRequestResult(detailedApp)
     val appViewConfiguration =
         AppViewConfiguration(1.toLong(), "anyString", "anyString", "", null, null, "", "", 0.0,
-            "", "", "")
+            "", "", "", null)
 
     val appViewModelManager =
         AppViewModelManager(appViewConfiguration, storeManager, marketName, appCenter,
@@ -110,7 +115,7 @@ class AppViewModelManagerTest {
     val appViewConfiguration =
         AppViewConfiguration((-1).toLong(), "anyString", "anyString", "", null, null, "md5", "",
             0.0,
-            "", "", "")
+            "", "", "", null)
 
     val appViewModelManager =
         AppViewModelManager(appViewConfiguration, storeManager, marketName, appCenter,
@@ -163,7 +168,7 @@ class AppViewModelManagerTest {
     val appViewConfiguration =
         AppViewConfiguration((-1).toLong(), "anyString", "anyString", "", null, null, null,
             "uniqueName", 0.0,
-            "", "", "")
+            "", "", "", null)
 
     val appViewModelManager =
         AppViewModelManager(appViewConfiguration, storeManager, marketName, appCenter,
@@ -215,7 +220,7 @@ class AppViewModelManagerTest {
     val appViewConfiguration =
         AppViewConfiguration((-1).toLong(), "packageName", "storeName", "", null, null, null, null,
             0.0,
-            "", "", "")
+            "", "", "", null)
 
     val appViewModelManager =
         AppViewModelManager(appViewConfiguration, storeManager, marketName, appCenter,
@@ -267,7 +272,7 @@ class AppViewModelManagerTest {
     val appViewConfiguration =
         AppViewConfiguration((-1).toLong(), "packageName", "storeName", "", null, null, null, null,
             0.0,
-            "", "", "")
+            "", "", "", null)
 
     val appViewModelManager =
         spy(AppViewModelManager(appViewConfiguration, storeManager, marketName, appCenter,

--- a/app/src/test/java/cm/aptoide/pt/app/AppViewPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/app/AppViewPresenterTest.java
@@ -89,7 +89,7 @@ public class AppViewPresenterTest {
             Collections.emptyList(), Collections.emptyList()), "modified", "app added", null,
             "weburls", true, "aptoide", AppViewFragment.OpenType.OPEN_AND_INSTALL, 0, null,
             "editorsChoice", "origin", false, "marketName", false, false, bdsFlags, "", "", false,
-            null, null);
+            null, null, null);
 
     errorAppModel = new AppModel(DetailedAppRequestResult.Error.GENERIC);
 
@@ -203,7 +203,7 @@ public class AppViewPresenterTest {
             "icon", new AppMedia("description", Collections.<String>emptyList(), "news",
             Collections.emptyList(), Collections.emptyList()), "modified", "app added", null,
             "weburls", true, "aptoide", AppViewFragment.OpenType.OPEN_ONLY, 0, null, "", "origin",
-            false, "marketName", false, false, bdsFlags, "", "", false, null, null);
+            false, "marketName", false, false, bdsFlags, "", "", false, null, null, null);
     DownloadModel downloadModel =
         new DownloadModel(DownloadModel.Action.INSTALL, 0, DownloadModel.DownloadState.ACTIVE);
     AppViewModel editorsChoiceAppViewModel =
@@ -248,7 +248,7 @@ public class AppViewPresenterTest {
             "icon", new AppMedia("description", Collections.<String>emptyList(), "news",
             Collections.emptyList(), Collections.emptyList()), "modified", "app added", null,
             "weburls", true, "aptoide", AppViewFragment.OpenType.OPEN_ONLY, 0, null, "", "origin",
-            false, "marketName", true, true, bdsFlags, "", "", false, null, null);
+            false, "marketName", true, true, bdsFlags, "", "", false, null, null, null);
     DownloadModel downloadModel =
         new DownloadModel(DownloadModel.Action.INSTALL, 0, DownloadModel.DownloadState.ACTIVE);
     AppViewModel appViewModel = new AppViewModel(appModel, downloadModel,

--- a/app/src/test/java/cm/aptoide/pt/navigation/BottomNavigationPresenterTest.java
+++ b/app/src/test/java/cm/aptoide/pt/navigation/BottomNavigationPresenterTest.java
@@ -21,7 +21,7 @@ import cm.aptoide.pt.notification.NotificationSyncScheduler;
 import cm.aptoide.pt.presenter.MainPresenter;
 import cm.aptoide.pt.presenter.View;
 import cm.aptoide.pt.root.RootAvailabilityManager;
-import cm.aptoide.pt.util.ApkFy;
+import cm.aptoide.pt.util.ApkFyManager;
 import cm.aptoide.pt.view.DeepLinkManager;
 import cm.aptoide.pt.view.MainActivity;
 import org.junit.Before;
@@ -43,7 +43,7 @@ public class BottomNavigationPresenterTest {
   private static final int MENU_ITEM_ID_TEST = 2;
   @Mock private InstallManager installManager;
   @Mock private RootInstallationRetryHandler rootInstallationRetryHandler;
-  @Mock private ApkFy apkFy;
+  @Mock private ApkFyManager apkFyManager;
   @Mock private ContentPuller contentPuller;
   @Mock private NotificationSyncScheduler notificationSyncScheduler;
   @Mock private InstallCompletedNotifier installCompletedNotifier;
@@ -73,7 +73,7 @@ public class BottomNavigationPresenterTest {
     navigationEvent = PublishSubject.create();
 
     presenter = new MainPresenter(mainView, installManager, rootInstallationRetryHandler,
-        CrashReport.getInstance(), apkFy, contentPuller, notificationSyncScheduler,
+        CrashReport.getInstance(), apkFyManager, contentPuller, notificationSyncScheduler,
         installCompletedNotifier, sharedPreferences, sharedPreferences, fragmentNavigator,
         deepLinkManager, true, bottomNavigationActivity, Schedulers.immediate(), Schedulers.io(),
         bottomNavigationNavigator, updatesManager, autoUpdateManager, permissionService,


### PR DESCRIPTION
**What does this PR do?**

   Adds support for oemid in the apkfy flow. In essence, if the apk contains the "oemid=" parameter in the aob file, it will send that parameter in the app download url list. It only sends this if it exists and if it is the apkfy app.

  Also, I've disabled v2 signing for the debug app so that it is easier to test these things in debug (and release has it disabled anyway).

**Database changed?**

   No

**How should this be manually tested?**

  Either get an apk with the aob file (w/ oemid) already included, or build a debug apk and insert the apkfy files (and remember to put the 'oemid=' parameter in the aob file). Then, you can check with Charles that when you download the app, this parameter is being sent.

**What are the relevant tickets?**

  [MOB-849](https://aptoide.atlassian.net/browse/MOB-849)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass