### PR TITLE
[APP-112] Change trending to 60d

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/search/suggestions/TrendingService.java
+++ b/app/src/main/java/cm/aptoide/pt/search/suggestions/TrendingService.java
@@ -42,7 +42,7 @@ public class TrendingService {
   public Observable<ListApps> getTrendingApps(int limit, int storeId) {
     ListAppsRequest.Body body =
         new ListAppsRequest.Body(storeCredentialsProvider.get(storeId), limit, sharedPreferences,
-            ListAppsRequest.Sort.trending30d);
+            ListAppsRequest.Sort.trending60d);
     body.setStoreId(storeId);
     return new ListAppsRequest(body, bodyInterceptor, httpClient, converterFactory,
         tokenInvalidator, sharedPreferences, appBundlesVisibilityManager).observe(false);

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/ListAppsRequest.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/ws/v7/ListAppsRequest.java
@@ -82,7 +82,7 @@ public class ListAppsRequest extends V7<ListApps, ListAppsRequest.Body> {
   }
 
   public enum Sort {
-    latest, trending7d, trending30d,
+    latest, trending7d, trending60d,
   }
 
   public static class Body extends BaseBody implements Endless {


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at changing trending from 30d to 60d. This does not affect the trending bundle in home because that one comes from web a ticket for it to be changed on MICRO was already created ( [MICRO-1046](https://aptoide.atlassian.net/browse/MICRO-1046) ) . It only affects the trending on search.

**Database changed?**

 No

**Where should the reviewer start?**

- [ ] TrendingService.java

**How should this be manually tested?**

Check on charles that the request is being made with 60d.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-112](https://aptoide.atlassian.net/browse/APP-112)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass