### PR TITLE
[APP-538] Update appc info view with eskills

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/app/view/AppCoinsInfoFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppCoinsInfoFragment.java
@@ -127,7 +127,7 @@ public class AppCoinsInfoFragment extends BackButtonFragment
     setHasOptionsMenu(true);
     setupToolbar();
     setupBottomAppBar();
-    youtubePlayer.loadVideo("j-Ejvmy5pUs", true);
+    youtubePlayer.loadVideo("uwoq5sLzZrs", true);
     attachPresenter(appCoinsInfoPresenter);
   }
 

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppCoinsInfoFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppCoinsInfoFragment.java
@@ -7,6 +7,10 @@ import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.text.Html;
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.method.LinkMovementMethod;
+import android.text.style.ClickableSpan;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -38,6 +42,7 @@ import com.jakewharton.rxbinding.view.RxView;
 import javax.inject.Inject;
 import javax.inject.Named;
 import rx.Observable;
+import rx.subjects.PublishSubject;
 
 /**
  * Created by D01 on 30/07/2018.
@@ -64,7 +69,9 @@ public class AppCoinsInfoFragment extends BackButtonFragment
   private NestedScrollView scrollView;
   private TextView appcMessageAppCoinsSection1;
   private TextView appcMessageAppcoinsSection3;
+  private TextView appcMessageAppcoinsSection4;
   private SocialMediaView socialMediaView;
+  private PublishSubject<Void> eSkillsClick;
 
   @Override public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -79,6 +86,7 @@ public class AppCoinsInfoFragment extends BackButtonFragment
     scrollView = view.findViewById(R.id.about_appcoins_scroll);
     appcMessageAppcoinsSection2a = view.findViewById(R.id.appc_message_appcoins_section_2a);
     appcMessageAppcoinsSection3 = view.findViewById(R.id.appc_message_appcoins_section_3);
+    appcMessageAppcoinsSection4 = view.findViewById(R.id.appc_message_appcoins_section_4);
 
     youtubePlayer = view.findViewById(R.id.youtube_player);
 
@@ -113,6 +121,9 @@ public class AppCoinsInfoFragment extends BackButtonFragment
 
     socialMediaView = view.findViewById(R.id.social_media_view);
 
+    eSkillsClick = PublishSubject.create();
+    setESkillsTextView();
+
     setHasOptionsMenu(true);
     setupToolbar();
     setupBottomAppBar();
@@ -123,6 +134,25 @@ public class AppCoinsInfoFragment extends BackButtonFragment
   @Override public ScreenTagHistory getHistoryTracker() {
     return ScreenTagHistory.Builder.build(this.getClass()
         .getSimpleName());
+  }
+
+  private void setESkillsTextView() {
+    String baseMessage = getString(R.string.appc_info_view_eskills_body);
+    String clickMessage = getString(R.string.appc_info_view_eskills_body_button);
+    String eSkillsMessage = String.format(baseMessage, clickMessage);
+
+    SpannableString eSkillsSpan = new SpannableString(eSkillsMessage);
+    ClickableSpan eSkillsClickSpan = new ClickableSpan() {
+      @Override public void onClick(View view) {
+        eSkillsClick.onNext(null);
+      }
+    };
+    eSkillsSpan.setSpan(eSkillsClickSpan, eSkillsMessage.indexOf(clickMessage),
+        eSkillsMessage.indexOf(clickMessage) + clickMessage.length(),
+        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+    appcMessageAppcoinsSection4.setText(eSkillsSpan);
+    appcMessageAppcoinsSection4.setMovementMethod(LinkMovementMethod.getInstance());
   }
 
   private void setupBottomAppBar() {
@@ -138,12 +168,23 @@ public class AppCoinsInfoFragment extends BackButtonFragment
         });
   }
 
+  @Override public void onDestroy() {
+    super.onDestroy();
+    eSkillsClick = null;
+  }
+
   @Override public void onDestroyView() {
     toolbar = null;
     appCardView = null;
     installButton = null;
     bottomInstallButton = null;
+    catappultDevButton = null;
+    appcMessageAppCoinsSection1 = null;
     appcMessageAppcoinsSection2a = null;
+    appcMessageAppcoinsSection3 = null;
+    appcMessageAppcoinsSection4 = null;
+    youtubePlayer = null;
+    scrollView = null;
     socialMediaView = null;
     super.onDestroyView();
   }
@@ -243,6 +284,10 @@ public class AppCoinsInfoFragment extends BackButtonFragment
     appcMessageAppCoinsSection1.setText(getString(R.string.appc_info_view_body_1_variable_no_data));
     setupTextView(getString(R.string.appc_info_view_title_5_variable_no_data),
         appcMessageAppcoinsSection3, getAppCoinsLogoString());
+  }
+
+  @Override public Observable<Void> eSkillsClick() {
+    return eSkillsClick;
   }
 
   private String getAppCoinsLogoString() {

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppCoinsInfoFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppCoinsInfoFragment.java
@@ -63,7 +63,7 @@ public class AppCoinsInfoFragment extends BackButtonFragment
   private Button catappultDevButton;
   private NestedScrollView scrollView;
   private TextView appcMessageAppCoinsSection1;
-  private TextView appcMessageAppcoinsSection4;
+  private TextView appcMessageAppcoinsSection3;
   private SocialMediaView socialMediaView;
 
   @Override public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -78,7 +78,7 @@ public class AppCoinsInfoFragment extends BackButtonFragment
     catappultDevButton = view.findViewById(R.id.catappult_dev_button);
     scrollView = view.findViewById(R.id.about_appcoins_scroll);
     appcMessageAppcoinsSection2a = view.findViewById(R.id.appc_message_appcoins_section_2a);
-    appcMessageAppcoinsSection4 = view.findViewById(R.id.appc_message_appcoins_section_4);
+    appcMessageAppcoinsSection3 = view.findViewById(R.id.appc_message_appcoins_section_3);
 
     youtubePlayer = view.findViewById(R.id.youtube_player);
 
@@ -235,14 +235,14 @@ public class AppCoinsInfoFragment extends BackButtonFragment
     appcMessageAppCoinsSection1.setText(
         String.format(getString(R.string.appc_info_view_body_1_variable), bonusAppc));
 
-    setupTextView(getString(R.string.appc_info_view_title_5_variable), appcMessageAppcoinsSection4,
+    setupTextView(getString(R.string.appc_info_view_title_5_variable), appcMessageAppcoinsSection3,
         bonusAppc, getAppCoinsLogoString());
   }
 
   @Override public void setNoBonusAppcView() {
     appcMessageAppCoinsSection1.setText(getString(R.string.appc_info_view_body_1_variable_no_data));
     setupTextView(getString(R.string.appc_info_view_title_5_variable_no_data),
-        appcMessageAppcoinsSection4, getAppCoinsLogoString());
+        appcMessageAppcoinsSection3, getAppCoinsLogoString());
   }
 
   private String getAppCoinsLogoString() {

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppCoinsInfoView.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppCoinsInfoView.java
@@ -34,4 +34,6 @@ public interface AppCoinsInfoView extends View {
   void setBonusAppc(int bonusPercentage);
 
   void setNoBonusAppcView();
+
+  Observable<Void> eSkillsClick();
 }

--- a/app/src/main/java/cm/aptoide/pt/view/AppCoinsInfoNavigator.java
+++ b/app/src/main/java/cm/aptoide/pt/view/AppCoinsInfoNavigator.java
@@ -4,8 +4,12 @@ import android.os.Bundle;
 import cm.aptoide.aptoideviews.socialmedia.SocialMediaView;
 import cm.aptoide.pt.CatappultNavigator;
 import cm.aptoide.pt.app.view.AppViewFragment;
+import cm.aptoide.pt.dataprovider.model.v7.Event;
+import cm.aptoide.pt.dataprovider.ws.v7.store.StoreContext;
+import cm.aptoide.pt.home.bundles.base.HomeEvent;
 import cm.aptoide.pt.navigator.FragmentNavigator;
 import cm.aptoide.pt.socialmedia.SocialMediaNavigator;
+import cm.aptoide.pt.store.view.StoreTabGridRecyclerFragment;
 
 /**
  * Created by D01 on 02/08/2018.
@@ -40,5 +44,16 @@ public class AppCoinsInfoNavigator {
 
   public void navigateToCatappultWebsite() {
     catappultNavigator.navigateToCatappultWebsite();
+  }
+
+  public void navigateToESkills() {
+    Event event = new Event();
+    event.setAction(null);
+    event.setData(null);
+    event.setType(null);
+    event.setName(Event.Name.eSkills);
+    fragmentNavigator.navigateTo(
+        StoreTabGridRecyclerFragment.newInstance(event, HomeEvent.Type.ESKILLS, "e-Skills",
+            "default", "eskills", StoreContext.home, true), true);
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/view/AppCoinsInfoPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/view/AppCoinsInfoPresenter.java
@@ -5,7 +5,6 @@ import cm.aptoide.pt.AppCoinsManager;
 import cm.aptoide.pt.app.view.AppCoinsInfoView;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.install.InstallManager;
-import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.presenter.Presenter;
 import cm.aptoide.pt.presenter.View;
 import cm.aptoide.pt.socialmedia.SocialMediaAnalytics;
@@ -60,11 +59,7 @@ public class AppCoinsInfoPresenter implements Presenter {
         .doOnNext(socialMediaType -> appCoinsInfoNavigator.navigateToESkills())
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(__ -> {
-        }, throwable -> {
-          Logger.getInstance()
-              .d("lol", "got an erorr");
-          crashReport.log(throwable);
-        });
+        }, crashReport::log);
   }
 
   private void handleBonusPercentage() {

--- a/app/src/main/java/cm/aptoide/pt/view/AppCoinsInfoPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/view/AppCoinsInfoPresenter.java
@@ -55,6 +55,7 @@ public class AppCoinsInfoPresenter implements Presenter {
     view.getLifecycleEvent()
         .filter(event -> event.equals(View.LifecycleEvent.CREATE))
         .flatMapSingle(__ -> RxJavaInterop.toV1Single(appCoinsManager.getBonusAppc()))
+        .observeOn(viewScheduler)
         .doOnNext(bonusAppcModel -> {
           if (bonusAppcModel.getHasBonusAppc()) {
             view.setBonusAppc(bonusAppcModel.getBonusPercentage());

--- a/app/src/main/java/cm/aptoide/pt/view/AppCoinsInfoPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/view/AppCoinsInfoPresenter.java
@@ -5,6 +5,7 @@ import cm.aptoide.pt.AppCoinsManager;
 import cm.aptoide.pt.app.view.AppCoinsInfoView;
 import cm.aptoide.pt.crashreports.CrashReport;
 import cm.aptoide.pt.install.InstallManager;
+import cm.aptoide.pt.logger.Logger;
 import cm.aptoide.pt.presenter.Presenter;
 import cm.aptoide.pt.presenter.View;
 import cm.aptoide.pt.socialmedia.SocialMediaAnalytics;
@@ -49,6 +50,21 @@ public class AppCoinsInfoPresenter implements Presenter {
     handlePlaceHolderVisibilityChange();
     handleSocialMediaPromotionClick();
     handleBonusPercentage();
+    handleOpenESkills();
+  }
+
+  private void handleOpenESkills() {
+    view.getLifecycleEvent()
+        .filter(event -> event.equals(View.LifecycleEvent.CREATE))
+        .flatMap(__ -> view.eSkillsClick())
+        .doOnNext(socialMediaType -> appCoinsInfoNavigator.navigateToESkills())
+        .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
+        .subscribe(__ -> {
+        }, throwable -> {
+          Logger.getInstance()
+              .d("lol", "got an erorr");
+          crashReport.log(throwable);
+        });
   }
 
   private void handleBonusPercentage() {

--- a/app/src/main/res/layout/fragment_appcoins_info.xml
+++ b/app/src/main/res/layout/fragment_appcoins_info.xml
@@ -269,7 +269,6 @@
               android:layout_width="0dp"
               android:layout_height="wrap_content"
               android:layout_marginTop="9dp"
-              android:paddingBottom="20dp"
               android:text="@string/appc_info_view_title_5_variable"
               app:layout_constraintEnd_toStartOf="@+id/guideline_right"
               app:layout_constraintHorizontal_bias="0"

--- a/app/src/main/res/layout/fragment_appcoins_info.xml
+++ b/app/src/main/res/layout/fragment_appcoins_info.xml
@@ -251,7 +251,7 @@
           </FrameLayout>
 
           <TextView
-              android:id="@+id/appc_message_appcoins_header_4"
+              android:id="@+id/appc_message_appcoins_header_3"
               style="@style/Aptoide.TextView.Medium.M.BlackAlpha"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
@@ -264,7 +264,7 @@
               />
 
           <TextView
-              android:id="@+id/appc_message_appcoins_section_4"
+              android:id="@+id/appc_message_appcoins_section_3"
               style="@style/Aptoide.TextView.Regular.M.BlackAlpha"
               android:layout_width="0dp"
               android:layout_height="wrap_content"
@@ -274,7 +274,7 @@
               app:layout_constraintEnd_toStartOf="@+id/guideline_right"
               app:layout_constraintHorizontal_bias="0"
               app:layout_constraintStart_toStartOf="@id/guideline_left"
-              app:layout_constraintTop_toBottomOf="@+id/appc_message_appcoins_header_4"
+              app:layout_constraintTop_toBottomOf="@+id/appc_message_appcoins_header_3"
               />
 
           <androidx.constraintlayout.widget.Guideline

--- a/app/src/main/res/layout/fragment_appcoins_info.xml
+++ b/app/src/main/res/layout/fragment_appcoins_info.xml
@@ -277,6 +277,33 @@
               app:layout_constraintTop_toBottomOf="@+id/appc_message_appcoins_header_3"
               />
 
+          <TextView
+              android:id="@+id/appc_message_appcoins_header_4"
+              style="@style/Aptoide.TextView.Medium.M.BlackAlpha"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_marginTop="19dp"
+              android:text="@string/appc_info_view_eskills_title"
+              app:layout_constraintEnd_toStartOf="@+id/guideline_right"
+              app:layout_constraintHorizontal_bias="0"
+              app:layout_constraintStart_toStartOf="@id/guideline_left"
+              app:layout_constraintTop_toBottomOf="@+id/appc_message_appcoins_section_3"
+              />
+
+          <TextView
+              android:id="@+id/appc_message_appcoins_section_4"
+              style="@style/Aptoide.TextView.Regular.M.BlackAlpha"
+              android:layout_width="0dp"
+              android:layout_height="wrap_content"
+              android:layout_marginTop="9dp"
+              android:paddingBottom="20dp"
+              android:text="@string/appc_info_view_eskills_body"
+              app:layout_constraintEnd_toStartOf="@+id/guideline_right"
+              app:layout_constraintHorizontal_bias="0"
+              app:layout_constraintStart_toStartOf="@id/guideline_left"
+              app:layout_constraintTop_toBottomOf="@+id/appc_message_appcoins_header_4"
+              />
+
           <androidx.constraintlayout.widget.Guideline
               android:id="@+id/guideline_left"
               android:layout_width="wrap_content"


### PR DESCRIPTION
**What does this PR do?**

This PR aims at implementing the eskills information inside the appc info view.
Also changed the youtube video being displayed there for a new one.

Also fixed a navigation/thread bug we had where if the user navigated to the appcoins info view and then navigated back, the app would be unusable.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppCoinsInfoFragment.java

**How should this be manually tested?**

Open the view, check that everything is ok. Click on the "here" button and check that you can navigate to the eskills more bundle view.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-538](https://aptoide.atlassian.net/browse/APP-538)

[APP-564](https://aptoide.atlassian.net/browse/APP-564)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass