### PR TITLE
[MOB-876] Removed redundant package name and app id

### DIFF
--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/GetAppRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/GetAppRequest.java
@@ -142,13 +142,13 @@ public class GetAppRequest extends V7<GetApp, GetAppRequest.Body> {
         SharedPreferences sharedPreferences) {
       this(packageName, refresh, sharedPreferences);
       this.storeName = storeName;
-      this.nodes = new Node(appId, packageName);
+      this.nodes = new Node();
     }
 
     public Body(String packageName, Boolean refresh, SharedPreferences sharedPreferences) {
       super(sharedPreferences);
       this.packageName = packageName;
-      this.nodes = new Node(packageName);
+      this.nodes = new Node();
     }
 
     public Body(String uname, SharedPreferences sharedPreferences) {
@@ -166,7 +166,7 @@ public class GetAppRequest extends V7<GetApp, GetAppRequest.Body> {
     public Body(long appId, SharedPreferences sharedPreferences) {
       super(sharedPreferences);
       this.appId = appId;
-      this.nodes = new Node(appId);
+      this.nodes = new Node();
     }
 
     public Long getAppId() {


### PR DESCRIPTION

**What does this PR do?**

This PR aims at removing a redundant package name or app id being sent in the nodes

**Database changed?**

No

**Where should the reviewer start?**

- [x] GetAppRequest.java

**How should this be manually tested?**

I could only reproduce it for the app id being null, not for the package name.
For the app id, send the following deeplink: adb shell am start -a "android.intent.action.VIEW" -d "aptoideinstall://package=org.nanobit.taboo&store=catappult&show_install_popup=false"
Make sure all appviews are opening (different opening types) as well as the things inside of it like the other versions, etc.

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-876](https://aptoide.atlassian.net/browse/MOB-876)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [x] New Kotlin code has unit tests
- [x] New flows in presenters unit tests
- [x] Mappers/Validators with any kind of logic unit tests
- [x] Functional tests pass