### PR TITLE
[DT-664] Bugfix OOS

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -112,6 +112,7 @@ dependencies {
   implementation(project(ModuleDependency.FEATURE_EDITORIAL))
   implementation(project(ModuleDependency.FEATURE_REACTIONS))
   implementation(project(ModuleDependency.FEATURE_SETTINGS))
+  implementation(project(ModuleDependency.FEATURE_OOS))
   implementation(project(ModuleDependency.ENVIRONMENT_INFO))
   implementation(project(ModuleDependency.EXTENSIONS))
   implementation(LibraryDependency.CUSTOM_CHROME_TAB)

--- a/app/src/main/java/cm/aptoide/pt/di/RepositoryModule.kt
+++ b/app/src/main/java/cm/aptoide/pt/di/RepositoryModule.kt
@@ -18,6 +18,7 @@ import cm.aptoide.pt.feature_flags.AptoideFeatureFlagsRepository
 import cm.aptoide.pt.feature_flags.data.FeatureFlagsRepository
 import cm.aptoide.pt.feature_flags.di.FeatureFlagsDataStore
 import cm.aptoide.pt.feature_home.di.WidgetsUrl
+import cm.aptoide.pt.feature_oos.UninstallPackagesFilter
 import cm.aptoide.pt.feature_search.data.AutoCompleteSuggestionsRepository
 import cm.aptoide.pt.feature_search.domain.repository.SearchStoreManager
 import cm.aptoide.pt.network.AptoideQLogicInterceptor
@@ -26,8 +27,8 @@ import cm.aptoide.pt.network.repository.IdsRepository
 import cm.aptoide.pt.profile.data.UserProfileRepository
 import cm.aptoide.pt.profile.di.UserProfileDataStore
 import cm.aptoide.pt.search.repository.AptoideAutoCompleteSuggestionsRepository
-import cm.aptoide.pt.search.repository.AptoideSearchStoreManager
 import cm.aptoide.pt.search.repository.AptoideAutoCompleteSuggestionsRepository.AutoCompleteSearchRetrofitService
+import cm.aptoide.pt.search.repository.AptoideSearchStoreManager
 import cm.aptoide.pt.settings.di.UserPreferencesDataStore
 import cm.aptoide.pt.settings.repository.UserPreferencesRepository
 import cm.aptoide.pt.userFeatureFlagsDataStore
@@ -174,4 +175,10 @@ class RepositoryModule {
   @Singleton
   fun provideAptoideFeatureFlagsRepository(): FeatureFlagsRepository =
     AptoideFeatureFlagsRepository()
+
+  @Singleton
+  @Provides
+  @UninstallPackagesFilter
+  fun providePackagesToFilter(): List<String> =
+    listOf(BuildConfig.APPLICATION_ID, "com.appcoins.wallet")
 }

--- a/feature-oos/src/main/java/cm/aptoide/pt/feature_oos/RepositoryModule.kt
+++ b/feature-oos/src/main/java/cm/aptoide/pt/feature_oos/RepositoryModule.kt
@@ -1,0 +1,7 @@
+package cm.aptoide.pt.feature_oos
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class UninstallPackagesFilter

--- a/feature-oos/src/main/java/cm/aptoide/pt/feature_oos/domain/InstalledAppsUseCase.kt
+++ b/feature-oos/src/main/java/cm/aptoide/pt/feature_oos/domain/InstalledAppsUseCase.kt
@@ -7,10 +7,14 @@ import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 @ViewModelScoped
-class InstalledAppsUseCase @Inject constructor(private val installManager: InstallManager) {
+class InstalledAppsUseCase @Inject constructor(
+  private val installManager: InstallManager
+) {
 
-  suspend fun getInstalledApps(): List<String> = installManager.getInstalledApps()
-    .map { it to (it.packageInfo.first()?.getAppSize() ?: 0) }
-    .sortedByDescending { it.second }
-    .map { it.first.packageName }
+  suspend fun getInstalledApps(filterPackages: List<String> = emptyList()): List<String> =
+    installManager.getInstalledApps()
+      .map { it to (it.packageInfo.first()?.getAppSize() ?: 0) }
+      .sortedByDescending { it.second }
+      .map { it.first.packageName }
+      .filter { !filterPackages.contains(it) }
 }

--- a/feature-oos/src/main/java/cm/aptoide/pt/feature_oos/presentation/InstalledAppsListViewModel.kt
+++ b/feature-oos/src/main/java/cm/aptoide/pt/feature_oos/presentation/InstalledAppsListViewModel.kt
@@ -3,7 +3,6 @@ package cm.aptoide.pt.feature_oos.presentation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cm.aptoide.pt.feature_oos.domain.InstalledAppsUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
@@ -11,9 +10,9 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
 class InstalledAppsListViewModel @Inject constructor(
-  private val installedAppsUseCase: InstalledAppsUseCase
+  private val installedAppsUseCase: InstalledAppsUseCase,
+  private val filterPackages: List<String> = emptyList()
 ) : ViewModel() {
 
   private val viewModelState = MutableStateFlow<InstalledAppsUiState>(InstalledAppsUiState.Loading)
@@ -27,7 +26,7 @@ class InstalledAppsListViewModel @Inject constructor(
 
   init {
     viewModelScope.launch {
-      val installedApps = installedAppsUseCase.getInstalledApps()
+      val installedApps = installedAppsUseCase.getInstalledApps(filterPackages)
       viewModelState.update { InstalledAppsUiState.Idle(installedApps) }
     }
   }

--- a/feature-oos/src/main/java/cm/aptoide/pt/feature_oos/repository/AvailableSpaceRepository.kt
+++ b/feature-oos/src/main/java/cm/aptoide/pt/feature_oos/repository/AvailableSpaceRepository.kt
@@ -15,6 +15,6 @@ class AvailableSpaceRepository @Inject constructor() {
 
   fun getRequiredSpace(appSize: Long): Long {
     val availableSpace = getAvailableSpace()
-    return appSize - availableSpace
+    return 2 * appSize - availableSpace
   }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR aims at applying fixes to the oos dialog.
In spanish the dialog had issues with longer app names due to the uninstall being bigger.
We added margin on the size to calculate if the out of space dialog should be shown or not.
Removal of gameshub from the list
If an app is being updated and runs out of space then we dont show that app on the dialog of out of space
Only using base apk to calculate the size needed to install, since dt does not have obbs. 

**Database changed?**

 No

**Where should the reviewer start?**

- [ ] OutOfSpaceDialog.kt

**How should this be manually tested?**

You can go to the availablespaceviewmodel and hardcode a small size to always see the dialog, or on the installview you can change the if condition to show the dialog to be always true..

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-664](https://aptoide.atlassian.net/browse/dt-664)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-664]: https://aptoide.atlassian.net/browse/DT-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ