### PR TITLE
[APP-676] Fix out of space event

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/database/RoomDownloadPersistence.java
+++ b/app/src/main/java/cm/aptoide/pt/database/RoomDownloadPersistence.java
@@ -85,4 +85,11 @@ public class RoomDownloadPersistence implements DownloadPersistence {
   @Override public Completable delete(String packageName, int versionCode) {
     return Completable.fromAction(() -> downloadDAO.remove(packageName, versionCode));
   }
+
+  @Override public Observable<List<RoomDownload>> getOutOfSpaceDownloads() {
+    return RxJavaInterop.toV1Observable(downloadDAO.getOutOfSpaceDownloads(),
+        BackpressureStrategy.BUFFER)
+        .onErrorReturn(throwable -> new ArrayList<>())
+        .subscribeOn(Schedulers.io());
+  }
 }

--- a/app/src/main/java/cm/aptoide/pt/download/view/DownloadViewActionPresenter.kt
+++ b/app/src/main/java/cm/aptoide/pt/download/view/DownloadViewActionPresenter.kt
@@ -87,8 +87,11 @@ open class DownloadViewActionPresenter(private val installManager: InstallManage
   }
 
   private fun handleOutOfSpaceError(downloadClick: DownloadClick): Completable {
-    return downloadNavigator.openOutOfSpaceDialog(downloadClick.download.size,
-        downloadClick.download.packageName)
+    return Completable.fromAction {
+      downloadAnalytics.sendNotEnoughSpaceError(downloadClick.download.md5)
+    }.andThen(
+        downloadNavigator.openOutOfSpaceDialog(downloadClick.download.size,
+            downloadClick.download.packageName))
         .andThen(downloadNavigator.outOfSpaceDialogResult()
             .filter { result -> result.clearedSuccessfully }).first().toCompletable()
         .andThen(resumeDownload(downloadClick))

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsFragment.java
@@ -31,7 +31,6 @@ import com.jakewharton.rxbinding.view.RxView;
 import javax.inject.Inject;
 import rx.Observable;
 import rx.Single;
-import rx.subjects.PublishSubject;
 
 import static cm.aptoide.pt.utils.GenericDialogs.EResponse.YES;
 
@@ -50,7 +49,6 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
   private ProgressBar progressBar;
   private BottomNavigationActivity bottomNavigationActivity;
   private SwipeRefreshLayout swipeRefreshLayout;
-  private PublishSubject<Void> appcUpgradesSectionLoaded;
 
   private EpoxyRecyclerView appsRecyclerView;
   private AppsController appsController;
@@ -62,7 +60,6 @@ public class AppsFragment extends NavigationTrackFragment implements AppsFragmen
   @Override public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     getFragmentComponent(savedInstanceState).inject(this);
-    appcUpgradesSectionLoaded = PublishSubject.create();
   }
 
   @Override public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsManager.java
@@ -188,6 +188,10 @@ public class AppsManager {
         });
   }
 
+  private void handleNotEnoughSpaceError(String md5) {
+    downloadAnalytics.sendNotEnoughSpaceError(md5);
+  }
+
   public Completable installApp(App app) {
     return installManager.getInstall(((DownloadApp) app).getMd5(),
         ((DownloadApp) app).getPackageName(), ((DownloadApp) app).getVersionCode())
@@ -345,6 +349,13 @@ public class AppsManager {
   @NotNull private Completable updateFirstLoadUpdatesSettings() {
     return Completable.fromAction(
         () -> SecurePreferences.setUpdatesFirstLoad(false, secureSharedPreferences));
+  }
+
+  public Observable<List<String>> observeOutOfSpaceApps() {
+    return installManager.getDownloadOutOfSpaceMd5List()
+        .distinctUntilChanged()
+        .doOnNext(
+            installList -> handleNotEnoughSpaceError(installList.get(installList.size() - 1)));
   }
 }
 

--- a/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/home/apps/AppsPresenter.java
@@ -73,6 +73,16 @@ public class AppsPresenter implements Presenter {
 
     handleRefreshApps();
 
+    handleOutOfSpaceAnalytics();
+  }
+
+  private void handleOutOfSpaceAnalytics() {
+    view.getLifecycleEvent()
+        .filter(lifecycleEvent -> lifecycleEvent == View.LifecycleEvent.CREATE)
+        .flatMap(__ -> appsManager.observeOutOfSpaceApps())
+        .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
+        .subscribe(created -> {
+        }, crashReport::log);
   }
 
   private void handleRefreshApps() {

--- a/app/src/main/java/cm/aptoide/pt/install/InstallAppSizeValidator.kt
+++ b/app/src/main/java/cm/aptoide/pt/install/InstallAppSizeValidator.kt
@@ -9,10 +9,10 @@ import cm.aptoide.pt.utils.FileUtils
 class InstallAppSizeValidator(val filePathProvider: FilePathProvider) {
 
   fun hasEnoughSpaceToInstallApp(download: RoomDownload): Boolean {
-    if (isAppAlreadyDownloaded(download)) {
-      return true
+    return if (isAppAlreadyDownloaded(download)) {
+      true
     } else {
-      return download.size <= getAvailableSpace()
+      download.size <= getAvailableSpace()
     }
   }
 

--- a/app/src/main/java/cm/aptoide/pt/install/InstallManager.java
+++ b/app/src/main/java/cm/aptoide/pt/install/InstallManager.java
@@ -58,7 +58,8 @@ public class InstallManager {
   private final InstallAppSizeValidator installAppSizeValidator;
   private final FileManager fileManager;
 
-  private final CompositeSubscription dispatchInstallationsSubscription = new CompositeSubscription();
+  private final CompositeSubscription dispatchInstallationsSubscription =
+      new CompositeSubscription();
   private final PublishSubject<InstallCandidate> installCandidateSubject = PublishSubject.create();
 
   public InstallManager(Context context, AptoideDownloadManager aptoideDownloadManager,
@@ -755,5 +756,13 @@ public class InstallManager {
         .first()
         .toSingle()
         .map(app -> app.getAppSize());
+  }
+
+  public Observable<List<String>> getDownloadOutOfSpaceMd5List() {
+    return downloadRepository.getOutOfSpaceDownloads()
+        .filter(list -> !list.isEmpty())
+        .flatMap(list -> Observable.from(list)
+            .map(download -> download.getMd5())
+            .toList());
   }
 }

--- a/aptoide-database/src/main/java/cm/aptoide/pt/database/room/DownloadDAO.java
+++ b/aptoide-database/src/main/java/cm/aptoide/pt/database/room/DownloadDAO.java
@@ -45,4 +45,10 @@ import static androidx.room.OnConflictStrategy.REPLACE;
   @Query("SELECT * from download where overallDownloadStatus="
       + RoomDownload.WAITING_TO_MOVE_FILES
       + " ORDER BY timeStamp ASC") Observable<List<RoomDownload>> getUnmovedFilesDownloads();
+
+  @Query("SELECT * from download where overallDownloadStatus="
+      + RoomDownload.ERROR
+      + " and downloadError="
+      + RoomDownload.NOT_ENOUGH_SPACE_ERROR
+      + " ORDER BY timeStamp ASC") Observable<List<RoomDownload>> getOutOfSpaceDownloads();
 }

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/DownloadPersistence.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/DownloadPersistence.java
@@ -27,4 +27,6 @@ public interface DownloadPersistence {
   Observable<List<RoomDownload>> getUnmovedFilesDownloads();
 
   Completable delete(String packageName, int versionCode);
+
+  Observable<List<RoomDownload>> getOutOfSpaceDownloads();
 }

--- a/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/DownloadsRepository.java
+++ b/downloadmanager/src/main/java/cm/aptoide/pt/downloadmanager/DownloadsRepository.java
@@ -69,4 +69,8 @@ public class DownloadsRepository {
                 || download.getOverallDownloadStatus() == (RoomDownload.PENDING))
             .toList());
   }
+
+  public Observable<List<RoomDownload>> getOutOfSpaceDownloads() {
+    return downloadPersistence.getOutOfSpaceDownloads();
+  }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing the download out of space event that was not being sent for the apps BN section and the search higlighted result download view.

**Database changed?**

   Yes (?)

**Where should the reviewer start?**

- [ ] AppsManager.java

**How should this be manually tested?**

Change the InstallAppValidator class in order to return no space available or fill your phone with apps (which will take more time)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-676](https://aptoide.atlassian.net/browse/APP-676)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass