### PR TITLE
[DT-813] Save last successful payment method

### DIFF
--- a/payments/base/payment-prefs/src/main/java/com/appcoins/payment_prefs/domain/PreSelectedPaymentUseCase.kt
+++ b/payments/base/payment-prefs/src/main/java/com/appcoins/payment_prefs/domain/PreSelectedPaymentUseCase.kt
@@ -10,5 +10,5 @@ class PreSelectedPaymentUseCase internal constructor(
     preSelectedPaymentStateRepository.saveLastSuccessfulPaymentMethod(paymentMethodId)
 
   fun getLastSuccessfulPaymentMethod() =
-    null//preSelectedPaymentStateRepository.getLastSuccessfulPaymentMethod()
+    preSelectedPaymentStateRepository.getLastSuccessfulPaymentMethod()
 }


### PR DESCRIPTION
**What does this PR do?**

It allows for the GH to save the last successful payment method, so when we are doing a second payment we enter that payment's view immediately, to save clicks.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] PreSelectedPaymentUseCase.kt

**How should this be manually tested?**
Test by doing some IAB purchases with different payment methods and see if the saved state is always the last successful payment (fail some payments on purpose to make sure every flow is working as intended)

  Flow on how to test this or QA Tickets related to this use-case: [DT-813](https://aptoide.atlassian.net/browse/DT-813)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-813](https://aptoide.atlassian.net/browse/DT-813)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-813]: https://aptoide.atlassian.net/browse/DT-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-813]: https://aptoide.atlassian.net/browse/DT-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ