### PR TITLE
[DT-424] Fix limited and uncached editorial article fetching

### DIFF
--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/usecase/ArticleUseCase.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/usecase/ArticleUseCase.kt
@@ -1,5 +1,6 @@
 package cm.aptoide.pt.feature_editorial.domain.usecase
 
+import cm.aptoide.pt.aptoide_network.di.StoreName
 import cm.aptoide.pt.aptoide_network.domain.UrlsCache
 import cm.aptoide.pt.feature_editorial.data.EditorialRepository
 import cm.aptoide.pt.feature_editorial.domain.ARTICLE_CACHE_ID_PREFIX
@@ -11,9 +12,11 @@ import javax.inject.Inject
 class ArticleUseCase @Inject constructor(
   private val editorialRepository: EditorialRepository,
   private val urlsCache: UrlsCache,
+  @StoreName private val storeName: String,
 ) {
-  suspend fun getDetails(articleId: String): Article =
-    urlsCache.get(id = ARTICLE_CACHE_ID_PREFIX + articleId)
-      ?.let { editorialRepository.getArticle(editorialUrl = it) }
-      ?: throw IllegalStateException()
+  suspend fun getDetails(articleId: String): Article {
+    val editorialUrl = urlsCache.get(id = ARTICLE_CACHE_ID_PREFIX + articleId)
+      ?: "card/get/id=$articleId/store_name=$storeName"
+    return editorialRepository.getArticle(editorialUrl)
+  }
 }


### PR DESCRIPTION
**What does this PR do?**

   - Fixes an issue where its not possible to fetch editorial articles that are not cached in the custom urls cache. This happens through deeplinks when fetching editorials outside of the latest nine articles, since the urls cache only caches those latest editorial urls.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] ArticleUseCase.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-424](https://aptoide.atlassian.net/browse/DT-424)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-424](https://aptoide.atlassian.net/browse/DT-424)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-424]: https://aptoide.atlassian.net/browse/DT-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-424]: https://aptoide.atlassian.net/browse/DT-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ