### PR TITLE
[APP-1280] Ready to install notification fix

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/notification/NotificationPolicyFactory.java
+++ b/app/src/main/java/cm/aptoide/pt/notification/NotificationPolicyFactory.java
@@ -1,6 +1,7 @@
 package cm.aptoide.pt.notification;
 
 import cm.aptoide.pt.install.InstalledAppsRepository;
+import cm.aptoide.pt.notification.policies.AlwaysShowPolicy;
 import cm.aptoide.pt.notification.policies.CampaignPolicy;
 import cm.aptoide.pt.notification.policies.DefaultPolicy;
 import cm.aptoide.pt.notification.policies.SocialPolicy;
@@ -12,7 +13,7 @@ import cm.aptoide.pt.notification.policies.SocialPolicy;
 public class NotificationPolicyFactory {
 
   private final NotificationProvider notificationProvider;
-  private InstalledAppsRepository installedAppsRepository;
+  private final InstalledAppsRepository installedAppsRepository;
 
   public NotificationPolicyFactory(NotificationProvider notificationProvider,
       InstalledAppsRepository installedAppsRepository) {
@@ -25,6 +26,7 @@ public class NotificationPolicyFactory {
       case AptoideNotification.APPS_READY_TO_INSTALL:
       case AptoideNotification.NEW_FEATURE:
       case AptoideNotification.APPC_PROMOTION:
+        return new AlwaysShowPolicy();
       case AptoideNotification.CAMPAIGN:
         return new CampaignPolicy(notification.getWhitelistedPackages(), installedAppsRepository);
       case AptoideNotification.COMMENT:

--- a/app/src/main/java/cm/aptoide/pt/notification/policies/AlwaysShowPolicy.java
+++ b/app/src/main/java/cm/aptoide/pt/notification/policies/AlwaysShowPolicy.java
@@ -1,0 +1,10 @@
+package cm.aptoide.pt.notification.policies;
+
+import cm.aptoide.pt.notification.Policy;
+import rx.Single;
+
+public class AlwaysShowPolicy implements Policy {
+  @Override public Single<Boolean> shouldShow() {
+    return Single.just(true);
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

   Fix: because of the new dependencies in the campaign notification (whitelisted packages) the Campaign notification policy should not be reused in other notification types. This creates a new policy, the same as the campaignpolicy used to be, in order to be used for Ready to install, appc promotion and new feature notifications.


**Database changed?**

   No

**Where should the reviewer start?**

- [ ] NotificationPolicyFactory.java

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-1280](https://aptoide.atlassian.net/browse/APP-1280)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-1280](https://aptoide.atlassian.net/browse/APP-1280)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass