### PR TITLE
[bugfix/MOB-809] Highlighted Bundle - More Button bug

### DIFF
--- a/app/src/main/res/layout/ads_bundle_item.xml
+++ b/app/src/main/res/layout/ads_bundle_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     >
   <include layout="@layout/apps_bundle_item"/>

--- a/app/src/main/res/layout/apps_bundle_item.xml
+++ b/app/src/main/res/layout/apps_bundle_item.xml
@@ -12,7 +12,7 @@
 
   <androidx.recyclerview.widget.RecyclerView
       android:id="@+id/apps_list"
-      android:layout_width="wrap_content"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:clipChildren="false"
       android:orientation="horizontal"


### PR DESCRIPTION
**What does this PR do?**

   Fixes a bug where the 'more' button was on top of the bundle title (specifically in the Highlighted bundle) when there was only 1 app.

**Database changed?**

   No

**How should this be manually tested?**

  Either modify the getStoreWidgets response in Charles to only return on app for "Highlighted" bundle, or you can go to "AdsBundleViewHolder" (or "AdsWithMoPubViewHolder") and simply subList the incoming content, e.g.: 

      appsInBundleAdapter.update((List<Application>) homeBundle.getContent().subList(0, 1));


**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-809](https://aptoide.atlassian.net/browse/MOB-809)


**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass