### PR TITLE
[DT-1199] Send channel parameter in broker methods/transactions

### DIFF
--- a/payments/base/arch/src/main/java/com/appcoins/payments/arch/PaymentsInitializer.kt
+++ b/payments/base/arch/src/main/java/com/appcoins/payments/arch/PaymentsInitializer.kt
@@ -10,6 +10,7 @@ object PaymentsInitializer {
   lateinit var getUserAgent: GetUserAgent
   var getAllowedIds: GetAllowedIds? = null
   lateinit var walletProvider: WalletProvider
+  lateinit var channel: String
 
   val context: Context
     get() = application.applicationContext
@@ -20,11 +21,13 @@ object PaymentsInitializer {
     getUserAgent: GetUserAgent,
     getAllowedIds: GetAllowedIds? = null,
     getWalletProvider: () -> WalletProvider,
+    channel: String
   ) {
     this.application = application
     this.environment = environment
     this.getUserAgent = getUserAgent
     this.getAllowedIds = getAllowedIds
     this.walletProvider = getWalletProvider()
+    this.channel = channel
   }
 }

--- a/payments/base/payment-manager/src/main/java/com/appcoins/payment_manager/di/PaymentsModule.kt
+++ b/payments/base/payment-manager/src/main/java/com/appcoins/payment_manager/di/PaymentsModule.kt
@@ -13,7 +13,10 @@ object PaymentsModule {
     PaymentManager.with(
       productInventoryRepository = ProductModule.productInventoryRepository,
       walletProvider = PaymentsInitializer.walletProvider,
-      paymentsRepository = PaymentsRepositoryImpl(NetworkModule.microServicesRestClient),
+      paymentsRepository = PaymentsRepositoryImpl(
+        restClient = NetworkModule.microServicesRestClient,
+        channel = PaymentsInitializer.channel
+      ),
       paymentMethodFactory = PaymentMethodFactoryProvider
     )
   }

--- a/payments/base/payment-manager/src/main/java/com/appcoins/payment_manager/repository/broker/PaymentsRepository.kt
+++ b/payments/base/payment-manager/src/main/java/com/appcoins/payment_manager/repository/broker/PaymentsRepository.kt
@@ -9,6 +9,7 @@ import java.time.Duration
 
 internal class PaymentsRepositoryImpl(
   private val restClient: RestClient,
+  private val channel: String
 ) : PaymentsRepository {
 
   override suspend fun getPaymentMethods(
@@ -23,6 +24,7 @@ internal class PaymentsRepositoryImpl(
         "price.value" to priceValue,
         "domain" to domain,
         "currency.type" to "fiat",
+        "channel" to channel,
       ),
       timeout = Duration.ofSeconds(30),
     )?.jsonToPaymentMethodsResponse()!!

--- a/payments/payment-methods/adyen/src/main/java/com/appcoins/payment_method/adyen/CreditCardPaymentMethod.kt
+++ b/payments/payment-methods/adyen/src/main/java/com/appcoins/payment_method/adyen/CreditCardPaymentMethod.kt
@@ -3,6 +3,7 @@ package com.appcoins.payment_method.adyen
 import com.adyen.checkout.components.model.payments.request.PaymentMethodDetails
 import com.appcoins.payment_method.adyen.repository.AdyenV2Repository
 import com.appcoins.payments.arch.PaymentMethod
+import com.appcoins.payments.arch.PaymentsInitializer
 import com.appcoins.payments.arch.ProductInfoData
 import com.appcoins.payments.arch.PurchaseRequest
 import com.appcoins.payments.arch.WalletData
@@ -57,7 +58,8 @@ class CreditCardPaymentMethod internal constructor(
         entityDomain = purchaseRequest.oemPackage,
         entityPromoCode = null,
         user = wallet.address,
-        referrerUrl = purchaseRequest.uri?.toString()
+        referrerUrl = purchaseRequest.uri?.toString(),
+        channel = PaymentsInitializer.channel
       )
     ).let {
       CreditCardTransaction(

--- a/payments/payment-methods/adyen/src/main/java/com/appcoins/payment_method/adyen/PaymentDetails.kt
+++ b/payments/payment-methods/adyen/src/main/java/com/appcoins/payment_method/adyen/PaymentDetails.kt
@@ -26,6 +26,7 @@ data class PaymentDetails(
   @Json("entity.promo_code") val entityPromoCode: String?,
   @Json("wallets.user") val user: String?,
   @Json("referrer_url") val referrerUrl: String?,
+  @Json("channel") val channel: String?,
 )
 
 @Json

--- a/payments/payment-methods/paypal/src/main/java/com/appcoins/payment_method/paypal/PaypalPaymentMethod.kt
+++ b/payments/payment-methods/paypal/src/main/java/com/appcoins/payment_method/paypal/PaypalPaymentMethod.kt
@@ -4,6 +4,7 @@ import com.appcoins.payment_method.paypal.model.PaypalTransaction
 import com.appcoins.payment_method.paypal.repository.PaypalRepository
 import com.appcoins.payment_method.paypal.repository.model.PaymentDetailsRequest
 import com.appcoins.payments.arch.PaymentMethod
+import com.appcoins.payments.arch.PaymentsInitializer
 import com.appcoins.payments.arch.ProductInfoData
 import com.appcoins.payments.arch.PurchaseRequest
 import com.appcoins.payments.arch.WalletData
@@ -53,6 +54,7 @@ class PaypalPaymentMethod internal constructor(
         entityPromoCode = null,
         user = wallet.address,
         referrerUrl = purchaseRequest.uri?.toString(),
+        channel = PaymentsInitializer.channel
       )
     ).let {
       PaypalTransaction(

--- a/payments/payment-methods/paypal/src/main/java/com/appcoins/payment_method/paypal/repository/model/PaymentDetailsRequest.kt
+++ b/payments/payment-methods/paypal/src/main/java/com/appcoins/payment_method/paypal/repository/model/PaymentDetailsRequest.kt
@@ -18,4 +18,5 @@ internal data class PaymentDetailsRequest(
   @Json("entity.promo_code") val entityPromoCode: String?,
   @Json("wallets.user") val user: String?,
   @Json("referrer_url") val referrerUrl: String?,
+  @Json("channel") val channel: String?,
 )


### PR DESCRIPTION
**What does this PR do?**

It sends a channel parameter in the [broker/8.20230522/methods?channel=<channel>](http://localhost/api/broker/8.20230522/methods?channel=<channel>) and in the body of the transactions creations `gateways/*/transactions` (in this case - adyen and paypal). 

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] PaymentsInitializer.kt
- [ ] PaymentsModule.kt
- [ ] PaymentsRepository.kt
- [ ] CreditCardPaymentMethod.kt
- [ ] PaymentDetails.kt
- [ ] PaymentDetailsRequest.kt
- [ ] PaypalPaymentMethod.kt

**How should this be manually tested?**

Make successful purchases with credit card and paypal and see if the `channel` parameter is called correctly in the supposed requests. (making it by gameshub it should send `GAMESHUB`)

  Flow on how to test this or QA Tickets related to this use-case: [DT-1199](https://aptoide.atlassian.net/browse/DT-1199)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1199](https://aptoide.atlassian.net/browse/DT-1199)

**Questions:**



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-1199]: https://aptoide.atlassian.net/browse/DT-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-1199]: https://aptoide.atlassian.net/browse/APP-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ