### PR TITLE
[DT 686] MMP links 2 touch attribution

### DIFF
--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadViewModel.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadViewModel.kt
@@ -73,13 +73,9 @@ class DownloadViewModel constructor(
 
   fun downloadApp(app: App) {
     viewModelScope.launch {
-      if (appInstaller.tasks.first() == null) {
-        viewModelState.update { DownloadUiState.Processing }
-        appInstaller.install(
-          app.getInstallPackageInfo(payloadMapper)
-        )
-        app.campaigns?.sendClickEvent()
-      }
+      viewModelState.update { DownloadUiState.Processing }
+      appInstaller.install(app.getInstallPackageInfo(payloadMapper))
+      app.campaigns?.sendInstallClickEvent()
     }
   }
 

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AptoideAppsRepository.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AptoideAppsRepository.kt
@@ -279,7 +279,8 @@ fun CampaignUrls.mapCampaigns(
       impressions = impressionsList,
       clicks = clicksList,
       repository = campaignRepository,
-      normalize = campaignUrlNormalizer.normalize
+      normalizeImpression = campaignUrlNormalizer.normalizeImpression,
+      normalizeClick = campaignUrlNormalizer.normalizeClick,
     )
   }
   return null

--- a/feature_campaigns/src/main/java/cm/aptoide/pt/feature_campaigns/data/CampaignUrlNormalizer.kt
+++ b/feature_campaigns/src/main/java/cm/aptoide/pt/feature_campaigns/data/CampaignUrlNormalizer.kt
@@ -1,6 +1,7 @@
 package cm.aptoide.pt.feature_campaigns.data
 
 import android.content.Context
+import android.net.Uri
 import com.google.android.gms.ads.identifier.AdvertisingIdClient
 import java.math.BigInteger
 import java.security.MessageDigest
@@ -21,20 +22,32 @@ class CampaignUrlNormalizer(context: Context) {
     getCurrentTimeStamp()
   }
 
-  val normalize: suspend (String, String) -> String = { url, adListId ->
+  val normalizeImpression: (String, String) -> String = this::normalizeUrl
+
+  val normalizeClick: (String, String, Boolean) -> String = { url, adListId, mmp ->
+    val newUrl = normalizeUrl(url, adListId)
+
+    val result = Uri.parse(newUrl)
+      .buildUpon()
+      .appendQueryParameter("mmp", mmp.toString())
+      .build()
+      .toString()
+
+    result
+  }
+
+  private fun normalizeUrl(url: String, adListId: String) : String {
     val campaignId = url.split("campaignId=")[1].split("&")[0]
     val bidId = calculateBidId(campaignId)
     val impressionId = calculateImpressionId(campaignId)
     val aaid = calculateAAID()
     val sha1Aaid = calculateSHA1(advertisingId)
 
-    val newUrl: String = url.replace("{{BID_ID}}", bidId)
+    return url.replace("{{BID_ID}}", bidId)
       .replace("{{IMPRESSION_ID}}", impressionId)
       .replace("{{AD_LIST_ID}}", adListId)
       .replace("{{AAID}}", aaid)
       .replace("{{AAID_SHA1}}", sha1Aaid)
-
-    newUrl
   }
 
   private fun calculateSHA1(aaid: String): String {

--- a/feature_campaigns/src/test/java/cm/aptoide/pt/feature_campaigns/CampaignImplTest.kt
+++ b/feature_campaigns/src/test/java/cm/aptoide/pt/feature_campaigns/CampaignImplTest.kt
@@ -33,13 +33,14 @@ internal class CampaignImplTest {
       impressions = listOf("dog", "cat"),
       clicks = urls,
       repository = repository,
-      normalize = { url, _ -> url }
+      normalizeImpression = { url, _ -> url },
+      normalizeClick = { url, _ , _-> url }
     )
     m And "Campaign has provided adListId"
     campaign.adListId = adListId
 
     m When "sending open conversion event"
-    campaign.sendClickEvent()
+    campaign.sendInstallClickEvent()
 
     m Then "Events sent as expected"
     assertEquals(sentEvents, repository.eventUrls)
@@ -60,7 +61,8 @@ internal class CampaignImplTest {
       impressions = urls,
       clicks = listOf("one", "bird"),
       repository = repository,
-      normalize = { url, _ -> url }
+      normalizeImpression = { url, _ -> url },
+      normalizeClick = { url, _ , _-> url }
     )
     m And "Campaign has provided adListId"
     campaign.adListId = adListId


### PR DESCRIPTION
**What does this PR do?**

This PR adds a new parameter to the campaigns click endpoint.
To do this, I separated the click and impressions events.
I also needed to change the database in order to store the click endpoints to be send after the installation is successful.

I also fixed an issue that was blocking multiple installations.

**Database changed?**

   Yes

**Where should the reviewer start?**

- [ ] DownloadViewModel.kt
- [ ] AptoideAppsRepository.kt
- [ ] CampaignImpl.kt
- [ ] CampaingUrlNormalizer.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-686](https://aptoide.atlassian.net/browse/DT-686)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-686](https://aptoide.atlassian.net/browse/DT-686)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-686]: https://aptoide.atlassian.net/browse/APP-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-686]: https://aptoide.atlassian.net/browse/APP-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ