### PR TITLE
[APP-81] Fix out of space inconsistency

### DIFF
--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AptoideDownloadManager.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/AptoideDownloadManager.java
@@ -197,44 +197,51 @@ public class AptoideDownloadManager implements DownloadManager {
   }
 
   private void moveFilesFromCompletedDownloads() {
-    moveFilesSubscription = downloadsRepository.getWaitingToMoveFilesDownloads()
-        .flatMap(roomDownloads -> Observable.just(roomDownloads)
+    moveFilesSubscription = Observable.just(true)
+        .flatMap(__ -> downloadsRepository.getWaitingToMoveFilesDownloads()
             .filter(downloads -> !downloads.isEmpty())
             .flatMapIterable(download -> download)
-            .flatMap(download -> moveCompletedDownloadFiles(download).doOnError(
-                Throwable::printStackTrace)
-                .andThen(Observable.just(download))))
-        .retry()
+            .flatMapCompletable(download -> moveCompletedDownloadFiles(download).doOnError(
+                throwable -> throwable.printStackTrace())
+                .onErrorResumeNext(throwable -> {
+                  throwable.printStackTrace();
+                  download.setDownloadError(RoomDownload.GENERIC_ERROR);
+                  download.setOverallDownloadStatus(RoomDownload.ERROR);
+                  return downloadsRepository.save(download);
+                }))
+            .retry())
         .subscribe(__ -> {
         }, Throwable::printStackTrace);
   }
 
   public Completable moveCompletedDownloadFiles(RoomDownload download) {
-    for (final RoomFileToDownload roomFileToDownload : download.getFilesToDownload()) {
-      String newFilePath = pathProvider.getFilePathFromFileType(roomFileToDownload);
-      if (!FileUtils.fileExists(pathProvider.getFilePathFromFileType(roomFileToDownload)
-          + roomFileToDownload.getFileName())) {
-        Logger.getInstance()
-            .d(TAG, "trying to move file : "
-                + roomFileToDownload.getFileName()
-                + " "
-                + roomFileToDownload.getPackageName());
-        fileUtils.copyFile(roomFileToDownload.getPath(), newFilePath,
-            roomFileToDownload.getFileName());
-        roomFileToDownload.setPath(newFilePath);
-      } else {
-        roomFileToDownload.setPath(newFilePath);
-        Logger.getInstance()
-            .d(TAG, "tried moving file: "
-                + roomFileToDownload.getFileName()
-                + " "
-                + roomFileToDownload.getPackageName()
-                + " but it was already moved. The path that we were trying to move to was "
-                + roomFileToDownload.getFilePath());
+    return Completable.fromAction(() -> {
+      for (final RoomFileToDownload roomFileToDownload : download.getFilesToDownload()) {
+        String newFilePath = pathProvider.getFilePathFromFileType(roomFileToDownload);
+        if (!FileUtils.fileExists(pathProvider.getFilePathFromFileType(roomFileToDownload)
+            + roomFileToDownload.getFileName())) {
+          Logger.getInstance()
+              .d(TAG, "trying to move file : "
+                  + roomFileToDownload.getFileName()
+                  + " "
+                  + roomFileToDownload.getPackageName());
+          fileUtils.copyFile(roomFileToDownload.getPath(), newFilePath,
+              roomFileToDownload.getFileName());
+          roomFileToDownload.setPath(newFilePath);
+        } else {
+          roomFileToDownload.setPath(newFilePath);
+          Logger.getInstance()
+              .d(TAG, "tried moving file: "
+                  + roomFileToDownload.getFileName()
+                  + " "
+                  + roomFileToDownload.getPackageName()
+                  + " but it was already moved. The path that we were trying to move to was "
+                  + roomFileToDownload.getFilePath());
+        }
       }
-    }
-    download.setOverallDownloadStatus(RoomDownload.COMPLETED);
-    return downloadsRepository.save(download);
+      download.setOverallDownloadStatus(RoomDownload.COMPLETED);
+    })
+        .andThen(downloadsRepository.save(download));
   }
 
   private void removeDownloadFiles(RoomDownload download) {


### PR DESCRIPTION
**What does this PR do?**

This PR aims at setting the download to the error state when it encounters an error while trying to move the download files. We are setting the general error because from the exception we can not distinguish the different exceptions.

Please confirm that the everything is working correctly

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AptoideDownloadManager.java

**How should this be manually tested?**

On a low storage device try to perform a download that only fails due to storage at the end of the download. For example, I tested downloading Lords Mobile on an emulator with 1000MB of internal storage and no SD Card.
This leads do the weird state that we were getting where it is possible do start the download, but it is not possible to move the file (this happens because when we are moving it, it clones the file).


**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-81](https://aptoide.atlassian.net/browse/APP-81)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass