### PR TITLE
[DT-551] Add Accept-Language okhttp interceptor

### DIFF
--- a/aptoide-network/src/main/java/cm/aptoide/pt/aptoide_network/data/network/AcceptLanguageInterceptor.kt
+++ b/aptoide-network/src/main/java/cm/aptoide/pt/aptoide_network/data/network/AcceptLanguageInterceptor.kt
@@ -1,0 +1,25 @@
+package cm.aptoide.pt.aptoide_network.data.network
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import okhttp3.Interceptor
+import okhttp3.Interceptor.Chain
+import okhttp3.Response
+import javax.inject.Inject
+
+class AcceptLanguageInterceptor @Inject constructor(
+  @ApplicationContext private val context: Context
+) : Interceptor {
+
+  override fun intercept(chain: Chain): Response {
+    val resources = context.resources
+    val originalRequest = chain.request()
+    val newRequest = originalRequest.newBuilder()
+      .addHeader(
+        "Accept-Language", resources.configuration.locale.language
+          + "-"
+          + resources.configuration.locale.country
+      ).build()
+    return chain.proceed(newRequest)
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

   - Adds an OkHttp interceptor responsible of adding the Accept-Language header with both the language and country locales.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AcceptLanguageInterceptor.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-551](https://aptoide.atlassian.net/browse/DT-551)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-551](https://aptoide.atlassian.net/browse/DT-551)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-551]: https://aptoide.atlassian.net/browse/DT-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-551]: https://aptoide.atlassian.net/browse/DT-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ