### PR TITLE
[DT-1150] Fixed the "no content for more articles" at the related tab

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/di/RepositoryModule.kt
+++ b/app/src/main/java/cm/aptoide/pt/di/RepositoryModule.kt
@@ -15,6 +15,7 @@ import cm.aptoide.pt.aptoide_network.di.StoreName
 import cm.aptoide.pt.aptoide_network.di.VersionCode
 import cm.aptoide.pt.environment_info.DeviceInfo
 import cm.aptoide.pt.feature_campaigns.data.CampaignUrlNormalizer
+import cm.aptoide.pt.feature_editorial.di.DefaultEditorialUrl
 import cm.aptoide.pt.feature_flags.AptoideFeatureFlagsRepository
 import cm.aptoide.pt.feature_flags.data.FeatureFlagsRepository
 import cm.aptoide.pt.feature_flags.di.FeatureFlagsDataStore
@@ -64,6 +65,12 @@ class RepositoryModule {
   @Provides
   @StoreDomain
   fun provideEnvironmentDomain(): String = BuildConfig.STORE_DOMAIN
+
+  @Singleton
+  @Provides
+  @DefaultEditorialUrl
+  fun provideDefaultEditorialUrl(): String =
+    "${BuildConfig.STORE_DOMAIN}user/action/item/cards/get/type=CURATION_1/limit=10/store_name=${BuildConfig.MARKET_NAME}/aptoide_uid=0/?subtype=COLLECTION&aab=1&aptoide_vercode=${BuildConfig.VERSION_CODE}"
 
   @Singleton
   @Provides

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/di/RepositoryModule.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/di/RepositoryModule.kt
@@ -11,6 +11,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @Module
@@ -31,3 +32,7 @@ internal object RepositoryModule {
     storeName
   )
 }
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultEditorialUrl


### PR DESCRIPTION
**What does this PR do?**

   Fixed the empty content for more articles on the related tab. The related where relying on the editorials of the bundle screen, but when the editorials where not on getWidgets api, we didn't have a fallback. The PR adds that fallback.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] RepositoryModule.kt
- [ ] ArticlesMetaUseCase.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-1150](https://aptoide.atlassian.net/browse/DT-1150)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1150](https://aptoide.atlassian.net/browse/DT-1150)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[DT-1150]: https://aptoide.atlassian.net/browse/DT-1150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1150]: https://aptoide.atlassian.net/browse/DT-1150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ