### PR TITLE
[DT-37] Navigate to app view

### DIFF
--- a/feature_appview/src/main/java/cm/aptoide/pt/feature_appview/presentation/AppViewView.kt
+++ b/feature_appview/src/main/java/cm/aptoide/pt/feature_appview/presentation/AppViewView.kt
@@ -98,7 +98,6 @@ fun MainAppViewView(
     modifier = Modifier
       .fillMaxWidth()
       .fillMaxHeight()
-      .padding(bottom = 60.dp)
   ) { paddingValues ->
     if (!uiState.isLoading) {
       uiState.app?.let {
@@ -551,6 +550,7 @@ fun DetailsView(
 fun ReportAppCard(onSelectReportApp: (DetailedApp) -> Unit, app: DetailedApp) {
   Card(
     modifier = Modifier
+      .padding(bottom = 24.dp)
       .height(48.dp)
       .padding(start = 16.dp, end = 16.dp)
       .fillMaxWidth()

--- a/feature_report_app/src/main/java/cm/aptoide/pt/feature_report_app/presentation/ReportAppView.kt
+++ b/feature_report_app/src/main/java/cm/aptoide/pt/feature_report_app/presentation/ReportAppView.kt
@@ -27,9 +27,9 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
 import cm.aptoide.pt.feature_report_app.R
 import cm.aptoide.pt.feature_report_app.domain.ReportApp
-import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
 import coil.compose.rememberImagePainter
 import coil.transform.RoundedCornersTransformation
 
@@ -64,7 +64,7 @@ fun MainReportAppView(
 
   LazyColumn(
     modifier = Modifier
-      .padding(16.dp, 24.dp, 16.dp, 32.dp)
+      .padding(start = 16.dp, end = 16.dp)
   ) {
     item { AppInfoRow(uiState.app) }
 
@@ -94,6 +94,7 @@ fun SubmitButton(onSubmitReport: () -> Unit) {
     onClick = { onSubmitReport() },
     shape = CircleShape,
     modifier = Modifier
+      .padding(bottom = 24.dp)
       .height(56.dp)
       .fillMaxWidth()
   ) {
@@ -135,7 +136,7 @@ fun ReportAdditionalInformation(
 fun AppInfoRow(app: ReportApp) {
   Row(
     modifier = Modifier
-      .padding(bottom = 32.dp)
+      .padding(bottom = 32.dp, top = 24.dp)
       .height(80.dp)
   ) {
     Image(


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at adding navigation to appview from home bundles & more.

Also took the chance to fix unnecessary padding on bottom of appview and report app view.

referenced PR: [DT-37](https://github.com/Aptoide/aptoide-client-dt/pull/13)

**Database changed?**

No

**Where should the reviewer start?**

- [ ] BundlesView.java

**How should this be manually tested?**

Open app and check the navigation to app view from home.

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-37](https://aptoide.atlassian.net/browse/DT-37)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass