### PR TITLE
[DT-1152] Make iab payments entry components disabled by default

### DIFF
--- a/payments/billing-sdk/src/main/AndroidManifest.xml
+++ b/payments/billing-sdk/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
   <application>
     <service
         android:name=".AppcoinsBillingService"
-        android:exported="true">
+        android:exported="true"
+        android:enabled="false">
       <intent-filter>
         <action android:name="${applicationId}.iab.action.BIND" />
       </intent-filter>

--- a/payments/uri-handler/src/main/AndroidManifest.xml
+++ b/payments/uri-handler/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
         android:name=".PaymentActivity"
         android:theme="@style/Theme.MaterialComponents.Transparent.NoDisplay"
         android:launchMode="singleInstance"
-        android:exported="true">
+        android:exported="true"
+        android:enabled="false">
 
       <intent-filter
           android:autoVerify="true"


### PR DESCRIPTION
**What does this PR do?**

   - Makes PaymentActivity and AppcBillingService components disabled by default in the respective manifests.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] payments\uri-handler\src\main\AndroidManifest.xml
- [ ] payments\billing-sdk\src\main\AndroidManifest.xml

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-1152](https://aptoide.atlassian.net/browse/DT-1152)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1152](https://aptoide.atlassian.net/browse/DT-1152)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-1152]: https://aptoide.atlassian.net/browse/DT-1152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1152]: https://aptoide.atlassian.net/browse/DT-1152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ