### PR TITLE
[DT 902] Payment with credit card fails on second attempt when first attempt is cancelled

### DIFF
--- a/payments/payment-methods/adyen/src/main/java/cm/aptoide/pt/payment_method/adyen/presentation/AdyenCreditCardViewModel.kt
+++ b/payments/payment-methods/adyen/src/main/java/cm/aptoide/pt/payment_method/adyen/presentation/AdyenCreditCardViewModel.kt
@@ -258,6 +258,7 @@ class AdyenCreditCardViewModel(
         action = action,
         configuration = redirectConfiguration
       ) { actionData ->
+        // FIX: this should not be called on second attempt with the data of the previous buy attempt
         if (actionData.paymentData != null || actionData.details != null) {
           viewModelScope.launch {
             try {

--- a/payments/payment-methods/adyen/src/main/java/cm/aptoide/pt/payment_method/adyen/repository/AdyenV2Repository.kt
+++ b/payments/payment-methods/adyen/src/main/java/cm/aptoide/pt/payment_method/adyen/repository/AdyenV2Repository.kt
@@ -169,7 +169,7 @@ internal class AdyenV2RepositoryImpl @Inject constructor(
       @Body paymentDetails: PaymentDetails,
     ): TransactionResponse
 
-    @PATCH("broker/8.20200815/gateways/adyen_v2/transactions/{uid}")
+    @PATCH("broker/8.20230518/gateways/adyen_v2/transactions/{uid}")
     suspend fun submitActionResult(
       @Path("uid") uid: String,
       @Header("authorization") ewt: String,


### PR DESCRIPTION
**What does this PR do?**

Fixes an issue of an unsuccessful buy attempt after a first cancelled attempt

**Database changed?**

   No

**Steps to reproduce
1º - Go to credit card payment
2º - Introduce a card with redirect
3º - On the webview, cancel
4º - Go to credit card payment again
5º - Introduce the same card
6º - On the webview add the password to pay
7º - Failed but should be success

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-902](https://aptoide.atlassian.net/browse/DT-902)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-902](https://aptoide.atlassian.net/browse/DT-902)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass