### PR TITLE
[MOB-1021] Temporary fix to search crash on scroll

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultAdapter.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultAdapter.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.DiffUtil;
+import androidx.recyclerview.widget.RecyclerView;
 import cm.aptoide.pt.app.view.screenshots.ScreenShotClickEvent;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.download.view.DownloadClick;
@@ -92,14 +93,19 @@ public class SearchResultAdapter extends DiffUtilAdapter<SearchItem, SearchResul
     return searchResults.size();
   }
 
-  public void setResultForSearch(String query, List<SearchAppResult> searchAppResults,
-      boolean hasMore) {
+  public void setResultForSearch(RecyclerView searchResultList, String query,
+      List<SearchAppResult> searchAppResults, boolean hasMore) {
     this.query = query;
     searchResults = new ArrayList<>(searchAppResults);
     // TODO
     //if (hasMore) {
     //  searchResults.add(new SearchLoadingItem());
     //}
+
+    // I'm sorry... Removing this will crash the search randomly on scroll (IndexOutOfBoundsException: Inconsistency detected. Invalid item position)
+    searchResultList.getRecycledViewPool()
+        .clear();
+
     notifyDataSetChanged();
   }
 

--- a/app/src/main/java/cm/aptoide/pt/search/view/SearchResultFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/search/view/SearchResultFragment.java
@@ -272,7 +272,7 @@ public class SearchResultFragment extends BackButtonFragment
       boolean isFreshResult, boolean hasMore, boolean hasError, SearchResultError error) {
     if (isFreshResult) {
       isFreshLoading = false;
-      searchResultsAdapter.setResultForSearch(query, searchAppResults, hasMore);
+      searchResultsAdapter.setResultForSearch(searchResultList,query, searchAppResults, hasMore);
       Animation animation = AnimationUtils.loadAnimation(getContext(), R.anim.slide_up_disappear);
       animation.setFillAfter(true);
       animation.setAnimationListener(new Animation.AnimationListener() {


### PR DESCRIPTION
**What does this PR do?**

   Temporary fix to search crash on scroll - IndexOutOfBoundsException: Inconsistency detected. Invalid item position

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] SearchResultAdapter.java

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [MOB-1021](https://aptoide.atlassian.net/browse/MOB-1021)

**What are the relevant tickets?**

  Tickets related to this pull-request: [MOB-1021](https://aptoide.atlassian.net/browse/MOB-1021)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass