### PR TITLE
[DT-1106] Decouple payments networking from project architecture

### DIFF
--- a/payments/base/network/build.gradle.kts
+++ b/payments/base/network/build.gradle.kts
@@ -9,5 +9,8 @@ android {
 }
 
 dependencies {
-  api(project(ModuleDependency.APTOIDE_NETWORK))
+  api(LibraryDependency.RETROFIT)
+  api(LibraryDependency.OK_HTTP)
+  api(LibraryDependency.RETROFIT_GSON_CONVERTER)
+  api(LibraryDependency.LOGGING_INTERCEPTOR)
 }

--- a/payments/base/network/src/main/java/com/appcoins/payments/network/di/NetworkModule.kt
+++ b/payments/base/network/src/main/java/com/appcoins/payments/network/di/NetworkModule.kt
@@ -1,19 +1,15 @@
 package com.appcoins.payments.network.di
 
-import cm.aptoide.pt.aptoide_network.data.network.AcceptLanguageInterceptor
-import cm.aptoide.pt.aptoide_network.data.network.QLogicInterceptor
-import cm.aptoide.pt.aptoide_network.data.network.UserAgentInterceptor
-import cm.aptoide.pt.aptoide_network.data.network.VersionCodeInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import java.util.concurrent.TimeUnit.SECONDS
 import javax.inject.Qualifier
 import javax.inject.Singleton
-
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -23,17 +19,11 @@ object NetworkModule {
   @Provides
   @Singleton
   fun providePaymentsBaseOkHttpClient(
-    userAgentInterceptor: UserAgentInterceptor,
-    qLogicInterceptor: QLogicInterceptor,
-    versionCodeInterceptor: VersionCodeInterceptor,
-    languageInterceptor: AcceptLanguageInterceptor,
+    @UserAgentInterceptor userAgentInterceptor: Interceptor,
     httpLoggingInterceptor: HttpLoggingInterceptor,
   ): OkHttpClient =
     OkHttpClient.Builder()
       .addInterceptor(userAgentInterceptor)
-      .addInterceptor(qLogicInterceptor)
-      .addInterceptor(versionCodeInterceptor)
-      .addInterceptor(languageInterceptor)
       .addInterceptor(httpLoggingInterceptor)
       .build()
 
@@ -41,17 +31,11 @@ object NetworkModule {
   @Provides
   @Singleton
   fun provideBrokerOkHttpClient(
-    userAgentInterceptor: UserAgentInterceptor,
-    qLogicInterceptor: QLogicInterceptor,
-    versionCodeInterceptor: VersionCodeInterceptor,
-    languageInterceptor: AcceptLanguageInterceptor,
+    @UserAgentInterceptor userAgentInterceptor: Interceptor,
     httpLoggingInterceptor: HttpLoggingInterceptor,
   ): OkHttpClient =
     OkHttpClient.Builder()
       .addInterceptor(userAgentInterceptor)
-      .addInterceptor(qLogicInterceptor)
-      .addInterceptor(versionCodeInterceptor)
-      .addInterceptor(languageInterceptor)
       .addInterceptor(httpLoggingInterceptor)
       .readTimeout(30, SECONDS)
       .writeTimeout(30, SECONDS)
@@ -65,3 +49,7 @@ annotation class PaymentsBaseOkHttp
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class BrokerOkHttp
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class UserAgentInterceptor

--- a/payments/base/payment-manager/build.gradle.kts
+++ b/payments/base/payment-manager/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
   api(project(ModuleDependency.PAYMENTS_ARCH))
   api(project(ModuleDependency.PAYMENT_PREFS))
   api(project(ModuleDependency.PRODUCT_INVENTORY))
-  implementation(project(ModuleDependency.PAYMENTS_NETWORK))
+  api(project(ModuleDependency.PAYMENTS_NETWORK))
 }


### PR DESCRIPTION
**What does this PR do?**

   Decouple payments networking modules from the project modules.
   
   Removed usage and dependency on  QLogicInterceptor, VersionCodeInterceptor, AcceptLanguageInterceptor.
   Payments endpoints don't use any data from these.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] NetworkModule.kt

**How should this be manually tested?**

  Just a regression

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1106](https://aptoide.atlassian.net/browse/DT-1106)


**What are the relevant PRs?**

  PRs related to this one: [#451](https://github.com/Aptoide/aptoide-client-dt/pull/451)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass