### PR TITLE
[DT-734] Refactor related editorials ViewModel key

### DIFF
--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
@@ -44,7 +44,7 @@ fun editorialsCardViewModel(
 fun relatedEditorialsCardViewModel(packageName: String): RelatedEditorialsCardViewModel {
   val injectionsProvider = hiltViewModel<InjectionsProvider>()
   return viewModel(
-    key = packageName,
+    key = "relatedEditorials/$packageName",
     factory = object : ViewModelProvider.Factory {
       override fun <T : ViewModel> create(modelClass: Class<T>): T {
         @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
**What does this PR do?**

   - Refactors the key used in the related editorials ViewModel, in order to avoid conflicts with other ViewModels.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] ViewModelProvider.kt (feature_editorial)

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-734](https://aptoide.atlassian.net/browse/DT-734)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-734](https://aptoide.atlassian.net/browse/DT-734)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-734]: https://aptoide.atlassian.net/browse/DT-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-734]: https://aptoide.atlassian.net/browse/DT-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ