### PR TITLE
[APP-2298] Move v10 specific UI and theme to its app module

### DIFF
--- a/app-games/src/main/java/cm/aptoide/pt/app_games/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/appview/AppViewScreen.kt
@@ -51,7 +51,6 @@ import cm.aptoide.pt.app_games.home.NoConnectionView
 import cm.aptoide.pt.app_games.installer.AppIcon
 import cm.aptoide.pt.app_games.theme.AppTheme
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
-import cm.aptoide.pt.download_view.presentation.DownloadViewScreen
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.presentation.AppUiState
 import cm.aptoide.pt.feature_apps.presentation.appViewModel

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/appview/DownloadView.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/appview/DownloadView.kt
@@ -30,9 +30,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.dp
+import cm.aptoide.pt.app_games.theme.AppTheme
+import cm.aptoide.pt.app_games.theme.AptoideTheme
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
 import cm.aptoide.pt.download_view.presentation.DownloadUiState
 import cm.aptoide.pt.download_view.presentation.rememberDownloadState
 import cm.aptoide.pt.extensions.PreviewAll

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/appview/DownloadView.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/appview/DownloadView.kt
@@ -1,0 +1,437 @@
+package cm.aptoide.pt.app_games.appview
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.Card
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.Icons.Outlined
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.unit.dp
+import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
+import cm.aptoide.pt.aptoide_ui.theme.AppTheme
+import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
+import cm.aptoide.pt.download_view.presentation.DownloadUiState
+import cm.aptoide.pt.download_view.presentation.rememberDownloadState
+import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_apps.data.randomApp
+
+@PreviewAll
+@Composable
+fun DownloadPreview() {
+  // A contrast divider to highlight items boundaries
+  val divider = @Composable {
+    Divider(
+      color = Color.Green.copy(alpha = 0.2f),
+      thickness = 8.dp
+    )
+  }
+  AptoideTheme(darkTheme = isSystemInDarkTheme()) {
+    val app = randomApp.copy(isAppCoins = false)
+    val states = listOf(
+      DownloadUiState.Install(installWith = {}),
+      DownloadUiState.Outdated({}, updateWith = {}, uninstall = {}),
+      DownloadUiState.Waiting(action = null),
+      DownloadUiState.Downloading(33, cancel = {}),
+      DownloadUiState.ReadyToInstall(cancel = {}),
+      DownloadUiState.Installing(66),
+      DownloadUiState.Uninstalling,
+      DownloadUiState.Installed({}, {}),
+      DownloadUiState.Error(retryWith = {})
+    )
+    LazyColumn {
+      states.forEach { uiState ->
+        item {
+          MainDownloadView {
+            DownloadState(
+              uiState = uiState,
+              tintColor = if (app.isAppCoins) {
+                AppTheme.colors.appCoinsColor
+              } else {
+                AppTheme.colors.primary
+              },
+              appSize = app.appSize,
+            )
+          }
+          divider()
+        }
+      }
+      item { divider() }
+    }
+  }
+}
+
+@PreviewAll
+@Composable
+fun DownloadAppcPreview() {
+  // A contrast divider to highlight items boundaries
+  val divider = @Composable {
+    Divider(
+      color = Color.Green.copy(alpha = 0.2f),
+      thickness = 8.dp
+    )
+  }
+  AptoideTheme(darkTheme = isSystemInDarkTheme()) {
+    val app = randomApp.copy(isAppCoins = true)
+    val states = listOf(
+      null,
+      DownloadUiState.Install(installWith = {}),
+      DownloadUiState.Outdated(open = {}, updateWith = {}, uninstall = {}),
+      DownloadUiState.Waiting(action = null),
+      DownloadUiState.Downloading(size = 33, cancel = {}),
+      DownloadUiState.ReadyToInstall(cancel = {}),
+      DownloadUiState.Installing(size = 66),
+      DownloadUiState.Uninstalling,
+      DownloadUiState.Installed({}, {}),
+      DownloadUiState.Error(retryWith = {}),
+    )
+    LazyColumn {
+      states.forEach { uiState ->
+        item {
+          MainDownloadView {
+            DownloadState(
+              uiState = uiState,
+              tintColor = if (app.isAppCoins) {
+                AppTheme.colors.appCoinsColor
+              } else {
+                AppTheme.colors.primary
+              },
+              appSize = app.appSize,
+            )
+          }
+          divider()
+        }
+      }
+      item { divider() }
+    }
+  }
+}
+
+@Composable
+fun DownloadViewScreen(app: App) {
+
+  val uiState = rememberDownloadState(app = app)
+
+  MainDownloadView {
+    DownloadState(
+      uiState = uiState,
+      tintColor = if (app.isAppCoins) {
+        AppTheme.colors.appCoinsColor
+      } else {
+        AppTheme.colors.primary
+      },
+      appSize = app.appSize,
+    )
+  }
+}
+
+@Composable
+fun MainDownloadView(
+  installButton: @Composable () -> Unit,
+) {
+  Card(
+    modifier = Modifier
+      .padding(start = 16.dp, end = 16.dp)
+      .fillMaxWidth()
+      .height(56.dp)
+      .clip(RoundedCornerShape(16.dp)),
+    elevation = 6.dp
+  ) {
+    Column {
+      installButton()
+    }
+  }
+}
+
+@Composable
+fun DownloadState(
+  uiState: DownloadUiState?,
+  tintColor: Color,
+  appSize: Long,
+) {
+  when (uiState) {
+    null -> Unit
+    is DownloadUiState.Install -> InstallButton(uiState.install)
+    is DownloadUiState.Outdated -> InstallButton(uiState.update)
+
+    is DownloadUiState.Waiting -> IndeterminateDownloadView(
+      label = "Downloading",
+      labelColor = tintColor,
+      progressColor = tintColor
+    )
+
+    is DownloadUiState.Downloading -> DownloadingDownloadView(
+      tintColor = tintColor,
+      progress = uiState.downloadProgress.toFloat(),
+      appSize = appSize,
+      onCloseClick = uiState.cancel
+    )
+
+    is DownloadUiState.Installing -> IndeterminateDownloadView(
+      label = "Installing",
+      labelColor = tintColor,
+      progressColor = tintColor
+    )
+
+    is DownloadUiState.Uninstalling -> IndeterminateDownloadView(
+      label = "Uninstalling",
+      labelColor = tintColor,
+      progressColor = tintColor
+    )
+
+    is DownloadUiState.Installed -> OpenButton(uiState.open)
+    is DownloadUiState.Error -> ErrorDownloadView(uiState.retry)
+    is DownloadUiState.ReadyToInstall -> IndeterminateDownloadView(
+      label = "Waiting for install",
+      labelColor = tintColor,
+      progressColor = tintColor
+    )
+  }
+  if (
+    uiState !is DownloadUiState.Install &&
+    uiState !is DownloadUiState.Installed &&
+    uiState !is DownloadUiState.Outdated
+  ) {
+    Divider(
+      color = AppTheme.colors.dividerColor,
+      thickness = 1.dp
+    )
+  }
+}
+
+@Composable
+fun InstallButton(onClick: () -> Unit) {
+  Button(
+    onClick = onClick,
+    shape = RoundedCornerShape(16.dp),
+    modifier = Modifier
+      .height(56.dp)
+      .fillMaxWidth()
+  ) {
+    Text(
+      text = "INSTALL",
+      maxLines = 1,
+      style = AppTheme.typography.button_L,
+      color = Color.White
+    )
+  }
+}
+
+@Composable
+fun ErrorDownloadView(onClick: () -> Unit) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(start = 16.dp, end = 16.dp)
+      .height(56.dp),
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    Box(modifier = Modifier.weight(1f)) {
+      GeneralErrorLabel()
+    }
+    Button(
+      onClick = onClick,
+      shape = RoundedCornerShape(16.dp),
+      modifier = Modifier.width(140.dp)
+    ) {
+      Text(
+        text = "RETRY",
+        maxLines = 1,
+        style = AppTheme.typography.button_M,
+        color = Color.White
+      )
+    }
+  }
+}
+
+@Composable
+fun GeneralErrorLabel() {
+  Row(verticalAlignment = Alignment.CenterVertically) {
+    Image(
+      imageVector = Outlined.ErrorOutline,
+      colorFilter = ColorFilter.tint(AppTheme.colors.error),
+      contentDescription = "Error icon",
+      modifier = Modifier
+        .padding(end = 8.dp)
+        .size(16.dp)
+    )
+    Text(
+      text = "Oops, an error occurred.",
+      style = AppTheme.typography.medium_XS,
+      color = AppTheme.colors.error
+    )
+  }
+}
+
+@Composable
+fun OpenButton(onClick: () -> Unit) {
+  Button(
+    onClick = onClick,
+    shape = RoundedCornerShape(16.dp),
+    modifier = Modifier
+      .height(56.dp)
+      .fillMaxWidth()
+  ) {
+    Text(
+      text = "OPEN",
+      maxLines = 1,
+      style = AppTheme.typography.button_L,
+      color = Color.White
+    )
+  }
+}
+
+@Composable
+fun DownloadingDownloadView(
+  tintColor: Color,
+  progress: Float,
+  appSize: Long,
+  onCloseClick: () -> Unit,
+) {
+  Column(
+    modifier = Modifier.fillMaxWidth()
+  ) {
+    DownloadingProgressLabel(
+      textColor = tintColor,
+      progress = progress,
+      appSize = appSize
+    )
+    DownloadingProgressBar(
+      progressColor = tintColor,
+      progress = progress,
+      onCloseClick = onCloseClick
+    )
+  }
+}
+
+@Composable
+fun DownloadingProgressBar(
+  progressColor: Color,
+  progress: Float,
+  onCloseClick: () -> Unit,
+) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(start = 16.dp, end = 16.dp, bottom = 15.dp)
+      .height(15.dp),
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    Box(
+      modifier = Modifier
+        .weight(1f)
+        .padding(end = 12.dp)
+    ) {
+      AptoideProgressBar(
+        progressColor = progressColor,
+        progress = progress
+      )
+    }
+    Icon(
+      imageVector = Icons.Default.Close,
+      contentDescription = "Cancel download",
+      modifier = Modifier
+        .size(12.dp)
+        .clickable(onClick = onCloseClick)
+    )
+  }
+}
+
+@Composable
+fun DownloadingProgressLabel(
+  textColor: Color,
+  progress: Float,
+  appSize: Long,
+) {
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(start = 16.dp, end = 40.dp, bottom = 2.dp, top = 12.dp)
+  ) {
+    Text(
+      text = "Downloading",
+      style = AppTheme.typography.medium_XS,
+      color = textColor,
+      modifier = Modifier.align(Alignment.TopStart)
+    )
+    Text(
+      text = "${progress.toInt()}% of " + TextFormatter.formatBytes(appSize),
+      style = AppTheme.typography.medium_XS,
+      color = textColor,
+      modifier = Modifier.align(Alignment.TopEnd)
+    )
+  }
+}
+
+@Composable
+fun IndeterminateDownloadView(
+  label: String,
+  labelColor: Color,
+  progressColor: Color,
+) {
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 19.dp)
+  ) {
+    Text(
+      text = label,
+      style = AppTheme.typography.medium_XS,
+      color = labelColor,
+      modifier = Modifier.padding(bottom = 6.dp)
+    )
+    AptoideIndeterminateProgressBar(progressColor = progressColor)
+  }
+}
+
+@Composable
+fun AptoideIndeterminateProgressBar(progressColor: Color) {
+  LinearProgressIndicator(
+    modifier = Modifier
+      .fillMaxWidth()
+      .height(2.dp),
+    backgroundColor = AppTheme.colors.downloadProgressBarBackgroundColor,
+    color = progressColor
+  )
+}
+
+@Composable
+fun AptoideProgressBar(
+  progressColor: Color,
+  progress: Float,
+) {
+  LinearProgressIndicator(
+    modifier = Modifier
+      .fillMaxWidth()
+      .height(8.dp)
+      .clip(
+        RoundedCornerShape(8.dp)
+      ),
+    backgroundColor = AppTheme.colors.downloadProgressBarBackgroundColor,
+    color = progressColor,
+    progress = progress / 100
+  )
+}

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/home/MainView.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/home/MainView.kt
@@ -4,7 +4,14 @@ import android.annotation.SuppressLint
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.*
+import androidx.compose.material.BottomNavigation
+import androidx.compose.material.BottomNavigationItem
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalElevationOverlay
+import androidx.compose.material.Scaffold
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
@@ -24,8 +31,8 @@ import cm.aptoide.pt.app_games.settings.settingsScreen
 import cm.aptoide.pt.app_games.theme.AppTheme
 import cm.aptoide.pt.app_games.theme.AptoideTheme
 import cm.aptoide.pt.app_games.toolbar.AppGamesToolBar
-import cm.aptoide.pt.aptoide_ui.snackbar.AptoideSnackBar
-import cm.aptoide.pt.installer.presentation.UserActionDialog
+import cm.aptoide.pt.app_games.theme.AptoideSnackBar
+import cm.aptoide.pt.app_games.installer.UserActionDialog
 import kotlinx.coroutines.launch
 
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/installer/UserActionDialog.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/installer/UserActionDialog.kt
@@ -1,0 +1,186 @@
+package cm.aptoide.pt.app_games.installer
+
+import android.app.Activity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.core.app.ActivityCompat
+import androidx.hilt.navigation.compose.hiltViewModel
+import cm.aptoide.pt.aptoide_ui.theme.AppTheme
+import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
+import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.installer.platform.UserActionRequest.ConfirmationAction
+import cm.aptoide.pt.installer.platform.UserActionRequest.InstallationAction
+import cm.aptoide.pt.installer.platform.UserActionRequest.PermissionAction
+import cm.aptoide.pt.installer.platform.UserConfirmation
+import cm.aptoide.pt.installer.platform.UserConfirmation.WRITE_EXTERNAL_RATIONALE
+import cm.aptoide.pt.installer.presentation.UserActionViewModel
+
+@Composable
+fun UserActionDialog() {
+  val viewModel = hiltViewModel<UserActionViewModel>()
+  val state by viewModel.uiState.collectAsState()
+  val context = LocalContext.current
+
+  val intentLauncher = rememberLauncherForActivityResult(
+    contract = ActivityResultContracts.StartActivityForResult(),
+    onResult = {
+      viewModel.onResult(it.resultCode == Activity.RESULT_OK)
+    }
+  )
+
+  val permissionLauncher = rememberLauncherForActivityResult(
+    contract = ActivityResultContracts.RequestPermission(),
+    onResult = { result ->
+      if (result) {
+        viewModel.onResult(true)
+      } else {
+        val deniedOrNull = (context as? Activity)?.let { activity ->
+          (state as? PermissionAction)?.run {
+            // Check if rationale can help
+            ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)
+              .takeIf { !it } // Turn [true] into [null] to conform with contract
+          }
+        }
+        viewModel.onResult(deniedOrNull)
+      }
+    }
+  )
+
+  LaunchedEffect(
+    key1 = state,
+    block = {
+      when (val it = state) {
+        is InstallationAction -> intentLauncher.launch(it.intent)
+        is PermissionAction -> permissionLauncher.launch(it.permission)
+        else -> Unit
+      }
+    }
+  )
+
+  (state as? ConfirmationAction)?.let {
+    PermissionsContent(rationale = it.confirmation.rationale) {
+      if (it.confirmation == WRITE_EXTERNAL_RATIONALE) {
+        DialogButton(
+          title = "Ok",
+          onClick = { viewModel.onResult(false) },
+        )
+      } else {
+        DialogButton(
+          title = "Cancel",
+          onClick = { viewModel.onResult(false) },
+        )
+        DialogButton(
+          title = "Settings",
+          onClick = { viewModel.onResult(true) },
+        )
+      }
+    }
+  }
+}
+
+private val UserConfirmation.rationale
+  get() = when (this) {
+    UserConfirmation.INSTALL_SOURCE -> "By default system doesn't allow Aptoide to install apps. You need to mark Aptoide as the installation source first."
+    UserConfirmation.WRITE_EXTERNAL_RATIONALE,
+    UserConfirmation.WRITE_EXTERNAL,
+    -> "In order to install the required game resources allow Aptoide to access external storage."
+  }
+
+@Composable
+private fun PermissionsContent(
+  rationale: String,
+  buttons: @Composable RowScope.() -> Unit,
+) {
+  Dialog(onDismissRequest = {}, properties = DialogProperties()) {
+    Box(
+      modifier = Modifier
+        .fillMaxWidth()
+        .wrapContentHeight()
+        .clip(RoundedCornerShape(24.dp))
+        .background(color = AppTheme.colors.background)
+        .padding(all = 24.dp),
+      contentAlignment = Alignment.Center
+    ) {
+      Column(verticalArrangement = Arrangement.Center) {
+        Text(
+          text = rationale,
+          style = AppTheme.typography.button_M,
+          color = Color.Black,
+          modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.spacedBy(16.dp),
+          content = buttons,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun DialogButton(title: String, onClick: () -> Unit) {
+  Button(
+    onClick = onClick,
+    shape = RoundedCornerShape(8.dp),
+    elevation = ButtonDefaults.elevation(defaultElevation = 0.dp),
+  ) {
+    Text(
+      text = title,
+      maxLines = 1,
+      style = AppTheme.typography.button_M,
+      color = Color.White,
+      overflow = TextOverflow.Ellipsis
+    )
+  }
+}
+
+@PreviewAll
+@Composable
+private fun PermissionsContentPreview() {
+  AptoideTheme(isSystemInDarkTheme()) {
+    PermissionsContent(
+      rationale = "I need it! Just give it to me!",
+      buttons = {
+        DialogButton(
+          title = "Cancel",
+          onClick = {},
+        )
+        DialogButton(
+          title = "Settings",
+          onClick = {},
+        )
+      },
+    )
+  }
+}

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/installer/UserActionDialog.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/installer/UserActionDialog.kt
@@ -34,8 +34,8 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.app.ActivityCompat
 import androidx.hilt.navigation.compose.hiltViewModel
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
+import cm.aptoide.pt.app_games.theme.AppTheme
+import cm.aptoide.pt.app_games.theme.AptoideTheme
 import cm.aptoide.pt.extensions.PreviewAll
 import cm.aptoide.pt.installer.platform.UserActionRequest.ConfirmationAction
 import cm.aptoide.pt.installer.platform.UserActionRequest.InstallationAction

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/theme/AppColors.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/theme/AppColors.kt
@@ -22,7 +22,9 @@ data class AppColors(
   val myGamesMessageTextColor: Color,
   val unselectedLabelColor: Color,
   val moreAppsViewBackColor: Color,
-  ) {
+  val appCoinsColor: Color,
+  val downloadProgressBarBackgroundColor: Color,
+) {
   val primary: Color
     get() = materialColors.primary
   val primaryVariant: Color

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/theme/AppTypography.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/theme/AppTypography.kt
@@ -15,5 +15,8 @@ data class AppTypography(
   val buttonTextLight: TextStyle,
   val buttonTextMedium: TextStyle,
   val gameTitleTextCondensed: TextStyle,
-
-  )
+  val medium_S: TextStyle,
+  val medium_XS: TextStyle,
+  val button_M: TextStyle,
+  val button_L: TextStyle,
+)

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/theme/AptoideSnackBar.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/theme/AptoideSnackBar.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.aptoide_ui.snackbar
+package cm.aptoide.pt.app_games.theme
 
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.padding

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/theme/AptoideSnackBar.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/theme/AptoideSnackBar.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 
 @Composable
 fun AptoideSnackBar(data: SnackbarData) {

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/theme/Color.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/theme/Color.kt
@@ -38,3 +38,5 @@ val lightGradient2End = Color(0xFFEDEDED)
 val alertRed = Color(0xFFC81111)
 
 val gray7 = Color(0xFF939393)
+
+val appCoins = Color(0xFFFF578C)

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/theme/Theme.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/theme/Theme.kt
@@ -64,6 +64,8 @@ val darkColorPalette = AppColors(
   installAppButtonColor = richOrange,
   materialColors = darkMaterialColorPalette,
   greyText = greyMedium,
+  appCoinsColor = appCoins,
+  downloadProgressBarBackgroundColor = grey,
 )
 
 private val lightMaterialColorPalette = lightColors(
@@ -98,6 +100,8 @@ val lightColorPalette = AppColors(
   installAppButtonColor = richOrange,
   materialColors = lightMaterialColorPalette,
   greyText = grey,
+  appCoinsColor = appCoins,
+  downloadProgressBarBackgroundColor = greyLight,
 )
 private val dmSansFontFamily = FontFamily(
   Font(R.font.dmsans_regular, FontWeight.Normal),
@@ -214,13 +218,40 @@ val lightTypography = AppTypography(
     lineHeight = 18.sp,
     color = textBlack
   ),
-
   buttonTextMedium = TextStyle(
     fontFamily = dmSansFontFamily,
     fontWeight = FontWeight(500),
     fontSize = 14.sp,
     lineHeight = 14.sp,
     color = textBlack
+  ),
+  medium_S = TextStyle(
+    fontFamily = FontFamily.SansSerif,
+    fontWeight = FontWeight(500),
+    fontSize = 14.sp,
+    lineHeight = 20.sp,
+    color = Color.Black
+  ),
+  medium_XS = TextStyle(
+    fontFamily = FontFamily.SansSerif,
+    fontWeight = FontWeight(500),
+    fontSize = 12.sp,
+    lineHeight = 16.sp,
+    color = Color.Black
+  ),
+  button_M = TextStyle(
+    fontFamily = FontFamily.SansSerif,
+    fontWeight = FontWeight(500),
+    fontSize = 11.sp,
+    lineHeight = 14.sp,
+    color = Color.White
+  ),
+  button_L = TextStyle(
+    fontFamily = FontFamily.SansSerif,
+    fontWeight = FontWeight(700),
+    fontSize = 14.sp,
+    lineHeight = 13.sp,
+    color = Color.White
   ),
 )
 
@@ -282,6 +313,34 @@ val darkTypography = AppTypography(
     fontSize = 14.sp,
     lineHeight = 14.sp,
     color = pureWhite
+  ),
+  medium_S = TextStyle(
+    fontFamily = FontFamily.SansSerif,
+    fontWeight = FontWeight(500),
+    fontSize = 14.sp,
+    lineHeight = 20.sp,
+    color = Color.White
+  ),
+  medium_XS = TextStyle(
+    fontFamily = FontFamily.SansSerif,
+    fontWeight = FontWeight(500),
+    fontSize = 12.sp,
+    lineHeight = 16.sp,
+    color = Color.White
+  ),
+  button_M = TextStyle(
+    fontFamily = FontFamily.SansSerif,
+    fontWeight = FontWeight(500),
+    fontSize = 11.sp,
+    lineHeight = 14.sp,
+    color = Color.White
+  ),
+  button_L = TextStyle(
+    fontFamily = FontFamily.SansSerif,
+    fontWeight = FontWeight(700),
+    fontSize = 14.sp,
+    lineHeight = 13.sp,
+    color = Color.White
   ),
 )
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,6 +133,9 @@ dependencies {
 
   // google play service
   implementation(LibraryDependency.PLAY_SERVICES_BASEMENT)
+
+  //Accompanist
+  implementation(LibraryDependency.ACCOMPANIST_WEBVIEW)
 }
 
 

--- a/app/src/main/java/cm/aptoide/pt/AptoideToolbar.kt
+++ b/app/src/main/java/cm/aptoide/pt/AptoideToolbar.kt
@@ -6,12 +6,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
-import cm.aptoide.pt.aptoide_ui.toolbar.AptoideActionBar
 import cm.aptoide.pt.home.appsRoute
 import cm.aptoide.pt.home.bonusRoute
 import cm.aptoide.pt.home.gamesRoute
-import cm.aptoide.pt.profile.presentation.ProfileButton
+import cm.aptoide.pt.profile.ProfileButton
 import cm.aptoide.pt.profile.profileRoute
+import cm.aptoide.pt.toolbar.AptoideActionBar
 
 @Composable
 fun AptoideToolbar(

--- a/app/src/main/java/cm/aptoide/pt/UrlViewScreen.kt
+++ b/app/src/main/java/cm/aptoide/pt/UrlViewScreen.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.aptoide_ui
+package cm.aptoide.pt
 
 import android.annotation.SuppressLint
 import android.content.Intent
@@ -7,7 +7,12 @@ import android.net.Uri
 import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebView
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -17,7 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraphBuilder
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
-import cm.aptoide.pt.aptoide_ui.toolbar.NavigationTopBar
+import cm.aptoide.pt.toolbar.NavigationTopBar
 import com.google.accompanist.web.AccompanistWebViewClient
 import com.google.accompanist.web.WebView
 import com.google.accompanist.web.rememberWebViewState

--- a/app/src/main/java/cm/aptoide/pt/apps/AppGraphicView.kt
+++ b/app/src/main/java/cm/aptoide/pt/apps/AppGraphicView.kt
@@ -31,13 +31,13 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.appCoinsButtonGradient
-import cm.aptoide.pt.aptoide_ui.theme.orangeGradient
-import cm.aptoide.pt.aptoide_ui.theme.shapes
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
+import cm.aptoide.pt.theme.AppTheme
 import cm.aptoide.pt.theme.GradientButton
+import cm.aptoide.pt.theme.appCoinsButtonGradient
+import cm.aptoide.pt.theme.orangeGradient
+import cm.aptoide.pt.theme.shapes
 
 @Preview(name = "Feature Graphic Item")
 @Composable

--- a/app/src/main/java/cm/aptoide/pt/apps/AppGraphicView.kt
+++ b/app/src/main/java/cm/aptoide/pt/apps/AppGraphicView.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.feature_apps.presentation
+package cm.aptoide.pt.apps
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -30,7 +30,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
-import cm.aptoide.pt.aptoide_ui.buttons.GradientButton
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.aptoide_ui.theme.appCoinsButtonGradient
@@ -38,6 +37,7 @@ import cm.aptoide.pt.aptoide_ui.theme.orangeGradient
 import cm.aptoide.pt.aptoide_ui.theme.shapes
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
+import cm.aptoide.pt.theme.GradientButton
 
 @Preview(name = "Feature Graphic Item")
 @Composable

--- a/app/src/main/java/cm/aptoide/pt/apps/AppGridView.kt
+++ b/app/src/main/java/cm/aptoide/pt/apps/AppGridView.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.feature_apps.presentation
+package cm.aptoide.pt.apps
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable

--- a/app/src/main/java/cm/aptoide/pt/apps/AppGridView.kt
+++ b/app/src/main/java/cm/aptoide/pt/apps/AppGridView.kt
@@ -28,9 +28,9 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
+import cm.aptoide.pt.theme.AppTheme
 
 @Preview
 @Composable

--- a/app/src/main/java/cm/aptoide/pt/apps/AppsRowView.kt
+++ b/app/src/main/java/cm/aptoide/pt/apps/AppsRowView.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.feature_apps.presentation
+package cm.aptoide.pt.apps
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/app/src/main/java/cm/aptoide/pt/appview/AppViewScreen.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/AppViewScreen.kt
@@ -8,10 +8,29 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.*
+import androidx.compose.material.Card
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.runtime.Composable
@@ -35,21 +54,19 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.navigation.NavGraphBuilder
+import cm.aptoide.pt.apps.AppsRowView
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.R
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.toolbar.AppViewTopBar
-import cm.aptoide.pt.download_view.presentation.DownloadViewScreen
 import cm.aptoide.pt.editorial.buildEditorialRoute
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.presentation.AppUiState
-import cm.aptoide.pt.feature_apps.presentation.AppsRowView
 import cm.aptoide.pt.feature_apps.presentation.appViewModel
 import cm.aptoide.pt.feature_appview.presentation.AppViewTab
-import cm.aptoide.pt.feature_appview.presentation.CustomScrollableTabRow
 import cm.aptoide.pt.feature_editorial.presentation.relatedEditorialsCardViewModel
+import cm.aptoide.pt.toolbar.AppViewTopBar
 
 private val tabsList = listOf(
   AppViewTab.DETAILS,

--- a/app/src/main/java/cm/aptoide/pt/appview/AppViewScreen.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/AppViewScreen.kt
@@ -59,13 +59,13 @@ import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.R
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.editorial.buildEditorialRoute
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.presentation.AppUiState
 import cm.aptoide.pt.feature_apps.presentation.appViewModel
 import cm.aptoide.pt.feature_appview.presentation.AppViewTab
 import cm.aptoide.pt.feature_editorial.presentation.relatedEditorialsCardViewModel
+import cm.aptoide.pt.theme.AppTheme
 import cm.aptoide.pt.toolbar.AppViewTopBar
 
 private val tabsList = listOf(

--- a/app/src/main/java/cm/aptoide/pt/appview/CustomScrollableTabRow.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/CustomScrollableTabRow.kt
@@ -23,8 +23,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.feature_appview.presentation.AppViewTab
+import cm.aptoide.pt.theme.AppTheme
 
 @Composable
 fun CustomScrollableTabRow(

--- a/app/src/main/java/cm/aptoide/pt/appview/CustomScrollableTabRow.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/CustomScrollableTabRow.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.feature_appview.presentation
+package cm.aptoide.pt.appview
 
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateDpAsState
@@ -24,14 +24,15 @@ import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-
+import cm.aptoide.pt.feature_appview.presentation.AppViewTab
 
 @Composable
 fun CustomScrollableTabRow(
   tabs: List<AppViewTab>,
   selectedTabIndex: Int,
   onTabClick: (Int) -> Unit,
-  contentColor: Color, backgroundColor: Color,
+  contentColor: Color,
+  backgroundColor: Color,
 ) {
   val density = LocalDensity.current
   val indicatorWidths = MutableList(tabs.size) { 0.dp }

--- a/app/src/main/java/cm/aptoide/pt/appview/DownloadView.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/DownloadView.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.download_view.presentation
+package cm.aptoide.pt.appview
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -34,6 +34,8 @@ import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter.Companion.formatBytes
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
+import cm.aptoide.pt.download_view.presentation.DownloadUiState
+import cm.aptoide.pt.download_view.presentation.rememberDownloadState
 import cm.aptoide.pt.extensions.PreviewAll
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp

--- a/app/src/main/java/cm/aptoide/pt/appview/DownloadView.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/DownloadView.kt
@@ -32,13 +32,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter.Companion.formatBytes
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
 import cm.aptoide.pt.download_view.presentation.DownloadUiState
 import cm.aptoide.pt.download_view.presentation.rememberDownloadState
 import cm.aptoide.pt.extensions.PreviewAll
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
+import cm.aptoide.pt.theme.AppTheme
+import cm.aptoide.pt.theme.AptoideTheme
 
 @PreviewAll
 @Composable

--- a/app/src/main/java/cm/aptoide/pt/appview/OtherVersionsView.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/OtherVersionsView.kt
@@ -24,10 +24,10 @@ import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.textformatter.DateUtils
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
 import cm.aptoide.pt.feature_apps.presentation.appVersions
+import cm.aptoide.pt.theme.AppTheme
 
 @Composable
 fun OtherVersionsView(packageName: String) {

--- a/app/src/main/java/cm/aptoide/pt/appview/ReportAppView.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/ReportAppView.kt
@@ -44,11 +44,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.feature_report_app.domain.ReportApp
 import cm.aptoide.pt.feature_report_app.presentation.ReportAppUiState
 import cm.aptoide.pt.feature_report_app.presentation.ReportAppViewModel
 import cm.aptoide.pt.feature_report_app.presentation.ReportOption
+import cm.aptoide.pt.theme.AppTheme
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 

--- a/app/src/main/java/cm/aptoide/pt/appview/ReviewsView.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/ReviewsView.kt
@@ -19,8 +19,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.theme.AppTheme
 
 @Composable
 fun ReviewsView(app: App) {

--- a/app/src/main/java/cm/aptoide/pt/bonus/BonusBanner.kt
+++ b/app/src/main/java/cm/aptoide/pt/bonus/BonusBanner.kt
@@ -21,9 +21,9 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.appCoinsButtonGradient
 import cm.aptoide.pt.extensions.format
+import cm.aptoide.pt.theme.AppTheme
+import cm.aptoide.pt.theme.appCoinsButtonGradient
 
 @Preview(name = "Feature Graphic Item")
 @Composable

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialScreen.kt
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialScreen.kt
@@ -3,11 +3,24 @@ package cm.aptoide.pt.editorial
 import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.*
+import androidx.compose.material.Button
+import androidx.compose.material.Card
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.runtime.Composable
@@ -29,12 +42,12 @@ import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.toolbar.NavigationTopBar
 import cm.aptoide.pt.aptoide_ui.video.YoutubePlayer
 import cm.aptoide.pt.feature_editorial.data.model.Media
 import cm.aptoide.pt.feature_editorial.domain.Paragraph
 import cm.aptoide.pt.feature_editorial.presentation.EditorialUiState
 import cm.aptoide.pt.feature_editorial.presentation.editorialViewModel
+import cm.aptoide.pt.toolbar.NavigationTopBar
 
 const val editorialRoute = "editorial/{articleId}"
 

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialScreen.kt
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialScreen.kt
@@ -41,12 +41,12 @@ import cm.aptoide.pt.appview.buildAppViewRoute
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.aptoide_ui.video.YoutubePlayer
 import cm.aptoide.pt.feature_editorial.data.model.Media
 import cm.aptoide.pt.feature_editorial.domain.Paragraph
 import cm.aptoide.pt.feature_editorial.presentation.EditorialUiState
 import cm.aptoide.pt.feature_editorial.presentation.editorialViewModel
+import cm.aptoide.pt.theme.AppTheme
 import cm.aptoide.pt.toolbar.NavigationTopBar
 
 const val editorialRoute = "editorial/{articleId}"

--- a/app/src/main/java/cm/aptoide/pt/editorial/EditorialsCardView.kt
+++ b/app/src/main/java/cm/aptoide/pt/editorial/EditorialsCardView.kt
@@ -25,9 +25,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
 import cm.aptoide.pt.feature_reactions.ui.ReactionsView
+import cm.aptoide.pt.theme.AppTheme
 
 var isNavigating = false
 

--- a/app/src/main/java/cm/aptoide/pt/home/BottomNavigationView.kt
+++ b/app/src/main/java/cm/aptoide/pt/home/BottomNavigationView.kt
@@ -30,8 +30,6 @@ import cm.aptoide.pt.BuildConfig
 import cm.aptoide.pt.analytics.presentation.ThemeListener
 import cm.aptoide.pt.appview.appViewScreen
 import cm.aptoide.pt.appview.reportAppScreen
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
 import cm.aptoide.pt.editorial.editorialScreen
 import cm.aptoide.pt.installer.UserActionDialog
 import cm.aptoide.pt.profile.editProfileScreen
@@ -40,7 +38,9 @@ import cm.aptoide.pt.search.presentation.searchScreen
 import cm.aptoide.pt.settings.presentation.themePreferences
 import cm.aptoide.pt.settings.sendFeedbackScreen
 import cm.aptoide.pt.settings.settingsScreen
+import cm.aptoide.pt.theme.AppTheme
 import cm.aptoide.pt.theme.AptoideSnackBar
+import cm.aptoide.pt.theme.AptoideTheme
 import cm.aptoide.pt.updates.updatesScreen
 import cm.aptoide.pt.urlViewScreen
 import kotlinx.coroutines.launch

--- a/app/src/main/java/cm/aptoide/pt/home/BottomNavigationView.kt
+++ b/app/src/main/java/cm/aptoide/pt/home/BottomNavigationView.kt
@@ -5,7 +5,14 @@ import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.*
+import androidx.compose.material.BottomNavigation
+import androidx.compose.material.BottomNavigationItem
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalElevationOverlay
+import androidx.compose.material.Scaffold
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -23,19 +30,19 @@ import cm.aptoide.pt.BuildConfig
 import cm.aptoide.pt.analytics.presentation.ThemeListener
 import cm.aptoide.pt.appview.appViewScreen
 import cm.aptoide.pt.appview.reportAppScreen
-import cm.aptoide.pt.aptoide_ui.snackbar.AptoideSnackBar
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
-import cm.aptoide.pt.aptoide_ui.urlViewScreen
 import cm.aptoide.pt.editorial.editorialScreen
-import cm.aptoide.pt.installer.presentation.UserActionDialog
+import cm.aptoide.pt.installer.UserActionDialog
 import cm.aptoide.pt.profile.editProfileScreen
 import cm.aptoide.pt.profile.profileScreen
 import cm.aptoide.pt.search.presentation.searchScreen
 import cm.aptoide.pt.settings.presentation.themePreferences
 import cm.aptoide.pt.settings.sendFeedbackScreen
 import cm.aptoide.pt.settings.settingsScreen
+import cm.aptoide.pt.theme.AptoideSnackBar
 import cm.aptoide.pt.updates.updatesScreen
+import cm.aptoide.pt.urlViewScreen
 import kotlinx.coroutines.launch
 
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")

--- a/app/src/main/java/cm/aptoide/pt/home/BundlesView.kt
+++ b/app/src/main/java/cm/aptoide/pt/home/BundlesView.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.appcoins.presentation.rememberBonus
 import cm.aptoide.pt.appview.buildAppViewRoute
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
+import cm.aptoide.pt.aptoide_ui.theme.greyMedium
 import cm.aptoide.pt.bonus.BonusBanner
 import cm.aptoide.pt.editorial.EditorialViewCard
 import cm.aptoide.pt.extensions.format
@@ -44,7 +45,6 @@ import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.Type
 import cm.aptoide.pt.feature_home.presentation.BundlesViewUiState
 import cm.aptoide.pt.feature_home.presentation.BundlesViewUiStateType.LOADING
-import cm.aptoide.pt.theme.greyMedium
 import java.util.Random
 
 @Composable

--- a/app/src/main/java/cm/aptoide/pt/home/BundlesView.kt
+++ b/app/src/main/java/cm/aptoide/pt/home/BundlesView.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.appcoins.presentation.rememberBonus
+import cm.aptoide.pt.apps.AppGraphicView
+import cm.aptoide.pt.apps.AppsRowView
 import cm.aptoide.pt.appview.buildAppViewRoute
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.aptoide_ui.theme.greyMedium
@@ -36,9 +38,7 @@ import cm.aptoide.pt.editorial.EditorialViewCard
 import cm.aptoide.pt.extensions.format
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
-import cm.aptoide.pt.feature_apps.presentation.AppGraphicView
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
-import cm.aptoide.pt.feature_apps.presentation.AppsRowView
 import cm.aptoide.pt.feature_apps.presentation.tagApps
 import cm.aptoide.pt.feature_editorial.presentation.editorialsCardViewModel
 import cm.aptoide.pt.feature_home.domain.Bundle

--- a/app/src/main/java/cm/aptoide/pt/home/BundlesView.kt
+++ b/app/src/main/java/cm/aptoide/pt/home/BundlesView.kt
@@ -31,8 +31,6 @@ import cm.aptoide.pt.appcoins.presentation.rememberBonus
 import cm.aptoide.pt.apps.AppGraphicView
 import cm.aptoide.pt.apps.AppsRowView
 import cm.aptoide.pt.appview.buildAppViewRoute
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.greyMedium
 import cm.aptoide.pt.bonus.BonusBanner
 import cm.aptoide.pt.editorial.EditorialViewCard
 import cm.aptoide.pt.extensions.format
@@ -45,6 +43,8 @@ import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.Type
 import cm.aptoide.pt.feature_home.presentation.BundlesViewUiState
 import cm.aptoide.pt.feature_home.presentation.BundlesViewUiStateType.LOADING
+import cm.aptoide.pt.theme.AppTheme
+import cm.aptoide.pt.theme.greyMedium
 import java.util.Random
 
 @Composable

--- a/app/src/main/java/cm/aptoide/pt/installer/UserActionDialog.kt
+++ b/app/src/main/java/cm/aptoide/pt/installer/UserActionDialog.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.installer.presentation
+package cm.aptoide.pt.installer
 
 import android.app.Activity
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -41,6 +41,8 @@ import cm.aptoide.pt.installer.platform.UserActionRequest.ConfirmationAction
 import cm.aptoide.pt.installer.platform.UserActionRequest.InstallationAction
 import cm.aptoide.pt.installer.platform.UserActionRequest.PermissionAction
 import cm.aptoide.pt.installer.platform.UserConfirmation
+import cm.aptoide.pt.installer.platform.UserConfirmation.WRITE_EXTERNAL_RATIONALE
+import cm.aptoide.pt.installer.presentation.UserActionViewModel
 
 @Composable
 fun UserActionDialog() {
@@ -86,7 +88,7 @@ fun UserActionDialog() {
 
   (state as? ConfirmationAction)?.let {
     PermissionsContent(rationale = it.confirmation.rationale) {
-      if (it.confirmation == UserConfirmation.WRITE_EXTERNAL_RATIONALE) {
+      if (it.confirmation == WRITE_EXTERNAL_RATIONALE) {
         DialogButton(
           title = "Ok",
           onClick = { viewModel.onResult(false) },

--- a/app/src/main/java/cm/aptoide/pt/installer/UserActionDialog.kt
+++ b/app/src/main/java/cm/aptoide/pt/installer/UserActionDialog.kt
@@ -34,8 +34,6 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.app.ActivityCompat
 import androidx.hilt.navigation.compose.hiltViewModel
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
 import cm.aptoide.pt.extensions.PreviewAll
 import cm.aptoide.pt.installer.platform.UserActionRequest.ConfirmationAction
 import cm.aptoide.pt.installer.platform.UserActionRequest.InstallationAction
@@ -43,6 +41,8 @@ import cm.aptoide.pt.installer.platform.UserActionRequest.PermissionAction
 import cm.aptoide.pt.installer.platform.UserConfirmation
 import cm.aptoide.pt.installer.platform.UserConfirmation.WRITE_EXTERNAL_RATIONALE
 import cm.aptoide.pt.installer.presentation.UserActionViewModel
+import cm.aptoide.pt.theme.AppTheme
+import cm.aptoide.pt.theme.AptoideTheme
 
 @Composable
 fun UserActionDialog() {

--- a/app/src/main/java/cm/aptoide/pt/profile/EditProfileView.kt
+++ b/app/src/main/java/cm/aptoide/pt/profile/EditProfileView.kt
@@ -69,11 +69,11 @@ import cm.aptoide.pt.aptoide_ui.animations.staticComposable
 import cm.aptoide.pt.aptoide_ui.buttons.GradientButton
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.aptoide_ui.theme.orangeGradient
+import cm.aptoide.pt.aptoide_ui.theme.shapes
+import cm.aptoide.pt.aptoide_ui.theme.textWhite
 import cm.aptoide.pt.aptoide_ui.toolbar.NavigationTopBar
 import cm.aptoide.pt.profile.data.model.UserProfile
 import cm.aptoide.pt.profile.presentation.userProfileData
-import cm.aptoide.pt.theme.shapes
-import cm.aptoide.pt.theme.textWhite
 import timber.log.Timber
 import java.io.File
 import java.io.FileOutputStream

--- a/app/src/main/java/cm/aptoide/pt/profile/EditProfileView.kt
+++ b/app/src/main/java/cm/aptoide/pt/profile/EditProfileView.kt
@@ -66,13 +66,13 @@ import androidx.core.content.FileProvider.getUriForFile
 import androidx.navigation.NavGraphBuilder
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.animations.staticComposable
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.orangeGradient
-import cm.aptoide.pt.aptoide_ui.theme.shapes
-import cm.aptoide.pt.aptoide_ui.theme.textWhite
 import cm.aptoide.pt.profile.data.model.UserProfile
 import cm.aptoide.pt.profile.presentation.userProfileData
+import cm.aptoide.pt.theme.AppTheme
 import cm.aptoide.pt.theme.GradientButton
+import cm.aptoide.pt.theme.orangeGradient
+import cm.aptoide.pt.theme.shapes
+import cm.aptoide.pt.theme.textWhite
 import cm.aptoide.pt.toolbar.NavigationTopBar
 import timber.log.Timber
 import java.io.File

--- a/app/src/main/java/cm/aptoide/pt/profile/EditProfileView.kt
+++ b/app/src/main/java/cm/aptoide/pt/profile/EditProfileView.kt
@@ -66,14 +66,14 @@ import androidx.core.content.FileProvider.getUriForFile
 import androidx.navigation.NavGraphBuilder
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.animations.staticComposable
-import cm.aptoide.pt.aptoide_ui.buttons.GradientButton
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.aptoide_ui.theme.orangeGradient
 import cm.aptoide.pt.aptoide_ui.theme.shapes
 import cm.aptoide.pt.aptoide_ui.theme.textWhite
-import cm.aptoide.pt.aptoide_ui.toolbar.NavigationTopBar
 import cm.aptoide.pt.profile.data.model.UserProfile
 import cm.aptoide.pt.profile.presentation.userProfileData
+import cm.aptoide.pt.theme.GradientButton
+import cm.aptoide.pt.toolbar.NavigationTopBar
 import timber.log.Timber
 import java.io.File
 import java.io.FileOutputStream

--- a/app/src/main/java/cm/aptoide/pt/profile/ProfileButton.kt
+++ b/app/src/main/java/cm/aptoide/pt/profile/ProfileButton.kt
@@ -12,8 +12,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.profile.presentation.userProfileData
+import cm.aptoide.pt.theme.AppTheme
 
 @Composable
 fun ProfileButton(onClick: () -> Unit) {

--- a/app/src/main/java/cm/aptoide/pt/profile/ProfileButton.kt
+++ b/app/src/main/java/cm/aptoide/pt/profile/ProfileButton.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.profile.presentation
+package cm.aptoide.pt.profile
 
 import android.net.Uri
 import androidx.compose.foundation.border
@@ -13,6 +13,7 @@ import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
+import cm.aptoide.pt.profile.presentation.userProfileData
 
 @Composable
 fun ProfileButton(onClick: () -> Unit) {

--- a/app/src/main/java/cm/aptoide/pt/profile/ProfileView.kt
+++ b/app/src/main/java/cm/aptoide/pt/profile/ProfileView.kt
@@ -49,11 +49,11 @@ import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
 import cm.aptoide.pt.aptoide_ui.dialogs.AptoideDialog
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
+import cm.aptoide.pt.aptoide_ui.theme.pinkishOrange
+import cm.aptoide.pt.aptoide_ui.theme.shapes
 import cm.aptoide.pt.aptoide_ui.toolbar.NavigationTopBar
 import cm.aptoide.pt.profile.presentation.userProfileData
 import cm.aptoide.pt.settings.settingsRoute
-import cm.aptoide.pt.theme.pinkishOrange
-import cm.aptoide.pt.theme.shapes
 
 const val profileRoute = "profile"
 

--- a/app/src/main/java/cm/aptoide/pt/profile/ProfileView.kt
+++ b/app/src/main/java/cm/aptoide/pt/profile/ProfileView.kt
@@ -47,12 +47,12 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraphBuilder
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.pinkishOrange
-import cm.aptoide.pt.aptoide_ui.theme.shapes
 import cm.aptoide.pt.profile.presentation.userProfileData
 import cm.aptoide.pt.settings.settingsRoute
+import cm.aptoide.pt.theme.AppTheme
 import cm.aptoide.pt.theme.AptoideDialog
+import cm.aptoide.pt.theme.pinkishOrange
+import cm.aptoide.pt.theme.shapes
 import cm.aptoide.pt.toolbar.NavigationTopBar
 
 const val profileRoute = "profile"

--- a/app/src/main/java/cm/aptoide/pt/profile/ProfileView.kt
+++ b/app/src/main/java/cm/aptoide/pt/profile/ProfileView.kt
@@ -47,13 +47,13 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraphBuilder
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
-import cm.aptoide.pt.aptoide_ui.dialogs.AptoideDialog
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.aptoide_ui.theme.pinkishOrange
 import cm.aptoide.pt.aptoide_ui.theme.shapes
-import cm.aptoide.pt.aptoide_ui.toolbar.NavigationTopBar
 import cm.aptoide.pt.profile.presentation.userProfileData
 import cm.aptoide.pt.settings.settingsRoute
+import cm.aptoide.pt.theme.AptoideDialog
+import cm.aptoide.pt.toolbar.NavigationTopBar
 
 const val profileRoute = "profile"
 

--- a/app/src/main/java/cm/aptoide/pt/search/presentation/SearchView.kt
+++ b/app/src/main/java/cm/aptoide/pt/search/presentation/SearchView.kt
@@ -4,13 +4,31 @@ import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.*
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
@@ -46,8 +64,6 @@ import cm.aptoide.pt.appview.buildAppViewRoute
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.animations.staticComposable
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
 import cm.aptoide.pt.extensions.PreviewAll
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
@@ -55,6 +71,8 @@ import cm.aptoide.pt.feature_search.domain.model.SearchSuggestionType
 import cm.aptoide.pt.feature_search.presentation.SearchUiState
 import cm.aptoide.pt.feature_search.presentation.SearchViewModel
 import cm.aptoide.pt.feature_search.utils.isValidSearch
+import cm.aptoide.pt.theme.AppTheme
+import cm.aptoide.pt.theme.AptoideTheme
 
 const val searchRoute = "search"
 

--- a/app/src/main/java/cm/aptoide/pt/settings/SendFeedbackView.kt
+++ b/app/src/main/java/cm/aptoide/pt/settings/SendFeedbackView.kt
@@ -44,15 +44,15 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.grey
-import cm.aptoide.pt.aptoide_ui.theme.greyMedium
-import cm.aptoide.pt.aptoide_ui.theme.orangeGradient
-import cm.aptoide.pt.aptoide_ui.theme.pinkishOrange
-import cm.aptoide.pt.aptoide_ui.theme.shapes
 import cm.aptoide.pt.settings.presentation.FeedbackViewModel
 import cm.aptoide.pt.settings.repository.sendMail
+import cm.aptoide.pt.theme.AppTheme
 import cm.aptoide.pt.theme.GradientButton
+import cm.aptoide.pt.theme.grey
+import cm.aptoide.pt.theme.greyMedium
+import cm.aptoide.pt.theme.orangeGradient
+import cm.aptoide.pt.theme.pinkishOrange
+import cm.aptoide.pt.theme.shapes
 import cm.aptoide.pt.toolbar.NavigationTopBar
 
 const val sendFeedbackRoute = "sendFeedback"

--- a/app/src/main/java/cm/aptoide/pt/settings/SendFeedbackView.kt
+++ b/app/src/main/java/cm/aptoide/pt/settings/SendFeedbackView.kt
@@ -46,14 +46,14 @@ import androidx.navigation.NavGraphBuilder
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
 import cm.aptoide.pt.aptoide_ui.buttons.GradientButton
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
+import cm.aptoide.pt.aptoide_ui.theme.grey
+import cm.aptoide.pt.aptoide_ui.theme.greyMedium
 import cm.aptoide.pt.aptoide_ui.theme.orangeGradient
+import cm.aptoide.pt.aptoide_ui.theme.pinkishOrange
+import cm.aptoide.pt.aptoide_ui.theme.shapes
 import cm.aptoide.pt.aptoide_ui.toolbar.NavigationTopBar
 import cm.aptoide.pt.settings.presentation.FeedbackViewModel
 import cm.aptoide.pt.settings.repository.sendMail
-import cm.aptoide.pt.theme.grey
-import cm.aptoide.pt.theme.greyMedium
-import cm.aptoide.pt.theme.pinkishOrange
-import cm.aptoide.pt.theme.shapes
 
 const val sendFeedbackRoute = "sendFeedback"
 

--- a/app/src/main/java/cm/aptoide/pt/settings/SendFeedbackView.kt
+++ b/app/src/main/java/cm/aptoide/pt/settings/SendFeedbackView.kt
@@ -44,16 +44,16 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
-import cm.aptoide.pt.aptoide_ui.buttons.GradientButton
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.aptoide_ui.theme.grey
 import cm.aptoide.pt.aptoide_ui.theme.greyMedium
 import cm.aptoide.pt.aptoide_ui.theme.orangeGradient
 import cm.aptoide.pt.aptoide_ui.theme.pinkishOrange
 import cm.aptoide.pt.aptoide_ui.theme.shapes
-import cm.aptoide.pt.aptoide_ui.toolbar.NavigationTopBar
 import cm.aptoide.pt.settings.presentation.FeedbackViewModel
 import cm.aptoide.pt.settings.repository.sendMail
+import cm.aptoide.pt.theme.GradientButton
+import cm.aptoide.pt.toolbar.NavigationTopBar
 
 const val sendFeedbackRoute = "sendFeedback"
 

--- a/app/src/main/java/cm/aptoide/pt/settings/SettingsView.kt
+++ b/app/src/main/java/cm/aptoide/pt/settings/SettingsView.kt
@@ -54,15 +54,13 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
-import cm.aptoide.pt.aptoide_ui.buildUrlViewRoute
-import cm.aptoide.pt.aptoide_ui.dialogs.AptoideDialog
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
+import cm.aptoide.pt.buildUrlViewRoute
 import cm.aptoide.pt.aptoide_ui.theme.grey
 import cm.aptoide.pt.aptoide_ui.theme.greyMedium
 import cm.aptoide.pt.aptoide_ui.theme.pastelOrange
 import cm.aptoide.pt.aptoide_ui.theme.pinkishOrange
 import cm.aptoide.pt.aptoide_ui.theme.shapes
-import cm.aptoide.pt.aptoide_ui.toolbar.NavigationTopBar
 import cm.aptoide.pt.settings.presentation.DeviceInfoViewModel
 import cm.aptoide.pt.settings.presentation.adultContentPreferences
 import cm.aptoide.pt.settings.presentation.appUpdatesPreferences
@@ -78,6 +76,8 @@ import cm.aptoide.pt.settings.presentation.systemAppsPreferences
 import cm.aptoide.pt.settings.presentation.themePreferences
 import cm.aptoide.pt.settings.presentation.updateAptoidePreferences
 import cm.aptoide.pt.settings.presentation.userPinPreferences
+import cm.aptoide.pt.theme.AptoideDialog
+import cm.aptoide.pt.toolbar.NavigationTopBar
 
 const val settingsRoute = "settings"
 

--- a/app/src/main/java/cm/aptoide/pt/settings/SettingsView.kt
+++ b/app/src/main/java/cm/aptoide/pt/settings/SettingsView.kt
@@ -54,10 +54,14 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
-import cm.aptoide.pt.aptoide_ui.animations.staticComposable
 import cm.aptoide.pt.aptoide_ui.buildUrlViewRoute
 import cm.aptoide.pt.aptoide_ui.dialogs.AptoideDialog
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
+import cm.aptoide.pt.aptoide_ui.theme.grey
+import cm.aptoide.pt.aptoide_ui.theme.greyMedium
+import cm.aptoide.pt.aptoide_ui.theme.pastelOrange
+import cm.aptoide.pt.aptoide_ui.theme.pinkishOrange
+import cm.aptoide.pt.aptoide_ui.theme.shapes
 import cm.aptoide.pt.aptoide_ui.toolbar.NavigationTopBar
 import cm.aptoide.pt.settings.presentation.DeviceInfoViewModel
 import cm.aptoide.pt.settings.presentation.adultContentPreferences
@@ -74,11 +78,6 @@ import cm.aptoide.pt.settings.presentation.systemAppsPreferences
 import cm.aptoide.pt.settings.presentation.themePreferences
 import cm.aptoide.pt.settings.presentation.updateAptoidePreferences
 import cm.aptoide.pt.settings.presentation.userPinPreferences
-import cm.aptoide.pt.theme.grey
-import cm.aptoide.pt.theme.greyMedium
-import cm.aptoide.pt.theme.pastelOrange
-import cm.aptoide.pt.theme.pinkishOrange
-import cm.aptoide.pt.theme.shapes
 
 const val settingsRoute = "settings"
 

--- a/app/src/main/java/cm/aptoide/pt/settings/SettingsView.kt
+++ b/app/src/main/java/cm/aptoide/pt/settings/SettingsView.kt
@@ -54,13 +54,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.buildUrlViewRoute
-import cm.aptoide.pt.aptoide_ui.theme.grey
-import cm.aptoide.pt.aptoide_ui.theme.greyMedium
-import cm.aptoide.pt.aptoide_ui.theme.pastelOrange
-import cm.aptoide.pt.aptoide_ui.theme.pinkishOrange
-import cm.aptoide.pt.aptoide_ui.theme.shapes
 import cm.aptoide.pt.settings.presentation.DeviceInfoViewModel
 import cm.aptoide.pt.settings.presentation.adultContentPreferences
 import cm.aptoide.pt.settings.presentation.appUpdatesPreferences
@@ -76,7 +70,13 @@ import cm.aptoide.pt.settings.presentation.systemAppsPreferences
 import cm.aptoide.pt.settings.presentation.themePreferences
 import cm.aptoide.pt.settings.presentation.updateAptoidePreferences
 import cm.aptoide.pt.settings.presentation.userPinPreferences
+import cm.aptoide.pt.theme.AppTheme
 import cm.aptoide.pt.theme.AptoideDialog
+import cm.aptoide.pt.theme.grey
+import cm.aptoide.pt.theme.greyMedium
+import cm.aptoide.pt.theme.pastelOrange
+import cm.aptoide.pt.theme.pinkishOrange
+import cm.aptoide.pt.theme.shapes
 import cm.aptoide.pt.toolbar.NavigationTopBar
 
 const val settingsRoute = "settings"

--- a/app/src/main/java/cm/aptoide/pt/theme/AppColors.kt
+++ b/app/src/main/java/cm/aptoide/pt/theme/AppColors.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.aptoide_ui.theme
+package cm.aptoide.pt.theme
 
 import androidx.compose.material.Colors
 import androidx.compose.ui.graphics.Color

--- a/app/src/main/java/cm/aptoide/pt/theme/AppIcons.kt
+++ b/app/src/main/java/cm/aptoide/pt/theme/AppIcons.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.aptoide_ui.theme
+package cm.aptoide.pt.theme
 
 import androidx.compose.ui.graphics.vector.ImageVector
 

--- a/app/src/main/java/cm/aptoide/pt/theme/AppTypography.kt
+++ b/app/src/main/java/cm/aptoide/pt/theme/AppTypography.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.aptoide_ui.theme
+package cm.aptoide.pt.theme
 
 import androidx.compose.material.Typography
 import androidx.compose.ui.text.TextStyle

--- a/app/src/main/java/cm/aptoide/pt/theme/AptoideDialog.kt
+++ b/app/src/main/java/cm/aptoide/pt/theme/AptoideDialog.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.aptoide_ui.dialogs
+package cm.aptoide.pt.theme
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
@@ -23,7 +23,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import cm.aptoide.pt.aptoide_ui.buttons.GradientButton
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.aptoide_ui.theme.appCoinsButtonGradient
 import cm.aptoide.pt.aptoide_ui.theme.shapes

--- a/app/src/main/java/cm/aptoide/pt/theme/AptoideDialog.kt
+++ b/app/src/main/java/cm/aptoide/pt/theme/AptoideDialog.kt
@@ -23,9 +23,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.appCoinsButtonGradient
-import cm.aptoide.pt.aptoide_ui.theme.shapes
 
 @Composable
 fun AptoideDialog(

--- a/app/src/main/java/cm/aptoide/pt/theme/AptoideSnackBar.kt
+++ b/app/src/main/java/cm/aptoide/pt/theme/AptoideSnackBar.kt
@@ -1,0 +1,30 @@
+package cm.aptoide.pt.theme
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Snackbar
+import androidx.compose.material.SnackbarData
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.unit.dp
+import cm.aptoide.pt.aptoide_ui.theme.AppTheme
+
+@Composable
+fun AptoideSnackBar(data: SnackbarData) {
+  Snackbar(
+    modifier = Modifier
+      .padding(12.dp)
+      .focusable(false)
+      .clearAndSetSemantics {},
+    shape = RoundedCornerShape(16.dp),
+    content = {
+      Text(
+        text = data.message,
+        style = AppTheme.typography.medium_S,
+      )
+    },
+  )
+}

--- a/app/src/main/java/cm/aptoide/pt/theme/AptoideSnackBar.kt
+++ b/app/src/main/java/cm/aptoide/pt/theme/AptoideSnackBar.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 
 @Composable
 fun AptoideSnackBar(data: SnackbarData) {

--- a/app/src/main/java/cm/aptoide/pt/theme/Color.kt
+++ b/app/src/main/java/cm/aptoide/pt/theme/Color.kt
@@ -1,17 +1,22 @@
-package cm.aptoide.pt.aptoide_ui.theme
+package cm.aptoide.pt.theme
 
 import androidx.compose.ui.graphics.Color
 
 
 val pinkishOrange = Color(0xFFFE6446)
+val pastelOrange = Color(0xFFFE9150)
 val black = Color(0xFF171717)
+val blackDarkMode = Color(0xFF212121)
+val negro = Color(0xFF4C4C4C)
 val grey = Color(0xFF6F6F6F)
 val greyMedium = Color(0xFFB3B3B3)
 val greyLight = Color(0xFFEBEBEB)
 
 val error = Color(0xFFFF3A3A)
 
-val yellow = Color(0xFFF9BF30)
+val purpleCatappult = Color(0xFF190054)
+val appCoins = Color(0xFFFF578C)
+
 val green = Color(0xFF25B47E)
 
 val textWhite = Color(0xFFFFFFFF)

--- a/app/src/main/java/cm/aptoide/pt/theme/GradientButton.kt
+++ b/app/src/main/java/cm/aptoide/pt/theme/GradientButton.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.aptoide_ui.buttons
+package cm.aptoide.pt.theme
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box

--- a/app/src/main/java/cm/aptoide/pt/theme/GradientButton.kt
+++ b/app/src/main/java/cm/aptoide/pt/theme/GradientButton.kt
@@ -18,10 +18,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.aptoide_ui.theme.greyLight
-import cm.aptoide.pt.aptoide_ui.theme.greyMedium
-import cm.aptoide.pt.aptoide_ui.theme.orangeGradient
-import cm.aptoide.pt.aptoide_ui.theme.textWhite
 
 @Composable
 fun GradientButton(

--- a/app/src/main/java/cm/aptoide/pt/theme/Gradients.kt
+++ b/app/src/main/java/cm/aptoide/pt/theme/Gradients.kt
@@ -1,7 +1,16 @@
-package cm.aptoide.pt.aptoide_ui.theme
+package cm.aptoide.pt.theme
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
+
+val orangeGradient = Brush.linearGradient(
+  colors = listOf(
+    orangeGradientStart,
+    pinkishOrange
+  ),
+  start = Offset(x = 29.2612f, y = 5.5355f),
+  end = Offset(x = 70.6041f, y = 132.895f)
+)
 
 val appCoinsGradient = Brush.linearGradient(
   colors = listOf(
@@ -11,6 +20,14 @@ val appCoinsGradient = Brush.linearGradient(
   ),
   start = Offset(x = 1.029f, y = 1.44f),
   end = Offset(x = 28.42f, y = 15.203f)
+)
+
+val appCoinsButtonGradient = Brush.horizontalGradient(
+  colorStops = arrayOf(
+    0.0f to orangeGradientStart,
+    0.192708f to orangeGradientMid,
+    0.760417f to orangeGradientEnd
+  ),
 )
 
 val blueGradient = Brush.linearGradient(

--- a/app/src/main/java/cm/aptoide/pt/theme/Shape.kt
+++ b/app/src/main/java/cm/aptoide/pt/theme/Shape.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.aptoide_ui.theme
+package cm.aptoide.pt.theme
 
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Shapes

--- a/app/src/main/java/cm/aptoide/pt/theme/Theme.kt
+++ b/app/src/main/java/cm/aptoide/pt/theme/Theme.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.aptoide_ui.theme
+package cm.aptoide.pt.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme

--- a/app/src/main/java/cm/aptoide/pt/toolbar/AptoideToolbar.kt
+++ b/app/src/main/java/cm/aptoide/pt/toolbar/AptoideToolbar.kt
@@ -24,9 +24,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
 import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.theme.AppTheme
+import cm.aptoide.pt.theme.AptoideTheme
 import kotlin.random.Random
 
 @PreviewAll

--- a/app/src/main/java/cm/aptoide/pt/toolbar/AptoideToolbar.kt
+++ b/app/src/main/java/cm/aptoide/pt/toolbar/AptoideToolbar.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.aptoide_ui.toolbar
+package cm.aptoide.pt.toolbar
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/cm/aptoide/pt/toolbar/Topbar.kt
+++ b/app/src/main/java/cm/aptoide/pt/toolbar/Topbar.kt
@@ -22,8 +22,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.grey
+import cm.aptoide.pt.theme.AppTheme
+import cm.aptoide.pt.theme.grey
 
 @Composable
 fun NavigationTopBar(

--- a/app/src/main/java/cm/aptoide/pt/toolbar/Topbar.kt
+++ b/app/src/main/java/cm/aptoide/pt/toolbar/Topbar.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.aptoide_ui.toolbar
+package cm.aptoide.pt.toolbar
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
@@ -12,7 +12,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -38,7 +38,7 @@ fun NavigationTopBar(
       onClick = onBackPressed
     ) {
       Icon(
-        imageVector = Icons.Filled.ArrowBack,
+        imageVector = Filled.ArrowBack,
         tint = AppTheme.colors.onBackground,
         contentDescription = "Back",
         modifier = Modifier.size(21.dp)
@@ -61,7 +61,7 @@ fun AppViewTopBar(onBackPressed: () -> Unit) {
       onClick = onBackPressed
     ) {
       Icon(
-        imageVector = Icons.Filled.ArrowBack,
+        imageVector = Filled.ArrowBack,
         tint = grey,
         contentDescription = "Back",
         modifier = Modifier.size(16.dp)

--- a/app/src/main/java/cm/aptoide/pt/updates/UpdatesView.kt
+++ b/app/src/main/java/cm/aptoide/pt/updates/UpdatesView.kt
@@ -1,8 +1,17 @@
 package cm.aptoide.pt.updates
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -23,10 +32,10 @@ import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.animations.staticComposable
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
-import cm.aptoide.pt.aptoide_ui.toolbar.AptoideActionBar
 import cm.aptoide.pt.feature_updates.domain.InstalledApp
 import cm.aptoide.pt.feature_updates.presentation.UpdatesUiState
 import cm.aptoide.pt.feature_updates.presentation.UpdatesViewModel
+import cm.aptoide.pt.toolbar.AptoideActionBar
 
 const val updatesRoute = "updates"
 
@@ -43,6 +52,7 @@ fun NavGraphBuilder.updatesScreen(
   )
 }
 
+@SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @Composable
 fun UpdatesScreen(
   uiState: UpdatesUiState,

--- a/app/src/main/java/cm/aptoide/pt/updates/UpdatesView.kt
+++ b/app/src/main/java/cm/aptoide/pt/updates/UpdatesView.kt
@@ -30,11 +30,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.animations.staticComposable
-import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.theme.AptoideTheme
 import cm.aptoide.pt.feature_updates.domain.InstalledApp
 import cm.aptoide.pt.feature_updates.presentation.UpdatesUiState
 import cm.aptoide.pt.feature_updates.presentation.UpdatesViewModel
+import cm.aptoide.pt.theme.AppTheme
+import cm.aptoide.pt.theme.AptoideTheme
 import cm.aptoide.pt.toolbar.AptoideActionBar
 
 const val updatesRoute = "updates"

--- a/aptoide-installer/build.gradle.kts
+++ b/aptoide-installer/build.gradle.kts
@@ -10,7 +10,6 @@ android {
 }
 
 dependencies {
-  implementation(project(ModuleDependency.APTOIDE_UI))
   implementation(project(ModuleDependency.INSTALL_MANAGER))
   implementation(project(ModuleDependency.APTOIDE_NETWORK))
   implementation(project(ModuleDependency.EXTENSIONS))

--- a/aptoide-ui/build.gradle.kts
+++ b/aptoide-ui/build.gradle.kts
@@ -11,6 +11,5 @@ android {
 
 dependencies {
   //Accompanist
-  implementation(LibraryDependency.ACCOMPANIST_WEBVIEW)
   implementation(project(ModuleDependency.EXTENSIONS))
 }

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/buttons/GradientButton.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/buttons/GradientButton.kt
@@ -18,10 +18,10 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import cm.aptoide.pt.aptoide_ui.theme.greyLight
+import cm.aptoide.pt.aptoide_ui.theme.greyMedium
 import cm.aptoide.pt.aptoide_ui.theme.orangeGradient
-import cm.aptoide.pt.theme.greyLight
-import cm.aptoide.pt.theme.greyMedium
-import cm.aptoide.pt.theme.textWhite
+import cm.aptoide.pt.aptoide_ui.theme.textWhite
 
 @Composable
 fun GradientButton(

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/dialogs/AptoideDialog.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/dialogs/AptoideDialog.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.window.DialogProperties
 import cm.aptoide.pt.aptoide_ui.buttons.GradientButton
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.aptoide_ui.theme.appCoinsButtonGradient
-import cm.aptoide.pt.theme.shapes
+import cm.aptoide.pt.aptoide_ui.theme.shapes
 
 @Composable
 fun AptoideDialog(

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/AptoideIcon.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/AptoideIcon.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.theme.aptoideIconOrange
-import cm.aptoide.pt.theme.textWhite
+import cm.aptoide.pt.aptoide_ui.theme.aptoideIconOrange
+import cm.aptoide.pt.aptoide_ui.theme.textWhite
 
 @Preview
 @Composable

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/AptoideTVIcon.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/AptoideTVIcon.kt
@@ -10,9 +10,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.theme.greyLight
-import cm.aptoide.pt.theme.aptoideTVIconOrange
-import cm.aptoide.pt.theme.iconsBlack
+import cm.aptoide.pt.aptoide_ui.theme.aptoideTVIconOrange
+import cm.aptoide.pt.aptoide_ui.theme.greyLight
+import cm.aptoide.pt.aptoide_ui.theme.iconsBlack
 
 @Preview
 @Composable

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/AptoideUploaderIcon.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/AptoideUploaderIcon.kt
@@ -12,9 +12,9 @@ import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.theme.blueGradient
-import cm.aptoide.pt.theme.darkBlue
-import cm.aptoide.pt.theme.iconsBlack
-import cm.aptoide.pt.theme.textWhite
+import cm.aptoide.pt.aptoide_ui.theme.darkBlue
+import cm.aptoide.pt.aptoide_ui.theme.iconsBlack
+import cm.aptoide.pt.aptoide_ui.theme.textWhite
 
 @Preview
 @Composable

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/ESkillsLogo.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/ESkillsLogo.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.theme.yellow
+import cm.aptoide.pt.aptoide_ui.theme.yellow
 
 @Preview
 @Composable

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/FacebookIcon.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/FacebookIcon.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.theme.greyMedium
+import cm.aptoide.pt.aptoide_ui.theme.greyMedium
 
 @Preview
 @Composable

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/InstagramIcon.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/InstagramIcon.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.theme.greyMedium
+import cm.aptoide.pt.aptoide_ui.theme.greyMedium
 
 @Preview
 @Composable

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/NoImageIconProfile.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/NoImageIconProfile.kt
@@ -1,16 +1,17 @@
 package cm.aptoide.pt.aptoide_ui.icons
 
-import androidx.compose.ui.graphics.*
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.theme.greyLight
-import cm.aptoide.pt.theme.greyMedium
+import cm.aptoide.pt.aptoide_ui.theme.greyLight
+import cm.aptoide.pt.aptoide_ui.theme.greyMedium
 
 @Preview
 @Composable

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/ReportIcon.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/ReportIcon.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.theme.error
+import cm.aptoide.pt.aptoide_ui.theme.error
 
 @Preview
 @Composable

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/ToolbarLogo.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/ToolbarLogo.kt
@@ -1,17 +1,18 @@
 package cm.aptoide.pt.aptoide_ui.icons
 
-import androidx.compose.ui.graphics.*
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.theme.aptoideIconBackgroundWhite
-import cm.aptoide.pt.theme.aptoideIconOrange
-import cm.aptoide.pt.theme.iconsBlack
+import cm.aptoide.pt.aptoide_ui.theme.aptoideIconBackgroundWhite
+import cm.aptoide.pt.aptoide_ui.theme.aptoideIconOrange
+import cm.aptoide.pt.aptoide_ui.theme.iconsBlack
 
 @Preview
 @Composable

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/TrustedIcon.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/TrustedIcon.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.theme.green
+import cm.aptoide.pt.aptoide_ui.theme.green
 
 @Preview
 @Composable

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/TwitterIcon.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/TwitterIcon.kt
@@ -1,17 +1,16 @@
 package cm.aptoide.pt.aptoide_ui.icons
 
-import androidx.compose.ui.graphics.*
-import cm.aptoide.pt.theme.greyMedium
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.theme.shapes
+import cm.aptoide.pt.aptoide_ui.theme.greyMedium
 
 @Preview
 @Composable

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/ViewsIcon.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/icons/ViewsIcon.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.theme.grey
+import cm.aptoide.pt.aptoide_ui.theme.grey
 
 @Preview
 @Composable

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/theme/AppColors.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/theme/AppColors.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.theme
+package cm.aptoide.pt.aptoide_ui.theme
 
 import androidx.compose.material.Colors
 import androidx.compose.ui.graphics.Color

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/theme/Color.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.theme
+package cm.aptoide.pt.aptoide_ui.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/theme/Gradients.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/theme/Gradients.kt
@@ -2,12 +2,6 @@ package cm.aptoide.pt.aptoide_ui.theme
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
-import cm.aptoide.pt.theme.blueGradientEnd
-import cm.aptoide.pt.theme.blueGradientStart
-import cm.aptoide.pt.theme.orangeGradientEnd
-import cm.aptoide.pt.theme.orangeGradientMid
-import cm.aptoide.pt.theme.orangeGradientStart
-import cm.aptoide.pt.theme.pinkishOrange
 
 val orangeGradient = Brush.linearGradient(
   colors = listOf(

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/theme/Shape.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/theme/Shape.kt
@@ -1,4 +1,4 @@
-package cm.aptoide.pt.theme
+package cm.aptoide.pt.aptoide_ui.theme
 
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Shapes

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/theme/Theme.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/theme/Theme.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
-import cm.aptoide.pt.aptoide_ui.icons.getBonusBackground
 import cm.aptoide.pt.aptoide_ui.icons.getAppcoinsLogo
 import cm.aptoide.pt.aptoide_ui.icons.getAptoideIcon
 import cm.aptoide.pt.aptoide_ui.icons.getAptoideTVIcon
@@ -29,26 +28,6 @@ import cm.aptoide.pt.aptoide_ui.icons.getToolbarLogo
 import cm.aptoide.pt.aptoide_ui.icons.getTrustedIcon
 import cm.aptoide.pt.aptoide_ui.icons.getTwitterIcon
 import cm.aptoide.pt.aptoide_ui.icons.getViewsIcon
-import cm.aptoide.pt.theme.AppColors
-import cm.aptoide.pt.theme.appCoins
-import cm.aptoide.pt.theme.aptoideIconBackgroundWhite
-import cm.aptoide.pt.theme.aptoideIconOrange
-import cm.aptoide.pt.theme.aptoideTVIconOrange
-import cm.aptoide.pt.theme.black
-import cm.aptoide.pt.theme.blackDarkMode
-import cm.aptoide.pt.theme.darkBlue
-import cm.aptoide.pt.theme.error
-import cm.aptoide.pt.theme.green
-import cm.aptoide.pt.theme.grey
-import cm.aptoide.pt.theme.greyLight
-import cm.aptoide.pt.theme.greyMedium
-import cm.aptoide.pt.theme.iconsBlack
-import cm.aptoide.pt.theme.negro
-import cm.aptoide.pt.theme.pastelOrange
-import cm.aptoide.pt.theme.pinkishOrange
-import cm.aptoide.pt.theme.purpleCatappult
-import cm.aptoide.pt.theme.shapes
-import cm.aptoide.pt.theme.textWhite
 
 private val darkMaterialColorPalette = darkColors(
   background = black,

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/toolbar/Topbar.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/toolbar/Topbar.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
-import cm.aptoide.pt.theme.grey
+import cm.aptoide.pt.aptoide_ui.theme.grey
 
 @Composable
 fun NavigationTopBar(

--- a/download-view/build.gradle.kts
+++ b/download-view/build.gradle.kts
@@ -10,7 +10,6 @@ android {
 }
 
 dependencies {
-  implementation(project(ModuleDependency.APTOIDE_UI))
   implementation(project(ModuleDependency.FEATURE_FLAGS))
   implementation(project(ModuleDependency.FEATURE_APPS))
   api(project(ModuleDependency.INSTALL_MANAGER))

--- a/feature-home/build.gradle.kts
+++ b/feature-home/build.gradle.kts
@@ -14,5 +14,4 @@ dependencies {
   implementation(project(ModuleDependency.FEATURE_APPS))
   implementation(project(ModuleDependency.FEATURE_EDITORIAL))
   implementation(project(ModuleDependency.FEATURE_REACTIONS))
-  implementation(project(ModuleDependency.APTOIDE_UI))
 }

--- a/feature-oos/build.gradle.kts
+++ b/feature-oos/build.gradle.kts
@@ -10,7 +10,6 @@ android {
 }
 
 dependencies {
-  implementation(project(ModuleDependency.APTOIDE_UI))
   implementation(project(ModuleDependency.FEATURE_APPS))
   implementation(project(ModuleDependency.INSTALL_MANAGER))
   implementation(project(ModuleDependency.EXTENSIONS))

--- a/feature-profile/build.gradle.kts
+++ b/feature-profile/build.gradle.kts
@@ -10,7 +10,6 @@ android {
 }
 
 dependencies {
-  implementation(project(ModuleDependency.APTOIDE_UI))
   implementation(project(ModuleDependency.FEATURE_SETTINGS))
 
   //store

--- a/feature-reactions/build.gradle.kts
+++ b/feature-reactions/build.gradle.kts
@@ -11,7 +11,6 @@ android {
 
 dependencies {
   implementation(project(ModuleDependency.APTOIDE_NETWORK))
-  implementation(project(ModuleDependency.APTOIDE_UI))
 
   //animations
   implementation(LibraryDependency.LOTTIE)

--- a/feature-settings/build.gradle.kts
+++ b/feature-settings/build.gradle.kts
@@ -10,7 +10,6 @@ android {
 }
 
 dependencies {
-  implementation(project(ModuleDependency.APTOIDE_UI))
   implementation(project(ModuleDependency.ENVIRONMENT_INFO))
 
   //store

--- a/feature_apps/build.gradle.kts
+++ b/feature_apps/build.gradle.kts
@@ -11,7 +11,6 @@ android {
 
 dependencies {
   implementation(project(ModuleDependency.APTOIDE_NETWORK))
-  implementation(project(ModuleDependency.APTOIDE_UI))
   implementation(project(ModuleDependency.EXTENSIONS))
   api(project(ModuleDependency.FEATURE_CAMPAIGNS))
 }

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/AppGraphicView.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/AppGraphicView.kt
@@ -35,9 +35,9 @@ import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
 import cm.aptoide.pt.aptoide_ui.theme.AppTheme
 import cm.aptoide.pt.aptoide_ui.theme.appCoinsButtonGradient
 import cm.aptoide.pt.aptoide_ui.theme.orangeGradient
+import cm.aptoide.pt.aptoide_ui.theme.shapes
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
-import cm.aptoide.pt.theme.shapes
 
 @Preview(name = "Feature Graphic Item")
 @Composable

--- a/feature_appview/build.gradle.kts
+++ b/feature_appview/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
   implementation(project(ModuleDependency.APTOIDE_NETWORK))
   implementation(project(ModuleDependency.FEATURE_APPS))
   api(project(ModuleDependency.FEATURE_REPORT_APP))
-  implementation(project(ModuleDependency.APTOIDE_UI))
   implementation(project(ModuleDependency.FEATURE_EDITORIAL))
   implementation(project(ModuleDependency.DOWNLOAD_VIEW))
   implementation(project(ModuleDependency.FEATURE_REACTIONS))

--- a/feature_report_app/build.gradle.kts
+++ b/feature_report_app/build.gradle.kts
@@ -11,5 +11,4 @@ android {
 }
 
 dependencies {
-  implementation(project(ModuleDependency.APTOIDE_UI))
 }

--- a/feature_search/build.gradle.kts
+++ b/feature_search/build.gradle.kts
@@ -19,7 +19,6 @@ android {
 dependencies {
   implementation(project(ModuleDependency.FEATURE_APPVIEW))
   implementation(project(ModuleDependency.APTOIDE_NETWORK))
-  implementation(project(ModuleDependency.APTOIDE_UI))
   implementation(project(ModuleDependency.FEATURE_APPS))
   implementation(project(ModuleDependency.EXTENSIONS))
 

--- a/feature_updates/build.gradle.kts
+++ b/feature_updates/build.gradle.kts
@@ -10,7 +10,6 @@ android {
 }
 
 dependencies {
-  implementation(project(ModuleDependency.APTOIDE_UI))
   implementation(project(ModuleDependency.INSTALL_MANAGER))
   implementation(project(ModuleDependency.EXTENSIONS))
 }


### PR DESCRIPTION
**What does this PR do?**

   - Moves UI components unique to v10 to its app module.
   - Moves the compose theme of v10 to its app module.
   - Fixes imports and missing classes that might've affected the app games module.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2298](https://aptoide.atlassian.net/browse/APP-2298)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2298](https://aptoide.atlassian.net/browse/APP-2298)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2298]: https://aptoide.atlassian.net/browse/APP-2298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2298]: https://aptoide.atlassian.net/browse/APP-2298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ