### PR TITLE
[MOB-825] Fixed UI notification issues;

### DIFF
--- a/app/src/main/res/layout/pushnotificationlayout.xml
+++ b/app/src/main/res/layout/pushnotificationlayout.xml
@@ -19,7 +19,6 @@
       >
     <TextView
         android:id="@+id/title"
-        style="@style/Aptoide.TextView.Regular.S.Black"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="10dp"
@@ -27,12 +26,16 @@
         android:layout_marginTop="5dp"
         android:layout_marginEnd="10dp"
         android:layout_marginRight="10dp"
+        android:layout_marginBottom="8dp"
+        android:fontFamily="sans-serif"
+        android:lineSpacingExtra="3dp"
+        android:textSize="14sp"
+        android:textStyle="bold"
         tools:text="teste"
         />
 
     <TextView
         android:id="@+id/description"
-        style="@style/Aptoide.TextView.Regular.S.Black"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
@@ -42,13 +45,15 @@
         android:layout_marginRight="10dp"
         android:layout_marginBottom="5dp"
         android:autoLink="all"
+        android:fontFamily="sans-serif"
+        android:lineSpacingExtra="3dp"
         android:scrollbars="vertical"
+        android:textSize="14sp"
         tools:text="description"
         />
 
     <TextView
         android:id="@+id/app_name"
-        style="@style/Aptoide.TextView.Regular.S.Black"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="10dp"
@@ -56,6 +61,9 @@
         android:layout_marginEnd="10dp"
         android:layout_marginRight="10dp"
         android:layout_marginBottom="5dp"
+        android:fontFamily="sans-serif"
+        android:lineSpacingExtra="3dp"
+        android:textSize="14sp"
         tools:text="app name"
         />
 


### PR DESCRIPTION
**What does this PR do?**

This PR fixes issues with the notification UI. The one mentioned in the ticket and the fact that once expanded, the notification would lose the notification header and functionality. The fix was forgoing the remote view and using a default android notification style;

**Database changed?**

  No

**Where should the reviewer start?**

- [ ] Foo.java

**How should this be manually tested?**

Mock a notification, either using charles or by inserting a dummy notification instead of fetching from network (what I did), and make sure everything is working as intended

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-825](https://aptoide.atlassian.net/browse/MOB-825)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass