### PR TITLE
[DT-895] Fix Adyen saved card prefix asterisks not being shown

### DIFF
--- a/payments/payment-methods/adyen-compose/src/main/java/com/appcoins/payment_method/adyen/presentation/AdyenCreditCardViewModel.kt
+++ b/payments/payment-methods/adyen-compose/src/main/java/com/appcoins/payment_method/adyen/presentation/AdyenCreditCardViewModel.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.Factory
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.adyen.checkout.adyen3ds2.Adyen3DS2Component
 import com.adyen.checkout.adyen3ds2.Adyen3DS2Configuration
 import com.adyen.checkout.card.CardComponent
 import com.adyen.checkout.card.CardComponentState
@@ -24,6 +25,7 @@ import com.adyen.checkout.components.model.payments.response.RedirectAction
 import com.adyen.checkout.components.model.payments.response.Threeds2Action
 import com.adyen.checkout.components.model.payments.response.Threeds2ChallengeAction
 import com.adyen.checkout.components.model.payments.response.Threeds2FingerprintAction
+import com.adyen.checkout.redirect.RedirectComponent
 import com.adyen.checkout.redirect.RedirectConfiguration
 import com.appcoins.payment_manager.di.PaymentsModule
 import com.appcoins.payment_method.adyen.CreditCardPaymentMethod
@@ -88,9 +90,6 @@ fun adyenCreditCardViewModel(
   val uiState by vm.uiState.collectAsState()
   return uiState to vm::buy
 }
-
-private var lastRedirectActionDataHash: Int? = null
-private var last3DSActionDataHash: Int? = null
 
 class AdyenCreditCardViewModel(
   private val paymentMethod: CreditCardPaymentMethod,
@@ -311,11 +310,7 @@ class AdyenCreditCardViewModel(
     action = action,
     configuration = redirectConfiguration
   ) { actionData ->
-    if (
-      actionData.hashCode() != lastRedirectActionDataHash
-      && (actionData.paymentData != null || actionData.details != null)
-    ) {
-      lastRedirectActionDataHash = actionData.hashCode()
+    if (actionData.paymentData != null || actionData.details != null) {
       onSubmit(actionData)
     }
   }
@@ -327,11 +322,7 @@ class AdyenCreditCardViewModel(
     action = action,
     configuration = threeDS2Configuration
   ) { actionData ->
-    if (
-      actionData.hashCode() != last3DSActionDataHash
-      && (actionData.paymentData != null || actionData.details != null)
-    ) {
-      last3DSActionDataHash = actionData.hashCode()
+    if (actionData.paymentData != null || actionData.details != null) {
       onSubmit(actionData)
     }
   }
@@ -411,6 +402,14 @@ private fun clearAdyenComponents(activity: ComponentActivity) {
   invalidateViewModel(
     activity = activity,
     viewModelKey = getCardComponentViewModelKey(isStoredPaymentMethod = true)
+  )
+  invalidateViewModel(
+    activity = activity,
+    viewModelKey = "$DEFAULT_VIEW_MODEL_KEY_PREFIX${RedirectComponent::class.java.canonicalName}"
+  )
+  invalidateViewModel(
+    activity = activity,
+    viewModelKey = "$DEFAULT_VIEW_MODEL_KEY_PREFIX${Adyen3DS2Component::class.java.canonicalName}"
   )
 }
 


### PR DESCRIPTION
**What does this PR do?**

   - Adds a known key to the stored payment method CardComponent (which is a ViewModel). This key can then be used to invalidate/clear this ViewModel.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AdyenCreditCardViewModel.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-895](https://aptoide.atlassian.net/browse/DT-895)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-895](https://aptoide.atlassian.net/browse/DT-895)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-895]: https://aptoide.atlassian.net/browse/DT-895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-895]: https://aptoide.atlassian.net/browse/DT-895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ