### PR TITLE
[Hotfix/APP-57] Attempt fix to new users rakam

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
+++ b/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
@@ -291,6 +291,9 @@ public abstract class AptoideApplication extends Application {
                 uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION),
             setUpFirstRunAnalytics(), installedRepository.syncWithDevice()
                 .subscribeOn(Schedulers.computation())))
+        .doOnError(throwable -> CrashReport.getInstance()
+            .log(throwable))
+        .onErrorComplete()
         .andThen(launchManager.launch()
             .subscribeOn(Schedulers.computation()))
         .subscribe(() -> { /* do nothing */}, error -> CrashReport.getInstance()

--- a/app/src/main/java/cm/aptoide/pt/LaunchManager.kt
+++ b/app/src/main/java/cm/aptoide/pt/LaunchManager.kt
@@ -1,7 +1,6 @@
 package cm.aptoide.pt
 
 import android.content.SharedPreferences
-import cm.aptoide.pt.logger.Logger
 import cm.aptoide.pt.preferences.secure.SecurePreferences
 import rx.Completable
 
@@ -14,13 +13,7 @@ class LaunchManager(private val firstLaunchManager: FirstLaunchManager,
                     private val secureSharedPreferences: SharedPreferences) {
 
   fun launch(): Completable {
-    return Completable.mergeDelayError(runFirstLaunch().doOnCompleted {
-      Logger.getInstance().d("nzxt", "runFirstLaunch() completed")
-    }, runUpdateLaunch().doOnCompleted {
-      Logger.getInstance().d("nzxt", "runUpdateLaunch() completed")
-    }).doOnCompleted {
-      Logger.getInstance().d("nzxt", "merge delay completed")
-    }
+    return Completable.mergeDelayError(runFirstLaunch(), runUpdateLaunch())
   }
 
   /**

--- a/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
@@ -88,7 +88,6 @@ public class FirstLaunchAnalytics {
     analyticsManager.logEvent(
         createFacebookFirstLaunchDataMap(utmSource, utmMedium, utmCampaign, utmContent, entryPoint),
         FIRST_LAUNCH_BI, AnalyticsManager.Action.OPEN, CONTEXT);
-    Logger.getInstance().d("nzxt", "sending " + FIRST_LAUNCH_RAKAM + " open");
     analyticsManager.logEvent(new HashMap<>(), FIRST_LAUNCH_RAKAM, AnalyticsManager.Action.OPEN,
         CONTEXT);
   }

--- a/aptoidepreferences/src/main/java/cm/aptoide/pt/preferences/secure/SecurePreferences.java
+++ b/aptoidepreferences/src/main/java/cm/aptoide/pt/preferences/secure/SecurePreferences.java
@@ -28,7 +28,7 @@ public class SecurePreferences {
 
   public static void setFirstRun(boolean b, SharedPreferences securePreferences) {
     Logger.getInstance()
-        .d("nzxt", "set first run -> " + b);
+        .d("First Run", "set first run -> " + b);
     securePreferences.edit()
         .putBoolean(SecureKeys.FIRST_RUN, b)
         .apply();


### PR DESCRIPTION
**What does this PR do?**

   New users in Rakam had a giant spike in latest version (v9.17.1.0). Also the retention is very high for that version. We believe that it is a bug and the issue was that the aptoide_first_launch event is being sent to rakam more than once per user.
   This is an attempt to fix the issue by setting the first_run flag in shared preferences earlier. 

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AptoideApplication.java

**How should this be manually tested?**

  Look into the aptoide_first_launch event (rakam). Test both first session and others.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-57](https://aptoide.atlassian.net/browse/APP-57)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass