### PR TITLE
[APP-733] size calculation error

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/download/DownloadFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/download/DownloadFactory.java
@@ -251,6 +251,9 @@ public class DownloadFactory {
     long dynamicSplitsSize = 0;
     for (DynamicSplit dynamicSplit : dynamicSplits) {
       dynamicSplitsSize += dynamicSplit.getFileSize();
+      for (Split configSplit : dynamicSplit.getConfigSplits()) {
+        dynamicSplitsSize += configSplit.getFilesize();
+      }
     }
     return dynamicSplitsSize + appBaseSize;
   }

--- a/app/src/main/java/cm/aptoide/pt/download/DownloadFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/download/DownloadFactory.java
@@ -160,7 +160,7 @@ public class DownloadFactory {
               update.getMainObbMd5(), update.getPatchObbPath(), update.getPatchObbMd5(),
               update.getUpdateVersionCode(), update.getUpdateVersionName(), update.getMainObbName(),
               update.getPatchObbName(), map(update.getRoomSplits()), dynamicSplits));
-      download.setSize(update.getSize());
+      download.setSize(calculateAppSize(update.getSize(), dynamicSplits));
       return download;
     } else {
       throw new InvalidAppException(validationResult.getMessage());

--- a/app/src/main/java/cm/aptoide/pt/download/DownloadFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/download/DownloadFactory.java
@@ -250,9 +250,14 @@ public class DownloadFactory {
   private long calculateAppSize(long appBaseSize, List<DynamicSplit> dynamicSplits) {
     long dynamicSplitsSize = 0;
     for (DynamicSplit dynamicSplit : dynamicSplits) {
-      dynamicSplitsSize += dynamicSplit.getFileSize();
-      for (Split configSplit : dynamicSplit.getConfigSplits()) {
-        dynamicSplitsSize += configSplit.getFilesize();
+
+      if (dynamicSplit.getDeliveryTypes()
+          .contains("INSTALL_TIME")) {
+
+        dynamicSplitsSize += dynamicSplit.getFileSize();
+        for (Split configSplit : dynamicSplit.getConfigSplits()) {
+          dynamicSplitsSize += configSplit.getFilesize();
+        }
       }
     }
     return dynamicSplitsSize + appBaseSize;


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing the bug we had regarding the download percentage.
This bug was happening only on apps with PAD and PFD. The reason for it was that we were only adding the main dynamic split apk size, instead of also summing the config apk's size of those dynamic split apks.

Also took the oportunity to count that size also for the updates, which had not been done previously


**Database changed?**

   No

**Where should the reviewer start?**

- [ ] DownloadFactory.java

**How should this be manually tested?**

Download an app (for example wwe supercard or league of legends: wild rift) and check that everything is ok regarding the app size and download percentage.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-733](https://aptoide.atlassian.net/browse/APP-733)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass