### PR TITLE
[MOB-1015] Fix crash in Search for Android 16

### DIFF
--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -212,7 +212,6 @@
   <attr name="loginInputBackground" format="reference" />
   <attr name="loginInputErrorBackground" format="reference" />
   <attr name="checkYourEmailBackground" format="reference" />
-  <attr name="searchBackgroundTriangleColor" format="color"/>
 
   <!--store theme specific attributes-->
   <attr name="datePickerStyle" format="reference" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -93,7 +93,6 @@
     <item name="loginInputBackground">@drawable/button_border_grey</item>
     <item name="loginInputErrorBackground">@drawable/button_border_red_orange</item>
     <item name="checkYourEmailBackground">@drawable/aptoide_gradient_vertical</item>
-    <item name="searchBackgroundTriangleColor">@color/search_background_grey_light</item>
 
     <!-- separators -->
     <item name="reviewsSeparator">@color/white</item>
@@ -354,7 +353,6 @@
     <item name="loginInputBackground">@drawable/button_border_white_dark</item>
     <item name="loginInputErrorBackground">@drawable/button_border_red_orange_dark</item>
     <item name="checkYourEmailBackground">@color/grey_dark</item>
-    <item name="searchBackgroundTriangleColor">@color/search_background_grey_dark</item>
 
     <!-- separators -->
     <item name="reviewsSeparator">@color/grey_dark</item>

--- a/aptoide-views/src/main/res/drawable-night/background_triangle.xml
+++ b/aptoide-views/src/main/res/drawable-night/background_triangle.xml
@@ -11,7 +11,7 @@
         android:pivotX="85%"
         android:pivotY="135%">
       <shape>
-        <solid android:color="@color/search_background_grey_light" />
+        <solid android:color="@color/search_background_grey_dark" />
 
       </shape>
     </rotate>
@@ -22,7 +22,7 @@
         android:pivotX="135%"
         android:pivotY="15%">
       <shape android:shape="rectangle">
-        <solid android:color="@color/search_background_grey_light" />
+        <solid android:color="@color/search_background_grey_dark" />
 
       </shape>
     </rotate>

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/model/MinimalAdInterface.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/model/MinimalAdInterface.java
@@ -1,8 +1,5 @@
 package cm.aptoide.pt.dataprovider.model;
 
-/**
- * Created by neuro on 15-10-2016.
- */
 public interface MinimalAdInterface {
 
   String getCpcUrl();


### PR DESCRIPTION
**What does this PR do?**

   fix: change the way we show the search results triangle in the background of each result. It was using an attr inside a drawable, which is not allowed in older versions and causes a runtime crash. Now we use (default/night) modes to show each search result version.

**Database changed?**

  No

**Where should the reviewer start?**

- [ ] background_triangle.xml 

**How should this be manually tested?**

  On a device/emulator 16 -> search for something on both dark and light themes. 

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-1015](https://aptoide.atlassian.net/browse/MOB-1015)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass