### PR TITLE
[APP-57] making sure analytics initialize before doing parallel work

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -1525,7 +1525,6 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
     return Arrays.asList(InstallAnalytics.CLICK_ON_INSTALL, DownloadAnalytics.RAKAM_DOWNLOAD_EVENT,
         InstallAnalytics.RAKAM_INSTALL_EVENT, SearchAnalytics.SEARCH,
         SearchAnalytics.SEARCH_RESULT_CLICK, FirstLaunchAnalytics.FIRST_LAUNCH_RAKAM,
-        SearchAnalytics.SEARCH_RESULT_CLICK, FirstLaunchAnalytics.FIRST_LAUNCH_RAKAM,
         UpdatesNotificationAnalytics.MOB_657_UPDATES_NOTIFICATION_PARTICIPATING_EVENT,
         UpdatesNotificationAnalytics.MOB_657_UPDATES_NOTIFICATION_CONVERSION_EVENT);
   }

--- a/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
+++ b/app/src/main/java/cm/aptoide/pt/AptoideApplication.java
@@ -277,12 +277,16 @@ public abstract class AptoideApplication extends Application {
     WorkManager.initialize(this, configuration);
 
     FacebookSdk.sdkInitialize(this);
-    initializeFlurry(this, BuildConfig.FLURRY_KEY);
     AppEventsLogger.activateApp(this);
     AppEventsLogger.newLogger(this);
 
+    initializeFlurry(this, BuildConfig.FLURRY_KEY);
+
     generateAptoideUuid().andThen(
         Completable.mergeDelayError(initializeRakamSdk(), initializeSentry()))
+        .doOnError(throwable -> CrashReport.getInstance()
+            .log(throwable))
+        .onErrorComplete()
         .andThen(
             Completable.mergeDelayError(startUpdatesNotification(), setUpInitialAdsUserProperty(),
                 handleAdsUserPropertyToggle(), sendAptoideApplicationStartAnalytics(

--- a/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
+++ b/app/src/main/java/cm/aptoide/pt/analytics/FirstLaunchAnalytics.java
@@ -187,10 +187,6 @@ public class FirstLaunchAnalytics {
 
   public Completable sendAppStart(android.app.Application application,
       SharedPreferences sharedPreferences, IdsRepository idsRepository) {
-
-    FacebookSdk.sdkInitialize(application);
-    AppEventsLogger.activateApp(application);
-    AppEventsLogger.newLogger(application);
     return idsRepository.getUniqueIdentifier()
         .doOnSuccess(AppEventsLogger::setUserID)
         .toObservable()


### PR DESCRIPTION
**What does this PR do?**

   making sure analytics initialize before doing parallel work

   delayed sending first run analytics so first session is set immediately after. 

   removed duplicated events from the rakam events whitelist

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AptoideApplication.java

**How should this be manually tested?**

  Test startup flow, check if we only send "aptoide_first_launch" event once and if rakam works every session

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-57](https://aptoide.atlassian.net/browse/APP-57)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass