### PR TITLE
[DT-1056] Implement onTransact in appcoins aidl binder

### DIFF
--- a/payments/billing-sdk/src/main/java/com/appcoins/billing/sdk/AppcoinsBillingBinder.kt
+++ b/payments/billing-sdk/src/main/java/com/appcoins/billing/sdk/AppcoinsBillingBinder.kt
@@ -1,15 +1,28 @@
 package com.appcoins.billing.sdk
 
+import android.content.pm.PackageManager
+import android.os.Binder
 import android.os.Bundle
+import android.os.Parcel
 import com.appcoins.billing.AppcoinsBilling
+import javax.inject.Inject
 
-class AppcoinsBillingBinder : AppcoinsBilling.Stub() {
+class AppcoinsBillingBinder @Inject constructor(
+  private val packageManager: PackageManager,
+) : AppcoinsBilling.Stub() {
 
   companion object {
     internal const val RESULT_BILLING_UNAVAILABLE =
       3 // this billing API version is not supported for the type requested
     internal const val RESULT_DEVELOPER_ERROR = 5 // invalid arguments provided to the API
     const val RESPONSE_CODE = "RESPONSE_CODE"
+  }
+
+  private var merchantName: String? = null
+
+  override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean {
+    merchantName = packageManager.getPackagesForUid(Binder.getCallingUid())?.firstOrNull()
+    return super.onTransact(code, data, reply, flags)
   }
 
   override fun isBillingSupported(apiVersion: Int, packageName: String?, type: String?): Int {

--- a/payments/billing-sdk/src/main/java/com/appcoins/billing/sdk/AppcoinsBillingService.kt
+++ b/payments/billing-sdk/src/main/java/com/appcoins/billing/sdk/AppcoinsBillingService.kt
@@ -3,10 +3,16 @@ package com.appcoins.billing.sdk
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class AppcoinsBillingService : Service() {
 
+  @Inject
+  lateinit var appcoinsBillingBinder: AppcoinsBillingBinder
+
   override fun onBind(intent: Intent): IBinder {
-    return AppcoinsBillingBinder()
+    return appcoinsBillingBinder
   }
 }


### PR DESCRIPTION
**What does this PR do?**
   
    - Creates the onTransact method that instantiates the merchant package name (calling app) to be used in the binder.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppcoinsBillingService.kt
- [ ] AppcoinsBillingBinder.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-1056](https://aptoide.atlassian.net/browse/DT-1056)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1056](https://aptoide.atlassian.net/browse/DT-1056)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-1056]: https://aptoide.atlassian.net/browse/DT-1056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1056]: https://aptoide.atlassian.net/browse/DT-1056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ