### PR TITLE
[HOTFIX/MOB-931] Fix Search Filter

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultFragment.java
@@ -513,7 +513,7 @@ public class SearchResultFragment extends BackButtonFragment
         .doOnNext(__ -> filtersChanged.onNext(null));
   }
 
-  @Override public Observable<Boolean> noResultsNewFilter() {
+  @Override public Observable<Boolean> changeFilterAfterNoResults() {
     return Observable.zip(filtersChanged(), previousSearchHadNoResults(), (aVoid, aVoid2) -> true);
   }
 

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultFragment.java
@@ -112,7 +112,6 @@ public class SearchResultFragment extends BackButtonFragment
   private PublishRelay<SearchAdResultWrapper> onAdClickRelay;
   private PublishSubject<SearchQueryEvent> suggestionClickedPublishSubject;
   private PublishSubject<SearchQueryEvent> queryTextChangedPublisher;
-  private float listItemPadding;
   private MenuItem searchMenuItem;
   private SearchView searchView;
   private String currentQuery;
@@ -615,8 +614,6 @@ public class SearchResultFragment extends BackButtonFragment
     noResultsPublishSubject = PublishSubject.create();
     filtersChanged = PublishSubject.create();
     previousSearchHadNoResults = PublishSubject.create();
-
-    listItemPadding = getResources().getDimension(R.dimen.padding_tiny);
 
     final List<SearchAppResult> searchResultAllStores = new ArrayList<>();
     final List<SearchAdResult> searchResultAdsAllStores = new ArrayList<>();

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultFragment.java
@@ -223,6 +223,7 @@ public class SearchResultFragment extends BackButtonFragment
   }
 
   @Override public void showResultsView() {
+    noResults = false;
     noSearchLayout.setVisibility(View.GONE);
     errorView.setVisibility(View.GONE);
     suggestionsResultList.setVisibility(View.GONE);

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultPresenter.java
@@ -202,8 +202,8 @@ import rx.schedulers.Schedulers;
     view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .observeOn(viewScheduler)
-        .flatMap(
-            __ -> Observable.merge(view.searchResultsReachedBottom(), view.changeFilterAfterNoResults()))
+        .flatMap(__ -> Observable.merge(view.searchResultsReachedBottom(),
+            view.changeFilterAfterNoResults()))
         .map(__ -> view.getViewModel())
         .observeOn(viewScheduler)
         .doOnNext(__ -> view.showLoadingMore())

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultPresenter.java
@@ -202,7 +202,8 @@ import rx.schedulers.Schedulers;
     view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .observeOn(viewScheduler)
-        .flatMap(__ -> view.searchResultsReachedBottom())
+        .flatMap(
+            __ -> Observable.merge(view.searchResultsReachedBottom(), view.noResultsNewFilter()))
         .map(__ -> view.getViewModel())
         .observeOn(viewScheduler)
         .doOnNext(__ -> view.showLoadingMore())

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultPresenter.java
@@ -203,7 +203,7 @@ import rx.schedulers.Schedulers;
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .observeOn(viewScheduler)
         .flatMap(
-            __ -> Observable.merge(view.searchResultsReachedBottom(), view.noResultsNewFilter()))
+            __ -> Observable.merge(view.searchResultsReachedBottom(), view.changeFilterAfterNoResults()))
         .map(__ -> view.getViewModel())
         .observeOn(viewScheduler)
         .doOnNext(__ -> view.showLoadingMore())

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultView.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultView.java
@@ -117,6 +117,8 @@ public interface SearchResultView extends SearchSuggestionsView {
 
   Observable<List<Filter>> filtersChangeEvents();
 
+  Observable<Boolean> noResultsNewFilter();
+
   interface Model {
 
     SearchQueryModel getSearchQueryModel();

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultView.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultView.java
@@ -117,7 +117,7 @@ public interface SearchResultView extends SearchSuggestionsView {
 
   Observable<List<Filter>> filtersChangeEvents();
 
-  Observable<Boolean> noResultsNewFilter();
+  Observable<Boolean> changeFilterAfterNoResults();
 
   interface Model {
 


### PR DESCRIPTION
**What does this PR do?**

 This PR aims at fixing a search filter problem where we get different results if we apply the search filters in a different order.
To summarize the problem, we perform the load more request (2nd request) when the list of search reaches the bottom. In case the previous results were "no results", then we don't reach the bottom, which means that if we change the filter, we will only make the 1st request. 
The problem is that some filters are not being correctly filtered by the API (this will be implemented in the future, in the ticket: https://aptoide.atlassian.net/browse/MICRO-937) , meaning that they will return us an empty list on that call and some results on the 2nd call. Since we not always make the 2nd call (like previously stated), we might get empty results or results with apps.

Note that this is a temporary solution because as soon as the API becomes coherent, then this will not be a problem anymore.


**Database changed?**

   No

**Where should the reviewer start?**

- [ ] SearchResultFragment.java

**How should this be manually tested?**

Open Search -> Select the trending GTA app -> apply the trusted filter -> apply the Appcoins filter -> notice that you will have one app. Then, remove the trusted filter (you will have no results after that) -> add the trusted filter again (notice that you will get one app again. Before, since we were only making 1 request after a no results view, you would get no apps, which would be inconsistent to what was shown before). 

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-931](https://aptoide.atlassian.net/browse/MOB-931)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass