### PR TITLE
[DT-841] Replace perAppViewModel with rememberDownloadState

### DIFF
--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadView.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadView.kt
@@ -25,8 +25,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -135,8 +133,7 @@ fun DownloadAppcPreview() {
 @Composable
 fun DownloadViewScreen(app: App) {
 
-  val downloadViewViewModel = perAppViewModel(app = app)
-  val uiState by downloadViewViewModel.uiState.collectAsState()
+  val uiState = rememberDownloadState(app = app)
 
   MainDownloadView(app) {
     DownloadState(
@@ -303,7 +300,8 @@ fun DownloadState(
     is DownloadUiState.Outdated -> InstallButton(uiState.update)
 
     is DownloadUiState.Processing,
-    is DownloadUiState.WifiPrompt -> IndeterminateDownloadView(
+    is DownloadUiState.WifiPrompt,
+    -> IndeterminateDownloadView(
       label = "Downloading",
       labelColor = tintColor,
       progressColor = tintColor


### PR DESCRIPTION
**What does this PR do?**

   A small refactoring for more convenient usage. 

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] ViewModelProvider.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-841](https://aptoide.atlassian.net/browse/DT-841)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-841](https://aptoide.atlassian.net/browse/DT-841)


**What are relevant PR's?**

  PR's related to this one: [#387](https://github.com/Aptoide/aptoide-client-dt/pull/387)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-841]: https://aptoide.atlassian.net/browse/DT-841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-841]: https://aptoide.atlassian.net/browse/DT-841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ