### PR TITLE
[DT-19] feature: add DataStore dependency.

### DIFF
--- a/buildSrc/src/main/kotlin/LibraryDependency.kt
+++ b/buildSrc/src/main/kotlin/LibraryDependency.kt
@@ -62,6 +62,7 @@ private object LibraryVersion {
   const val FILE_DOWNLOADER_OK_HTTP = "1.0.0"
   const val CUSTOM_CHROME_TAB = "1.2.0"
   const val FIREBASE = "31.0.1"
+  const val DATASTORE = "1.0.0"
 }
 
 object LibraryDependency {
@@ -124,4 +125,6 @@ object LibraryDependency {
   const val FIREBASE_BOM = "com.google.firebase:firebase-bom:${LibraryVersion.FIREBASE}"
   const val FIREBASE_ANALYTICS = "com.google.firebase:firebase-analytics-ktx"
   const val FIREBASE_CRASHLYTICS = "com.google.firebase:firebase-crashlytics-ktx"
+  const val FIREBASE_MESSAGING = "com.google.firebase:firebase-messaging-ktx"
+  const val DATASTORE = "androidx.datastore:datastore-preferences:${LibraryVersion.DATASTORE}"
 }


### PR DESCRIPTION
**What does this PR do?**

   This PR adds DataStore dependency to the project build. This is related to the DT-19 Firebase Notifications integration which is mostly done in app-dt module.
   DataStore will be used to save the result of the runtime notifications permission.

**Where should the reviewer start?**

- [ ] LibraryDendency.kt

**How should this be manually tested?**

  Just check if Dependency file does not have any errors, the real testing should be done in the other PR.

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-19](https://aptoide.atlassian.net/browse/DT-19)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass