### PR TITLE
[DT-516] Extract extension and composable for metered connection

### DIFF
--- a/extensions/src/main/AndroidManifest.xml
+++ b/extensions/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <application
       android:allowBackup="true"
       android:label="@string/app_name"

--- a/extensions/src/main/java/cm/aptoide/pt/extensions/Composables.kt
+++ b/extensions/src/main/java/cm/aptoide/pt/extensions/Composables.kt
@@ -2,8 +2,12 @@ package cm.aptoide.pt.extensions
 
 import android.content.res.Configuration
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun isActiveNetworkMetered() = LocalContext.current.isActiveNetworkMetered
 
 @Composable
 fun <T> runPreviewable(

--- a/extensions/src/main/java/cm/aptoide/pt/extensions/ContextExtensions.kt
+++ b/extensions/src/main/java/cm/aptoide/pt/extensions/ContextExtensions.kt
@@ -1,0 +1,9 @@
+package cm.aptoide.pt.extensions
+
+import android.content.Context
+import android.net.ConnectivityManager
+
+val Context.isActiveNetworkMetered
+  get() = (getSystemService(
+    Context.CONNECTIVITY_SERVICE
+  ) as ConnectivityManager).isActiveNetworkMetered


### PR DESCRIPTION
**What does this PR do?**

   - Creates extracted context extension functions to check if the network is metered

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] ContextExtensions.kt
- [ ] Composables.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-516](https://aptoide.atlassian.net/browse/DT-516)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-516](https://aptoide.atlassian.net/browse/DT-516)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-516]: https://aptoide.atlassian.net/browse/DT-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-516]: https://aptoide.atlassian.net/browse/DT-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ