### PR TITLE
[APP-968] Handling gdpr dialog acceptance in case it is not the first run

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/presenter/MainPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/presenter/MainPresenter.java
@@ -146,6 +146,18 @@ public class MainPresenter implements Presenter {
           throw new OnErrorNotImplementedException(throwable);
         });
 
+    view.getLifecycleEvent()
+        .filter(event -> View.LifecycleEvent.CREATE.equals(event))
+        .filter(created -> !firstCreated)
+        .flatMap(__ -> view.acceptedGDPR()
+            .map(__1 -> true))
+        .filter(hasAccepted -> hasAccepted)
+        .observeOn(viewScheduler)
+        .doOnNext(__ -> navigate())
+        .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
+        .subscribe(__ -> {
+        }, throwable -> crashReport.log(throwable));
+
     setupInstallErrorsDisplay();
     shortcutManagement();
     setupUpdatesNumber();


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing a bug where if the user rotated the screen and accepted the gdpr dialog, home would not load properly.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] MainPresenter.java

**How should this be manually tested?**

Open home, rotate your screen and check that home loads correctly.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-968](https://aptoide.atlassian.net/browse/APP-968)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass