### PR TITLE
[APP-2310] Support update ownership api

### DIFF
--- a/aptoide-installer/src/main/AndroidManifest.xml
+++ b/aptoide-installer/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+  <uses-permission android:name="android.permission.ENFORCE_UPDATE_OWNERSHIP" />
+  <uses-permission android:name="android.permission.UPDATE_PACKAGES_WITHOUT_USER_ACTION" />
   <!--Permissions for the Android below 11 (R)-->
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstaller.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstaller.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInstaller.PACKAGE_SOURCE_STORE
 import android.content.pm.PackageInstaller.Session
+import android.content.pm.PackageInstaller.SessionParams.USER_ACTION_NOT_REQUIRED
 import android.os.Build
 import android.os.Environment
 import cm.aptoide.pt.extensions.checkMd5
@@ -55,6 +56,12 @@ class AptoideInstaller @Inject constructor(
         android.content.pm.PackageInstaller
           .SessionParams(android.content.pm.PackageInstaller.SessionParams.MODE_FULL_INSTALL)
           .apply {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+              setRequestUpdateOwnership(true)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+              setRequireUserAction(USER_ACTION_NOT_REQUIRED)
+            }
             setAppPackageName(packageName)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
               setPackageSource(PACKAGE_SOURCE_STORE)


### PR DESCRIPTION
**What does this PR do?**

This PR aims to add App ownership and to update the app without the user having to accept it.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AptoideInstaller.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2310](https://aptoide.atlassian.net/browse/APP-2310)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2310](https://aptoide.atlassian.net/browse/APP-2310)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2310]: https://aptoide.atlassian.net/browse/APP-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2310]: https://aptoide.atlassian.net/browse/APP-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ