### PR TITLE
[APP-426] Apps BN does not open if autoupdate is running

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/autoupdate/AutoUpdateManager.kt
+++ b/app/src/main/java/cm/aptoide/pt/autoupdate/AutoUpdateManager.kt
@@ -33,8 +33,8 @@ open class AutoUpdateManager(private val downloadFactory: DownloadFactory,
           .flatMapCompletable { download ->
             installManager.install(download, shouldInstall)
                 .doOnSubscribe {
-                  downloadAnalytics.downloadStartEvent(download, AnalyticsManager.Action.CLICK
-                      , DownloadAnalytics.AppContext.AUTO_UPDATE, false)
+                  downloadAnalytics.downloadStartEvent(download, AnalyticsManager.Action.CLICK,
+                      DownloadAnalytics.AppContext.AUTO_UPDATE, false)
                 }
           }
           .toCompletable()
@@ -83,7 +83,7 @@ open class AutoUpdateManager(private val downloadFactory: DownloadFactory,
   private fun getInstall(): Observable<Install> {
     return getAutoUpdateModel().flatMap {
       installManager.getInstall(it.md5,
-              it.packageName, it.versionCode)
+          it.packageName, it.versionCode)
           .first { install -> install.hasDownloadStarted() }
     }
   }

--- a/app/src/main/java/cm/aptoide/pt/download/DownloadFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/download/DownloadFactory.java
@@ -157,6 +157,7 @@ public class DownloadFactory {
     download.setVersionCode(versionCode);
     download.setPackageName(packageName);
     download.setVersionName(versionName);
+    download.setIcon("");
     download.setAction(RoomDownload.ACTION_UPDATE);
     download.setHasAppc(hasAppc);
     download.setSize(0);


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing a bug where Apps BN section wouldn't open if the auto update download was running in the background.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Foo.java
- [ ] Bar.kt

**How should this be manually tested?**

  Set the app to perform the auto update and then try to open the Apps BN section

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-426](https://aptoide.atlassian.net/browse/APP-426)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass