### PR TITLE
[DT-525] Add `aab=1` query parameter to the search query

### DIFF
--- a/feature_search/src/main/java/cm/aptoide/pt/feature_search/data/network/service/SearchRetrofitService.kt
+++ b/feature_search/src/main/java/cm/aptoide/pt/feature_search/data/network/service/SearchRetrofitService.kt
@@ -36,6 +36,7 @@ class SearchRetrofitService @Inject constructor(
       @Query(value = "query", encoded = true) query: String,
       @Query(value = "limit") limit: Int,
       @Query(value = "store_name") storeName: String? = null,
+      @Query("aab") aab: Int = 1,
     ): Response<BaseV7DataListResponse<AppJSON>>
 
     @GET("listApps/group_name=popular-search")


### PR DESCRIPTION
**What does this PR do?**

   Add `aab=1` query parameter to the search query to include AAB apps in the search results.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] SearchRetrofitService.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-525](https://aptoide.atlassian.net/browse/APP-525)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-525](https://aptoide.atlassian.net/browse/APP-525)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-525]: https://aptoide.atlassian.net/browse/APP-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-525]: https://aptoide.atlassian.net/browse/APP-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ