### PR TITLE
[DT-855] Make DownloadViewModel processing state more advanced

### DIFF
--- a/download-view/build.gradle.kts
+++ b/download-view/build.gradle.kts
@@ -16,4 +16,5 @@ dependencies {
   api(project(ModuleDependency.INSTALL_MANAGER))
   implementation(project(ModuleDependency.FEATURE_CAMPAIGNS))
   implementation(project(ModuleDependency.EXTENSIONS))
+  implementation(project(ModuleDependency.NETWORK_LISTENER))
 }

--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadUiState.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadUiState.kt
@@ -13,8 +13,9 @@ sealed class DownloadUiState {
     val onAction: ((Boolean?) -> Unit),
   ) : DownloadUiState()
 
-  data class Processing(
-    val cancel: (() -> Unit)?,
+  data class Waiting(
+    val blocker: ExecutionBlocker = ExecutionBlocker.QUEUE,
+    val action: (() -> Unit)?,
   ) : DownloadUiState()
 
   data class Downloading(
@@ -47,4 +48,10 @@ sealed class DownloadUiState {
   data class ReadyToInstall(
     val cancel: () -> Unit,
   ) : DownloadUiState()
+}
+
+enum class ExecutionBlocker {
+  QUEUE,
+  CONNECTION,
+  UNMETERED,
 }

--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadView.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadView.kt
@@ -53,7 +53,7 @@ fun DownloadPreview() {
     val states = listOf(
       DownloadUiState.Install(install = {}),
       DownloadUiState.Outdated({}, {}, {}),
-      DownloadUiState.Processing(null),
+      DownloadUiState.Waiting(action = null),
       DownloadUiState.Downloading(33, cancel = {}),
       DownloadUiState.ReadyToInstall(cancel = {}),
       DownloadUiState.Installing(66),
@@ -98,7 +98,7 @@ fun DownloadAppcPreview() {
     val states = listOf(
       DownloadUiState.Install(install = {}),
       DownloadUiState.Outdated({}, {}, {}),
-      DownloadUiState.Processing(null),
+      DownloadUiState.Waiting(action = null),
       DownloadUiState.Downloading(33, cancel = {}),
       DownloadUiState.ReadyToInstall(cancel = {}),
       DownloadUiState.Installing(66),
@@ -299,7 +299,7 @@ fun DownloadState(
     is DownloadUiState.Install -> InstallButton(uiState.install)
     is DownloadUiState.Outdated -> InstallButton(uiState.update)
 
-    is DownloadUiState.Processing,
+    is DownloadUiState.Waiting,
     is DownloadUiState.WifiPrompt,
     -> IndeterminateDownloadView(
       label = "Downloading",

--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/ViewModelProvider.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/ViewModelProvider.kt
@@ -12,6 +12,7 @@ import cm.aptoide.pt.download_view.presentation.DownloadUiState.Install
 import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.install_manager.InstallManager
+import cm.aptoide.pt.network_listener.NetworkConnectionImpl
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -22,6 +23,7 @@ interface InstallAppUseCaseProvider {
 @HiltViewModel
 class InjectionsProvider @Inject constructor(
   val provider: InstallAppUseCaseProvider,
+  val networkConnectionImpl: NetworkConnectionImpl,
   val installedAppOpener: InstalledAppOpener,
   val payloadMapper: PayloadMapper,
 ) : ViewModel()
@@ -44,6 +46,7 @@ fun rememberDownloadState(
           return DownloadViewModel(
             app = app,
             installManager = injectionsProvider.provider.installManager,
+            networkConnectionImpl = injectionsProvider.networkConnectionImpl,
             installedAppOpener = injectionsProvider.installedAppOpener,
             payloadMapper = injectionsProvider.payloadMapper,
             automaticInstall = automaticInstall,

--- a/network-listener/src/main/java/cm/aptoide/pt/network_listener/NetworkConnectionImpl.kt
+++ b/network-listener/src/main/java/cm/aptoide/pt/network_listener/NetworkConnectionImpl.kt
@@ -9,9 +9,11 @@ import cm.aptoide.pt.install_manager.environment.NetworkConnection.State
 import cm.aptoide.pt.install_manager.environment.NetworkConnection.State.GONE
 import cm.aptoide.pt.install_manager.environment.NetworkConnection.State.METERED
 import cm.aptoide.pt.install_manager.environment.NetworkConnection.State.UNMETERED
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
 
-class NetworkConnectionImpl(
-  private val context: Context,
+class NetworkConnectionImpl @Inject constructor(
+  @ApplicationContext private val context: Context,
 ) : NetworkConnection {
 
   override val state: State

--- a/network-listener/src/main/java/cm/aptoide/pt/network_listener/di/NetworkListenerModule.kt
+++ b/network-listener/src/main/java/cm/aptoide/pt/network_listener/di/NetworkListenerModule.kt
@@ -1,12 +1,10 @@
 package cm.aptoide.pt.network_listener.di
 
-import android.content.Context
 import cm.aptoide.pt.install_manager.environment.NetworkConnection
 import cm.aptoide.pt.network_listener.NetworkConnectionImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
@@ -16,9 +14,7 @@ object NetworkListenerModule {
 
   @Provides
   @Singleton
-  fun provideNetworkConnectionImpl(
-    @ApplicationContext context: Context,
-  ): NetworkConnection {
-    return NetworkConnectionImpl(context)
-  }
+  fun provideNetworkConnection(
+    networkConnectionImpl: NetworkConnectionImpl,
+  ): NetworkConnection = networkConnectionImpl
 }


### PR DESCRIPTION
**What does this PR do?**

   - Rename the download ViewModel processing state to waiting and make it more advanced, being able to distinguish between different waiting states.
   - Refactor the Network connection implementation dependency injection.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-855](https://aptoide.atlassian.net/browse/DT-855)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-855](https://aptoide.atlassian.net/browse/DT-855)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-855]: https://aptoide.atlassian.net/browse/DT-855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-855]: https://aptoide.atlassian.net/browse/DT-855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ