### PR TITLE
[Feature/APP-103] new setting: enforce native installer

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -126,7 +126,7 @@ import cm.aptoide.pt.database.room.AptoideDatabase;
 import cm.aptoide.pt.dataprovider.NetworkOperatorManager;
 import cm.aptoide.pt.dataprovider.WebService;
 import cm.aptoide.pt.dataprovider.aab.AppBundlesVisibilityManager;
-import cm.aptoide.pt.dataprovider.aab.HardwareSpecsFilterPersistence;
+import cm.aptoide.pt.dataprovider.aab.AppBundlesVisibilitySettingsProvider;
 import cm.aptoide.pt.dataprovider.ads.AdNetworkUtils;
 import cm.aptoide.pt.dataprovider.cache.L2Cache;
 import cm.aptoide.pt.dataprovider.cache.POSTCacheInterceptor;
@@ -313,7 +313,6 @@ import retrofit2.CallAdapter;
 import retrofit2.Converter;
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
-import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import rx.Completable;
 import rx.Single;
 import rx.schedulers.Schedulers;
@@ -1569,14 +1568,15 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
   }
 
   @Singleton @Provides AppBundlesVisibilityManager providesAppBundlesVisibilityManager(
-      HardwareSpecsFilterPersistence hardwareSpecsFilterPersistence) {
+      AppBundlesVisibilitySettingsProvider AppBundlesVisibilitySettingsProvider) {
     return new AppBundlesVisibilityManager(AptoideUtils.isMIUIwithAABFix(),
-        AptoideUtils.isDeviceMIUI(), hardwareSpecsFilterPersistence);
+        AptoideUtils.isDeviceMIUI(), AppBundlesVisibilitySettingsProvider);
   }
 
-  @Singleton @Provides HardwareSpecsFilterPersistence providesHardwareSpecsFilterPersistence(
+  @Singleton @Provides
+  AppBundlesVisibilitySettingsProvider providesAppBundlesVisibilitySettingsProvider(
       @Named("default") SharedPreferences sharedPreferences) {
-    return new HardwareSpecsFilterPersistence(sharedPreferences);
+    return new AppBundlesVisibilitySettingsProvider(sharedPreferences);
   }
 
   @Singleton @Provides AppCenterRepository providesAppCenterRepository(AppService appService) {

--- a/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
@@ -20,7 +20,7 @@ import cm.aptoide.analytics.implementation.navigation.NavigationTracker;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.dataprovider.WebService;
 import cm.aptoide.pt.dataprovider.aab.AppBundlesVisibilityManager;
-import cm.aptoide.pt.dataprovider.aab.HardwareSpecsFilterPersistence;
+import cm.aptoide.pt.dataprovider.aab.AppBundlesVisibilitySettingsProvider;
 import cm.aptoide.pt.dataprovider.exception.AptoideWsV7Exception;
 import cm.aptoide.pt.dataprovider.exception.NoNetworkConnectionException;
 import cm.aptoide.pt.dataprovider.model.v7.GetApp;
@@ -547,7 +547,7 @@ public class DeepLinkIntentReceiver extends ActivityView {
             ((AptoideApplication) getApplicationContext()).getTokenInvalidator(),
             ((AptoideApplication) getApplicationContext()).getDefaultSharedPreferences(),
             new AppBundlesVisibilityManager(AptoideUtils.isMIUIwithAABFix(),
-                AptoideUtils.isDeviceMIUI(), new HardwareSpecsFilterPersistence(
+                AptoideUtils.isDeviceMIUI(), new AppBundlesVisibilitySettingsProvider(
                 ((AptoideApplication) getApplicationContext()).getDefaultSharedPreferences())))
             .observe()
             .toBlocking()

--- a/app/src/main/java/cm/aptoide/pt/app/view/OtherVersionsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/OtherVersionsFragment.java
@@ -17,7 +17,7 @@ import cm.aptoide.pt.R;
 import cm.aptoide.pt.app.view.displayable.OtherVersionDisplayable;
 import cm.aptoide.pt.dataprovider.WebService;
 import cm.aptoide.pt.dataprovider.aab.AppBundlesVisibilityManager;
-import cm.aptoide.pt.dataprovider.aab.HardwareSpecsFilterPersistence;
+import cm.aptoide.pt.dataprovider.aab.AppBundlesVisibilitySettingsProvider;
 import cm.aptoide.pt.dataprovider.interfaces.SuccessRequestListener;
 import cm.aptoide.pt.dataprovider.model.v7.listapp.App;
 import cm.aptoide.pt.dataprovider.model.v7.listapp.ListAppVersions;
@@ -155,7 +155,7 @@ public class OtherVersionsFragment extends AptoideBaseFragment<BaseAdapter> {
             ((AptoideApplication) getContext().getApplicationContext()).getDefaultSharedPreferences(),
             getContext().getResources(),
             new AppBundlesVisibilityManager(AptoideUtils.isMIUIwithAABFix(),
-                AptoideUtils.isDeviceMIUI(), new HardwareSpecsFilterPersistence(
+                AptoideUtils.isDeviceMIUI(), new AppBundlesVisibilitySettingsProvider(
                 ((AptoideApplication) getContext().getApplicationContext()).getDefaultSharedPreferences()))),
         otherVersionsSuccessRequestListener, err -> err.printStackTrace());
 

--- a/app/src/main/java/cm/aptoide/pt/install/InstallManager.java
+++ b/app/src/main/java/cm/aptoide/pt/install/InstallManager.java
@@ -18,6 +18,7 @@ import cm.aptoide.pt.downloadmanager.DownloadsRepository;
 import cm.aptoide.pt.install.installer.InstallCandidate;
 import cm.aptoide.pt.install.installer.InstallationState;
 import cm.aptoide.pt.logger.Logger;
+import cm.aptoide.pt.preferences.managed.ManagedKeys;
 import cm.aptoide.pt.preferences.managed.ManagerPreferences;
 import cm.aptoide.pt.preferences.secure.SecurePreferences;
 import cm.aptoide.pt.root.RootAvailabilityManager;
@@ -240,11 +241,15 @@ public class InstallManager {
   }
 
   public Completable install(RoomDownload download) {
-    return install(download, false, false, true);
+    boolean shouldForceDefaultInstall =
+        sharedPreferences.getBoolean(ManagedKeys.ENFORCE_NATIVE_INSTALLER_KEY, false);
+    return install(download, shouldForceDefaultInstall, false, true);
   }
 
   public Completable install(RoomDownload download, boolean shouldInstall) {
-    return install(download, false, false, shouldInstall);
+    boolean shouldForceDefaultInstall =
+        sharedPreferences.getBoolean(ManagedKeys.ENFORCE_NATIVE_INSTALLER_KEY, false);
+    return install(download, shouldForceDefaultInstall, false, shouldInstall);
   }
 
   private Completable defaultInstall(RoomDownload download) {
@@ -252,7 +257,9 @@ public class InstallManager {
   }
 
   public Completable splitInstall(RoomDownload download) {
-    return install(download, false, true, true);
+    boolean shouldForceDefaultInstall =
+        sharedPreferences.getBoolean(ManagedKeys.ENFORCE_NATIVE_INSTALLER_KEY, false);
+    return install(download, shouldForceDefaultInstall, !shouldForceDefaultInstall, true);
   }
 
   private Completable install(RoomDownload download, boolean forceDefaultInstall,

--- a/app/src/main/java/cm/aptoide/pt/install/installer/DefaultInstaller.java
+++ b/app/src/main/java/cm/aptoide/pt/install/installer/DefaultInstaller.java
@@ -118,7 +118,7 @@ public class DefaultInstaller implements Installer {
               } else {
                 if (candidate.getForceDefaultInstall()) {
                   return startDefaultInstallation(context, installation,
-                      candidate.getShouldSetPackageInstaller());
+                      false);
                 } else {
                   return startInstallation(context, installation,
                       candidate.getShouldSetPackageInstaller());

--- a/app/src/main/java/cm/aptoide/pt/repository/request/RequestFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/repository/request/RequestFactory.java
@@ -7,7 +7,7 @@ import android.view.WindowManager;
 import cm.aptoide.accountmanager.AptoideAccountManager;
 import cm.aptoide.pt.AppCoinsManager;
 import cm.aptoide.pt.dataprovider.aab.AppBundlesVisibilityManager;
-import cm.aptoide.pt.dataprovider.aab.HardwareSpecsFilterPersistence;
+import cm.aptoide.pt.dataprovider.aab.AppBundlesVisibilitySettingsProvider;
 import cm.aptoide.pt.dataprovider.interfaces.TokenInvalidator;
 import cm.aptoide.pt.dataprovider.ws.BodyInterceptor;
 import cm.aptoide.pt.dataprovider.ws.v2.aptwords.AdsApplicationVersionCodeProvider;
@@ -58,7 +58,8 @@ import retrofit2.Converter;
     this.appCoinsManager = appCoinsManager;
     AppBundlesVisibilityManager appBundlesVisibilityManager =
         new AppBundlesVisibilityManager(AptoideUtils.isMIUIwithAABFix(),
-            AptoideUtils.isDeviceMIUI(), new HardwareSpecsFilterPersistence(sharedPreferences));
+            AptoideUtils.isDeviceMIUI(),
+            new AppBundlesVisibilitySettingsProvider(sharedPreferences));
     listStoresRequestFactory =
         new ListStoresRequestFactory(bodyInterceptor, httpClient, converterFactory,
             tokenInvalidator, sharedPreferences);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -805,14 +805,14 @@
   <string name="login_error_invalid_email">This email isn\'t valid!</string>
   <string name="login_completed_title">Done!</string>
   <string name="login_completed_body">Ready for the best apps?</string>
-  
+
   <!--Notification-->
   <string name="notification_updates_available">Some apps are ready to be updated!</string>
   <string name="notification_install_ready_plural_title">Some apps are ready to be installed!</string>
   <string name="notification_install_ready_plural_body">Tap here to install them.</string>
   <string name="notification_install_ready_singular_title">An app is ready to be installed!</string>
   <string name="notification_install_ready_singular_body">Tap here to install %s.</string>
-  
+
   <!--Incentive Bonus Badge-->
   <string name="incentives_badge_full">Up to %s%% Bonus</string>
   <string name="incentives_badge_up_to">Up to</string>
@@ -820,7 +820,7 @@
   <string name="incentives_badge_bonus">Bonus</string>
   <string name="incentives_banner_title">Up to %s%% bonus in every purchase!</string>
   <string name="incentives_banner_body">Use your AppCoins Credits to get more items in apps with this symbol %s</string>
-  
+
   <!--Empty States-->
   <string name="search_no_results_title">There are no results for your search.</string>
   <string name="search_no_results_body">Try using other words or play with the filters!</string>
@@ -833,5 +833,10 @@
   <string name="search_filters_all_stores">All stores</string>
   <string name="search_filters_followed_stores">Followed stores</string>
   <string name="search_filters_clear">Clear</string>
+
+  <!-- App bundles/MIUI -->
+  <string name="settings_force_native_installer_title">Force Native Installer</string>
+  <string name="settings_force_native_installer_summary">Enable this only if you are have a MIUI device and can\'t install applications. This will force the native installer. You will stop seeing some app versions</string>
+
 
 </resources>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -23,6 +23,11 @@
         app:key="appTheme"
         app:summary="@string/settings_dark_theme_system"
         app:title="@string/settings_dark_theme_title" />
+    <SwitchPreferenceCompat
+        app:defaultValue="false"
+        app:key="forceNativeInstaller"
+        app:summary="@string/settings_force_native_installer_summary"
+        app:title="@string/settings_force_native_installer_title" />
   </PreferenceCategory>
   <PreferenceCategory app:title="@string/updates">
     <SwitchPreferenceCompat

--- a/aptoidepreferences/src/main/java/cm/aptoide/pt/preferences/managed/ManagedKeys.java
+++ b/aptoidepreferences/src/main/java/cm/aptoide/pt/preferences/managed/ManagedKeys.java
@@ -28,6 +28,7 @@ public class ManagedKeys {
   public static final String DONT_SHOW_ME_AGAIN = "dontshowpreviewdialogagain";
   public static final String DONT_SHOW_CLEANED_VERSION = "dontshowpreviewdialogcleanpref";
   public static final String AUTO_UPDATE_ENABLE = "auto_update";
+  public static final String ENFORCE_NATIVE_INSTALLER_KEY = "forceNativeInstaller";
   public static final String CAMPAIGN_SOCIAL_NOTIFICATIONS_PREFERENCE_VIEW_KEY =
       "notification_campaign_and_social";
   public static final String SHOW_PROMOTIONS_DIALOG = "show_promotions_dialog";

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilityManager.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilityManager.java
@@ -2,18 +2,19 @@ package cm.aptoide.pt.dataprovider.aab;
 
 public class AppBundlesVisibilityManager {
   private final boolean isMIUIWithAABFix;
-  private boolean isDeviceMIUI;
-  private final HardwareSpecsFilterProvider hardwareSpecsFilterProvider;
+  private final boolean isDeviceMIUI;
+  private final SettingsValuesProvider settingsValuesProvider;
 
   public AppBundlesVisibilityManager(boolean isMIUIWithAABFix, boolean isDeviceMIUI,
-      HardwareSpecsFilterProvider hardwareSpecsFilterProvider) {
+      SettingsValuesProvider SettingsValuesProvider) {
     this.isMIUIWithAABFix = isMIUIWithAABFix;
     this.isDeviceMIUI = isDeviceMIUI;
-    this.hardwareSpecsFilterProvider = hardwareSpecsFilterProvider;
+    this.settingsValuesProvider = SettingsValuesProvider;
   }
 
   public boolean shouldEnableAppBundles() {
-    return !isDeviceMIUI || !hardwareSpecsFilterProvider.isOnlyShowCompatibleApps() || (isDeviceMIUI
-        && isMIUIWithAABFix);
+    return !settingsValuesProvider.isEnforceNativeInstaller() && (!isDeviceMIUI
+        || !settingsValuesProvider.isOnlyShowCompatibleApps()
+        || (isDeviceMIUI && isMIUIWithAABFix));
   }
 }

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilitySettingsProvider.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilitySettingsProvider.java
@@ -3,14 +3,18 @@ package cm.aptoide.pt.dataprovider.aab;
 import android.content.SharedPreferences;
 import cm.aptoide.pt.preferences.managed.ManagedKeys;
 
-public class HardwareSpecsFilterPersistence implements HardwareSpecsFilterProvider {
+public class AppBundlesVisibilitySettingsProvider implements SettingsValuesProvider {
   private final SharedPreferences sharedPreferences;
 
-  public HardwareSpecsFilterPersistence(SharedPreferences sharedPreferences) {
+  public AppBundlesVisibilitySettingsProvider(SharedPreferences sharedPreferences) {
     this.sharedPreferences = sharedPreferences;
   }
 
   @Override public boolean isOnlyShowCompatibleApps() {
     return sharedPreferences.getBoolean(ManagedKeys.HWSPECS_FILTER, true);
+  }
+
+  @Override public boolean isEnforceNativeInstaller() {
+    return sharedPreferences.getBoolean(ManagedKeys.ENFORCE_NATIVE_INSTALLER_KEY, false);
   }
 }

--- a/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/aab/HardwareSpecsFilterProvider.java
+++ b/dataprovider/src/main/java/cm/aptoide/pt/dataprovider/aab/HardwareSpecsFilterProvider.java
@@ -1,5 +1,7 @@
 package cm.aptoide.pt.dataprovider.aab;
 
-interface HardwareSpecsFilterProvider {
+interface SettingsValuesProvider {
   boolean isOnlyShowCompatibleApps();
+
+  boolean isEnforceNativeInstaller();
 }

--- a/dataprovider/src/test/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilityManagerTest.java
+++ b/dataprovider/src/test/java/cm/aptoide/pt/dataprovider/aab/AppBundlesVisibilityManagerTest.java
@@ -9,29 +9,50 @@ public class AppBundlesVisibilityManagerTest {
 
   @Test public void shouldEnableAppBundles_MIUI_CompatibleAppsOnly() {
     AppBundlesVisibilityManager appBundlesVisibilityManager =
-        new AppBundlesVisibilityManager(false, true, () -> true);
+        new AppBundlesVisibilityManager(false, true, getMockedSettingsValuesProvider(true, false));
 
     assertFalse(appBundlesVisibilityManager.shouldEnableAppBundles());
   }
 
   @Test public void shouldEnableAppBundles_MIUI_ShowNonCompatibleApps() {
     AppBundlesVisibilityManager appBundlesVisibilityManager =
-        new AppBundlesVisibilityManager(false, true, () -> false);
+        new AppBundlesVisibilityManager(false, true, getMockedSettingsValuesProvider(false, false));
 
     assertTrue(appBundlesVisibilityManager.shouldEnableAppBundles());
   }
 
   @Test public void shouldEnableAppBundles_NonMIUI_ShowNonCompatibleApps() {
     AppBundlesVisibilityManager appBundlesVisibilityManager =
-        new AppBundlesVisibilityManager(false, false, () -> false);
+        new AppBundlesVisibilityManager(false, false,
+            getMockedSettingsValuesProvider(false, false));
 
     assertTrue(appBundlesVisibilityManager.shouldEnableAppBundles());
   }
 
   @Test public void shouldEnableAppBundles_NonMIUI_CompatibleAppsOnly() {
     AppBundlesVisibilityManager appBundlesVisibilityManager =
-        new AppBundlesVisibilityManager(false, false, () -> true);
+        new AppBundlesVisibilityManager(false, false, getMockedSettingsValuesProvider(true, false));
 
     assertTrue(appBundlesVisibilityManager.shouldEnableAppBundles());
+  }
+
+  @Test public void shouldEnableAppBundles_EnforceNativeInstaller() {
+    AppBundlesVisibilityManager appBundlesVisibilityManager =
+        new AppBundlesVisibilityManager(false, false, getMockedSettingsValuesProvider(true, true));
+
+    assertFalse(appBundlesVisibilityManager.shouldEnableAppBundles());
+  }
+
+  private SettingsValuesProvider getMockedSettingsValuesProvider(boolean isOnlyShowCompatibleApps,
+      boolean isEnforceNativeInstaller) {
+    return new SettingsValuesProvider() {
+      @Override public boolean isOnlyShowCompatibleApps() {
+        return isOnlyShowCompatibleApps;
+      }
+
+      @Override public boolean isEnforceNativeInstaller() {
+        return isEnforceNativeInstaller;
+      }
+    };
   }
 }


### PR DESCRIPTION
**What does this PR do?**

   new setting - enforce native installer. This will allow Xiaomi users to recover from the state of not being able to install any application in the app because of the PackageInstaller.


EDIT: Strings on this branch are on temporary. The ones from dev are the correct ones.

**Database changed?**

  No

**Where should the reviewer start?**

- [ ] settings.xml
- [ ] AppBundlesVisibilityManager.java
- [ ] InstallManager.java

**How should this be manually tested?**

  - Test installations with both setting on/off on Xiaomi and non-xiaomi devices.


**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-103](https://aptoide.atlassian.net/browse/APP-103)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass