### PR TITLE
[DT-1012] Improve editorials url caching

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/home/BundlesView.kt
+++ b/app/src/main/java/cm/aptoide/pt/home/BundlesView.kt
@@ -109,7 +109,7 @@ fun BundlesView(
 
             Type.EDITORIAL -> EditorialMetaView(
               title = it.title,
-              requestUrl = it.view,
+              tag = it.tag,
               navigate = navigate
             )
 
@@ -215,10 +215,10 @@ fun AppsSimpleListView(
 @Composable
 fun EditorialMetaView(
   title: String,
-  requestUrl: String?,
+  tag: String,
   navigate: (String) -> Unit,
-) = requestUrl?.let {
-  val editorialsCardViewModel = editorialsCardViewModel(requestUrl = it)
+) {
+  val editorialsCardViewModel = editorialsCardViewModel(tag = tag)
   val uiState by editorialsCardViewModel.uiState.collectAsState()
   val items = uiState
 

--- a/feature-home/src/main/java/cm/aptoide/pt/feature_home/domain/AptoideUrlsCacheInitializer.kt
+++ b/feature-home/src/main/java/cm/aptoide/pt/feature_home/domain/AptoideUrlsCacheInitializer.kt
@@ -2,7 +2,7 @@ package cm.aptoide.pt.feature_home.domain
 
 import cm.aptoide.pt.aptoide_network.domain.UrlsCacheInitializer
 import cm.aptoide.pt.feature_editorial.data.EditorialRepository
-import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
+import cm.aptoide.pt.feature_editorial.domain.usecase.tagsUrls
 import cm.aptoide.pt.feature_home.data.WidgetsRepository
 
 class AptoideUrlsCacheInitializer(
@@ -19,8 +19,7 @@ class AptoideUrlsCacheInitializer(
           ?.let { url ->
             articlesRepository
               .getArticlesMeta(editorialWidgetUrl = url, subtype = null)
-              .map(ArticleMeta::idToUrl)
-          }
-          ?.toMap() ?: emptyMap())
+              .tagsUrls(url)
+          } ?: emptyMap())
     }
 }

--- a/feature_editorial/build.gradle.kts
+++ b/feature_editorial/build.gradle.kts
@@ -11,8 +11,6 @@ android {
 
 dependencies {
   implementation(project(ModuleDependency.APTOIDE_NETWORK))
-  implementation(project(ModuleDependency.APTOIDE_UI))
   implementation(project(ModuleDependency.FEATURE_APPS))
-  implementation(project(ModuleDependency.FEATURE_REACTIONS))
   implementation(project(ModuleDependency.EXTENSIONS))
 }

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/AptoideEditorialRepository.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/AptoideEditorialRepository.kt
@@ -82,14 +82,15 @@ private fun Data.toDomainModel(
   campaignRepository: CampaignRepository,
   campaignUrlNormalizer: CampaignUrlNormalizer,
 ): Article = Article(
-  id = this.id,
-  title = this.title,
-  caption = this.caption,
-  subtype = ArticleType.valueOf(this.subtype),
-  image = this.background,
-  date = this.date,
-  views = this.views,
-  content = map(this.content, campaignRepository, campaignUrlNormalizer)
+  id = id,
+  title = title,
+  caption = caption,
+  subtype = ArticleType.valueOf(subtype),
+  image = background,
+  date = date,
+  views = views,
+  relatedTag = RELATED_ARTICLE_CACHE_ID_PREFIX + id,
+  content = map(content, campaignRepository, campaignUrlNormalizer)
 )
 
 fun map(
@@ -124,16 +125,16 @@ fun map(
   return contentList
 }
 
-private fun ContentAction.toDomainModel(): Action = Action(title = this.title, url = this.url)
+private fun ContentAction.toDomainModel(): Action = Action(title = title, url = url)
 
 private fun EditorialJson.toDomainModel(): ArticleMeta = ArticleMeta(
-  id = this.card_id,
-  title = this.title,
-  url = this.url,
-  caption = this.message,
-  subtype = ArticleType.valueOf(this.subtype),
-  summary = this.summary,
-  image = this.icon,
-  date = this.date,
-  views = this.views
+  id = card_id,
+  title = title,
+  url = url,
+  caption = message,
+  subtype = ArticleType.valueOf(subtype),
+  summary = summary,
+  image = icon,
+  date = date,
+  views = views
 )

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/Article.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/Article.kt
@@ -10,7 +10,9 @@ import java.time.format.DateTimeFormatter
 import kotlin.random.Random
 import kotlin.random.nextInt
 
+const val EDITORIAL_DEFAULT_TAG = "editorial"
 const val ARTICLE_CACHE_ID_PREFIX = "editorial-"
+const val RELATED_ARTICLE_CACHE_ID_PREFIX = "related-editorial-"
 
 data class Article(
   val id: String,
@@ -20,6 +22,7 @@ data class Article(
   val image: String,
   val date: String,
   val views: Long,
+  val relatedTag: String,
   val content: List<Paragraph>,
 )
 
@@ -41,9 +44,7 @@ data class ArticleMeta(
   val subtype: ArticleType,
   val date: String,
   val views: Long,
-) {
-  val idToUrl = ARTICLE_CACHE_ID_PREFIX + id to url
-}
+)
 
 enum class ArticleType {
   APP_OF_THE_WEEK,
@@ -68,6 +69,7 @@ val randomArticle
       .minusDays(Random.nextLong(30))
       .format(DateTimeFormatter.ofPattern("uuuu-MM-dd hh:mm:ss")).toString(),
     views = Random.nextLong(50000L),
+    relatedTag = "",
     content = List(Random.nextInt(1..4)) {
       Paragraph(
         title = getRandomString(range = 1..2, capitalize = true),

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/usecase/RelatedArticlesMetaUseCase.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/usecase/RelatedArticlesMetaUseCase.kt
@@ -3,6 +3,7 @@ package cm.aptoide.pt.feature_editorial.domain.usecase
 import cm.aptoide.pt.aptoide_network.domain.UrlsCache
 import cm.aptoide.pt.feature_editorial.data.EditorialRepository
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
+import cm.aptoide.pt.feature_editorial.domain.EDITORIAL_DEFAULT_TAG
 import dagger.hilt.android.scopes.ViewModelScoped
 import timber.log.Timber
 import javax.inject.Inject
@@ -15,7 +16,7 @@ class RelatedArticlesMetaUseCase @Inject constructor(
   suspend fun getRelatedArticlesMeta(packageName: String): List<ArticleMeta> =
     try {
       editorialRepository.getRelatedArticlesMeta(packageName)
-        .also { urlsCache.putAll(it.associate(ArticleMeta::idToUrl)) }
+        .also { urlsCache.putAll(it.tagsUrls(urlsCache.get(EDITORIAL_DEFAULT_TAG))) }
     } catch (t: Throwable) {
       Timber.w(t)
       emptyList()

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/EditorialsCardViewModel.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/EditorialsCardViewModel.kt
@@ -10,10 +10,10 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.util.*
+import java.util.UUID
 
 class EditorialsCardViewModel(
-  editorialWidgetUrl: String,
+  tag: String,
   subtype: String?,
   articlesMetaUseCase: ArticlesMetaUseCase
 ) : ViewModel() {
@@ -31,7 +31,7 @@ class EditorialsCardViewModel(
 
   init {
     viewModelScope.launch {
-      val metaList = articlesMetaUseCase.getArticlesMeta(editorialWidgetUrl, subtype)
+      val metaList = articlesMetaUseCase.getArticlesMeta(tag, subtype)
       viewModelState.update { metaList }
     }
   }

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
@@ -20,18 +20,18 @@ class InjectionsProvider @Inject constructor(
 
 @Composable
 fun editorialsCardViewModel(
-  requestUrl: String,
+  tag: String,
   subtype: String? = null,
   salt: String? = null
 ): EditorialsCardViewModel {
   val injectionsProvider = hiltViewModel<InjectionsProvider>()
   return viewModel(
-    key = requestUrl + subtype + salt,
+    key = tag + subtype + salt,
     factory = object : ViewModelProvider.Factory {
       override fun <T : ViewModel> create(modelClass: Class<T>): T {
         @Suppress("UNCHECKED_CAST")
         return EditorialsCardViewModel(
-          editorialWidgetUrl = requestUrl,
+          tag = tag,
           subtype = subtype,
           articlesMetaUseCase = injectionsProvider.articlesMetaUseCase,
         ) as T


### PR DESCRIPTION
**What does this PR do?**

   Improve editorials url caching by filling up the cache with "related" tags and urls.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] No preference

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-1012](https://aptoide.atlassian.net/browse/DT-1012)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1012](https://aptoide.atlassian.net/browse/DT-1012)


**What are the relevant PRs?**

  PRs related to this one: [#409](https://github.com/Aptoide/aptoide-client-dt/pull/409)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-1012]: https://aptoide.atlassian.net/browse/DT-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1012]: https://aptoide.atlassian.net/browse/DT-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ