### PR TITLE
[APP-1341] Lords Mobile md5

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/download/FileDownloadManagerProvider.java
+++ b/app/src/main/java/cm/aptoide/pt/download/FileDownloadManagerProvider.java
@@ -11,9 +11,9 @@ import rx.subjects.PublishSubject;
 
 public class FileDownloadManagerProvider implements FileDownloaderProvider {
 
-  private String downloadsPath;
-  private com.liulishuo.filedownloader.FileDownloader fileDownloader;
-  private Md5Comparator md5Comparator;
+  private final String downloadsPath;
+  private final com.liulishuo.filedownloader.FileDownloader fileDownloader;
+  private final Md5Comparator md5Comparator;
 
   public FileDownloadManagerProvider(String downloadsPath,
       com.liulishuo.filedownloader.FileDownloader fileDownloader, Md5Comparator md5Comparator) {
@@ -27,8 +27,9 @@ public class FileDownloadManagerProvider implements FileDownloaderProvider {
       String packageName, int versionCode, String fileName,
       PublishSubject<FileDownloadCallback> downloadStatusCallback, String attributionId) {
     return new FileDownloadManager(fileDownloader,
-        new FileDownloadTask(downloadStatusCallback, md5, md5Comparator, fileName, attributionId),
-        downloadsPath, mainDownloadPath, fileType, packageName, versionCode, fileName);
+        new FileDownloadTask(downloadStatusCallback, md5, md5Comparator, fileName, attributionId,
+            !packageName.equals("com.igg.android.lordsmobile")), downloadsPath, mainDownloadPath,
+        fileType, packageName, versionCode, fileName);
   }
 }
 

--- a/app/src/main/java/cm/aptoide/pt/download/FileDownloadTask.java
+++ b/app/src/main/java/cm/aptoide/pt/download/FileDownloadTask.java
@@ -64,7 +64,7 @@ public class FileDownloadTask extends FileDownloadLargeFileListener {
       downloadStatus.onNext(fileDownloadTaskStatus1);
 
       FileDownloadTaskStatus fileDownloadTaskStatus;
-      if (attributionId != null || isMd5Approved(md5, fileName)) {
+      if (attributionId != null || isMd5Approved(md5, fileName, shouldConfirmMd5)) {
         fileDownloadTaskStatus =
             new FileDownloadTaskStatus(AppDownloadStatus.AppDownloadState.COMPLETED,
                 new FileDownloadProgressResult(baseDownloadTask.getLargeFileTotalBytes(),
@@ -122,7 +122,7 @@ public class FileDownloadTask extends FileDownloadLargeFileListener {
         new FileDownloadTaskStatus(AppDownloadStatus.AppDownloadState.WARN, md5, null));
   }
 
-  private boolean isMd5Approved(String md5, String fileName) {
+  private boolean isMd5Approved(String md5, String fileName, boolean shouldConfirmMd5) {
     if (shouldConfirmMd5) {
       return md5Comparator.compareMd5(md5, fileName);
     } else {


### PR DESCRIPTION
**What does this PR do?**

This pr aims at removing the md5 check in lords mobile

**Database changed?**

 No

**Where should the reviewer start?**

- [ ] FileDownloadTask.java

**How should this be manually tested?**

Perform a download of an app different than lords mobile. Confirm that the md5 is checked (there is a log for it with "computeMd5"). Check that there is not that confirmation for the lords mobile download.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-1341](https://aptoide.atlassian.net/browse/APP-1341)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass