### PR TITLE
[MOB-964] ToolboxContentProvider changes

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/toolbox/ToolboxContentProvider.java
+++ b/app/src/main/java/cm/aptoide/pt/toolbox/ToolboxContentProvider.java
@@ -123,7 +123,7 @@ public class ToolboxContentProvider extends ContentProvider {
           return create("loginAvatar", account.getAvatar());
         default:
           throw new IllegalArgumentException(
-              "Only /token, /repo, /passHash, /loginType and /loginName supported.");
+              "Only /token, /refreshToken, /repo, /passHash, /loginType, /loginName, loginNickname and loginAvatar supported.");
       }
     } else {
       throw new SecurityException("Package not authorized to access provider.");

--- a/app/src/main/java/cm/aptoide/pt/toolbox/ToolboxContentProvider.java
+++ b/app/src/main/java/cm/aptoide/pt/toolbox/ToolboxContentProvider.java
@@ -43,13 +43,13 @@ public class ToolboxContentProvider extends ContentProvider {
   private static final String BACKUP_PACKAGE = "pt.aptoide.backupapps";
   private static final String UPLOADER_PACKAGE = "pt.caixamagica.aptoide.uploader";
   private static final int TOKEN = 1;
-  private static final int REPO = 2;
+  private static final int STORE_NAME = 2;
   private static final int PASSHASH = 3;
   private static final int LOGIN_TYPE = 4;
-  private static final int LOGIN_NAME = 5;
+  private static final int LOGIN_EMAIL = 5;
   private static final int CHANGE_PREFERENCE = 6;
   private static final int REFRESH_TOKEN = 7;
-  private static final int LOGIN_NICKNAME = 8;
+  private static final int LOGIN_NAME = 8;
   private static final int LOGIN_AVATAR = 9;
 
   @Inject AuthenticationPersistence authenticationPersistence;
@@ -64,12 +64,12 @@ public class ToolboxContentProvider extends ContentProvider {
     uriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "token", TOKEN);
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "refreshToken", REFRESH_TOKEN);
-    uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "repo", REPO);
+    uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "storeName", STORE_NAME);
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "loginType", LOGIN_TYPE);
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "passHash", PASSHASH);
-    uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "loginName", LOGIN_NAME);
+    uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "loginEmail", LOGIN_EMAIL);
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "changePreference", CHANGE_PREFERENCE);
-    uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "loginNickname", LOGIN_NICKNAME);
+    uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "loginName", LOGIN_NAME);
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "loginAvatar", LOGIN_AVATAR);
     ((AptoideApplication) getContext().getApplicationContext()).getApplicationComponent()
         .inject(this);
@@ -101,8 +101,8 @@ public class ToolboxContentProvider extends ContentProvider {
           return create("userToken", authentication.getAccessToken());
         case REFRESH_TOKEN:
           return create("userRefreshToken", authentication.getRefreshToken());
-        case REPO:
-          return create("userRepo", account.getStore()
+        case STORE_NAME:
+          return create("storeName", account.getStore()
               .getName());
         case PASSHASH:
           if (AptoideAccountManager.APTOIDE_SIGN_UP_TYPE.equals(authentication.getType())) {
@@ -115,15 +115,15 @@ public class ToolboxContentProvider extends ContentProvider {
         case LOGIN_TYPE:
           return create("loginType", authentication.getType()
               .toLowerCase(Locale.US));
+        case LOGIN_EMAIL:
+          return create("loginEmail", authentication.getEmail());
         case LOGIN_NAME:
-          return create("loginName", authentication.getEmail());
-        case LOGIN_NICKNAME:
-          return create("loginNickname", account.getNickname());
+          return create("loginName", account.getNickname());
         case LOGIN_AVATAR:
           return create("loginAvatar", account.getAvatar());
         default:
           throw new IllegalArgumentException(
-              "Only /token, /refreshToken, /repo, /passHash, /loginType, /loginName, loginNickname and loginAvatar supported.");
+              "Only /token, /refreshToken, /storeName, /passHash, /loginType, /loginEmail, /loginName and /loginAvatar supported.");
       }
     } else {
       throw new SecurityException("Package not authorized to access provider.");

--- a/app/src/main/java/cm/aptoide/pt/toolbox/ToolboxContentProvider.java
+++ b/app/src/main/java/cm/aptoide/pt/toolbox/ToolboxContentProvider.java
@@ -49,6 +49,8 @@ public class ToolboxContentProvider extends ContentProvider {
   private static final int LOGIN_NAME = 5;
   private static final int CHANGE_PREFERENCE = 6;
   private static final int REFRESH_TOKEN = 7;
+  private static final int LOGIN_NICKNAME = 8;
+  private static final int LOGIN_AVATAR = 9;
 
   @Inject AuthenticationPersistence authenticationPersistence;
   @Inject @Named("default") SharedPreferences sharedPreferences;
@@ -67,6 +69,8 @@ public class ToolboxContentProvider extends ContentProvider {
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "passHash", PASSHASH);
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "loginName", LOGIN_NAME);
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "changePreference", CHANGE_PREFERENCE);
+    uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "loginNickname", LOGIN_NICKNAME);
+    uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "loginAvatar", LOGIN_AVATAR);
     ((AptoideApplication) getContext().getApplicationContext()).getApplicationComponent()
         .inject(this);
     return true;
@@ -113,6 +117,10 @@ public class ToolboxContentProvider extends ContentProvider {
               .toLowerCase(Locale.US));
         case LOGIN_NAME:
           return create("loginName", authentication.getEmail());
+        case LOGIN_NICKNAME:
+          return create("loginNickname", account.getNickname());
+        case LOGIN_AVATAR:
+          return create("loginAvatar", account.getAvatar());
         default:
           throw new IllegalArgumentException(
               "Only /token, /repo, /passHash, /loginType and /loginName supported.");

--- a/app/src/main/java/cm/aptoide/pt/toolbox/ToolboxContentProvider.java
+++ b/app/src/main/java/cm/aptoide/pt/toolbox/ToolboxContentProvider.java
@@ -43,13 +43,13 @@ public class ToolboxContentProvider extends ContentProvider {
   private static final String BACKUP_PACKAGE = "pt.aptoide.backupapps";
   private static final String UPLOADER_PACKAGE = "pt.caixamagica.aptoide.uploader";
   private static final int TOKEN = 1;
-  private static final int STORE_NAME = 2;
+  private static final int REPO = 2;
   private static final int PASSHASH = 3;
   private static final int LOGIN_TYPE = 4;
-  private static final int LOGIN_EMAIL = 5;
+  private static final int LOGIN_NAME = 5;
   private static final int CHANGE_PREFERENCE = 6;
   private static final int REFRESH_TOKEN = 7;
-  private static final int LOGIN_NAME = 8;
+  private static final int LOGIN_NICKNAME = 8;
   private static final int LOGIN_AVATAR = 9;
 
   @Inject AuthenticationPersistence authenticationPersistence;
@@ -64,12 +64,12 @@ public class ToolboxContentProvider extends ContentProvider {
     uriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "token", TOKEN);
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "refreshToken", REFRESH_TOKEN);
-    uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "storeName", STORE_NAME);
+    uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "repo", REPO);
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "loginType", LOGIN_TYPE);
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "passHash", PASSHASH);
-    uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "loginEmail", LOGIN_EMAIL);
-    uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "changePreference", CHANGE_PREFERENCE);
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "loginName", LOGIN_NAME);
+    uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "changePreference", CHANGE_PREFERENCE);
+    uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "loginNickname", LOGIN_NICKNAME);
     uriMatcher.addURI(BuildConfig.CONTENT_AUTHORITY, "loginAvatar", LOGIN_AVATAR);
     ((AptoideApplication) getContext().getApplicationContext()).getApplicationComponent()
         .inject(this);
@@ -101,8 +101,8 @@ public class ToolboxContentProvider extends ContentProvider {
           return create("userToken", authentication.getAccessToken());
         case REFRESH_TOKEN:
           return create("userRefreshToken", authentication.getRefreshToken());
-        case STORE_NAME:
-          return create("storeName", account.getStore()
+        case REPO:
+          return create("userRepo", account.getStore()
               .getName());
         case PASSHASH:
           if (AptoideAccountManager.APTOIDE_SIGN_UP_TYPE.equals(authentication.getType())) {
@@ -115,15 +115,15 @@ public class ToolboxContentProvider extends ContentProvider {
         case LOGIN_TYPE:
           return create("loginType", authentication.getType()
               .toLowerCase(Locale.US));
-        case LOGIN_EMAIL:
-          return create("loginEmail", authentication.getEmail());
         case LOGIN_NAME:
-          return create("loginName", account.getNickname());
+          return create("loginName", authentication.getEmail());
+        case LOGIN_NICKNAME:
+          return create("loginNickname", account.getNickname());
         case LOGIN_AVATAR:
           return create("loginAvatar", account.getAvatar());
         default:
           throw new IllegalArgumentException(
-              "Only /token, /refreshToken, /storeName, /passHash, /loginType, /loginEmail, /loginName and /loginAvatar supported.");
+              "Only /token, /refreshToken, /repo, /passHash, /loginType, /loginName, loginNickname and loginAvatar supported.");
       }
     } else {
       throw new SecurityException("Package not authorized to access provider.");


### PR DESCRIPTION
**What does this PR do?**
Adds two fields necessary for the new AutoLogin uploader view.
Name (nickname) and the Avatar path.

**Database changed?**
 No

**Where should the reviewer start?**

- ToolboxContentProvider.java

**How should this be manually tested?**
Using an uploader version with the autologin changes, login in vanilla and then go to uploader and check if the name and avatar show up.

**What are the relevant tickets?**

https://aptoide.atlassian.net/browse/MOB-964

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass