### PR TITLE
[HOTFIX/MOB-940] Avoiding a false first load request 

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultPresenter.java
@@ -420,6 +420,8 @@ import rx.schedulers.Schedulers;
     view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .map(__ -> view.getViewModel())
+        .filter(viewModel -> viewModel.getAllStoresSearchAppResults()
+            .isEmpty())
         .flatMap(model -> search(model))
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing a load more request after coming from the appview.
When we open search, we make a request, to load the apps. The problem is that if we come back from the appview, the search view will be created (we will restore the correct state as fixed in a previous pull request) and we will end up doing a "false" first load search request. This is happening because in the search refactor we removed a filter we had in the doFirstSearch() method where we would check the offset.

Visually this has no side effects, but we will be doing load more requests for each appview opened from this search, which is not ideal.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] SearchResultPresenter.java

**How should this be manually tested?**

Search an app, click on any result to go to the appview, press back and check in charles that a load more request was not done.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-940](https://aptoide.atlassian.net/browse/MOB-940)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass