### PR TITLE
[hotfix/MOB-939] Cancel Installation bug

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -534,7 +534,7 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
         new FileUtils(), ToolboxManager.isDebug(sharedPreferences) || BuildConfig.DEBUG,
         installedRepository, BuildConfig.ROOT_TIMEOUT, rootAvailabilityManager, sharedPreferences,
         installerAnalytics, getInstallingStateTimeout(), appInstallerStatusReceiver,
-        rootInstallerProvider);
+        rootInstallerProvider, application);
   }
 
   private int getInstallingStateTimeout() {

--- a/app/src/main/java/cm/aptoide/pt/install/InstallManager.java
+++ b/app/src/main/java/cm/aptoide/pt/install/InstallManager.java
@@ -74,6 +74,7 @@ public class InstallManager {
 
   public void start() {
     aptoideDownloadManager.start();
+    installer.dispatchInstallations();
   }
 
   private void waitForDownloadAndInstall(String md5, boolean forceDefaultInstall,
@@ -98,6 +99,7 @@ public class InstallManager {
 
   public void stop() {
     aptoideDownloadManager.stop();
+    installer.stopDispatching();
   }
 
   private Completable stopForegroundAndInstall(String md5, int downloadAction,
@@ -106,11 +108,11 @@ public class InstallManager {
         .d(TAG, "going to pop install from: " + md5 + "and download action: " + downloadAction);
     switch (downloadAction) {
       case RoomDownload.ACTION_INSTALL:
-        return installer.install(context, md5, forceDefaultInstall, shouldSetPackageInstaller);
+        return installer.install(md5, forceDefaultInstall, shouldSetPackageInstaller);
       case RoomDownload.ACTION_UPDATE:
-        return installer.update(context, md5, forceDefaultInstall, shouldSetPackageInstaller);
+        return installer.update(md5, forceDefaultInstall, shouldSetPackageInstaller);
       case RoomDownload.ACTION_DOWNGRADE:
-        return installer.downgrade(context, md5, forceDefaultInstall, shouldSetPackageInstaller);
+        return installer.downgrade(md5, forceDefaultInstall, shouldSetPackageInstaller);
       default:
         return Completable.error(
             new IllegalArgumentException("Invalid download action " + downloadAction));

--- a/app/src/main/java/cm/aptoide/pt/install/Installer.java
+++ b/app/src/main/java/cm/aptoide/pt/install/Installer.java
@@ -1,6 +1,5 @@
 package cm.aptoide.pt.install;
 
-import android.content.Context;
 import cm.aptoide.pt.install.installer.InstallationState;
 import rx.Completable;
 import rx.Observable;
@@ -10,16 +9,17 @@ import rx.Observable;
  */
 public interface Installer {
 
-  Completable install(Context context, String md5, boolean forceDefaultInstall,
-      boolean shouldSetPackageInstaller);
+  void dispatchInstallations();
 
-  Completable update(Context context, String md5, boolean forceDefaultInstall,
-      boolean shouldSetPackageInstaller);
+  Completable install(String md5, boolean forceDefaultInstall, boolean shouldSetPackageInstaller);
 
-  Completable downgrade(Context context, String md5, boolean forceDefaultInstall,
-      boolean shouldSetPackageInstaller);
+  Completable update(String md5, boolean forceDefaultInstall, boolean shouldSetPackageInstaller);
 
-  Completable uninstall(Context context, String packageName, String versionName);
+  Completable downgrade(String md5, boolean forceDefaultInstall, boolean shouldSetPackageInstaller);
+
+  Completable uninstall(String packageName, String versionName);
 
   Observable<InstallationState> getState(String packageName, int versionCode);
+
+  void stopDispatching();
 }

--- a/app/src/main/java/cm/aptoide/pt/install/installer/DefaultInstaller.java
+++ b/app/src/main/java/cm/aptoide/pt/install/installer/DefaultInstaller.java
@@ -44,6 +44,8 @@ import org.jetbrains.annotations.NotNull;
 import rx.Completable;
 import rx.Observable;
 import rx.schedulers.Schedulers;
+import rx.subjects.PublishSubject;
+import rx.subscriptions.CompositeSubscription;
 
 /**
  * Created by marcelobenites on 7/18/16.
@@ -65,13 +67,17 @@ public class DefaultInstaller implements Installer {
   private RootInstallerProvider rootInstallerProvider;
   private int installingStateTimeout;
 
+  private Context context;
+  private CompositeSubscription dispatchInstallationsSubscription = new CompositeSubscription();
+  private PublishSubject<InstallationCandidate> installCandidateSubject = PublishSubject.create();
+
   public DefaultInstaller(PackageManager packageManager, InstallationProvider installationProvider,
       AppInstaller appInstaller, FileUtils fileUtils, boolean debug,
       InstalledRepository installedRepository, int rootTimeout,
       RootAvailabilityManager rootAvailabilityManager, SharedPreferences sharedPreferences,
       InstallerAnalytics installerAnalytics, int installingStateTimeout,
       AppInstallerStatusReceiver appInstallerStatusReceiver,
-      RootInstallerProvider rootInstallerProvider) {
+      RootInstallerProvider rootInstallerProvider, Context context) {
     this.packageManager = packageManager;
     this.installationProvider = installationProvider;
     this.appInstaller = appInstaller;
@@ -85,13 +91,69 @@ public class DefaultInstaller implements Installer {
     this.rootAvailabilityManager = rootAvailabilityManager;
     this.sharedPreferences = sharedPreferences;
     this.installingStateTimeout = installingStateTimeout;
+    this.context = context;
   }
 
   public PackageManager getPackageManager() {
     return packageManager;
   }
 
-  @Override public Completable install(Context context, String md5, boolean forceDefaultInstall,
+  @Override public synchronized void dispatchInstallations() {
+    // Responsible for moving files and starting the installation process
+    dispatchInstallationsSubscription.add(installCandidateSubject.flatMap(
+        candidate -> moveInstallationFiles(candidate.getInstallation()).andThen(
+            Observable.just(candidate)))
+        .flatMap(candidate -> Observable.just(isInstalled(candidate.getInstallation()
+            .getPackageName(), candidate.getInstallation()
+            .getVersionCode()))
+            .onErrorReturn(throwable -> false)
+            .first()
+            .flatMap(isInstalled -> {
+              Installation installation = candidate.getInstallation();
+              if (isInstalled) {
+                installation.setStatus(RoomInstalled.STATUS_COMPLETED);
+                return installation.save()
+                    .toObservable()
+                    .map(__ -> installation);
+              } else {
+                if (candidate.getForceDefaultInstall()) {
+                  return startDefaultInstallation(context, installation,
+                      candidate.getShouldSetPackageInstaller());
+                } else {
+                  return startInstallation(context, installation,
+                      candidate.getShouldSetPackageInstaller());
+                }
+              }
+            }))
+        .doOnError((throwable) -> CrashReport.getInstance()
+            .log(throwable))
+        .retry()
+        .subscribe(__ -> {
+        }, Throwable::printStackTrace));
+
+    // Responsible for removing installation files when an app is installed
+    dispatchInstallationsSubscription.add(
+        installCandidateSubject.map(InstallationCandidate::getInstallation)
+            .flatMap(installation -> installedRepository.get(installation.getPackageName(),
+                installation.getVersionCode())
+                .filter(installed -> installed.getStatus() == RoomInstalled.STATUS_COMPLETED)
+                .map(__ -> installation))
+            .doOnNext(this::removeInstallationFiles)
+            .doOnError((throwable) -> CrashReport.getInstance()
+                .log(throwable))
+            .retry()
+            .subscribe(__ -> {
+            }, Throwable::printStackTrace));
+  }
+
+  @Override public void stopDispatching() {
+    dispatchInstallationsSubscription.clear();
+    if (!dispatchInstallationsSubscription.isUnsubscribed()) {
+      dispatchInstallationsSubscription.unsubscribe();
+    }
+  }
+
+  @Override public Completable install(String md5, boolean forceDefaultInstall,
       boolean shouldSetPackageInstaller) {
     return rootAvailabilityManager.isRootAvailable()
         .doOnSuccess(isRoot -> installerAnalytics.installationType(
@@ -102,54 +164,31 @@ public class DefaultInstaller implements Installer {
         .doOnNext(installation -> {
           installation.setStatus(RoomInstalled.STATUS_INSTALLING);
           installation.setType(RoomInstalled.TYPE_UNKNOWN);
+          installCandidateSubject.onNext(
+              new InstallationCandidate(installation, forceDefaultInstall,
+                  shouldSetPackageInstaller));
         })
-        .flatMap(installation -> moveInstallationFiles(installation).andThen(
-            Observable.just(installation)))
-        .flatMap(installation -> Observable.just(
-            isInstalled(installation.getPackageName(), installation.getVersionCode()))
-            .onErrorReturn(throwable -> false)
-            .first()
-            .flatMap(isInstalled -> {
-              if (isInstalled) {
-                installation.setStatus(RoomInstalled.STATUS_COMPLETED);
-                return installation.save()
-                    .toObservable()
-                    .map(__ -> installation);
-              } else {
-                if (forceDefaultInstall) {
-                  return startDefaultInstallation(context, installation, shouldSetPackageInstaller);
-                } else {
-                  return startInstallation(context, installation, shouldSetPackageInstaller);
-                }
-              }
-            }))
         .first()
-        .doOnError((throwable) -> CrashReport.getInstance()
-            .log(throwable))
-        .flatMap(installation -> installedRepository.get(installation.getPackageName(),
-            installation.getVersionCode())
-            .filter(installed -> installed.getStatus() == RoomInstalled.STATUS_COMPLETED)
-            .map(__ -> installation))
-        .doOnNext(this::removeInstallationFiles)
+        .toSingle()
         .toCompletable();
   }
 
-  @Override public Completable update(Context context, String md5, boolean forceDefaultInstall,
+  @Override public Completable update(String md5, boolean forceDefaultInstall,
       boolean shouldSetPackageInstaller) {
-    return install(context, md5, forceDefaultInstall, shouldSetPackageInstaller);
+    return install(md5, forceDefaultInstall, shouldSetPackageInstaller);
   }
 
-  @Override public Completable downgrade(Context context, String md5, boolean forceDefaultInstall,
+  @Override public Completable downgrade(String md5, boolean forceDefaultInstall,
       boolean shouldSetPackageInstaller) {
     return installationProvider.getInstallation(md5)
         .first()
-        .flatMapCompletable(installation -> uninstall(context, installation.getPackageName(),
-            installation.getVersionName()))
+        .flatMapCompletable(
+            installation -> uninstall(installation.getPackageName(), installation.getVersionName()))
         .toCompletable()
-        .andThen(install(context, md5, forceDefaultInstall, shouldSetPackageInstaller));
+        .andThen(install(md5, forceDefaultInstall, shouldSetPackageInstaller));
   }
 
-  @Override public Completable uninstall(Context context, String packageName, String versionName) {
+  @Override public Completable uninstall(String packageName, String versionName) {
     final Uri uri = Uri.fromParts("package", packageName, null);
     final IntentFilter intentFilter = new IntentFilter();
     intentFilter.addAction(Intent.ACTION_PACKAGE_REMOVED);

--- a/app/src/main/java/cm/aptoide/pt/install/installer/InstallationCandidate.kt
+++ b/app/src/main/java/cm/aptoide/pt/install/installer/InstallationCandidate.kt
@@ -1,0 +1,4 @@
+package cm.aptoide.pt.install.installer
+
+data class InstallationCandidate(val installation: Installation, val forceDefaultInstall: Boolean,
+                                 val shouldSetPackageInstaller: Boolean)


### PR DESCRIPTION
**What does this PR do?**

   This fixes a bug where the cancel wasn't being properly detected when using a package installer installation. This actually had other implications, such as certain analytics events not being sent in these cases as well.

   To give technical context to the issue: the issue was that the defaultInstall() chain in DefaultInstaller needs to observe emissions throughout the installation progress, however the parent chain that called this (install() chain in DefaultInstaller) was a Completable and was only listening for the first emission, so it was not updating the status accordingly. The fix was basically to separate these two chains to their own subscription through a subject. This way the installation status is continually updated in it's own subscription, while the install() chain Completes immediately as it should.
   As a future note, this is a good first step to ensure we also allow installations to begin while the MainActivity is killed (e.g. downloads still work while activity is down). To actually finish implementing this in the future, we will also need to do something similar to the stopForegroundAndInstall() in InstallManager.

**Database changed?**

   No


**How should this be manually tested?**

  Almost every installation is now being used with Package Installer, so simply have a device with API > 21 and install something. You should be able to cancel and the status should update accordingly. Also please check with both split installs and normal installs and see if everything is ok.

**What are the relevant tickets?**

  [MOB-939](https://aptoide.atlassian.net/browse/MOB-939)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass