### PR TITLE
[DT-418] Cancel installation while in queue

### DIFF
--- a/install-manager/src/test/java/cm/aptoide/pt/install_manager/TasksTest.kt
+++ b/install-manager/src/test/java/cm/aptoide/pt/install_manager/TasksTest.kt
@@ -276,6 +276,115 @@ internal class TasksTest {
   }
 
   @Test
+  fun `Return cancellation on second download if download is cancelled when another one is downloading and don't save task info`() = coScenario { scope ->
+    m Given "task info repository mock without saved data"
+    val taskInfoRepository = TaskInfoRepositoryMock()
+    m And "package downloader mock that will wait for cancellation"
+    val packageDownloader = PackageDownloaderMock(waitForCancel = true)
+    m And "install manager initialised with those mocks"
+    val installManager = createBuilderWithMocks(scope).apply {
+      this.taskInfoRepository = taskInfoRepository
+      this.packageDownloader = packageDownloader
+    }.build()
+
+    m And "installation for the provided package name started"
+    val taskDownload = installManager.getApp("package").install(installInfo)
+    val taskDownloadToCancel = installManager.getApp("packageToCancel").install(installInfo)
+
+    m And "collect the task state and progress"
+    var resultDownloadStates = emptyList<Pair<Task.State, Int>>()
+    var resultDownloadToCancel = emptyList<Pair<Task.State, Int>>()
+
+    scope.launch {
+      resultDownloadStates = taskDownload.stateAndProgress.toList()
+      resultDownloadToCancel = taskDownloadToCancel.stateAndProgress.toList()
+    }
+
+    m And "wait for download starts"
+    scope.advanceUntilIdle()
+
+    m When "cancel the second download task"
+    taskDownloadToCancel.cancel()
+
+    m And "wait for all coroutines to finish"
+    scope.advanceUntilIdle()
+
+    m And "collect the tasks states and progress again"
+    val resultDownload = taskDownload.stateAndProgress.toList()
+    val resultDownloadToCancelFinalState = taskDownloadToCancel.stateAndProgress.toList()
+
+    m Then "first assert data has all the states"
+    assertEquals(
+      listOf(
+        Task.State.PENDING to -1,
+        Task.State.DOWNLOADING to 0,
+        Task.State.DOWNLOADING to 25,
+        Task.State.DOWNLOADING to 50,
+        Task.State.DOWNLOADING to 75,
+        Task.State.READY_TO_INSTALL to -1,
+        Task.State.INSTALLING to 0,
+        Task.State.INSTALLING to 25,
+        Task.State.INSTALLING to 50,
+        Task.State.INSTALLING to 75,
+        Task.State.COMPLETED to -1
+      ),
+      resultDownloadStates
+    )
+    assertEquals(
+      listOf(
+        Task.State.CANCELED to -1
+      ),
+      resultDownloadToCancel
+    )
+
+    m And "second assert collected data contains only last state"
+    assertEquals(listOf(Task.State.COMPLETED to -1), resultDownload)
+    assertEquals(listOf(Task.State.CANCELED to -1), resultDownloadToCancelFinalState)
+
+    m And "task removed from the repo"
+    assertTrue(taskInfoRepository.info.isEmpty())
+  }
+
+  @Test
+  fun `Return cancellation if download is cancelled before starting and don't save task info`() = coScenario { scope ->
+    m Given "task info repository mock without saved data"
+    val taskInfoRepository = TaskInfoRepositoryMock()
+    m And "package downloader mock that will wait for cancellation"
+    val packageDownloader = PackageDownloaderMock(waitForCancel = true)
+    m And "install manager initialised with those mocks"
+    val installManager = createBuilderWithMocks(scope).apply {
+      this.taskInfoRepository = taskInfoRepository
+      this.packageDownloader = packageDownloader
+    }.build()
+    m And "installation for the provided package name started"
+    val task = installManager.getApp("package").install(installInfo)
+    m And "collect the task state and progress"
+    var result = emptyList<Pair<Task.State, Int>>()
+    scope.launch {
+      result = task.stateAndProgress.toList()
+    }
+
+    m When "cancel the task"
+    task.cancel()
+    m And "wait for all coroutines to finish"
+    scope.advanceUntilIdle()
+    m And "collect the task state and progress again"
+    val result2 = task.stateAndProgress.toList()
+
+    m Then "first collected data has all the states"
+    assertEquals(
+      listOf(
+        Task.State.CANCELED to -1
+      ),
+      result
+    )
+    m And "second collected data contains only last state"
+    assertEquals(listOf(Task.State.CANCELED to -1), result2)
+    m And "task removed from the repo"
+    assertTrue(taskInfoRepository.info.isEmpty())
+  }
+
+  @Test
   fun `Return cancellation if download cancelled and don't save task info`() = coScenario { scope ->
     m Given "task info repository mock without saved data"
     val taskInfoRepository = TaskInfoRepositoryMock()

--- a/install-manager/src/test/java/cm/aptoide/pt/install_manager/TestData.kt
+++ b/install-manager/src/test/java/cm/aptoide/pt/install_manager/TestData.kt
@@ -211,7 +211,7 @@ internal class PackageDownloaderMock(
       downloading.add(packageName)
       for (it in 0..4) {
         wait()
-        if (it > 1 && waitForCancel) blocker.await()
+        if (it == 2 && waitForCancel) blocker.await()
         if (cancelled.contains(packageName)) throw CancellationException("Cancelled")
         emit(it * 25)
         if (it > 1 && letItCrash) throw RuntimeException("Problem!")


### PR DESCRIPTION
**What does this PR do?**

This PR enables cancelation for downloads that are pending on installation.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] TasksTest.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-418](https://aptoide.atlassian.net/browse/DT-418)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-418](https://aptoide.atlassian.net/browse/DT-418)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[DT-418]: https://aptoide.atlassian.net/browse/DT-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-418]: https://aptoide.atlassian.net/browse/DT-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ