### PR TITLE
[DT-465] port v10 search

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/di/RepositoryModule.kt
+++ b/app/src/main/java/cm/aptoide/pt/di/RepositoryModule.kt
@@ -10,10 +10,12 @@ import cm.aptoide.pt.aptoide_network.di.StoreName
 import cm.aptoide.pt.aptoide_network.di.VersionCode
 import cm.aptoide.pt.feature_campaigns.data.CampaignUrlNormalizer
 import cm.aptoide.pt.feature_home.di.WidgetsUrl
+import cm.aptoide.pt.feature_search.domain.repository.SearchStoreManager
 import cm.aptoide.pt.home.BottomNavigationManager
 import cm.aptoide.pt.network.AptoideUserAgentInterceptor
 import cm.aptoide.pt.profile.data.UserProfileRepository
 import cm.aptoide.pt.profile.di.UserProfileDataStore
+import cm.aptoide.pt.search.AptoideSearchStoreManager
 import cm.aptoide.pt.settings.data.UserPreferencesRepository
 import cm.aptoide.pt.settings.di.UserPreferencesDataStore
 import cm.aptoide.pt.userPreferencesDataStore
@@ -94,4 +96,8 @@ class RepositoryModule {
   ): UserPreferencesRepository {
     return UserPreferencesRepository(dataStore)
   }
+
+  @Singleton
+  @Provides
+  fun provideSearchStoreManager(): SearchStoreManager = AptoideSearchStoreManager()
 }

--- a/app/src/main/java/cm/aptoide/pt/home/BottomNavigationView.kt
+++ b/app/src/main/java/cm/aptoide/pt/home/BottomNavigationView.kt
@@ -28,7 +28,7 @@ import cm.aptoide.pt.aptoide_ui.toolbar.AptoideActionBar
 import cm.aptoide.pt.aptoide_ui.urlViewScreen
 import cm.aptoide.pt.feature_home.presentation.BundlesScreen
 import cm.aptoide.pt.feature_home.presentation.ScreenType
-import cm.aptoide.pt.feature_search.presentation.search.SearchScreen
+import cm.aptoide.pt.feature_search.presentation.SearchScreen
 import cm.aptoide.pt.feature_updates.presentation.UpdatesScreen
 import cm.aptoide.pt.profile.presentation.ProfileButton
 import cm.aptoide.pt.profile.presentation.editProfileScreen

--- a/app/src/main/java/cm/aptoide/pt/search/AptoideSearchStoreManager.kt
+++ b/app/src/main/java/cm/aptoide/pt/search/AptoideSearchStoreManager.kt
@@ -1,0 +1,16 @@
+package cm.aptoide.pt.search
+
+import cm.aptoide.pt.feature_search.domain.repository.SearchStoreManager
+import cm.aptoide.pt.BuildConfig
+
+
+class AptoideSearchStoreManager: SearchStoreManager {
+
+  override fun shouldAddStore(): Boolean {
+    return false
+  }
+
+  override fun getStore(): String {
+    return BuildConfig.MARKET_NAME
+  }
+}

--- a/feature_search/src/main/java/cm/aptoide/pt/feature_search/data/network/service/SearchRetrofitService.kt
+++ b/feature_search/src/main/java/cm/aptoide/pt/feature_search/data/network/service/SearchRetrofitService.kt
@@ -7,6 +7,7 @@ import cm.aptoide.pt.feature_search.data.network.RemoteSearchRepository
 import cm.aptoide.pt.feature_search.data.network.model.SearchAppJsonList
 import cm.aptoide.pt.feature_search.data.network.model.TopSearchAppJsonList
 import cm.aptoide.pt.feature_search.data.network.response.SearchAutoCompleteSuggestionsResponse
+import cm.aptoide.pt.feature_search.domain.repository.SearchStoreManager
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import retrofit2.Response
@@ -19,7 +20,8 @@ import javax.inject.Singleton
 @Singleton
 class SearchRetrofitService @Inject constructor(
   @RetrofitBuzz private val autoCompleteSearchSuggestionsService: AutoCompleteSearchRetrofitService,
-  @RetrofitV7 private val searchAppRetrofitService: SearchAppRetrofitService
+  @RetrofitV7 private val searchAppRetrofitService: SearchAppRetrofitService,
+  private val searchStoreManager: SearchStoreManager,
 ) :
   RemoteSearchRepository {
 
@@ -28,13 +30,17 @@ class SearchRetrofitService @Inject constructor(
   }
 
   override suspend fun searchApp(keyword: String): Response<BaseV7DataListResponse<SearchAppJsonList>> {
-    return searchAppRetrofitService.searchApp(keyword, 15)
+    return if (searchStoreManager.shouldAddStore()) {
+      searchAppRetrofitService.searchApp(keyword, 15, searchStoreManager.getStore())
+    } else {
+      searchAppRetrofitService.searchApp(keyword, 15, null)
+    }
   }
 
   interface AutoCompleteSearchRetrofitService {
     @GET("/v1/suggestion/app/{query}")
     suspend fun getAutoCompleteSuggestions(
-      @Path(value = "query", encoded = true) query: String
+      @Path(value = "query", encoded = true) query: String,
     ): Response<SearchAutoCompleteSuggestionsResponse>
   }
 
@@ -42,7 +48,8 @@ class SearchRetrofitService @Inject constructor(
     @GET("listSearchApps")
     suspend fun searchApp(
       @Query(value = "query", encoded = true) query: String,
-      @Query(value = "limit") limit: Int
+      @Query(value = "limit") limit: Int,
+      @Query(value = "store_name") storeName: String? = null,
     ): Response<BaseV7DataListResponse<SearchAppJsonList>>
   }
 
@@ -60,6 +67,4 @@ class SearchRetrofitService @Inject constructor(
     )
     return flowOf(fakeList)
   }
-
-
 }

--- a/feature_search/src/main/java/cm/aptoide/pt/feature_search/di/RepositoryModule.kt
+++ b/feature_search/src/main/java/cm/aptoide/pt/feature_search/di/RepositoryModule.kt
@@ -10,6 +10,7 @@ import cm.aptoide.pt.feature_search.data.database.SearchHistoryRepository
 import cm.aptoide.pt.feature_search.data.network.RemoteSearchRepository
 import cm.aptoide.pt.feature_search.data.network.service.SearchRetrofitService
 import cm.aptoide.pt.feature_search.domain.repository.SearchRepository
+import cm.aptoide.pt.feature_search.domain.repository.SearchStoreManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -22,12 +23,11 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object RepositoryModule {
 
-
   @Singleton
   @Provides
   fun provideSearchRepository(
     searchHistoryRepository: SearchHistoryRepository,
-    remoteSearchRepository: RemoteSearchRepository
+    remoteSearchRepository: RemoteSearchRepository,
   ): SearchRepository {
     return AptoideSearchRepository(searchHistoryRepository, remoteSearchRepository)
   }
@@ -36,11 +36,13 @@ object RepositoryModule {
   @Provides
   fun provideRemoteSearchRepository(
     @RetrofitBuzz retrofitBuzz: Retrofit,
-    @RetrofitV7 retrofitV7: Retrofit
+    @RetrofitV7 retrofitV7: Retrofit,
+    searchStoreManager: SearchStoreManager,
   ): RemoteSearchRepository {
     return SearchRetrofitService(
       retrofitBuzz.create(SearchRetrofitService.AutoCompleteSearchRetrofitService::class.java),
-      retrofitV7.create(SearchRetrofitService.SearchAppRetrofitService::class.java)
+      retrofitV7.create(SearchRetrofitService.SearchAppRetrofitService::class.java),
+      searchStoreManager
     )
   }
 
@@ -56,5 +58,4 @@ object RepositoryModule {
     return Room.databaseBuilder(appContext, SearchHistoryDatabase::class.java, "aptoide_search.db")
       .build()
   }
-
 }

--- a/feature_search/src/main/java/cm/aptoide/pt/feature_search/domain/repository/SearchStoreManager.kt
+++ b/feature_search/src/main/java/cm/aptoide/pt/feature_search/domain/repository/SearchStoreManager.kt
@@ -1,0 +1,8 @@
+package cm.aptoide.pt.feature_search.domain.repository
+
+interface SearchStoreManager {
+
+  fun shouldAddStore(): Boolean
+
+  fun getStore(): String
+}

--- a/feature_search/src/main/java/cm/aptoide/pt/feature_search/presentation/SearchAppBarState.kt
+++ b/feature_search/src/main/java/cm/aptoide/pt/feature_search/presentation/SearchAppBarState.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.feature_search.presentation.search
+package cm.aptoide.pt.feature_search.presentation
 
 enum class SearchAppBarState {
   OPENED, CLOSED, RESULTS

--- a/feature_search/src/main/java/cm/aptoide/pt/feature_search/presentation/SearchUiState.kt
+++ b/feature_search/src/main/java/cm/aptoide/pt/feature_search/presentation/SearchUiState.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.feature_search.presentation.search
+package cm.aptoide.pt.feature_search.presentation
 
 import cm.aptoide.pt.feature_search.domain.model.SearchApp
 import cm.aptoide.pt.feature_search.domain.model.SearchSuggestions

--- a/feature_search/src/main/java/cm/aptoide/pt/feature_search/presentation/SearchView.kt
+++ b/feature_search/src/main/java/cm/aptoide/pt/feature_search/presentation/SearchView.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.feature_search.presentation.search
+package cm.aptoide.pt.feature_search.presentation
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
@@ -44,6 +44,7 @@ import cm.aptoide.pt.feature_search.R
 import cm.aptoide.pt.feature_search.domain.model.SearchApp
 import cm.aptoide.pt.feature_search.domain.model.SearchSuggestion
 import cm.aptoide.pt.feature_search.domain.model.SearchSuggestionType
+import cm.aptoide.pt.feature_search.presentation.SearchAppBarState.CLOSED
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import coil.transform.RoundedCornersTransformation
@@ -426,7 +427,7 @@ fun SearchAppBarPreview() {
   SearchAppBar(
     query = "facebook",
     onSearchQueryChanged = {},
-    onSearchQueryClick = {}, onSearchFocus = {}, SearchAppBarState.CLOSED
+    onSearchQueryClick = {}, onSearchFocus = {}, CLOSED
   )
 }
 

--- a/feature_search/src/main/java/cm/aptoide/pt/feature_search/presentation/SearchViewModel.kt
+++ b/feature_search/src/main/java/cm/aptoide/pt/feature_search/presentation/SearchViewModel.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.feature_search.presentation.search
+package cm.aptoide.pt.feature_search.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -8,6 +8,7 @@ import cm.aptoide.pt.feature_search.domain.model.SearchSuggestionType.TOP_APTOID
 import cm.aptoide.pt.feature_search.domain.model.SearchSuggestions
 import cm.aptoide.pt.feature_search.domain.repository.SearchRepository
 import cm.aptoide.pt.feature_search.domain.usecase.*
+import cm.aptoide.pt.feature_search.presentation.SearchUiState.HasSearchSuggestions
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -127,7 +128,7 @@ private data class SearchViewModelState(
 ) {
 
   fun toUiState(): SearchUiState =
-    SearchUiState.HasSearchSuggestions(
+    HasSearchSuggestions(
       isLoading = isLoading,
       errorMessages = hasErrors,
       searchSuggestions = searchSuggestions,


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at putting v10 search in DT, where it should be store based. Meanwhile, in V10 it should stay for all stores.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] SearchRepository.kt

**How should this be manually tested?**

Open the app and make a search

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-465](https://aptoide.atlassian.net/browse/DT-465)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-465]: https://aptoide.atlassian.net/browse/DT-465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ