### PR TITLE
[DT-560] change gm categories sort

### DIFF
--- a/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/data/CategoriesRepository.kt
+++ b/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/data/CategoriesRepository.kt
@@ -7,5 +7,7 @@ interface CategoriesRepository {
 
   suspend fun getCategoriesList(url: String): List<Category>
 
+  suspend fun getGlobalCategoriesList(url: String): List<Category>
+
   suspend fun getAppsCategories(packageNames: List<String>): List<AppCategory>
 }


### PR DESCRIPTION
**What does this PR do?**

This PR aims at changing the sort used on the games match categories. We are getting the same value that is being used on the categories request that comes from the getStoreWidgets. We also started doing the games match categories request on the categories bundle

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AptoideCategoriesRepository.kt

**How should this be manually tested?**

Open the categories bundle and open the games match categories view. Check that the order is the same. In case it isn't please confirm if its not the diference in the api. (Currently when i am opening this PR, the categories more view is only returning 9 apps).

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-560](https://aptoide.atlassian.net/browse/DT-560)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-560]: https://aptoide.atlassian.net/browse/DT-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ