### PR TITLE
[APP-133] Clearing obbs folder for the app before moving them

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/install/installer/DefaultInstaller.java
+++ b/app/src/main/java/cm/aptoide/pt/install/installer/DefaultInstaller.java
@@ -282,6 +282,8 @@ public class DefaultInstaller implements Installer {
     boolean filesMoved = false;
     String destinationPath = OBB_FOLDER + installation.getPackageName() + "/";
 
+    fileUtils.deleteDir(new File(destinationPath));
+
     for (RoomFileToDownload file : installation.getFiles()) {
 
       if (file.getFileType() == RoomFileToDownload.OBB
@@ -289,7 +291,6 @@ public class DefaultInstaller implements Installer {
           && !file.getPath()
           .equals(destinationPath)) {
         fileUtils.copyFile(file.getPath(), destinationPath, file.getFileName());
-        FileUtils.removeFile(file.getPath());
         file.setPath(destinationPath);
         filesMoved = true;
       }


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing a bug where after an app with obbs gets updated, the old obbs would still remain inside the obbs folder.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] DefaultInstaller.java

**How should this be manually tested?**

Download the PUBG versions just like it is in the ticket and check if there are more than one version of obb files.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-133](https://aptoide.atlassian.net/browse/APP-133)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass