### PR TITLE
[APP-585] Update apps with aab

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/database/RoomDownloadPersistence.java
+++ b/app/src/main/java/cm/aptoide/pt/database/RoomDownloadPersistence.java
@@ -19,7 +19,7 @@ import rx.schedulers.Schedulers;
 
 public class RoomDownloadPersistence implements DownloadPersistence {
 
-  private DownloadDAO downloadDAO;
+  private final DownloadDAO downloadDAO;
 
   public RoomDownloadPersistence(DownloadDAO downloadDAO) {
     this.downloadDAO = downloadDAO;
@@ -80,5 +80,9 @@ public class RoomDownloadPersistence implements DownloadPersistence {
         BackpressureStrategy.BUFFER)
         .onErrorReturn(throwable -> new ArrayList<>())
         .subscribeOn(Schedulers.io());
+  }
+
+  @Override public Completable delete(String packageName, int versionCode) {
+    return Completable.fromAction(() -> downloadDAO.remove(packageName, versionCode));
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
@@ -171,7 +171,12 @@ public class AppsManager {
               .flatMapSingle(installManager::filterInstalled)
               .filter(installed -> installed != null)
               .doOnNext(item -> Logger.getInstance()
-                  .d("Apps", "filtered installed - is not installed -> " + item.getPackageName()))
+                  .d("Apps", "filtered installed - is not installed -> "
+                      + item.getPackageName()
+                      + " "
+                      + item.getMd5()
+                      + " "
+                      + item.getVersionName()))
               .toList()
               .doOnNext(__ -> Logger.getInstance()
                   .d("Apps", "emit list of installs from getDownloadApps - after toList"))

--- a/app/src/main/java/cm/aptoide/pt/install/InstallManager.java
+++ b/app/src/main/java/cm/aptoide/pt/install/InstallManager.java
@@ -58,8 +58,8 @@ public class InstallManager {
   private final InstallAppSizeValidator installAppSizeValidator;
   private final FileManager fileManager;
 
-  private CompositeSubscription dispatchInstallationsSubscription = new CompositeSubscription();
-  private PublishSubject<InstallCandidate> installCandidateSubject = PublishSubject.create();
+  private final CompositeSubscription dispatchInstallationsSubscription = new CompositeSubscription();
+  private final PublishSubject<InstallCandidate> installCandidateSubject = PublishSubject.create();
 
   public InstallManager(Context context, AptoideDownloadManager aptoideDownloadManager,
       Installer installer, RootAvailabilityManager rootAvailabilityManager,
@@ -615,7 +615,9 @@ public class InstallManager {
           if (databaseInstalled.getVersionCode() == installed.getVersionCode()) {
             installed.setType(databaseInstalled.getType());
             installed.setStatus(RoomInstalled.STATUS_COMPLETED);
-            return installedRepository.save(installed);
+            return installedRepository.save(installed)
+                .andThen(downloadRepository.remove(installed.getPackageName(),
+                    installed.getVersionCode()));
           } else {
             return installedRepository.remove(databaseInstalled.getPackageName(),
                 databaseInstalled.getVersionCode());

--- a/aptoide-database/src/main/java/cm/aptoide/pt/database/room/DownloadDAO.java
+++ b/aptoide-database/src/main/java/cm/aptoide/pt/database/room/DownloadDAO.java
@@ -13,12 +13,16 @@ import static androidx.room.OnConflictStrategy.REPLACE;
 
   @Query("SELECT * from download") Observable<List<RoomDownload>> getAll();
 
-  @Query("SELECT * from download where md5 = :md5 LIMIT 1 ") Single<RoomDownload> getAsSingle(String md5);
+  @Query("SELECT * from download where md5 = :md5 LIMIT 1 ") Single<RoomDownload> getAsSingle(
+      String md5);
 
-  @Query("SELECT * from download where md5 = :md5 LIMIT 1 ") Observable<RoomDownload> getAsObservable(String md5);
-
+  @Query("SELECT * from download where md5 = :md5 LIMIT 1 ")
+  Observable<RoomDownload> getAsObservable(String md5);
 
   @Query("DELETE from download where md5= :md5") void remove(String md5);
+
+  @Query("DELETE from download where packageName=:packageName and versionCode=:versionCode")
+  void remove(String packageName, int versionCode);
 
   @Insert(onConflict = REPLACE) void insertAll(List<RoomDownload> downloads);
 

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/DownloadPersistence.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/DownloadPersistence.java
@@ -25,4 +25,6 @@ public interface DownloadPersistence {
   Observable<List<RoomDownload>> getAsList(String md5);
 
   Observable<List<RoomDownload>> getUnmovedFilesDownloads();
+
+  Completable delete(String packageName, int versionCode);
 }

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/DownloadsRepository.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/DownloadsRepository.java
@@ -12,7 +12,7 @@ import rx.Single;
 
 public class DownloadsRepository {
 
-  private DownloadPersistence downloadPersistence;
+  private final DownloadPersistence downloadPersistence;
 
   public DownloadsRepository(DownloadPersistence downloadPersistence) {
     this.downloadPersistence = downloadPersistence;
@@ -24,6 +24,10 @@ public class DownloadsRepository {
 
   public Completable remove(String md5) {
     return downloadPersistence.delete(md5);
+  }
+
+  public Completable remove(String packageName, int versionCode) {
+    return downloadPersistence.delete(packageName, versionCode);
   }
 
   public Single<RoomDownload> getDownloadAsSingle(String md5) {


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at fixing an issue in the apps bottom navigation section where we would have multiple entries from the same app on the ready to install state.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] InstallManager.java

**How should this be manually tested?**

 Install an older version from Netflix, then go to apps, pull to refresh to get the update for that recently installed app and then update that app. Confirm that we only have one entry on ready to install after the download is performed.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-585](https://aptoide.atlassian.net/browse/APP-585)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass