### PR TITLE
[DT-1049] Convert campaign click after download starts

### DIFF
--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadViewModel.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadViewModel.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 
 // In case resolution vas cancelled the [onResolve] should not be called
 typealias ConstraintsResolver = (can: Throwable?, onResolve: (Constraints) -> Unit) -> Unit
@@ -171,7 +170,6 @@ class DownloadViewModel(
         installPackageInfo = installPackageInfo,
         constraints = constraints,
       )
-      viewModelScope.launch { campaigns?.sendInstallClickEvent() }
     } catch (e: Exception) {
       viewModelState.update {
         DownloadUiState.Error(retryWith = ::install)


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing several things regarding campaigns.
Fix widget campaign conversion due to null ad list id.
Adapt click url conversion based on new requirements.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] DownloadViewModel.kt

**How should this be manually tested?**

Test if downloads work correctly

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1049](https://aptoide.atlassian.net/browse/DT-1049)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-1049]: https://aptoide.atlassian.net/browse/DT-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ