### PR TITLE
[APP-30] Fix out of space dialog title size

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/download/view/outofspace/OutOfSpaceDialogFragment.kt
+++ b/app/src/main/java/cm/aptoide/pt/download/view/outofspace/OutOfSpaceDialogFragment.kt
@@ -98,12 +98,10 @@ class OutOfSpaceDialogFragment : BaseDialogView(), OutOfSpaceDialogView {
     out_of_space_description.text = spannable
   }
 
-  override fun requiredSpaceToInstall(removedAppsize: Long) {
-    val missingRequiredSpace = requiredSpace - removedAppsize
+  override fun requiredSpaceToInstall(requiredAppSpace: Long) {
     val requiredSpaceString: String =
-        AptoideUtils.StringU.formatBytes(missingRequiredSpace, false)
+        AptoideUtils.StringU.formatBytes(requiredAppSpace, false)
     setOutOfSpaceMessage(requiredSpaceString)
-    requiredSpace = missingRequiredSpace
   }
 
   override fun showGeneralOutOfSpaceError() {

--- a/app/src/main/java/cm/aptoide/pt/download/view/outofspace/OutOfSpaceDialogFragment.kt
+++ b/app/src/main/java/cm/aptoide/pt/download/view/outofspace/OutOfSpaceDialogFragment.kt
@@ -24,13 +24,13 @@ class OutOfSpaceDialogFragment : BaseDialogView(), OutOfSpaceDialogView {
   private var requiredSpace: Long = 0
 
   companion object {
-    const val REQUIRED_SPACE = "required_space"
+    const val APP_SIZE = "app_size"
     const val APP_PACKAGE_NAME = "package_name"
     const val OUT_OF_SPACE_REQUEST_CODE = 1994
 
     fun newInstance(requiredSpace: Long, packageName: String) = OutOfSpaceDialogFragment().apply {
       arguments = Bundle(2).apply {
-        putLong(REQUIRED_SPACE, requiredSpace)
+        putLong(APP_SIZE, requiredSpace)
         putString(APP_PACKAGE_NAME, packageName)
       }
     }
@@ -39,7 +39,7 @@ class OutOfSpaceDialogFragment : BaseDialogView(), OutOfSpaceDialogView {
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
     arguments?.let {
-      requiredSpace = arguments!!.getLong(REQUIRED_SPACE)
+      requiredSpace = arguments!!.getLong(APP_SIZE)
     }
     setupViews(requiredSpace)
     attachPresenter(presenter)

--- a/app/src/main/java/cm/aptoide/pt/download/view/outofspace/OutOfSpaceDialogPresenter.kt
+++ b/app/src/main/java/cm/aptoide/pt/download/view/outofspace/OutOfSpaceDialogPresenter.kt
@@ -14,9 +14,20 @@ class OutOfSpaceDialogPresenter(private val view: OutOfSpaceDialogView,
 
   override fun present() {
     loadAppsToUninstall()
+    loadRequiredStorageSize()
     uninstallApp()
     handleDismissDialogButtonClick()
     handleUninstalledEnoughApps()
+  }
+
+  private fun loadRequiredStorageSize() {
+    view.lifecycleEvent
+        .filter { lifecycleEvent -> lifecycleEvent == View.LifecycleEvent.CREATE }
+        .flatMapSingle { outOfSpaceManager.getRequiredStorageSize() }
+        .doOnNext {
+          view.requiredSpaceToInstall(it)
+        }.compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
+        .subscribe({}, { e -> crashReporter.log(e) })
   }
 
   private fun handleUninstalledEnoughApps() {

--- a/app/src/main/java/cm/aptoide/pt/download/view/outofspace/OutOfSpaceManager.kt
+++ b/app/src/main/java/cm/aptoide/pt/download/view/outofspace/OutOfSpaceManager.kt
@@ -8,10 +8,10 @@ import rx.subjects.PublishSubject
 
 class OutOfSpaceManager(
     private val installManager: InstallManager,
-    private val requiredSpace: Long,
+    private val appSize: Long,
     private val uninstalledEnoughApps: PublishSubject<Void>) {
 
-  private var uninstalledSpace: Long = requiredSpace
+  private var uninstalledSpace: Long = appSize
 
 
   fun getInstalledApps(): Observable<List<InstalledApp>> {

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -766,7 +766,7 @@ import rx.subscriptions.CompositeSubscription;
   @FragmentScope @Provides OutOfSpaceManager providesOutOfSpaceManager(
       InstallManager installManager) {
     return new OutOfSpaceManager(installManager,
-        arguments.getLong(OutOfSpaceDialogFragment.REQUIRED_SPACE), PublishSubject.create());
+        arguments.getLong(OutOfSpaceDialogFragment.APP_SIZE), PublishSubject.create());
   }
 
   @FragmentScope @Provides EditorialNavigator providesEditorialNavigator(AppNavigator appNavigator,

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -138,6 +138,7 @@ import cm.aptoide.pt.home.more.apps.ListAppsMoreManager;
 import cm.aptoide.pt.home.more.apps.ListAppsMorePresenter;
 import cm.aptoide.pt.home.more.apps.ListAppsMoreRepository;
 import cm.aptoide.pt.install.InstallAnalytics;
+import cm.aptoide.pt.install.InstallAppSizeValidator;
 import cm.aptoide.pt.install.InstallManager;
 import cm.aptoide.pt.navigator.ActivityNavigator;
 import cm.aptoide.pt.navigator.FragmentNavigator;
@@ -764,9 +765,10 @@ import rx.subscriptions.CompositeSubscription;
   }
 
   @FragmentScope @Provides OutOfSpaceManager providesOutOfSpaceManager(
-      InstallManager installManager) {
+      InstallManager installManager, InstallAppSizeValidator installAppSizeValidator) {
     return new OutOfSpaceManager(installManager,
-        arguments.getLong(OutOfSpaceDialogFragment.APP_SIZE), PublishSubject.create());
+        arguments.getLong(OutOfSpaceDialogFragment.APP_SIZE), PublishSubject.create(),
+        installAppSizeValidator);
   }
 
   @FragmentScope @Provides EditorialNavigator providesEditorialNavigator(AppNavigator appNavigator,


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing the size we display on the out of space dialog. Before we were displaying the size of the app we need to install, but after some testing we realizaed it wouldn't make sense. It should be the appsize - available storage, meaning we would only have to get the missing space instead of the whole app space.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] OutOfSpaceDialogManager.kt

**How should this be manually tested?**

Same as before. Try to get a device with lower storage (can user an emulator where you can set your own memory values) and perform the flow of downloading an app that does not fit in order to get to the dialog. 

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-30](https://aptoide.atlassian.net/browse/APP-30)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass