### PR TITLE
[HOTFIX/MOB-941] Different results for the same filters

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultFragment.java
@@ -253,9 +253,23 @@ public class SearchResultFragment extends BackButtonFragment
     allStoresResultList.setLayoutAnimation(layoutAnimationController);
     allStoresResultList.scheduleLayoutAnimation();
 
+    progressBarResults.setAnimation(null);
     progressBarResults.setVisibility(VISIBLE);
     Animation animation = AnimationUtils.loadAnimation(getContext(), R.anim.slide_down_appear);
     animation.setFillAfter(true);
+    animation.setAnimationListener(new Animation.AnimationListener() {
+      @Override public void onAnimationStart(Animation animation) {
+
+      }
+
+      @Override public void onAnimationEnd(Animation animation) {
+        progressBarResults.setVisibility(View.GONE);
+      }
+
+      @Override public void onAnimationRepeat(Animation animation) {
+
+      }
+    });
     progressBarResults.startAnimation(animation);
   }
 
@@ -269,8 +283,22 @@ public class SearchResultFragment extends BackButtonFragment
     }
     if (!isLoadMore) {
       allStoresResultAdapter.setResultForSearch(query, searchResultDiffModel);
+      progressBarResults.setAnimation(null);
       Animation animation = AnimationUtils.loadAnimation(getContext(), R.anim.slide_up_disappear);
       animation.setFillAfter(true);
+      animation.setAnimationListener(new Animation.AnimationListener() {
+        @Override public void onAnimationStart(Animation animation) {
+
+        }
+
+        @Override public void onAnimationEnd(Animation animation) {
+          progressBarResults.setVisibility(View.GONE);
+        }
+
+        @Override public void onAnimationRepeat(Animation animation) {
+
+        }
+      });
       progressBarResults.startAnimation(animation);
 
       allStoresResultList.setLayoutAnimation(

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultPresenter.java
@@ -202,8 +202,7 @@ import rx.schedulers.Schedulers;
     view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .observeOn(viewScheduler)
-        .flatMap(__ -> Observable.merge(view.searchResultsReachedBottom(),
-            view.changeFilterAfterNoResults()))
+        .flatMap(__ -> view.shouldLoadMoreResults())
         .map(__ -> view.getViewModel())
         .observeOn(viewScheduler)
         .doOnNext(__ -> view.showLoadingMore())

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultView.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultView.java
@@ -37,7 +37,7 @@ public interface SearchResultView extends SearchSuggestionsView {
 
   void setAllStoresAdsEmpty();
 
-  Observable<Void> searchResultsReachedBottom();
+  Observable<Void> shouldLoadMoreResults();
 
   void showLoadingMore();
 
@@ -117,7 +117,7 @@ public interface SearchResultView extends SearchSuggestionsView {
 
   Observable<List<Filter>> filtersChangeEvents();
 
-  Observable<Boolean> changeFilterAfterNoResults();
+  //Observable<Boolean> changeFilterAfterNoResults();
 
   interface Model {
 

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultView.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultView.java
@@ -117,8 +117,6 @@ public interface SearchResultView extends SearchSuggestionsView {
 
   Observable<List<Filter>> filtersChangeEvents();
 
-  //Observable<Boolean> changeFilterAfterNoResults();
-
   interface Model {
 
     SearchQueryModel getSearchQueryModel();

--- a/app/src/main/res/layout-v21/global_search_fragment.xml
+++ b/app/src/main/res/layout-v21/global_search_fragment.xml
@@ -37,7 +37,7 @@
       android:layout_marginTop="?attr/actionBarSize"
       android:visibility="gone"
       tools:visibility="visible"
-      android:animateLayoutChanges="true"
+      android:animateLayoutChanges="false"
       >
 
     <androidx.cardview.widget.CardView

--- a/app/src/main/res/layout/global_search_fragment.xml
+++ b/app/src/main/res/layout/global_search_fragment.xml
@@ -37,7 +37,6 @@
       android:layout_marginTop="?attr/actionBarSize"
       android:visibility="gone"
       tools:visibility="visible"
-      android:animateLayoutChanges="true"
       >
 
     <androidx.cardview.widget.CardView

--- a/app/src/main/res/layout/global_search_fragment.xml
+++ b/app/src/main/res/layout/global_search_fragment.xml
@@ -37,6 +37,7 @@
       android:layout_marginTop="?attr/actionBarSize"
       android:visibility="gone"
       tools:visibility="visible"
+      android:animateLayoutChanges="true"
       >
 
     <androidx.cardview.widget.CardView


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing different results for the same filters. Just like in a previous issue, we were allowing that the conditions/results from one query could affect the conditions or results of the next one. In this case, the fact that we had no results in a previous query was not allowing us to make the respective load more request from the new query (filters changed).
I took the chance to refactor the code from another ticket where we were not able to load more after getting 2 no results in a row, by merging everything on the same place, which makes it way easier to manage than the previous solution.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] SearchResultFragment.java

**How should this be manually tested?**

Search for "lords mobile" apply the filters Followed stores and then appcoins. Then press clear and apply the filters Appcoins and Followed stores. Confirm that the results are the same.

Since we also changed another flow, also test the search of "grand theft auto san andreas" and apply the filters Trusted + Appcoins and then Appcoins + trusted and check that it shows the same results.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-941](https://aptoide.atlassian.net/browse/MOB-941)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass