### PR TITLE
[DT-1068] Make payment methods initialised by feature flags

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/feature_flags/AptoideFeatureFlagsRepository.kt
+++ b/app/src/main/java/cm/aptoide/pt/feature_flags/AptoideFeatureFlagsRepository.kt
@@ -1,9 +1,9 @@
 package cm.aptoide.pt.feature_flags
 
 import cm.aptoide.pt.feature_flags.data.FeatureFlagsRepository
+import org.json.JSONObject
 
 class AptoideFeatureFlagsRepository : FeatureFlagsRepository {
 
-  override suspend fun getFeatureFlags(): Map<String, String> =
-    emptyMap()
+  override suspend fun getFeatureFlags(): JSONObject = JSONObject()
 }

--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/WalletInstallationViewModel.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/WalletInstallationViewModel.kt
@@ -10,7 +10,14 @@ import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.feature_flags.domain.FeatureFlags
 import cm.aptoide.pt.install_manager.InstallManager
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -18,7 +25,7 @@ import javax.inject.Inject
 @HiltViewModel
 class WalletInstallationViewModel @Inject constructor(
   installManager: InstallManager,
-  featureFlags: FeatureFlags
+  featureFlags: FeatureFlags,
 ) : ViewModel() {
 
   private val appInstaller = installManager.getApp("com.appcoins.wallet")

--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/WalletInstallationViewModel.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/WalletInstallationViewModel.kt
@@ -47,7 +47,7 @@ class WalletInstallationViewModel @Inject constructor(
       ) { packageInfo, task -> Pair(packageInfo, task) }
         .catch { throwable -> throwable.printStackTrace() }
         .collect { (info, task) ->
-          val enabled = featureFlags.get("enable_wallet_companion_app").equals("true")
+          val enabled = featureFlags.getFlag("enable_wallet_companion_app", false)
           viewModelState.update { enabled && info == null && task == null }
         }
     }

--- a/feature-flags/src/main/java/cm/aptoide/pt/feature_flags/data/FeatureFlagsLocalRepository.kt
+++ b/feature-flags/src/main/java/cm/aptoide/pt/feature_flags/data/FeatureFlagsLocalRepository.kt
@@ -1,7 +1,9 @@
 package cm.aptoide.pt.feature_flags.data
 
+import org.json.JSONObject
+
 interface FeatureFlagsLocalRepository {
 
-  suspend fun getFeatureFlags(): Map<String, String>
-  suspend fun saveFeatureFlags(featureFlags: Map<String, String>)
+  suspend fun getFeatureFlags(): JSONObject
+  suspend fun saveFeatureFlags(featureFlags: JSONObject)
 }

--- a/feature-flags/src/main/java/cm/aptoide/pt/feature_flags/data/FeatureFlagsRepository.kt
+++ b/feature-flags/src/main/java/cm/aptoide/pt/feature_flags/data/FeatureFlagsRepository.kt
@@ -1,6 +1,8 @@
 package cm.aptoide.pt.feature_flags.data
 
+import org.json.JSONObject
+
 interface FeatureFlagsRepository {
 
-  suspend fun getFeatureFlags(): Map<String, String>
+  suspend fun getFeatureFlags(): JSONObject
 }

--- a/feature-flags/src/main/java/cm/aptoide/pt/feature_flags/data/SettingsLocalRepositoryImpl.kt
+++ b/feature-flags/src/main/java/cm/aptoide/pt/feature_flags/data/SettingsLocalRepositoryImpl.kt
@@ -3,31 +3,31 @@ package cm.aptoide.pt.feature_flags.data
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
+import org.json.JSONObject
 
 class SettingsLocalRepositoryImpl(
   private val featureFlagsDataStore: DataStore<Preferences>,
 ) : FeatureFlagsLocalRepository {
 
   companion object {
-    private val FEATURE_FLAGS = stringSetPreferencesKey("featureFlags")
-    private const val DELIMITER = "∰"
+    private val FEATURE_FLAGS = stringPreferencesKey("featureFlags")
   }
 
-  override suspend fun getFeatureFlags(): Map<String, String> =
-    featureFlagsDataStore.data.map { it[FEATURE_FLAGS] }
+  override suspend fun getFeatureFlags(): JSONObject = try {
+    featureFlagsDataStore.data
+      .map { it[FEATURE_FLAGS] }
       .firstOrNull()
-      ?.map { it.split(DELIMITER) }
-      ?.associate { it[0] to it[1] }
-      ?: emptyMap()
+      .let { JSONObject(it ?: "{}") }
+  } catch (t: Throwable) {
+    JSONObject()
+  }
 
-  override suspend fun saveFeatureFlags(featureFlags: Map<String, String>) {
+  override suspend fun saveFeatureFlags(featureFlags: JSONObject) {
     featureFlagsDataStore.edit { preferences ->
-      preferences[FEATURE_FLAGS] = featureFlags.entries
-        .map { "${it.key}$DELIMITER${it.value}" }
-        .toSet()
+      preferences[FEATURE_FLAGS] = featureFlags.toString()
     }
   }
 }

--- a/feature-flags/src/main/java/cm/aptoide/pt/feature_flags/domain/FeatureFlags.kt
+++ b/feature-flags/src/main/java/cm/aptoide/pt/feature_flags/domain/FeatureFlags.kt
@@ -4,6 +4,7 @@ import cm.aptoide.pt.feature_flags.data.FeatureFlagsLocalRepository
 import cm.aptoide.pt.feature_flags.data.FeatureFlagsRepository
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.json.JSONObject
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -13,20 +14,34 @@ class FeatureFlags @Inject constructor(
   private val settingsLocalRepository: FeatureFlagsLocalRepository,
 ) {
 
-  private val featureFlags = mutableMapOf<String, String>()
+  private var featureFlags = JSONObject()
   private val mutex = Mutex()
 
   suspend fun initialize() = mutex.withLock {
-    val featureFlagsResult = try {
+    featureFlags = try {
       settingsRepository.getFeatureFlags()
         .apply { settingsLocalRepository.saveFeatureFlags(this) }
     } catch (error: Throwable) {
       settingsLocalRepository.getFeatureFlags()
     }
-    featureFlags.putAll(featureFlagsResult)
   }
 
-  suspend fun get(key: String): String? = mutex.withLock {
-    featureFlags[key]
+  suspend fun getFlag(key: String): Boolean? = mutex.withLock {
+    runCatching { featureFlags.getBoolean(key) }.getOrNull()
+  }
+
+  suspend fun getFlag(key: String, default: Boolean): Boolean = mutex.withLock {
+    featureFlags.optBoolean(key, default)
+  }
+
+  suspend fun getStrings(key: String): List<String> = mutex.withLock {
+    featureFlags.optJSONArray(key)?.run {
+      val result = mutableListOf<String>()
+      val size = length()
+      for (i in 0..size) {
+        result += optString(i)
+      }
+      result.filterNot { it.isBlank() }
+    } ?: emptyList()
   }
 }

--- a/payments/base/arch/src/main/java/com/appcoins/payments/arch/PaymentMethodFactory.kt
+++ b/payments/base/arch/src/main/java/com/appcoins/payments/arch/PaymentMethodFactory.kt
@@ -1,11 +1,11 @@
 package com.appcoins.payments.arch
 
 interface PaymentMethodFactory<T> {
-  fun create(
+  suspend fun create(
     wallet: WalletData,
     developerWallet: String,
     productInfo: ProductInfoData,
     paymentMethodData: PaymentMethodData,
     purchaseRequest: PurchaseRequest,
-  ): PaymentMethod<T>?
+  ): PaymentMethod<out T>?
 }

--- a/payments/base/payment-manager/src/main/java/com/appcoins/payment_manager/manager/PaymentManager.kt
+++ b/payments/base/payment-manager/src/main/java/com/appcoins/payment_manager/manager/PaymentManager.kt
@@ -19,7 +19,7 @@ class PaymentManagerImpl @Inject constructor(
   private val productInventoryRepository: ProductInventoryRepository,
   private val walletProvider: WalletProvider,
   private val brokerRepository: BrokerRepository,
-  private val paymentMethodFactory: Array<PaymentMethodFactory<*>>,
+  private val paymentMethodFactory: PaymentMethodFactory<*>,
 ) : PaymentManager {
 
   private val cachedPaymentMethods = HashMap<String, PaymentMethod<*>>()
@@ -50,16 +50,15 @@ class PaymentManagerImpl @Inject constructor(
       priceCurrency = productInfo.priceCurrency,
       priceValue = productInfo.priceValue
     ).items.mapNotNull { paymentMethodData ->
-      paymentMethodFactory.firstNotNullOfOrNull {
-        it.create(
-          productInfo = productInfo,
-          developerWallet = developerWallet,
-          wallet = wallet,
-          paymentMethodData = paymentMethodData,
-          purchaseRequest = purchaseRequest
-        )
-      }?.also { cachedPaymentMethods[paymentMethodData.id] = it }
+      paymentMethodFactory.create(
+        productInfo = productInfo,
+        developerWallet = developerWallet,
+        wallet = wallet,
+        paymentMethodData = paymentMethodData,
+        purchaseRequest = purchaseRequest
+      )
     }
+    cachedPaymentMethods.putAll(paymentMethods.associateBy { it.id })
 
     return paymentMethods
   }

--- a/payments/payment-methods/adyen/src/main/java/com/appcoins/payment_method/adyen/CreditCardPaymentMethodFactory.kt
+++ b/payments/payment-methods/adyen/src/main/java/com/appcoins/payment_method/adyen/CreditCardPaymentMethodFactory.kt
@@ -20,13 +20,13 @@ class CreditCardPaymentMethodFactory @Inject internal constructor(
     private const val CREDIT_CARD = "credit_card"
   }
 
-  override fun create(
+  override suspend fun create(
     wallet: WalletData,
     developerWallet: String,
     productInfo: ProductInfoData,
     paymentMethodData: PaymentMethodData,
     purchaseRequest: PurchaseRequest,
-  ): PaymentMethod<Pair<String, PaymentMethodDetails>>? {
+  ): PaymentMethod<out Pair<String, PaymentMethodDetails>>? {
     if (paymentMethodData.id != CREDIT_CARD) return null
 
     return CreditCardPaymentMethod(

--- a/payments/payment-methods/paypal/src/main/java/com/appcoins/payment_method/paypal/PaypalPaymentMethodFactory.kt
+++ b/payments/payment-methods/paypal/src/main/java/com/appcoins/payment_method/paypal/PaypalPaymentMethodFactory.kt
@@ -18,7 +18,7 @@ class PaypalPaymentMethodFactory @Inject internal constructor(
     private const val PAYPAL = "paypal"
   }
 
-  override fun create(
+  override suspend fun create(
     wallet: WalletData,
     developerWallet: String,
     productInfo: ProductInfoData,


### PR DESCRIPTION
**What does this PR do?**

   Adds flexibility to alter payment methods by feature flags. 

   In order to do so 2 things were made:
   1. Allow FeatureFlags operate with more complex structures than strings via JSON.
   2. Make the PaymentMethodFactory create call suspend to be able to do network calls.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] By commits

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-1068](https://aptoide.atlassian.net/browse/DT-1068)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1068](https://aptoide.atlassian.net/browse/DT-1068)


**What are the relevant PRs?**

  PRs related to this one: [#431](https://github.com/Aptoide/aptoide-client-dt/pull/431)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-1068]: https://aptoide.atlassian.net/browse/DT-1068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1068]: https://aptoide.atlassian.net/browse/DT-1068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ