### PR TITLE
[APP-1376] Request Apps Flyer impression

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
+++ b/app/src/main/java/cm/aptoide/pt/ApplicationModule.java
@@ -93,6 +93,9 @@ import cm.aptoide.pt.app.DownloadStateParser;
 import cm.aptoide.pt.app.ReviewsManager;
 import cm.aptoide.pt.app.ReviewsRepository;
 import cm.aptoide.pt.app.ReviewsService;
+import cm.aptoide.pt.app.appsflyer.AppsFlyerManager;
+import cm.aptoide.pt.app.appsflyer.AppsFlyerRepository;
+import cm.aptoide.pt.app.appsflyer.AppsFlyerService;
 import cm.aptoide.pt.app.aptoideinstall.AptoideInstallManager;
 import cm.aptoide.pt.app.aptoideinstall.AptoideInstallRepository;
 import cm.aptoide.pt.app.migration.AppcMigrationManager;
@@ -1257,6 +1260,36 @@ import static com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API;
         .addConverterFactory(converterFactory)
         .addCallAdapterFactory(rxCallAdapterFactory)
         .build();
+  }
+
+  @Singleton @Provides AppsFlyerManager providesAppsFlyerManager(
+      AppsFlyerRepository appsFlyerRepository) {
+    return new AppsFlyerManager(appsFlyerRepository);
+  }
+
+  @Singleton @Provides AppsFlyerRepository providesAppsFlyerRepository(
+      AppsFlyerService appsFlyerService) {
+    return new AppsFlyerRepository(appsFlyerService);
+  }
+
+  @Singleton @Provides AppsFlyerService providesAppsFlyerService(
+      @Named("apps-flyer-retrofit") Retrofit retrofit) {
+    return retrofit.create(AppsFlyerService.class);
+  }
+
+  @Singleton @Provides @Named("apps-flyer-retrofit") Retrofit providesAppsFlyerRetrofit(
+      @Named("appsflyer-host") String appsFlyerHost, @Named("default") OkHttpClient httpClient,
+      Converter.Factory converterFactory, @Named("rx") CallAdapter.Factory rxCallAdapterFactory) {
+
+    return new Retrofit.Builder().baseUrl(appsFlyerHost)
+        .client(httpClient)
+        .addConverterFactory(converterFactory)
+        .addCallAdapterFactory(rxCallAdapterFactory)
+        .build();
+  }
+
+  @Singleton @Provides @Named("appsflyer-host") String providesAppsFlyerBaseUrl() {
+    return "https://impression.appsflyer.com";
   }
 
   @Singleton @Provides @Named("reactions-host") String providesReactionsHost() {

--- a/app/src/main/java/cm/aptoide/pt/app/appsflyer/AppsFlyerManager.kt
+++ b/app/src/main/java/cm/aptoide/pt/app/appsflyer/AppsFlyerManager.kt
@@ -1,0 +1,10 @@
+package cm.aptoide.pt.app.appsflyer
+
+import rx.Single
+
+class AppsFlyerManager(private val appsFlyerRepository: AppsFlyerRepository) {
+
+  fun registerImpression(): Single<Boolean> {
+    return appsFlyerRepository.registerImpression()
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/app/appsflyer/AppsFlyerRepository.kt
+++ b/app/src/main/java/cm/aptoide/pt/app/appsflyer/AppsFlyerRepository.kt
@@ -1,0 +1,13 @@
+package cm.aptoide.pt.app.appsflyer
+
+import rx.Single
+
+class AppsFlyerRepository(private val appsFlyerService: AppsFlyerService) {
+
+  fun registerImpression(): Single<Boolean> {
+    return appsFlyerService.registerImpression().map { response ->
+      response.isSuccessful
+    }
+  }
+
+}

--- a/app/src/main/java/cm/aptoide/pt/app/appsflyer/AppsFlyerResponse.kt
+++ b/app/src/main/java/cm/aptoide/pt/app/appsflyer/AppsFlyerResponse.kt
@@ -1,0 +1,3 @@
+package cm.aptoide.pt.app.appsflyer
+
+data class AppsFlyerResponse(val ok: String)

--- a/app/src/main/java/cm/aptoide/pt/app/appsflyer/AppsFlyerService.kt
+++ b/app/src/main/java/cm/aptoide/pt/app/appsflyer/AppsFlyerService.kt
@@ -1,0 +1,11 @@
+package cm.aptoide.pt.app.appsflyer
+
+import retrofit2.Response
+import retrofit2.http.GET
+import rx.Single
+
+interface AppsFlyerService {
+  @GET("com.igg.android.lordsmobile?pid=aptoide_int&af_siteid=aptoide&c=project42&af_click_lookback=7d&af_ad_id=android&af_channel=editorial&af_ad=article&af_c_id=com.igg.android.lordsmobile")
+  fun registerImpression(
+  ): Single<Response<AppsFlyerResponse>>
+}

--- a/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
+++ b/app/src/main/java/cm/aptoide/pt/app/view/AppViewPresenter.java
@@ -256,7 +256,13 @@ public class AppViewPresenter implements Presenter {
   }
 
   public Observable<AppViewModel> loadAds(AppViewModel appViewModel) {
-    return loadOrganicAds(appViewModel).map(__ -> appViewModel)
+    return appViewManager.registerAppsFlyerImpression(appViewModel.getAppModel()
+            .getPackageName())
+        .doOnError(Throwable::printStackTrace)
+        .toObservable()
+        .subscribeOn(Schedulers.io())
+        .flatMap(__ -> loadOrganicAds(appViewModel))
+        .map(__ -> appViewModel)
         .onErrorReturn(throwable -> {
           crashReport.log(throwable);
           return appViewModel;
@@ -265,7 +271,7 @@ public class AppViewPresenter implements Presenter {
 
   private Observable<SearchAdResult> loadOrganicAds(AppViewModel appViewModel) {
     return Single.just(appViewModel.getAppModel()
-        .getMinimalAd())
+            .getMinimalAd())
         .observeOn(Schedulers.io())
         .flatMap(adResult -> {
           if (adResult == null) {
@@ -292,7 +298,7 @@ public class AppViewPresenter implements Presenter {
     DownloadModel.Action action = appViewModel.getDownloadModel()
         .getAction();
     return handleOpenAppViewDialogInput(appViewModel.getAppModel()).filter(
-        shouldDownload -> shouldDownload)
+            shouldDownload -> shouldDownload)
         .flatMapCompletable(__ -> appViewManager.getAdsVisibilityStatus()
             .doOnSuccess(status -> appViewAnalytics.clickOnInstallButton(appModel.getPackageName(),
                 appModel.getDeveloper()
@@ -306,13 +312,13 @@ public class AppViewPresenter implements Presenter {
                 appModel.getObb() != null))
             .flatMapCompletable(status -> downloadApp(action, appModel, status,
                 appModel.getOpenType() == AppViewFragment.OpenType.APK_FY_INSTALL_POPUP).doOnError(
-                throwable -> {
-                  if (throwable instanceof InvalidAppException) {
-                    view.showInvalidAppInfoErrorDialog();
-                  } else {
-                    view.showGenericErrorDialog();
-                  }
-                })
+                    throwable -> {
+                      if (throwable instanceof InvalidAppException) {
+                        view.showInvalidAppInfoErrorDialog();
+                      } else {
+                        view.showGenericErrorDialog();
+                      }
+                    })
                 .onErrorComplete()))
         .switchIfEmpty(Observable.just(false))
         .map(__ -> appViewModel)
@@ -332,8 +338,8 @@ public class AppViewPresenter implements Presenter {
             .map(__ -> true);
       } else if (appModel.getOpenType() == AppViewFragment.OpenType.APK_FY_INSTALL_POPUP) {
         return view.showOpenAndInstallApkFyDialog(appModel.getMarketName(), appModel.getAppName(),
-            appModel.getAppc(), appModel.getRating()
-                .getAverage(), appModel.getIcon(), appModel.getPackageDownloads())
+                appModel.getAppc(), appModel.getRating()
+                    .getAverage(), appModel.getIcon(), appModel.getPackageDownloads())
             .map(__ -> true);
       }
     }
@@ -343,8 +349,8 @@ public class AppViewPresenter implements Presenter {
   @VisibleForTesting
   public Observable<AppViewModel> loadOtherAppViewComponents(AppViewModel appViewModel) {
     return Observable.zip(updateSimilarAppsBundles(appViewModel.getAppModel()),
-        updateReviews(appViewModel.getAppModel()),
-        (similarAppsBundles, reviewsViewModel) -> Observable.just(appViewModel))
+            updateReviews(appViewModel.getAppModel()),
+            (similarAppsBundles, reviewsViewModel) -> Observable.just(appViewModel))
         .first()
         .map(__ -> appViewModel);
   }
@@ -518,9 +524,8 @@ public class AppViewPresenter implements Presenter {
         && similarAppsViewModel.hasAd()
         && !similarAppsViewModel.hasRecordedAdImpression()) {
       similarAppsViewModel.setHasRecordedAdImpression(true);
-      appViewAnalytics.
-          similarAppBundleImpression(similarAppsViewModel.getAd()
-              .getNetwork(), true);
+      appViewAnalytics.similarAppBundleImpression(similarAppsViewModel.getAd()
+          .getNetwork(), true);
     }
   }
 
@@ -1002,8 +1007,8 @@ public class AppViewPresenter implements Presenter {
   private Observable<List<SimilarAppsBundle>> updateSuggestedApps(AppModel appViewModel,
       List<SimilarAppsBundle> list) {
     return appViewManager.loadSimilarAppsViewModel(appViewModel.getPackageName(),
-        appViewModel.getMedia()
-            .getKeywords())
+            appViewModel.getMedia()
+                .getKeywords())
         .map(similarAppsViewModel -> {
           if (similarAppsViewModel.hasSimilarApps()) {
             list.add(
@@ -1016,7 +1021,7 @@ public class AppViewPresenter implements Presenter {
 
   private Observable<ReviewsViewModel> updateReviews(AppModel appViewModel) {
     return appViewManager.loadReviewsViewModel(appViewModel.getStore()
-        .getName(), appViewModel.getPackageName(), view.getLanguageFilter())
+            .getName(), appViewModel.getPackageName(), view.getLanguageFilter())
         .observeOn(viewScheduler)
         .doOnError(__ -> view.hideReviews())
         .doOnSuccess(reviewsViewModel -> {
@@ -1053,13 +1058,13 @@ public class AppViewPresenter implements Presenter {
                 success -> permissionManager.requestExternalStoragePermission(permissionService))
             .flatMapSingle(__1 -> appViewManager.getAppViewModel())
             .flatMapCompletable(app -> appViewManager.resumeDownload(app.getAppModel()
-                .getMd5(), app.getAppModel()
-                .getAppId(), app.getDownloadModel()
-                .getAction(), app.getAppModel()
-                .getMalware()
-                .getRank()
-                .toString(), app.getAppModel()
-                .getOpenType() == AppViewFragment.OpenType.APK_FY_INSTALL_POPUP)
+                    .getMd5(), app.getAppModel()
+                    .getAppId(), app.getDownloadModel()
+                    .getAction(), app.getAppModel()
+                    .getMalware()
+                    .getRank()
+                    .toString(), app.getAppModel()
+                    .getOpenType() == AppViewFragment.OpenType.APK_FY_INSTALL_POPUP)
                 .retry()))
         .compose(view.bindUntilEvent(View.LifecycleEvent.DESTROY))
         .subscribe(created -> {
@@ -1098,7 +1103,7 @@ public class AppViewPresenter implements Presenter {
                           .flatMapCompletable(status -> downloadApp(action, appModel, status,
                               appModel.getOpenType()
                                   == AppViewFragment.OpenType.APK_FY_INSTALL_POPUP).observeOn(
-                              viewScheduler)
+                                  viewScheduler)
                               .doOnCompleted(() -> {
                                 String conversionUrl = appModel.getCampaignUrl();
                                 if (!conversionUrl.isEmpty()) {
@@ -1223,16 +1228,16 @@ public class AppViewPresenter implements Presenter {
   private Completable downloadApp(DownloadModel.Action action, AppModel appModel,
       WalletAdsOfferManager.OfferResponseStatus status, boolean isApkfy) {
     return Observable.defer(() -> {
-      if (appViewManager.shouldShowRootInstallWarningPopup()) {
-        return view.showRootInstallWarningPopup()
-            .doOnNext(answer -> appViewManager.allowRootInstall(answer))
-            .map(__ -> action);
-      }
-      return Observable.just(action);
-    })
+          if (appViewManager.shouldShowRootInstallWarningPopup()) {
+            return view.showRootInstallWarningPopup()
+                .doOnNext(answer -> appViewManager.allowRootInstall(answer))
+                .map(__ -> action);
+          }
+          return Observable.just(action);
+        })
         .observeOn(viewScheduler)
         .flatMap(__ -> permissionManager.requestDownloadAccessWithWifiBypass(permissionService,
-            appModel.getSize())
+                appModel.getSize())
             .flatMap(
                 success -> permissionManager.requestExternalStoragePermission(permissionService))
             .observeOn(Schedulers.io())
@@ -1394,12 +1399,12 @@ public class AppViewPresenter implements Presenter {
 
   private Completable downloadWallet(WalletApp walletApp) {
     return Observable.defer(() -> {
-      if (appViewManager.shouldShowRootInstallWarningPopup()) {
-        return view.showRootInstallWarningPopup()
-            .doOnNext(answer -> appViewManager.allowRootInstall(answer));
-      }
-      return Observable.just(null);
-    })
+          if (appViewManager.shouldShowRootInstallWarningPopup()) {
+            return view.showRootInstallWarningPopup()
+                .doOnNext(answer -> appViewManager.allowRootInstall(answer));
+          }
+          return Observable.just(null);
+        })
         .observeOn(viewScheduler)
         .flatMap(__ -> permissionManager.requestDownloadAccessWithWifiBypass(permissionService,
             walletApp.getSize()))

--- a/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
+++ b/app/src/main/java/cm/aptoide/pt/view/FragmentModule.java
@@ -56,6 +56,7 @@ import cm.aptoide.pt.app.DownloadStateParser;
 import cm.aptoide.pt.app.FlagManager;
 import cm.aptoide.pt.app.FlagService;
 import cm.aptoide.pt.app.ReviewsManager;
+import cm.aptoide.pt.app.appsflyer.AppsFlyerManager;
 import cm.aptoide.pt.app.aptoideinstall.AptoideInstallManager;
 import cm.aptoide.pt.app.migration.AppcMigrationManager;
 import cm.aptoide.pt.app.view.AppCoinsInfoFragment;
@@ -448,14 +449,15 @@ import rx.subscriptions.CompositeSubscription;
       AppcMigrationManager appcMigrationManager,
       LocalNotificationSyncManager localNotificationSyncManager,
       AppcPromotionNotificationStringProvider appcPromotionNotificationStringProvider,
-      DynamicSplitsManager dynamicSplitsManager, SplitAnalyticsMapper splitAnalyticsMapper) {
+      DynamicSplitsManager dynamicSplitsManager, SplitAnalyticsMapper splitAnalyticsMapper,
+      AppsFlyerManager appsFlyerManager) {
     return new AppViewManager(appViewModelManager, installManager, downloadFactory, appCenter,
         reviewsManager, adsManager, flagManager, storeUtilsProxy, aptoideAccountManager,
         moPubAdsManager, downloadStateParser, appViewAnalytics, notificationAnalytics,
         installAnalytics, (Type.APPS_GROUP.getPerLineCount(resources, windowManager) * 6),
         marketName, appCoinsManager, promotionsManager, appcMigrationManager,
         localNotificationSyncManager, appcPromotionNotificationStringProvider, dynamicSplitsManager,
-        splitAnalyticsMapper);
+        splitAnalyticsMapper, appsFlyerManager);
   }
 
   @FragmentScope @Provides AppViewModelManager providesAppViewModelManager(


### PR DESCRIPTION
**What does this PR do?**

This PR aims at implementing a request to apps flyer impressions when opening the lords mobile appview

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppViewPresenter.java

**How should this be manually tested?**

Open the app go to lords mobile appview and confirm that you see the request to impression apps flyer endpoint on charles. 
Note that you will have to enable ssl proxying for it and to make it easier, focus that endpoint.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-1376](https://aptoide.atlassian.net/browse/APP-1376)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass