### PR TITLE
[APP-676] fix: search highlighted result view errors not being shown

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/download/view/DownloadViewStatusHelper.kt
+++ b/app/src/main/java/cm/aptoide/pt/download/view/DownloadViewStatusHelper.kt
@@ -22,14 +22,7 @@ class DownloadViewStatusHelper(val context: Context) {
     installButton.setOnClickListener {
       downloadClickSubject.onNext(DownloadClick(download, DownloadEvent.INSTALL))
     }
-    download.downloadModel?.let { downloadModel ->
-      if (downloadModel.downloadState == DownloadStatusModel.DownloadState.GENERIC_ERROR) {
-        downloadClickSubject.onNext(
-            DownloadClick(download, DownloadEvent.GENERIC_ERROR))
-      } else if (downloadModel.downloadState == DownloadStatusModel.DownloadState.NOT_ENOUGH_STORAGE_ERROR) {
-        downloadClickSubject.onNext(DownloadClick(download, DownloadEvent.OUT_OF_SPACE_ERROR))
-      }
-    }
+
     downloadProgressView.setEventListener(object : DownloadEventListener {
       override fun onActionClick(action: DownloadEventListener.Action) {
         when (action.type) {
@@ -44,8 +37,19 @@ class DownloadViewStatusHelper(val context: Context) {
     })
   }
 
-  fun setDownloadStatus(download: Download, installButton: Button,
-                        downloadProgressView: DownloadProgressView) {
+  fun setDownloadStatus(
+    download: Download, installButton: Button,
+    downloadProgressView: DownloadProgressView,
+    downloadClickSubject: PublishSubject<DownloadClick>
+  ) {
+    download.downloadModel?.let { downloadModel ->
+      if (downloadModel.downloadState == DownloadStatusModel.DownloadState.GENERIC_ERROR) {
+        downloadClickSubject.onNext(
+          DownloadClick(download, DownloadEvent.GENERIC_ERROR))
+      } else if (downloadModel.downloadState == DownloadStatusModel.DownloadState.NOT_ENOUGH_STORAGE_ERROR) {
+        downloadClickSubject.onNext(DownloadClick(download, DownloadEvent.OUT_OF_SPACE_ERROR))
+      }
+    }
     download.downloadModel?.let { downloadModel ->
       if (downloadModel.isDownloadingOrInstalling()) {
         setDownloadState(downloadProgressView, downloadModel.progress, downloadModel.downloadState)

--- a/app/src/main/java/cm/aptoide/pt/search/view/item/SearchResultViewHolder.kt
+++ b/app/src/main/java/cm/aptoide/pt/search/view/item/SearchResultViewHolder.kt
@@ -53,7 +53,7 @@ class SearchResultViewHolder(itemView: View,
     val downloadModel = app.downloadModel
     if (app.isHighlightedResult && downloadModel != null) {
       downloadViewStatusHelper.setDownloadStatus(app.download, itemView.install_button,
-          itemView.download_progress_view)
+          itemView.download_progress_view, downloadClickSubject)
       setupMediaAdapter(app.screenshots)
 
       if (!itemView.install_button.hasOnClickListeners()) {


### PR DESCRIPTION
**What does this PR do?**

   Now the highlighted view correctly reacts to download error events since the download state is now being updated correctly to the download state error handler.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] DownloadViewStatusHelper.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-676](https://aptoide.atlassian.net/browse/APP-676)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-676](https://aptoide.atlassian.net/browse/APP-676)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass