### PR TITLE
[HOTFIX/MOB-938] Wrong results after navigating from search

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultAdapter.java
@@ -7,6 +7,7 @@ import android.view.ViewGroup;
 import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 import cm.aptoide.pt.crashreports.CrashReport;
+import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.search.SearchResultDiffModel;
 import cm.aptoide.pt.search.model.SearchAdResult;
 import cm.aptoide.pt.search.model.SearchAdResultWrapper;
@@ -24,7 +25,7 @@ public class SearchResultAdapter extends RecyclerView.Adapter<SearchResultItemVi
 
   private final PublishRelay<SearchAdResultWrapper> onAdClickRelay;
   private final PublishRelay<SearchAppResultWrapper> onItemViewClick;
-  private final List<SearchAdResult> searchAdResults;
+  private List<SearchAdResult> searchAdResults;
   private List<SearchAppResult> searchResults;
   private String query;
   private boolean adsLoaded = false;
@@ -121,7 +122,7 @@ public class SearchResultAdapter extends RecyclerView.Adapter<SearchResultItemVi
     return searchResults.get(position - searchAdResults.size());
   }
 
-  public void setResultForSearch(String query, SearchResultDiffModel searchResultDiffModel){
+  public void setResultForSearch(String query, SearchResultDiffModel searchResultDiffModel) {
     this.query = query;
     searchResults = searchResultDiffModel.getSearchResultsList();
     notifyDataSetChanged();
@@ -159,11 +160,9 @@ public class SearchResultAdapter extends RecyclerView.Adapter<SearchResultItemVi
   }
 
   public void restoreState(List<SearchAppResult> apps, List<SearchAdResult> ads) {
-    this.searchResults.clear();
-    this.searchResults.addAll(apps);
+    this.searchResults = apps;
 
-    this.searchAdResults.clear();
-    this.searchAdResults.addAll(ads);
+    this.searchAdResults = ads;
 
     notifyDataSetChanged();
     adsLoaded = true;

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultAdapter.java
@@ -7,7 +7,6 @@ import android.view.ViewGroup;
 import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 import cm.aptoide.pt.crashreports.CrashReport;
-import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.search.SearchResultDiffModel;
 import cm.aptoide.pt.search.model.SearchAdResult;
 import cm.aptoide.pt.search.model.SearchAdResultWrapper;


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing an issue where if you do a search, open an AppView, then come back, the results would change. Basically we would loose the results that we had before and we would just load new results (with the next offset value).
This was happening because in the restoration of the search view, we were clearing the list.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] SearchResultAdapter.java

**How should this be manually tested?**

Open search, search for example for facebook. After that navigate to the first result, opening its appview. Then, navigate back, and check that the results being shown are the same as before you navigated to the appview.  

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-938](https://aptoide.atlassian.net/browse/MOB-938)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass