### PR TITLE
[DT-44] Refactor and extend the editorial and reactions modules

### DIFF
--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/textformatter/DateUtils.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/textformatter/DateUtils.kt
@@ -35,7 +35,7 @@ class DateUtils private constructor() : DateUtils() {
      * @param timeDate Timestamp to format as date difference from now
      * @return Friendly-formatted date diff string
      */
-    fun getTimeDiffString(timeDate: String): String {
+    fun getTimeDiffString(timeDate: String, onPrefix: Boolean = false): String {
       val timeDateAsMilliseconds = convertStringDateToLong(timeDate)
       val startDateTime = Calendar.getInstance()
       val endDateTime = Calendar.getInstance()
@@ -54,7 +54,6 @@ class DateUtils private constructor() : DateUtils() {
         } else {
           return "$hours hours ago"
         }
-
       } else if (hours <= 0) {
         if (minutes > 0) return "$minutes minutes ago" else return mTimestampLabelJustNow
       } else if (isToday) {
@@ -62,10 +61,16 @@ class DateUtils private constructor() : DateUtils() {
       } else if (isYesterday) {
         mTimestampLabelYesterday
       } else if (startDateTime.timeInMillis - timeDateAsMilliseconds < millisInADay * 6) {
-        weekdays[endDateTime[Calendar.DAY_OF_WEEK]]
+        weekdays[endDateTime[Calendar.DAY_OF_WEEK]].withPreposition(onPrefix)
       } else {
-        TextFormatter.formatDate(timeDate)
+        TextFormatter.formatDate(timeDate).withPreposition(onPrefix)
       }
+    }
+
+    private fun String.withPreposition(onPrefix: Boolean) = if (onPrefix) {
+      "on $this"
+    } else {
+      this
     }
 
     private fun convertStringDateToLong(date: String): Long {
@@ -73,6 +78,5 @@ class DateUtils private constructor() : DateUtils() {
       val date = formatter.parse(date)
       return date.time
     }
-
   }
 }

--- a/feature-reactions/src/main/java/cm/aptoide/pt/feature_reactions/di/UseCaseModule.kt
+++ b/feature-reactions/src/main/java/cm/aptoide/pt/feature_reactions/di/UseCaseModule.kt
@@ -1,0 +1,21 @@
+package cm.aptoide.pt.feature_reactions.di
+
+import cm.aptoide.pt.feature_reactions.domain.usecase.ReactionsUseCase
+import cm.aptoide.pt.feature_reactions.presentation.ReactionsUseCaseProvider
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+
+@Module
+@InstallIn(ViewModelComponent::class)
+object UseCaseModule {
+
+  @Provides
+  fun provideReactionsUseCaseProvider(
+    reactionsUseCase: ReactionsUseCase
+  ): ReactionsUseCaseProvider =
+    object : ReactionsUseCaseProvider {
+      override val reactionsUseCase: ReactionsUseCase = reactionsUseCase
+    }
+}

--- a/feature-reactions/src/main/java/cm/aptoide/pt/feature_reactions/domain/usecase/ReactionsUseCase.kt
+++ b/feature-reactions/src/main/java/cm/aptoide/pt/feature_reactions/domain/usecase/ReactionsUseCase.kt
@@ -1,0 +1,19 @@
+package cm.aptoide.pt.feature_reactions.domain.usecase
+
+import cm.aptoide.pt.feature_reactions.ReactionsRepository
+import dagger.hilt.android.scopes.ViewModelScoped
+import javax.inject.Inject
+
+@ViewModelScoped
+class ReactionsUseCase @Inject constructor(
+  private val reactionsRepository: ReactionsRepository
+) {
+  suspend fun getReactions(id: String) = reactionsRepository.getTotalReactions(id)
+    .let { reactionsResult ->
+      if (reactionsResult is ReactionsRepository.ReactionsResult.Success) {
+        reactionsResult.data
+      } else {
+        throw IllegalStateException()
+      }
+    }
+}

--- a/feature-reactions/src/main/java/cm/aptoide/pt/feature_reactions/presentation/ReactionsUiState.kt
+++ b/feature-reactions/src/main/java/cm/aptoide/pt/feature_reactions/presentation/ReactionsUiState.kt
@@ -1,0 +1,7 @@
+package cm.aptoide.pt.feature_reactions.presentation
+
+import cm.aptoide.pt.feature_reactions.data.Reactions
+
+data class ReactionsUiState(
+  val reactions: Reactions,
+)

--- a/feature-reactions/src/main/java/cm/aptoide/pt/feature_reactions/presentation/ReactionsViewModel.kt
+++ b/feature-reactions/src/main/java/cm/aptoide/pt/feature_reactions/presentation/ReactionsViewModel.kt
@@ -1,0 +1,38 @@
+package cm.aptoide.pt.feature_reactions.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cm.aptoide.pt.feature_reactions.data.Reactions
+import cm.aptoide.pt.feature_reactions.domain.usecase.ReactionsUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class ReactionsViewModel(
+  id: String,
+  private val reactionsUseCase: ReactionsUseCase
+) : ViewModel() {
+
+  private val viewModelState =
+    MutableStateFlow(ReactionsUiState(reactions = Reactions(-1, emptyList())))
+
+  val uiState = viewModelState
+    .stateIn(
+      viewModelScope,
+      SharingStarted.Eagerly,
+      viewModelState.value
+    )
+
+  init {
+    viewModelScope.launch {
+      try {
+        val data = reactionsUseCase.getReactions(id)
+        viewModelState.update { it.copy(reactions = data) }
+      } catch (throwable: Throwable) {
+        throwable.printStackTrace()
+      }
+    }
+  }
+}

--- a/feature-reactions/src/main/java/cm/aptoide/pt/feature_reactions/presentation/ViewModelProvider.kt
+++ b/feature-reactions/src/main/java/cm/aptoide/pt/feature_reactions/presentation/ViewModelProvider.kt
@@ -1,0 +1,36 @@
+package cm.aptoide.pt.feature_reactions.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import cm.aptoide.pt.feature_reactions.domain.usecase.ReactionsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+interface ReactionsUseCaseProvider {
+  val reactionsUseCase: ReactionsUseCase
+}
+
+@HiltViewModel
+class InjectionsProvider @Inject constructor(
+  val provider: ReactionsUseCaseProvider,
+) : ViewModel()
+
+@Composable
+fun reactionsViewModel(id: String): ReactionsViewModel {
+  val injectionsProvider = hiltViewModel<InjectionsProvider>()
+  return viewModel(
+    key = id,
+    factory = object : ViewModelProvider.Factory {
+      override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        @Suppress("UNCHECKED_CAST")
+        return ReactionsViewModel(
+          id = id,
+          reactionsUseCase = injectionsProvider.provider.reactionsUseCase,
+        ) as T
+      }
+    }
+  )
+}

--- a/feature-reactions/src/main/java/cm/aptoide/pt/feature_reactions/ui/ReactionsView.kt
+++ b/feature-reactions/src/main/java/cm/aptoide/pt/feature_reactions/ui/ReactionsView.kt
@@ -1,0 +1,65 @@
+package cm.aptoide.pt.feature_reactions.ui
+
+import android.view.LayoutInflater
+import android.widget.ImageButton
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import cm.aptoide.pt.feature_reactions.R
+import cm.aptoide.pt.feature_reactions.ReactionMapper.mapReaction
+import cm.aptoide.pt.feature_reactions.ReactionMapper.mapUserReaction
+import cm.aptoide.pt.feature_reactions.TopReactionsPreview
+import cm.aptoide.pt.feature_reactions.presentation.reactionsViewModel
+
+@Composable
+fun ReactionsView(id: String, isNavigating: Boolean) {
+  val reactionsViewModel = reactionsViewModel(id = id)
+  val uiState by reactionsViewModel.uiState.collectAsState()
+  val topReactionsPreview = TopReactionsPreview()
+  AndroidView(
+    modifier = Modifier
+      .wrapContentWidth()
+      .padding(end = 16.dp),
+    factory = { context ->
+      val view = LayoutInflater.from(context)
+        .inflate(R.layout.reactions_layout, null, false)
+      val reactButton: ImageButton = view.findViewById(R.id.add_reactions)
+      view.apply {
+        //can potentially set listeners here.
+        topReactionsPreview.initialReactionsSetup(view)
+        reactButton.setOnClickListener {
+          val reactionsPopup = ReactionsPopup(view.context, reactButton)
+          reactionsPopup.setOnReactionsItemClickListener {
+            topReactionsPreview.setReactions(
+              uiState.reactions.top,
+              uiState.reactions.reactionsNumber + 1,
+              view.context
+            )
+            if (topReactionsPreview.isReactionValid(it.name)) {
+              reactButton.setImageResource(mapReaction(it.name))
+            } else {
+              reactButton.setImageResource(mapReaction(mapUserReaction(it)))
+            }
+            reactionsPopup.dismiss()
+          }
+
+          reactionsPopup.show()
+        }
+      }
+    },
+    update = { view ->
+      if (!isNavigating) {
+        topReactionsPreview.setReactions(
+          uiState.reactions.top,
+          uiState.reactions.reactionsNumber,
+          view.context
+        )
+      }
+    }
+  )
+}

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/di/RepositoryModule.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/di/RepositoryModule.kt
@@ -7,8 +7,6 @@ import cm.aptoide.pt.feature_apps.data.network.service.AppsRemoteService
 import cm.aptoide.pt.feature_apps.data.network.service.AptoideAppsNetworkService
 import cm.aptoide.pt.feature_apps.data.network.service.WidgetsRemoteService
 import cm.aptoide.pt.feature_apps.domain.BundleActionMapper
-import cm.aptoide.pt.feature_editorial.data.EditorialRepository
-import cm.aptoide.pt.feature_reactions.ReactionsRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -25,16 +23,12 @@ internal object RepositoryModule {
   fun providesBundlesRepository(
     widgetsRepository: WidgetsRepository,
     appsRepository: AppsRepository,
-    editorialRepository: EditorialRepository,
-    reactionsManager: ReactionsRepository,
     bundleActionMapper: BundleActionMapper,
     myAppsBundleProvider: MyAppsBundleProvider
   ): BundlesRepository {
     return AptoideBundlesRepository(
       widgetsRepository = widgetsRepository,
       appsRepository = appsRepository,
-      editorialRepository = editorialRepository,
-      reactionsRepository = reactionsManager,
       bundleActionMapper = bundleActionMapper,
       myAppsBundleProvider
     )

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/Bundle.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/Bundle.kt
@@ -2,7 +2,6 @@ package cm.aptoide.pt.feature_apps.domain
 
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.MyAppsApp
-import cm.aptoide.pt.feature_apps.data.Editorial
 
 open class Bundle(
   val title: String,
@@ -10,13 +9,8 @@ open class Bundle(
   val type: Type,
   val bundleIcon: String? = null,
   val graphic: String? = null,
-  val bundleAction: BundleAction? = null
-)
-
-data class EditorialBundle(val editorialsList: List<Editorial>) : Bundle(
-  title = "Editorial",
-  appsList = emptyList(),
-  type = Type.EDITORIAL
+  val bundleAction: BundleAction? = null,
+  val view: String? = null
 )
 
 data class MyAppsBundle(

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/BundlesView.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/BundlesView.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -28,8 +27,8 @@ import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.File
 import cm.aptoide.pt.feature_apps.domain.*
 import cm.aptoide.pt.feature_editorial.presentation.EditorialViewCard
-import cm.aptoide.pt.feature_editorial.presentation.EditorialViewModel
 import cm.aptoide.pt.feature_editorial.presentation.EditorialViewScreen
+import cm.aptoide.pt.feature_editorial.presentation.editorialViewModel
 import cm.aptoide.pt.feature_editorial.presentation.editorialsMetaViewModel
 import java.util.*
 
@@ -258,7 +257,7 @@ private fun NavigationGraph(
     }
     composable("editorial/{articleId}") {
       topAppBarState.value = false
-      val viewModel = hiltViewModel<EditorialViewModel>()
+      val viewModel = editorialViewModel(it.arguments?.getString("articleId")!!)
       EditorialViewScreen(viewModel)
     }
   }

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/BundlesView.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/BundlesView.kt
@@ -30,6 +30,7 @@ import cm.aptoide.pt.feature_apps.domain.*
 import cm.aptoide.pt.feature_editorial.presentation.EditorialViewCard
 import cm.aptoide.pt.feature_editorial.presentation.EditorialViewModel
 import cm.aptoide.pt.feature_editorial.presentation.EditorialViewScreen
+import cm.aptoide.pt.feature_editorial.presentation.editorialsMetaViewModel
 import java.util.*
 
 @Composable
@@ -102,24 +103,7 @@ private fun BundlesView(
                 Type.FEATURE_GRAPHIC -> AppsGraphicListView(it.appsList, false)
                 Type.ESKILLS -> AppsListView(it.appsList)
                 Type.FEATURED_APPC -> AppsGraphicListView(it.appsList, true)
-                Type.EDITORIAL -> {
-                  if (it is EditorialBundle) {
-                    it.editorialsList.firstOrNull()?.let { editorial ->
-                      EditorialViewCard(
-                        articleId = editorial.id,
-                        title = editorial.title,
-                        image = editorial.image,
-                        subtype = editorial.subtype,
-                        summary = editorial.summary,
-                        date = editorial.date,
-                        views = editorial.views,
-                        reactionsNumber = editorial.reactionsNumber,
-                        reactions = editorial.reactionsTop,
-                        navController = nav,
-                      )
-                    }
-                  }
-                }
+                Type.EDITORIAL -> EditorialMetaView(requestUrl = it.view, nav = nav)
                 Type.UNKNOWN_BUNDLE -> {}
               }
             }
@@ -155,6 +139,26 @@ fun AppsGraphicListView(appsList: List<App>, bonusBanner: Boolean) {
     items(appsList) {
       AppGraphicView(it, bonusBanner)
     }
+  }
+}
+
+@Composable
+fun EditorialMetaView(requestUrl: String?, nav: NavHostController) = requestUrl?.let {
+  val editorialsMetaViewModel = editorialsMetaViewModel(requestUrl = it)
+  val uiState by editorialsMetaViewModel.uiState.collectAsState()
+  uiState.editorialsMetas.firstOrNull()?.let { editorial ->
+    EditorialViewCard(
+      articleId = editorial.id,
+      title = editorial.title,
+      image = editorial.image,
+      subtype = editorial.subtype,
+      summary = editorial.summary,
+      date = editorial.date,
+      views = editorial.views,
+      reactionsNumber = editorial.reactionsNumber,
+      reactions = editorial.reactionsTop,
+      navController = nav,
+    )
   }
 }
 

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/BundlesView.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/BundlesView.kt
@@ -154,8 +154,6 @@ fun EditorialMetaView(requestUrl: String?, nav: NavHostController) = requestUrl?
       summary = editorial.summary,
       date = editorial.date,
       views = editorial.views,
-      reactionsNumber = editorial.reactionsNumber,
-      reactions = editorial.reactionsTop,
       navController = nav,
     )
   }

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/AptoideEditorialRepository.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/AptoideEditorialRepository.kt
@@ -70,7 +70,7 @@ class AptoideEditorialRepository @Inject constructor(
 private fun Data.toDomainModel(): ArticleDetail {
   return ArticleDetail(
     this.title,
-    ArticleType.GAME_OF_THE_WEEK,
+    ArticleType.valueOf(this.subtype),
     this.background,
     this.date,
     this.views,
@@ -92,7 +92,7 @@ private fun EditorialJson.toDomainModel(): Article {
   return Article(
     this.id,
     this.title,
-    ArticleType.GAME_OF_THE_WEEK,
+    ArticleType.valueOf(this.subtype),
     this.summary,
     this.icon,
     this.date,

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/AptoideEditorialRepository.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/AptoideEditorialRepository.kt
@@ -42,11 +42,14 @@ class AptoideEditorialRepository @Inject constructor(
       }
     }
 
-  override fun getArticleMeta(editorialWidgetUrl: String): Flow<EditorialRepository.EditorialResult> =
+  override fun getArticleMeta(
+    editorialWidgetUrl: String,
+    subtype: String?
+  ): Flow<EditorialRepository.EditorialResult> =
     flow {
       if (editorialWidgetUrl.contains("cards/")) {
         val editorialMetaResponse =
-          editorialRemoteService.getArticleMeta(editorialWidgetUrl.split("cards/")[1])
+          editorialRemoteService.getArticleMeta(editorialWidgetUrl.split("cards/")[1], subtype)
 
         if (editorialMetaResponse.isSuccessful) {
           editorialMetaResponse.body()?.datalist?.list

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/Article.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/Article.kt
@@ -11,5 +11,10 @@ class Article(
 )
 
 enum class ArticleType(val label: String) {
-  GAME_OF_THE_WEEK("Game of The Week");
+  APP_OF_THE_WEEK("App of The Week"),
+  COLLECTION("Collection"),
+  GAME_OF_THE_WEEK("Game of The Week"),
+  NEW_APP("New App"),
+  NEWS("News"),
+  OTHER("Other")
 }

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/EditorialRepository.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/EditorialRepository.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 interface EditorialRepository {
   fun getLatestArticle(): Flow<EditorialResult>
   fun getArticleDetail(articleId: String): Flow<EditorialDetailResult>
-  fun getArticleMeta(editorialWidgetUrl: String): Flow<EditorialResult>
+  fun getArticleMeta(editorialWidgetUrl: String, subtype: String?): Flow<EditorialResult>
 
   sealed interface EditorialResult {
     data class Success(val data: List<Article>) : EditorialResult

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/di/UseCaseModule.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/di/UseCaseModule.kt
@@ -1,7 +1,8 @@
 package cm.aptoide.pt.feature_editorial.data.di
 
 import cm.aptoide.pt.feature_editorial.domain.usecase.EditorialsMetaUseCase
-import cm.aptoide.pt.feature_editorial.presentation.EditorialsMetaUseCaseProvider
+import cm.aptoide.pt.feature_editorial.domain.usecase.GetEditorialDetailUseCase
+import cm.aptoide.pt.feature_editorial.presentation.EditorialDependenciesProvider
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -13,9 +14,11 @@ object UseCaseModule {
 
   @Provides
   fun provideEditorialsMetaUseCaseProvider(
+    getEditorialDetailUseCase: GetEditorialDetailUseCase,
     editorialsMetaUseCase: EditorialsMetaUseCase
-  ): EditorialsMetaUseCaseProvider =
-    object : EditorialsMetaUseCaseProvider {
+  ): EditorialDependenciesProvider =
+    object : EditorialDependenciesProvider {
       override val editorialsMetaUseCase: EditorialsMetaUseCase = editorialsMetaUseCase
+      override val getEditorialDetailUseCase: GetEditorialDetailUseCase = getEditorialDetailUseCase
     }
 }

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/di/UseCaseModule.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/di/UseCaseModule.kt
@@ -1,7 +1,7 @@
 package cm.aptoide.pt.feature_editorial.data.di
 
-import cm.aptoide.pt.feature_editorial.data.EditorialRepository
-import cm.aptoide.pt.feature_editorial.domain.usecase.GetEditorialDetailUseCase
+import cm.aptoide.pt.feature_editorial.domain.usecase.EditorialsMetaUseCase
+import cm.aptoide.pt.feature_editorial.presentation.EditorialsMetaUseCaseProvider
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -12,7 +12,10 @@ import dagger.hilt.android.components.ViewModelComponent
 object UseCaseModule {
 
   @Provides
-  fun provideGetEditorialDetailUseCase(editorialRepository: EditorialRepository): GetEditorialDetailUseCase {
-    return GetEditorialDetailUseCase(editorialRepository)
-  }
+  fun provideEditorialsMetaUseCaseProvider(
+    editorialsMetaUseCase: EditorialsMetaUseCase
+  ): EditorialsMetaUseCaseProvider =
+    object : EditorialsMetaUseCaseProvider {
+      override val editorialsMetaUseCase: EditorialsMetaUseCase = editorialsMetaUseCase
+    }
 }

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/network/RemoteAppViewRepository.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/network/RemoteAppViewRepository.kt
@@ -6,6 +6,9 @@ import retrofit2.Response
 
 interface EditorialRemoteService {
   suspend fun getLatestEditorial(): Response<BaseV7DataListResponse<EditorialJson>>
-  suspend fun getArticleMeta(widgetUrl: String): Response<BaseV7DataListResponse<EditorialJson>>
+  suspend fun getArticleMeta(
+    widgetUrl: String,
+    subtype: String?
+  ): Response<BaseV7DataListResponse<EditorialJson>>
   suspend fun getEditorialDetail(articleId: String): Response<EditorialDetailJson>
 }

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/network/service/EditorialNetworkService.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/network/service/EditorialNetworkService.kt
@@ -7,6 +7,7 @@ import cm.aptoide.pt.feature_editorial.data.network.model.EditorialJson
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 class EditorialNetworkService(private val editorialRemoteDataSource: Retrofit) :
   EditorialRemoteService {
@@ -15,8 +16,11 @@ class EditorialNetworkService(private val editorialRemoteDataSource: Retrofit) :
     return editorialRemoteDataSource.getLatestEditorial()
   }
 
-  override suspend fun getArticleMeta(widgetUrl: String): Response<BaseV7DataListResponse<EditorialJson>> {
-    return editorialRemoteDataSource.getArticleMeta(widgetUrl)
+  override suspend fun getArticleMeta(
+    widgetUrl: String,
+    subtype: String?
+  ): Response<BaseV7DataListResponse<EditorialJson>> {
+    return editorialRemoteDataSource.getArticleMeta(widgetUrl, subtype)
   }
 
   override suspend fun getEditorialDetail(articleId: String): Response<EditorialDetailJson> {
@@ -30,6 +34,7 @@ class EditorialNetworkService(private val editorialRemoteDataSource: Retrofit) :
     @GET("cards/{widgetUrl}/aptoide_uid=0/")
     suspend fun getArticleMeta(
       @Path("widgetUrl", encoded = true) widgetUrl: String,
+      @Query("subtype") subtype: String?,
     ): Response<BaseV7DataListResponse<EditorialJson>>
 
     @GET("card/get/type=CURATION_1/id={id}/aptoide_uid=0/aab=true")

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/EditorialMeta.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/EditorialMeta.kt
@@ -1,9 +1,9 @@
-package cm.aptoide.pt.feature_apps.data
+package cm.aptoide.pt.feature_editorial.domain
 
 import cm.aptoide.pt.feature_editorial.data.ArticleType
 import cm.aptoide.pt.feature_reactions.data.TopReaction
 
-data class Editorial(
+data class EditorialMeta(
   val id: String,
   val title: String,
   val summary: String,

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/EditorialMeta.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/EditorialMeta.kt
@@ -1,7 +1,6 @@
 package cm.aptoide.pt.feature_editorial.domain
 
 import cm.aptoide.pt.feature_editorial.data.ArticleType
-import cm.aptoide.pt.feature_reactions.data.TopReaction
 
 data class EditorialMeta(
   val id: String,
@@ -11,6 +10,4 @@ data class EditorialMeta(
   val subtype: ArticleType,
   val date: String,
   val views: Long,
-  val reactionsNumber: Int,
-  val reactionsTop: List<TopReaction>
 )

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/usecase/EditorialsMetaUseCase.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/usecase/EditorialsMetaUseCase.kt
@@ -11,8 +11,8 @@ import javax.inject.Inject
 class EditorialsMetaUseCase @Inject constructor(
   private val editorialRepository: EditorialRepository
 ) {
-  fun getEditorialsMeta(editorialWidgetUrl: String): Flow<List<EditorialMeta>> =
-    editorialRepository.getArticleMeta(editorialWidgetUrl)
+  fun getEditorialsMeta(editorialWidgetUrl: String, subtype: String?): Flow<List<EditorialMeta>> =
+    editorialRepository.getArticleMeta(editorialWidgetUrl, subtype)
       .map { editorialResult ->
         if (editorialResult is EditorialRepository.EditorialResult.Success) {
           editorialResult.data.map { article ->

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/usecase/EditorialsMetaUseCase.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/usecase/EditorialsMetaUseCase.kt
@@ -2,7 +2,6 @@ package cm.aptoide.pt.feature_editorial.domain.usecase
 
 import cm.aptoide.pt.feature_editorial.data.EditorialRepository
 import cm.aptoide.pt.feature_editorial.domain.EditorialMeta
-import cm.aptoide.pt.feature_reactions.ReactionsRepository
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -10,32 +9,22 @@ import javax.inject.Inject
 
 @ViewModelScoped
 class EditorialsMetaUseCase @Inject constructor(
-  private val editorialRepository: EditorialRepository,
-  private val reactionsRepository: ReactionsRepository
+  private val editorialRepository: EditorialRepository
 ) {
   fun getEditorialsMeta(editorialWidgetUrl: String): Flow<List<EditorialMeta>> =
     editorialRepository.getArticleMeta(editorialWidgetUrl)
       .map { editorialResult ->
         if (editorialResult is EditorialRepository.EditorialResult.Success) {
           editorialResult.data.map { article ->
-            reactionsRepository.getTotalReactions(article.id)
-              .let {
-                if (it is ReactionsRepository.ReactionsResult.Success) {
-                  EditorialMeta(
-                    id = article.id,
-                    title = article.title,
-                    summary = article.summary,
-                    image = article.image,
-                    subtype = article.subtype,
-                    date = article.date,
-                    views = article.views,
-                    reactionsNumber = it.data.reactionsNumber,
-                    reactionsTop = it.data.top
-                  )
-                } else {
-                  throw IllegalStateException()
-                }
-              }
+            EditorialMeta(
+              id = article.id,
+              title = article.title,
+              summary = article.summary,
+              image = article.image,
+              subtype = article.subtype,
+              date = article.date,
+              views = article.views,
+            )
           }
         } else {
           throw IllegalStateException()

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/usecase/EditorialsMetaUseCase.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/usecase/EditorialsMetaUseCase.kt
@@ -1,0 +1,44 @@
+package cm.aptoide.pt.feature_editorial.domain.usecase
+
+import cm.aptoide.pt.feature_editorial.data.EditorialRepository
+import cm.aptoide.pt.feature_editorial.domain.EditorialMeta
+import cm.aptoide.pt.feature_reactions.ReactionsRepository
+import dagger.hilt.android.scopes.ViewModelScoped
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+@ViewModelScoped
+class EditorialsMetaUseCase @Inject constructor(
+  private val editorialRepository: EditorialRepository,
+  private val reactionsRepository: ReactionsRepository
+) {
+  fun getEditorialsMeta(editorialWidgetUrl: String): Flow<List<EditorialMeta>> =
+    editorialRepository.getArticleMeta(editorialWidgetUrl)
+      .map { editorialResult ->
+        if (editorialResult is EditorialRepository.EditorialResult.Success) {
+          editorialResult.data.map { article ->
+            reactionsRepository.getTotalReactions(article.id)
+              .let {
+                if (it is ReactionsRepository.ReactionsResult.Success) {
+                  EditorialMeta(
+                    id = article.id,
+                    title = article.title,
+                    summary = article.summary,
+                    image = article.image,
+                    subtype = article.subtype,
+                    date = article.date,
+                    views = article.views,
+                    reactionsNumber = it.data.reactionsNumber,
+                    reactionsTop = it.data.top
+                  )
+                } else {
+                  throw IllegalStateException()
+                }
+              }
+          }
+        } else {
+          throw IllegalStateException()
+        }
+      }
+}

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/EditorialView.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/EditorialView.kt
@@ -1,7 +1,5 @@
 package cm.aptoide.pt.feature_editorial.presentation
 
-import android.view.LayoutInflater
-import android.widget.ImageButton
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -17,17 +15,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.navigation.NavController
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.feature_editorial.R
 import cm.aptoide.pt.feature_editorial.data.ArticleType
-import cm.aptoide.pt.feature_reactions.ReactionMapper.mapReaction
-import cm.aptoide.pt.feature_reactions.ReactionMapper.mapUserReaction
-import cm.aptoide.pt.feature_reactions.TopReactionsPreview
-import cm.aptoide.pt.feature_reactions.data.TopReaction
-import cm.aptoide.pt.feature_reactions.ui.ReactionsPopup
+import cm.aptoide.pt.feature_reactions.ui.ReactionsView
 import coil.compose.rememberImagePainter
 import coil.transform.RoundedCornersTransformation
 
@@ -42,8 +35,6 @@ fun EditorialViewCard(
   summary: String,
   date: String,
   views: Long,
-  reactionsNumber: Int,
-  reactions: List<TopReaction>,
   navController: NavController,
 ) {
   Column(
@@ -104,41 +95,8 @@ fun EditorialViewCard(
       modifier = Modifier
         .height(32.dp), verticalAlignment = Alignment.CenterVertically
     ) {
-      val topReactionsPreview = TopReactionsPreview()
-      AndroidView(
-        modifier = Modifier
-          .wrapContentWidth()
-          .padding(end = 16.dp),
-        factory = { context ->
-          val view = LayoutInflater.from(context)
-            .inflate(R.layout.reactions_layout, null, false)
-          val reactButton: ImageButton = view.findViewById(R.id.add_reactions)
-          view.apply {
-            //can potentially set listeners here.
-            topReactionsPreview.initialReactionsSetup(view)
-            reactButton.setOnClickListener {
-              val reactionsPopup = ReactionsPopup(view.context, reactButton)
-              reactionsPopup.setOnReactionsItemClickListener {
-                topReactionsPreview.setReactions(reactions, reactionsNumber + 1, view.context)
-                if (topReactionsPreview.isReactionValid(it.name)) {
-                  reactButton.setImageResource(mapReaction(it.name))
-                } else {
-                  reactButton.setImageResource(mapReaction(mapUserReaction(it)))
-                }
-                reactionsPopup.dismiss()
-              }
-
-              reactionsPopup.show()
-            }
-          }
-        },
-        update = { view ->
-          //bug here, this will only work once.
-          if (!isNavigating) {
-            topReactionsPreview.setReactions(reactions, reactionsNumber, view.context)
-          }
-        }
-      )
+      //bug here, isNavigating will only work once.
+      ReactionsView(id = articleId, isNavigating = isNavigating)
       Text(
         text = TextFormatter.formatDate(date),
         modifier = Modifier.padding(end = 16.dp),

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/EditorialsMetaUiState.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/EditorialsMetaUiState.kt
@@ -1,0 +1,7 @@
+package cm.aptoide.pt.feature_editorial.presentation
+
+import cm.aptoide.pt.feature_editorial.domain.EditorialMeta
+
+data class EditorialsMetaUiState(
+  val editorialsMetas: List<EditorialMeta>,
+)

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/EditorialsMetaViewModel.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/EditorialsMetaViewModel.kt
@@ -1,0 +1,31 @@
+package cm.aptoide.pt.feature_editorial.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cm.aptoide.pt.feature_editorial.domain.usecase.EditorialsMetaUseCase
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+
+class EditorialsMetaViewModel(
+  editorialWidgetUrl: String,
+  editorialsMetaUseCase: EditorialsMetaUseCase
+) : ViewModel() {
+
+  private val viewModelState =
+    MutableStateFlow(EditorialsMetaUiState(editorialsMetas = emptyList()))
+
+  val uiState = viewModelState
+    .stateIn(
+      viewModelScope,
+      SharingStarted.Eagerly,
+      viewModelState.value
+    )
+
+  init {
+    viewModelScope.launch {
+      editorialsMetaUseCase.getEditorialsMeta(editorialWidgetUrl)
+        .catch { throwable -> throwable.printStackTrace() }
+        .collect { metaList -> viewModelState.update { it.copy(editorialsMetas = metaList) } }
+    }
+  }
+}

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/EditorialsMetaViewModel.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/EditorialsMetaViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.launch
 
 class EditorialsMetaViewModel(
   editorialWidgetUrl: String,
+  subtype:String?,
   editorialsMetaUseCase: EditorialsMetaUseCase
 ) : ViewModel() {
 
@@ -23,7 +24,7 @@ class EditorialsMetaViewModel(
 
   init {
     viewModelScope.launch {
-      editorialsMetaUseCase.getEditorialsMeta(editorialWidgetUrl)
+      editorialsMetaUseCase.getEditorialsMeta(editorialWidgetUrl, subtype)
         .catch { throwable -> throwable.printStackTrace() }
         .collect { metaList -> viewModelState.update { it.copy(editorialsMetas = metaList) } }
     }

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
@@ -6,16 +6,18 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import cm.aptoide.pt.feature_editorial.domain.usecase.EditorialsMetaUseCase
+import cm.aptoide.pt.feature_editorial.domain.usecase.GetEditorialDetailUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
-interface EditorialsMetaUseCaseProvider {
+interface EditorialDependenciesProvider {
   val editorialsMetaUseCase: EditorialsMetaUseCase
+  val getEditorialDetailUseCase: GetEditorialDetailUseCase
 }
 
 @HiltViewModel
 class InjectionsProvider @Inject constructor(
-  val provider: EditorialsMetaUseCaseProvider,
+  val provider: EditorialDependenciesProvider,
 ) : ViewModel()
 
 @Composable
@@ -29,6 +31,23 @@ fun editorialsMetaViewModel(requestUrl: String): EditorialsMetaViewModel {
         return EditorialsMetaViewModel(
           editorialWidgetUrl = requestUrl,
           editorialsMetaUseCase = injectionsProvider.provider.editorialsMetaUseCase,
+        ) as T
+      }
+    }
+  )
+}
+
+@Composable
+fun editorialViewModel(articleId: String): EditorialViewModel {
+  val injectionsProvider = hiltViewModel<InjectionsProvider>()
+  return viewModel(
+    key = articleId,
+    factory = object : ViewModelProvider.Factory {
+      override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        @Suppress("UNCHECKED_CAST")
+        return EditorialViewModel(
+          articleId = articleId,
+          getEditorialDetailUseCase = injectionsProvider.provider.getEditorialDetailUseCase,
         ) as T
       }
     }

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
@@ -1,0 +1,36 @@
+package cm.aptoide.pt.feature_editorial.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import cm.aptoide.pt.feature_editorial.domain.usecase.EditorialsMetaUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+interface EditorialsMetaUseCaseProvider {
+  val editorialsMetaUseCase: EditorialsMetaUseCase
+}
+
+@HiltViewModel
+class InjectionsProvider @Inject constructor(
+  val provider: EditorialsMetaUseCaseProvider,
+) : ViewModel()
+
+@Composable
+fun editorialsMetaViewModel(requestUrl: String): EditorialsMetaViewModel {
+  val injectionsProvider = hiltViewModel<InjectionsProvider>()
+  return viewModel(
+    key = requestUrl,
+    factory = object : ViewModelProvider.Factory {
+      override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        @Suppress("UNCHECKED_CAST")
+        return EditorialsMetaViewModel(
+          editorialWidgetUrl = requestUrl,
+          editorialsMetaUseCase = injectionsProvider.provider.editorialsMetaUseCase,
+        ) as T
+      }
+    }
+  )
+}

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
@@ -21,15 +21,16 @@ class InjectionsProvider @Inject constructor(
 ) : ViewModel()
 
 @Composable
-fun editorialsMetaViewModel(requestUrl: String): EditorialsMetaViewModel {
+fun editorialsMetaViewModel(requestUrl: String, subtype: String? = null): EditorialsMetaViewModel {
   val injectionsProvider = hiltViewModel<InjectionsProvider>()
   return viewModel(
-    key = requestUrl,
+    key = requestUrl + subtype,
     factory = object : ViewModelProvider.Factory {
       override fun <T : ViewModel> create(modelClass: Class<T>): T {
         @Suppress("UNCHECKED_CAST")
         return EditorialsMetaViewModel(
           editorialWidgetUrl = requestUrl,
+          subtype = subtype,
           editorialsMetaUseCase = injectionsProvider.provider.editorialsMetaUseCase,
         ) as T
       }


### PR DESCRIPTION
**What does this PR do?**

   Make editorial an reactions logic easy to reuse.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] By commits

**How should this be manually tested?**

  Start the app, go the the editorial article

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-44](https://aptoide.atlassian.net/browse/DT-44)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass