### PR TITLE
[APP-2222] fix editorial label color

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/appview/RelatedContentView.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/RelatedContentView.kt
@@ -1,7 +1,6 @@
 package cm.aptoide.pt.appview
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -76,12 +75,12 @@ fun RelatedContentCard(
       )
       Card(
         elevation = 0.dp,
+        backgroundColor = AppTheme.colors.editorialLabelColor,
         modifier = Modifier
           .padding(start = 8.dp, top = 8.dp)
           .wrapContentWidth()
           .height(24.dp)
           .clip(RoundedCornerShape(16.dp))
-          .background(color = AppTheme.colors.editorialLabelColor)
       ) {
         Text(
           text = "App of The Week",

--- a/app/src/main/java/cm/aptoide/pt/appview/RelatedContentView.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/RelatedContentView.kt
@@ -1,37 +1,14 @@
 package cm.aptoide.pt.appview
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Card
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.ColorPainter
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
-import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.editorial.isNavigating
-import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
+import cm.aptoide.pt.editorial.RelatedEditorialViewCard
 import cm.aptoide.pt.feature_editorial.presentation.relatedEditorialsCardViewModel
-import cm.aptoide.pt.feature_reactions.ui.ReactionsView
 
 @Composable
 fun RelatedContentView(
@@ -45,92 +22,7 @@ fun RelatedContentView(
     modifier = Modifier.padding(top = 24.dp)
   ) {
     uiState?.forEach { editorialMeta ->
-      RelatedContentCard(editorialMeta, onRelatedContentClick)
-    }
-  }
-
-}
-
-@Composable
-fun RelatedContentCard(
-  articleMeta: ArticleMeta,
-  onRelatedContentClick: (String) -> Unit
-) {
-  Column(
-    modifier = Modifier
-      .padding(start = 16.dp, end = 16.dp, bottom = 24.dp)
-      .height(256.dp)
-      .fillMaxWidth()
-      .clickable { onRelatedContentClick(articleMeta.id) }
-  ) {
-    Box(contentAlignment = Alignment.TopStart, modifier = Modifier.padding(bottom = 8.dp)) {
-      AptoideAsyncImage(
-        data = articleMeta.image,
-        contentDescription = "Article Image",
-        placeholder = ColorPainter(AppTheme.colors.placeholderColor),
-        modifier = Modifier
-          .fillMaxWidth()
-          .height(168.dp)
-          .clip(RoundedCornerShape(16.dp))
-      )
-      Card(
-        elevation = 0.dp,
-        backgroundColor = AppTheme.colors.editorialLabelColor,
-        modifier = Modifier
-          .padding(start = 8.dp, top = 8.dp)
-          .wrapContentWidth()
-          .height(24.dp)
-          .clip(RoundedCornerShape(16.dp))
-      ) {
-        Text(
-          text = "App of The Week",
-          style = AppTheme.typography.button_S,
-          color = Color.White,
-          textAlign = TextAlign.Center,
-          modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 4.dp)
-        )
-      }
-    }
-    Text(
-      text = articleMeta.title,
-      maxLines = 1,
-      overflow = TextOverflow.Ellipsis,
-      modifier = Modifier.align(Alignment.Start),
-      style = AppTheme.typography.medium_M
-    )
-    Text(
-      text = articleMeta.summary,
-      maxLines = 2,
-      overflow = TextOverflow.Ellipsis,
-      modifier = Modifier.align(Alignment.Start),
-      style = AppTheme.typography.regular_XXS
-    )
-    Row(
-      modifier = Modifier
-        .height(32.dp), verticalAlignment = Alignment.CenterVertically
-    ) {
-      //bug here, isNavigating will only work once.
-      ReactionsView(id = articleMeta.id, isNavigating = isNavigating)
-      Text(
-        text = TextFormatter.formatDateToSystemLocale(LocalContext.current, articleMeta.date),
-        modifier = Modifier.padding(end = 16.dp),
-        style = AppTheme.typography.regular_XXS,
-        textAlign = TextAlign.Center,
-        color = AppTheme.colors.editorialDateColor
-      )
-      Image(
-        imageVector = AppTheme.icons.ViewsIcon,
-        contentDescription = "Editorial views",
-        modifier = Modifier
-          .padding(end = 8.dp)
-          .width(14.dp)
-          .height(8.dp)
-      )
-      Text(
-        text = TextFormatter.withSuffix(articleMeta.views) + " views",
-        style = AppTheme.typography.regular_XXS,
-        textAlign = TextAlign.Center, color = AppTheme.colors.greyText
-      )
+      RelatedEditorialViewCard(editorialMeta, onRelatedContentClick)
     }
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialScreen.kt
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialScreen.kt
@@ -2,7 +2,6 @@ package cm.aptoide.pt.editorial
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -96,12 +95,12 @@ fun EditorialViewScreen(
           )
           Card(
             elevation = 0.dp,
+            backgroundColor = AppTheme.colors.editorialLabelColor,
             modifier = Modifier
               .padding(start = 16.dp, top = 12.dp)
               .wrapContentWidth()
               .height(30.dp)
               .clip(RoundedCornerShape(16.dp))
-              .background(color = AppTheme.colors.editorialLabelColor)
           ) {
             Text(
               text = state.article.caption.uppercase(),

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialsCardView.kt
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialsCardView.kt
@@ -1,7 +1,6 @@
 package cm.aptoide.pt.editorial
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -62,12 +61,12 @@ fun EditorialViewCard(
       )
       Card(
         elevation = 0.dp,
+        backgroundColor = AppTheme.colors.editorialLabelColor,
         modifier = Modifier
           .padding(start = 8.dp, top = 8.dp)
           .wrapContentWidth()
           .height(24.dp)
           .clip(RoundedCornerShape(16.dp))
-          .background(color = AppTheme.colors.editorialLabelColor)
       ) {
         Text(
           text = label,

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialsCardView.kt
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialsCardView.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -25,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
+import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
 import cm.aptoide.pt.feature_reactions.ui.ReactionsView
 
 var isNavigating = false
@@ -50,73 +52,130 @@ fun EditorialViewCard(
       }
   ) {
     Box(contentAlignment = Alignment.TopStart, modifier = Modifier.padding(bottom = 8.dp)) {
-      AptoideAsyncImage(
-        data = image,
-        contentDescription = "Background Image",
-        placeholder = ColorPainter(AppTheme.colors.placeholderColor),
-        modifier = Modifier
-          .width(280.dp)
-          .height(136.dp)
-          .clip(RoundedCornerShape(16.dp))
-      )
-      Card(
-        elevation = 0.dp,
-        backgroundColor = AppTheme.colors.editorialLabelColor,
-        modifier = Modifier
-          .padding(start = 8.dp, top = 8.dp)
-          .wrapContentWidth()
-          .height(24.dp)
-          .clip(RoundedCornerShape(16.dp))
-      ) {
-        Text(
-          text = label,
-          style = AppTheme.typography.button_S,
-          color = Color.White,
-          textAlign = TextAlign.Center,
-          modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 4.dp)
-        )
-      }
+      EditorialImage(image = image, modifier = Modifier
+        .width(280.dp)
+        .height(136.dp)
+        .clip(RoundedCornerShape(16.dp)))
+      EditorialTypeLabel(label = label)
     }
-    Text(
-      text = title,
-      maxLines = 1,
-      overflow = TextOverflow.Ellipsis,
-      modifier = Modifier.align(Alignment.Start),
-      style = AppTheme.typography.medium_M
-    )
-    Text(
-      text = summary,
-      maxLines = 2,
-      overflow = TextOverflow.Ellipsis,
-      modifier = Modifier.align(Alignment.Start),
-      style = AppTheme.typography.regular_XXS
-    )
+    EditorialTitle(title = title, modifier = Modifier.align(Alignment.Start))
+    EditorialSummary(summary = summary, modifier = Modifier.align(Alignment.Start))
     Row(
       modifier = Modifier
         .height(32.dp), verticalAlignment = Alignment.CenterVertically
     ) {
       //bug here, isNavigating will only work once.
       ReactionsView(id = articleId, isNavigating = isNavigating)
-      Text(
-        text = TextFormatter.formatDateToSystemLocale(LocalContext.current, date),
-        modifier = Modifier.padding(end = 16.dp),
-        style = AppTheme.typography.regular_XXS,
-        textAlign = TextAlign.Center,
-        color = AppTheme.colors.editorialDateColor
-      )
-      Image(
-        imageVector = AppTheme.icons.ViewsIcon,
-        contentDescription = "Editorial views",
-        modifier = Modifier
-          .padding(end = 8.dp)
-          .width(14.dp)
-          .height(8.dp)
-      )
-      Text(
-        text = TextFormatter.withSuffix(views) + " views",
-        style = AppTheme.typography.regular_XXS,
-        textAlign = TextAlign.Center, color = AppTheme.colors.greyText
-      )
+      EditorialDate(date = date)
+      EditorialViewsIcon()
+      EditorialViewsText(views = views)
     }
   }
 }
+
+@Composable
+fun RelatedEditorialViewCard(
+  articleMeta: ArticleMeta,
+  onRelatedContentClick: (String) -> Unit,
+) {
+  Column(
+    modifier = Modifier
+      .padding(start = 16.dp, end = 16.dp, bottom = 24.dp)
+      .height(256.dp)
+      .fillMaxWidth()
+      .clickable { onRelatedContentClick(articleMeta.id) }
+  ) {
+    Box(contentAlignment = Alignment.TopStart, modifier = Modifier.padding(bottom = 8.dp)) {
+      EditorialImage(image = articleMeta.image, modifier = Modifier
+        .fillMaxWidth()
+        .height(168.dp)
+        .clip(RoundedCornerShape(16.dp)))
+      EditorialTypeLabel(label = articleMeta.caption.uppercase())
+    }
+    EditorialTitle(title = articleMeta.title, modifier = Modifier.align(Alignment.Start))
+    EditorialSummary(summary = articleMeta.summary, modifier = Modifier.align(Alignment.Start))
+    Row(
+      modifier = Modifier
+        .height(32.dp), verticalAlignment = Alignment.CenterVertically
+    ) {
+      //bug here, isNavigating will only work once.
+      ReactionsView(id = articleMeta.id, isNavigating = isNavigating)
+      EditorialDate(date = articleMeta.date)
+      EditorialViewsIcon()
+      EditorialViewsText(views = articleMeta.views)
+    }
+  }
+}
+
+@Composable
+fun EditorialImage(image: String, modifier: Modifier) = AptoideAsyncImage(
+  data = image,
+  contentDescription = "Background Image",
+  placeholder = ColorPainter(AppTheme.colors.placeholderColor),
+  modifier = modifier
+)
+
+@Composable
+fun EditorialTypeLabel(label: String) = Card(
+  elevation = 0.dp,
+  backgroundColor = AppTheme.colors.editorialLabelColor,
+  modifier = Modifier
+    .padding(start = 8.dp, top = 8.dp)
+    .wrapContentWidth()
+    .height(24.dp)
+    .clip(RoundedCornerShape(16.dp))
+) {
+  Text(
+    text = label,
+    style = AppTheme.typography.button_S,
+    color = Color.White,
+    textAlign = TextAlign.Center,
+    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 4.dp)
+  )
+}
+
+@Composable
+fun EditorialTitle(title: String, modifier: Modifier) = Text(
+  text = title,
+  maxLines = 1,
+  overflow = TextOverflow.Ellipsis,
+  modifier = modifier,
+  style = AppTheme.typography.medium_M
+)
+
+@Composable
+fun EditorialSummary(summary: String, modifier: Modifier) = Text(
+  text = summary,
+  maxLines = 2,
+  overflow = TextOverflow.Ellipsis,
+  modifier = modifier,
+  style = AppTheme.typography.regular_XXS
+)
+
+@Composable
+fun EditorialDate(date: String) = Text(
+  text = TextFormatter.formatDateToSystemLocale(LocalContext.current, date),
+  modifier = Modifier.padding(end = 16.dp),
+  style = AppTheme.typography.regular_XXS,
+  textAlign = TextAlign.Center,
+  color = AppTheme.colors.editorialDateColor
+)
+
+@Composable
+fun EditorialViewsIcon() = Image(
+  imageVector = AppTheme.icons.ViewsIcon,
+  contentDescription = "Editorial views",
+  modifier = Modifier
+    .padding(end = 8.dp)
+    .width(14.dp)
+    .height(8.dp)
+)
+
+@Composable
+fun EditorialViewsText(views: Long) = Text(
+  text = TextFormatter.withSuffix(views) + " views",
+  style = AppTheme.typography.regular_XXS,
+  textAlign = TextAlign.Center, color = AppTheme.colors.greyText
+)
+
+


### PR DESCRIPTION
**What does this PR do?**

Fixes the background color of the Editorial Label. 
Since it's a Card, its background color is dictated by its backgroundColor parameter and not by the background inside the modifier.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] RelatedContentView.kt
- [ ] EditorialsCardView.kt
- [ ] EditorialScreen.kt

**How should this be manually tested?**

Open every view Editorial related, both in light and dark theme, and see if the label background color always stays the correct one. 
  Flow on how to test this or QA Tickets related to this use-case: [APP-2222](https://aptoide.atlassian.net/browse/APP-2222)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2222](https://aptoide.atlassian.net/browse/APP-2222)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2222]: https://aptoide.atlassian.net/browse/APP-2222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2222]: https://aptoide.atlassian.net/browse/APP-2222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ