### PR TITLE
[APP-82] Replace delete account URL

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/view/settings/SettingsFragment.java
@@ -372,10 +372,7 @@ public class SettingsFragment extends PreferenceFragmentCompat
         R.string.setting_category_autoupdate_message));
 
     subscriptions.add(RxPreference.clicks(deleteAccount)
-        .flatMapSingle(__ -> authenticationPersistence.getAuthentication())
-        .map(authentication -> authentication.getAccessToken())
-        .observeOn(AndroidSchedulers.mainThread())
-        .doOnNext(accessToken -> openDeleteAccountView(accessToken))
+        .doOnNext(accessToken -> openDeleteAccountView())
         .subscribe());
 
     subscriptions.add(RxPreference.clicks(socialCampaignNotifications)
@@ -710,10 +707,10 @@ public class SettingsFragment extends PreferenceFragmentCompat
     }
   }
 
-  private void openDeleteAccountView(String accessToken) {
+  private void openDeleteAccountView() {
     CustomTabsHelper.getInstance()
-        .openInChromeCustomTab(getString(R.string.settings_url_delete_account, accessToken),
-            getContext(), themeManager.getAttributeForTheme(R.attr.colorPrimary).resourceId);
+        .openInChromeCustomTab(getString(R.string.settings_url_delete_account), getContext(),
+            themeManager.getAttributeForTheme(R.attr.colorPrimary).resourceId);
   }
 
   private void handleSocialNotifications(Boolean isChecked) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -524,7 +524,7 @@
   <!--URL -->
   <string name="all_url_terms_conditions" translatable="false">https://www.aptoide.com/legal/terms?header=0&amp;menu=0</string>
   <string name="all_url_privacy_policy" translatable="false">https://www.aptoide.com/legal/privacy?header=0&amp;menu=0</string>
-  <string name="settings_url_delete_account" translatable="false">https://www.aptoide.com/account/delete?access_token=%1$s</string>
+  <string name="settings_url_delete_account" translatable="false">https://en.aptoide.com/company/legal?section=delete</string>
 
   <!--APPC-->
   <string name="appc_title_iab">Spend Your AppCoins</string>


### PR DESCRIPTION
**What does this PR do?**

This PR aims at replacing the delete account url for a new one.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] SettingsFragment.java

**How should this be manually tested?**

  Open my account and go to delete account section. This section only shows up when you are logged in

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-82](https://aptoide.atlassian.net/browse/APP-82)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass