### PR TITLE
[APP-2226] Appview for Related and Versions tabs

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/appview/OtherVersionsView.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/OtherVersionsView.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -32,13 +30,15 @@ import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
 import cm.aptoide.pt.feature_apps.presentation.appVersions
 
 @Composable
-fun OtherVersionsView(packageName: String, listScope: LazyListScope?) {
+fun OtherVersionsView(packageName: String) {
   val (uiState, _) = appVersions(packageName = packageName)
-
-  listScope?.item { Box(modifier = Modifier.padding(top = 26.dp)) }
-  (uiState as? AppsListUiState.Idle)?.run {
-    listScope?.items(apps) { app ->
-      OtherVersionRow(app)
+  Column(
+    modifier = Modifier.padding(top = 24.dp)
+  ) {
+    (uiState as? AppsListUiState.Idle)?.run {
+      apps.forEach { app ->
+        OtherVersionRow(app)
+      }
     }
   }
 }

--- a/app/src/main/java/cm/aptoide/pt/appview/RelatedContentView.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/RelatedContentView.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.Text
@@ -40,15 +38,18 @@ import cm.aptoide.pt.feature_reactions.ui.ReactionsView
 fun RelatedContentView(
   packageName: String,
   onRelatedContentClick: (String) -> Unit,
-  listScope: LazyListScope?,
+
 ) {
   val editorialsMetaViewModel = relatedEditorialsCardViewModel(packageName = packageName)
   val uiState by editorialsMetaViewModel.uiState.collectAsState()
-
-  listScope?.item { Box(modifier = Modifier.padding(top = 24.dp)) }
-  listScope?.items(uiState ?: emptyList()) { editorialMeta ->
-    RelatedContentCard(editorialMeta, onRelatedContentClick)
+  Column(
+    modifier = Modifier.padding(top = 24.dp)
+  ) {
+    uiState?.forEach { editorialMeta ->
+      RelatedContentCard(editorialMeta, onRelatedContentClick)
+    }
   }
+
 }
 
 @Composable

--- a/feature_appview/src/main/java/cm/aptoide/pt/feature_appview/presentation/CustomScrollableTabRow.kt
+++ b/feature_appview/src/main/java/cm/aptoide/pt/feature_appview/presentation/CustomScrollableTabRow.kt
@@ -15,8 +15,6 @@ import androidx.compose.material.TabRowDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -36,13 +34,7 @@ fun CustomScrollableTabRow(
   contentColor: Color, backgroundColor: Color,
 ) {
   val density = LocalDensity.current
-  val tabWidths = remember {
-    val tabWidthStateList = mutableStateListOf<Dp>()
-    repeat(tabs.size) {
-      tabWidthStateList.add(0.dp)
-    }
-    tabWidthStateList
-  }
+  val indicatorWidths = MutableList(tabs.size) { 0.dp }
   ScrollableTabRow(
     selectedTabIndex = selectedTabIndex,
     contentColor = contentColor,
@@ -53,7 +45,7 @@ fun CustomScrollableTabRow(
       TabRowDefaults.Indicator(
         modifier = Modifier.customTabIndicatorOffset(
           currentTabPosition = tabPositions[selectedTabIndex],
-          tabWidth = tabWidths[selectedTabIndex]
+          tabWidth = indicatorWidths[selectedTabIndex]
         )
       )
     }
@@ -70,7 +62,7 @@ fun CustomScrollableTabRow(
               style = AppTheme.typography.medium_M,
               color = AppTheme.colors.appViewTabRowColor,
               onTextLayout = { textLayoutResult ->
-                tabWidths[tabIndex] =
+                indicatorWidths[tabIndex] =
                   with(density) { textLayoutResult.size.width.toDp() }
               }
             )
@@ -79,7 +71,7 @@ fun CustomScrollableTabRow(
               text = tab.tabName,
               style = AppTheme.typography.medium_M,
               onTextLayout = { textLayoutResult ->
-                tabWidths[tabIndex] =
+                indicatorWidths[tabIndex] =
                   with(density) { textLayoutResult.size.width.toDp() }
               }
             )


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the repopulating of the Related and Versions tabs for the appview by replacing the lazyItems inside of those tabs with "normal" items, and it also hides the Related tab when the app doesn't have related editorials.

Note that on CustomScrollableTabRow the indicatorWidths list has a fixed size, if we change the number of possible tabs in the appview we should change that as well.

**Database changed?**

 No

**Where should the reviewer start?**

- [ ] AppViewScreen.kt
- [ ] OtherVersionsView.kt
- [ ] RelatedContentView.kt
- [ ] CustomScrollableTabRow.kt

**How should this be manually tested?**

The tester should open several appviews and test going in and out of Related and Versions (to info for example) to see if they don't get duplicated content in the appview or content where it shouldn't be.

They should also open and close different appviews to see if the Related tab doesn't appear on some and to see if the app doesn't crash on apps that have Related content.

  Flow on how to test this or QA Tickets related to this use-case: [APP-2226](https://aptoide.atlassian.net/browse/APP-2226)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2226](https://aptoide.atlassian.net/browse/APP-2226)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2226]: https://aptoide.atlassian.net/browse/APP-2226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ