### PR TITLE
[DT-373] Make adListId nullable

### DIFF
--- a/feature_appview/src/main/java/cm/aptoide/pt/feature_appview/presentation/AppViewViewModel.kt
+++ b/feature_appview/src/main/java/cm/aptoide/pt/feature_appview/presentation/AppViewViewModel.kt
@@ -14,7 +14,7 @@ class AppViewViewModel constructor(
   private val getAppInfoUseCase: GetAppInfoUseCase,
   private val getOtherVersionsUseCase: GetAppOtherVersionsUseCase,
   private val packageName: String,
-  private val adListId: String,
+  private val adListId: String?,
   tabsList: TabsListProvider,
 ) : ViewModel() {
 

--- a/feature_appview/src/main/java/cm/aptoide/pt/feature_appview/presentation/ViewModelProvider.kt
+++ b/feature_appview/src/main/java/cm/aptoide/pt/feature_appview/presentation/ViewModelProvider.kt
@@ -19,7 +19,7 @@ class InjectionsProvider @Inject constructor(
 ) : ViewModel()
 
 @Composable
-fun perPackageNameViewModel(packageName: String, adListId: String): AppViewViewModel {
+fun perPackageNameViewModel(packageName: String, adListId: String?): AppViewViewModel {
   val injectionsProvider = hiltViewModel<InjectionsProvider>()
   return viewModel(
     viewModelStoreOwner = LocalContext.current as AppCompatActivity,

--- a/feature_campaigns/src/main/java/cm/aptoide/pt/feature_campaigns/CampaignImpl.kt
+++ b/feature_campaigns/src/main/java/cm/aptoide/pt/feature_campaigns/CampaignImpl.kt
@@ -14,13 +14,15 @@ data class CampaignImpl constructor(
   private val repository: CampaignRepository,
   private val normalize: suspend (String, String) -> String
 ) : Campaign {
-  var adListId: String = ""
+  var adListId: String? = null
 
   override suspend fun sendImpressionEvent() = withContext(Dispatchers.IO) {
+    val adListId = adListId ?: return@withContext
     impressions.forEach { repository.knock(normalize(it, adListId)) }
   }
 
   override suspend fun sendClickEvent() = withContext(Dispatchers.IO) {
+    val adListId = adListId ?: return@withContext
     clicks.forEach { repository.knock(normalize(it, adListId)) }
   }
 }


### PR DESCRIPTION
**What does this PR do?**

   Make adListId nullable and don't actually call campaign actions when adListId is null.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] CampaignImpl.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-373](https://aptoide.atlassian.net/browse/DT-373)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-373](https://aptoide.atlassian.net/browse/DT-373)

**What are the relevant PRs?**

  PRs related to this one: [#102](https://github.com/Aptoide/aptoide-client-dt/pull/102)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-373]: https://aptoide.atlassian.net/browse/DT-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-373]: https://aptoide.atlassian.net/browse/DT-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ