### PR TITLE
[APPP-2998] Fix missing default editorial url error

### DIFF
--- a/app-games/src/main/java/cm/aptoide/pt/app_games/di/RepositoryModule.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/di/RepositoryModule.kt
@@ -18,6 +18,7 @@ import cm.aptoide.pt.aptoide_network.di.StoreName
 import cm.aptoide.pt.aptoide_network.di.VersionCode
 import cm.aptoide.pt.environment_info.DeviceInfo
 import cm.aptoide.pt.feature_campaigns.data.CampaignUrlNormalizer
+import cm.aptoide.pt.feature_editorial.di.DefaultEditorialUrl
 import cm.aptoide.pt.feature_flags.data.FeatureFlagsRepository
 import cm.aptoide.pt.feature_flags.di.FeatureFlagsDataStore
 import cm.aptoide.pt.feature_home.di.WidgetsUrl
@@ -40,6 +41,12 @@ class RepositoryModule {
   @Provides
   @WidgetsUrl
   fun provideWidgetsUrl(): String = "getStoreWidgets?limit=25"
+
+  @Singleton
+  @Provides
+  @DefaultEditorialUrl
+  fun provideDefaultEditorialUrl(): String =
+    "${BuildConfig.STORE_DOMAIN}user/action/item/cards/get/type=CURATION_1/limit=10/store_name=${BuildConfig.MARKET_NAME}/aptoide_uid=0/?subtype=COLLECTION&aab=1&aptoide_vercode=${BuildConfig.VERSION_CODE}"
 
   @Singleton
   @Provides


### PR DESCRIPTION
**What does this PR do?**

   - Fixes missing default editorial url error by adding a provides method.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] RepositoryModule.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2298](https://aptoide.atlassian.net/browse/APP-2298)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2298](https://aptoide.atlassian.net/browse/APP-2298)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2298]: https://aptoide.atlassian.net/browse/APP-2298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2298]: https://aptoide.atlassian.net/browse/APP-2298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ