### PR TITLE
[hotfix/MOB-1037] Out of Space Dialog Missing- Highlighted

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/download/view/DownloadDialogProvider.kt
+++ b/app/src/main/java/cm/aptoide/pt/download/view/DownloadDialogProvider.kt
@@ -5,7 +5,9 @@ import cm.aptoide.pt.R
 import cm.aptoide.pt.themes.ThemeManager
 import cm.aptoide.pt.utils.GenericDialogs
 import com.google.android.material.snackbar.Snackbar
+import rx.Completable
 import rx.Observable
+import rx.android.schedulers.AndroidSchedulers
 
 class DownloadDialogProvider(val fragment: Fragment,
                              val themeManager: ThemeManager) {
@@ -30,5 +32,22 @@ class DownloadDialogProvider(val fragment: Fragment,
       Snackbar.make(v, R.string.downgrading_msg, Snackbar.LENGTH_SHORT)
           .show()
     }
+  }
+
+  fun showGenericError(): Completable {
+    return showDialog("",
+        fragment.getString(R.string.error_occured)).toCompletable()
+  }
+
+  fun showOutOfSpaceError(): Completable {
+    return showDialog(fragment.getString(R.string.out_of_space_dialog_title),
+        fragment.getString(R.string.out_of_space_dialog_message)).toCompletable()
+  }
+
+  private fun showDialog(title: String,
+                         message: String): Observable<GenericDialogs.EResponse> {
+    return GenericDialogs.createGenericOkMessage(fragment.context, title, message,
+        themeManager.getAttributeForTheme(R.attr.dialogsTheme).resourceId)
+        .subscribeOn(AndroidSchedulers.mainThread())
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/download/view/DownloadEvent.kt
+++ b/app/src/main/java/cm/aptoide/pt/download/view/DownloadEvent.kt
@@ -12,5 +12,5 @@ fun DownloadEventListener.Action.toDownloadEvent(): DownloadEvent {
 }
 
 enum class DownloadEvent {
-  INSTALL, RESUME, PAUSE, CANCEL
+  INSTALL, RESUME, PAUSE, CANCEL, GENERIC_ERROR, OUT_OF_SPACE_ERROR
 }

--- a/app/src/main/java/cm/aptoide/pt/download/view/DownloadViewActionPresenter.kt
+++ b/app/src/main/java/cm/aptoide/pt/download/view/DownloadViewActionPresenter.kt
@@ -63,12 +63,15 @@ open class DownloadViewActionPresenter(private val installManager: InstallManage
         .filter { lifecycleEvent -> lifecycleEvent == View.LifecycleEvent.CREATE }
         .flatMap {
           eventObservable
+              .skipWhile { event -> event.action == DownloadEvent.GENERIC_ERROR || event.action == DownloadEvent.OUT_OF_SPACE_ERROR }
               .flatMapCompletable { event ->
                 when (event.action) {
                   DownloadEvent.INSTALL -> installApp(event)
                   DownloadEvent.RESUME -> resumeDownload(event)
                   DownloadEvent.PAUSE -> pauseDownload(event)
                   DownloadEvent.CANCEL -> cancelDownload(event)
+                  DownloadEvent.GENERIC_ERROR -> downloadDialogProvider.showGenericError()
+                  DownloadEvent.OUT_OF_SPACE_ERROR -> downloadDialogProvider.showOutOfSpaceError()
                 }
               }
               .retry()

--- a/app/src/main/java/cm/aptoide/pt/download/view/DownloadViewStatusHelper.kt
+++ b/app/src/main/java/cm/aptoide/pt/download/view/DownloadViewStatusHelper.kt
@@ -22,6 +22,15 @@ class DownloadViewStatusHelper(val context: Context) {
     installButton.setOnClickListener {
       downloadClickSubject.onNext(DownloadClick(download, DownloadEvent.INSTALL))
     }
+    download.downloadModel?.let { downloadModel ->
+      if (downloadModel.downloadState == DownloadStatusModel.DownloadState.GENERIC_ERROR) {
+        downloadClickSubject.onNext(
+            DownloadClick(download, DownloadEvent.GENERIC_ERROR))
+      } else if (downloadModel.downloadState == DownloadStatusModel.DownloadState.NOT_ENOUGH_STORAGE_ERROR) {
+        downloadClickSubject.onNext(
+            DownloadClick(download, DownloadEvent.OUT_OF_SPACE_ERROR))
+      }
+    }
     downloadProgressView.setEventListener(object : DownloadEventListener {
       override fun onActionClick(action: DownloadEventListener.Action) {
         when (action.type) {


### PR DESCRIPTION
**What does this PR do?**

   Error dialogs were missing in the new download component. This basically adds them back.

**Database changed?**

   No

**How should this be manually tested?**

  Get a device with low storage (or simulate it) and go to search and look for "Creative Destruction". If you click install (and assuming you have low storage), an out of space error should appear correctly.

**What are the relevant tickets?**

  [MOB-1037](https://aptoide.atlassian.net/browse/MOB-1037)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass