### PR TITLE
[DT-1120] Remove attribution event from Success View

### DIFF
--- a/payments/payment-methods/adyen/src/main/java/com/appcoins/payment_method/adyen/presentation/AdyenCreditCardScreenUiState.kt
+++ b/payments/payment-methods/adyen/src/main/java/com/appcoins/payment_method/adyen/presentation/AdyenCreditCardScreenUiState.kt
@@ -21,11 +21,7 @@ sealed class AdyenCreditCardScreenUiState {
     val forgetCard: (() -> Unit)?,
   ) : AdyenCreditCardScreenUiState()
 
-  data class Success(
-    val packageName: String,
-    val valueInDollars: String,
-    val uid: String,
-  ) : AdyenCreditCardScreenUiState()
+  data class Success(val packageName: String) : AdyenCreditCardScreenUiState()
 
   data class Redirect(
     val action: RedirectAction,

--- a/payments/payment-methods/adyen/src/main/java/com/appcoins/payment_method/adyen/presentation/AdyenCreditCardViewModel.kt
+++ b/payments/payment-methods/adyen/src/main/java/com/appcoins/payment_method/adyen/presentation/AdyenCreditCardViewModel.kt
@@ -186,11 +186,7 @@ class AdyenCreditCardViewModel(
                       preSelectedPaymentUseCase.saveLastSuccessfulPaymentMethod(this.id)
 
                       viewModelState.update {
-                        AdyenCreditCardScreenUiState.Success(
-                          packageName = purchaseRequest.domain,
-                          valueInDollars = productInfo.priceInDollars,
-                          uid = transaction.uid
-                        )
+                        AdyenCreditCardScreenUiState.Success(packageName = purchaseRequest.domain)
                       }
                     }
 

--- a/payments/payment-methods/paypal/src/main/java/com/appcoins/payment_method/paypal/presentation/PaypalUIState.kt
+++ b/payments/payment-methods/paypal/src/main/java/com/appcoins/payment_method/paypal/presentation/PaypalUIState.kt
@@ -23,8 +23,5 @@ sealed class PaypalUIState {
   object Error : PaypalUIState()
   object NoConnection : PaypalUIState()
   object Canceled : PaypalUIState()
-  data class Success(
-    val valueInDollars: String,
-    val uid: String,
-  ) : PaypalUIState()
+  object Success : PaypalUIState()
 }

--- a/payments/payment-methods/paypal/src/main/java/com/appcoins/payment_method/paypal/presentation/PaypalViewModel.kt
+++ b/payments/payment-methods/paypal/src/main/java/com/appcoins/payment_method/paypal/presentation/PaypalViewModel.kt
@@ -153,12 +153,7 @@ class PaypalViewModel internal constructor(
             -> {
               preSelectedPaymentUseCase.saveLastSuccessfulPaymentMethod(paypalPaymentMethod.id)
 
-              viewModelState.update {
-                PaypalUIState.Success(
-                  valueInDollars = paypalPaymentMethod.productInfo.priceInDollars,
-                  uid = transaction.uid
-                )
-              }
+              viewModelState.update { PaypalUIState.Success }
             }
 
             else -> Unit
@@ -194,13 +189,7 @@ class PaypalViewModel internal constructor(
                 -> {
                   preSelectedPaymentUseCase.saveLastSuccessfulPaymentMethod(paypalPaymentMethod.id)
 
-                  viewModelState.update {
-                    PaypalUIState.Success(
-
-                      valueInDollars = paypalPaymentMethod.productInfo.priceInDollars,
-                      uid = transaction.uid
-                    )
-                  }
+                  viewModelState.update { PaypalUIState.Success }
                 }
 
                 else -> viewModelState.update { PaypalUIState.Error }


### PR DESCRIPTION
**What does this PR do?**

This PR aims at supporting both attribution v4 and v6. This was done by just removing the analytic event from the success view.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] Foo.java
- [ ] Bar.kt

**How should this be manually tested?**

Check that the event is not being sent. if you want you can also test both attribution flows, eventhough those were not changed.

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1120](https://aptoide.atlassian.net/browse/DT-1120)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-1120]: https://aptoide.atlassian.net/browse/DT-1120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ