### PR TITLE
[APP-118] feature: support new web pattern /app for both http and https

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -388,6 +388,21 @@
 
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
+        <data
+            android:host="*.aptoide.com"
+            android:pathPattern="/app"
+            android:scheme="http" />
+        <data
+            android:host="*.aptoide.com"
+            android:pathPattern="/app"
+            android:scheme="https" />
+      </intent-filter>
+
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
 
         <data
             android:host="*.aptoide.com"


### PR DESCRIPTION
**What does this PR do?**

   Support new web pattern /app for both http and https
   Example: https://game-of-sultans.en.aptoide.com/app

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AndroidManifest.xml

**How should this be manually tested?**

  Test both deeplinks:
  - adb shell am start -a "android.intent.action.VIEW" -d "https://game-of-sultans.en.aptoide.com/app"
  - adb shell am start -a "android.intent.action.VIEW" -d "http://game-of-sultans.en.aptoide.com/app"

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-118](https://aptoide.atlassian.net/browse/APP-118)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass