### PR TITLE
[APP-704] fix: download url is null

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/download/DownloadFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/download/DownloadFactory.java
@@ -82,24 +82,22 @@ public class DownloadFactory {
 
     if (mainObbPath != null) {
       downloads.add(
-          RoomFileToDownload.createFileToDownload(mainObbPath, null, mainObbMd5, mainObbName,
+          RoomFileToDownload.createFileToDownload(mainObbPath, mainObbPath, mainObbMd5, mainObbName,
               RoomFileToDownload.OBB, packageName, versionCode, versionName, cachePath,
               RoomFileToDownload.MAIN));
     }
 
     if (patchObbPath != null) {
-      downloads.add(
-          RoomFileToDownload.createFileToDownload(patchObbPath, null, patchObbMd5, patchObbName,
-              RoomFileToDownload.OBB, packageName, versionCode, versionName, cachePath,
-              RoomFileToDownload.PATCH));
+      downloads.add(RoomFileToDownload.createFileToDownload(patchObbPath, patchObbPath, patchObbMd5,
+          patchObbName, RoomFileToDownload.OBB, packageName, versionCode, versionName, cachePath,
+          RoomFileToDownload.PATCH));
     }
 
     if (splits != null) {
       for (Split split : splits) {
-        downloads.add(
-            RoomFileToDownload.createFileToDownload(split.getPath(), null, split.getMd5sum(),
-                split.getMd5sum() + "." + split.getName(), RoomFileToDownload.SPLIT, packageName,
-                versionCode, versionName, cachePath, RoomFileToDownload.BASE));
+        downloads.add(RoomFileToDownload.createFileToDownload(split.getPath(), split.getPath(),
+            split.getMd5sum(), split.getMd5sum() + "." + split.getName(), RoomFileToDownload.SPLIT,
+            packageName, versionCode, versionName, cachePath, RoomFileToDownload.BASE));
       }
     }
 
@@ -111,16 +109,16 @@ public class DownloadFactory {
 
           int splitType = splitTypeSubFileTypeMapper.mapSplitToSubFileType(dynamicSplit.getType());
 
-          downloads.add(RoomFileToDownload.createFileToDownload(dynamicSplit.getPath(), null,
-              dynamicSplit.getMd5Sum(), dynamicSplit.getMd5Sum() + "." + dynamicSplit.getName(),
-              RoomFileToDownload.SPLIT, packageName, versionCode, versionName, cachePath,
-              splitType));
+          downloads.add(RoomFileToDownload.createFileToDownload(dynamicSplit.getPath(),
+              dynamicSplit.getPath(), dynamicSplit.getMd5Sum(),
+              dynamicSplit.getMd5Sum() + "." + dynamicSplit.getName(), RoomFileToDownload.SPLIT,
+              packageName, versionCode, versionName, cachePath, splitType));
 
           for (Split configSplit : dynamicSplit.getConfigSplits()) {
-            downloads.add(RoomFileToDownload.createFileToDownload(configSplit.getPath(), null,
-                configSplit.getMd5sum(), configSplit.getMd5sum() + "." + configSplit.getName(),
-                RoomFileToDownload.SPLIT, packageName, versionCode, versionName, cachePath,
-                splitType));
+            downloads.add(RoomFileToDownload.createFileToDownload(configSplit.getPath(),
+                configSplit.getPath(), configSplit.getMd5sum(),
+                configSplit.getMd5sum() + "." + configSplit.getName(), RoomFileToDownload.SPLIT,
+                packageName, versionCode, versionName, cachePath, splitType));
           }
         }
       }


### PR DESCRIPTION
This PR behavior needs to be reviewed by PO.

Avoiding passing null to alternate paths or app will crash when download starts. 

**What does this PR do?**

   Ok so digging into this problem I knew it would be really difficult to reproduce it, since the error ratio is not very high apart from exactly that day (27 oct) where we had a spike.

My first approach was going to be to give more information to the console about exactly what package name and md5 are those errors from with a log on console. 

While doing the implementation, trying to find some apps with splits, I actually ended up crashing Aptoide once with Facebook Messenger. The log was exactly the same and my information was correctly sent to the console. I tried the same download again and no error, the download went well and the app was installed. Because this happened so early on testing my developments I thought I could just brute force it by forcing alot of downloads. 

After 1h  of forcing downloads and also adding other debug tools like charles, couldn’t reproduce again.

Went for Flurry to try to find the log of my device, to try to find the md5 of the facebook messenger version I got the error from. In 100 logs of devices, some came with additional information, which I didn’t see before.

With new information I have a breadcrumb of events before the crash that I can look into, and the clicked on install button gives me the package name. I try to download this package on my device and :boom: 

So, whats happening:

There are actually two issues, one in infrastructure/backend and another one on the client.

   1. Infra/Backend → Some paths are returning 404. The examples I could reproduce are in the ticket.

This is an app with app bundles, both base and the only split that the API returns are giving 404. This situation was reported to INFRA.

   2.  Client → Because of the nature of the splits and how API returns them, we do not have alternate paths for them. We rely on the alternate path of an apk to try a different download url when we have a 404. The alternate path is basically the same source as the main path only with the difference that the url comes with the info of the app base64encoded. This was to try to bypass some restrictions in specific regions like China where urls are blocked. Although it doesn’t currently work today, we still support this flow in the Client. Because the splits do not have a valid altpath, we currently pass nothing to it, and this is the mistake. 

I have made the changes to avoid the crash by passing the main link as the secondary link. This way we do 3 retries again for the same url and only then show an error to the user. Is not not an elegant solution but it will work. The issue with the solution is that we will stop seeing crashes related to this problem on Flurry and Sentry. And we rely on other sources to know what is going on.

The user will be shown the generic error dialog.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] DownloadFactory.java

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-704](https://aptoide.atlassian.net/browse/APP-704)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-704](https://aptoide.atlassian.net/browse/APP-704)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass