### PR TITLE
[DT-589] Rename state composable and fix app games import errors

### DIFF
--- a/app-games/src/main/java/cm/aptoide/pt/app_games/categories/presentation/CategoryGridView.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/categories/presentation/CategoryGridView.kt
@@ -19,8 +19,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -38,7 +36,7 @@ import cm.aptoide.pt.app_games.home.LoadingBundleView
 import cm.aptoide.pt.app_games.theme.AppTheme
 import cm.aptoide.pt.extensions.PreviewAll
 import cm.aptoide.pt.feature_categories.domain.Category
-import cm.aptoide.pt.feature_categories.presentation.categoriesViewModel
+import cm.aptoide.pt.feature_categories.presentation.rememberCategoriesState
 import cm.aptoide.pt.feature_home.domain.Bundle
 
 @Composable
@@ -46,8 +44,7 @@ fun CategoriesBundle(
   bundle: Bundle,
   navigate: (String) -> Unit,
 ) = bundle.view?.let {
-  val categoriesViewModel = categoriesViewModel(requestUrl = it)
-  val uiState by categoriesViewModel.uiState.collectAsState()
+  val uiState = rememberCategoriesState(requestUrl = it)
 
   Column(
     modifier = Modifier

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/editorial/EditorialView.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/editorial/EditorialView.kt
@@ -21,8 +21,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
@@ -41,7 +39,7 @@ import cm.aptoide.pt.app_games.theme.AptoideTheme
 import cm.aptoide.pt.extensions.PreviewAll
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
 import cm.aptoide.pt.feature_editorial.domain.randomArticleMeta
-import cm.aptoide.pt.feature_editorial.presentation.editorialsCardViewModel
+import cm.aptoide.pt.feature_editorial.presentation.rememberEditorialsCardState
 import cm.aptoide.pt.feature_home.domain.Bundle
 
 // Containers
@@ -52,12 +50,11 @@ fun EditorialBundle(
   filterId: String? = null,
   subtype: String? = null,
 ) {
-  val editorialsCardViewModel = editorialsCardViewModel(
+  val (uiState, _) = rememberEditorialsCardState(
     tag = bundle.tag,
     subtype = subtype,
     salt = bundle.timestamp
   )
-  val uiState by editorialsCardViewModel.uiState.collectAsState()
   val items = uiState?.filter { it.id != filterId }
   val lazyListState = rememberLazyListState()
 

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/feature_apps/presentation/AppGridView.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/feature_apps/presentation/AppGridView.kt
@@ -38,7 +38,7 @@ import cm.aptoide.pt.extensions.PreviewAll
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
-import cm.aptoide.pt.feature_apps.presentation.tagApps
+import cm.aptoide.pt.feature_apps.presentation.rememberAppsByTag
 import cm.aptoide.pt.feature_home.domain.Bundle
 
 @Composable
@@ -46,7 +46,7 @@ fun AppsGridBundle(
   bundle: Bundle,
   navigate: (String) -> Unit,
 ) {
-  val (uiState, _) = tagApps(bundle.tag, bundle.timestamp)
+  val (uiState, _) = rememberAppsByTag(bundle.tag, bundle.timestamp)
 
   Column(
     modifier = Modifier.padding(bottom = 28.dp)

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/feature_apps/presentation/CarouselAppView.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/feature_apps/presentation/CarouselAppView.kt
@@ -39,7 +39,7 @@ import cm.aptoide.pt.extensions.PreviewAll
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
-import cm.aptoide.pt.feature_apps.presentation.tagApps
+import cm.aptoide.pt.feature_apps.presentation.rememberAppsByTag
 import cm.aptoide.pt.feature_home.domain.Bundle
 
 @Composable
@@ -47,7 +47,7 @@ fun CarouselBundle(
   bundle: Bundle,
   navigate: (String) -> Unit,
 ) {
-  val (uiState, _) = tagApps(bundle.tag, bundle.timestamp)
+  val (uiState, _) = rememberAppsByTag(bundle.tag, bundle.timestamp)
 
   Column(
     modifier = Modifier.padding(bottom = 16.dp)

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/feature_apps/presentation/CarouselLargeAppView.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/feature_apps/presentation/CarouselLargeAppView.kt
@@ -48,7 +48,7 @@ import cm.aptoide.pt.feature_apps.presentation.AppsListUiState.Error
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState.Idle
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState.Loading
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState.NoConnection
-import cm.aptoide.pt.feature_apps.presentation.tagApps
+import cm.aptoide.pt.feature_apps.presentation.rememberAppsByTag
 import cm.aptoide.pt.feature_home.domain.Bundle
 
 @Composable
@@ -56,7 +56,7 @@ fun CarouselLargeBundle(
   bundle: Bundle,
   navigate: (String) -> Unit,
 ) {
-  val (uiState, _) = tagApps(bundle.tag, bundle.timestamp)
+  val (uiState, _) = rememberAppsByTag(bundle.tag, bundle.timestamp)
 
   if (!bundle.background.isNullOrEmpty()) {
     Box(

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/feature_apps/presentation/PublisherTakeoverAppView.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/feature_apps/presentation/PublisherTakeoverAppView.kt
@@ -43,7 +43,7 @@ import cm.aptoide.pt.feature_apps.presentation.AppsListUiState.Error
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState.Idle
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState.Loading
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState.NoConnection
-import cm.aptoide.pt.feature_apps.presentation.tagApps
+import cm.aptoide.pt.feature_apps.presentation.rememberAppsByTag
 import cm.aptoide.pt.feature_home.domain.Bundle
 
 @Composable
@@ -51,8 +51,8 @@ fun PublisherTakeover(
   bundle: Bundle,
   navigate: (String) -> Unit,
 ) {
-  val (uiState, _) = tagApps(bundle.tag, bundle.timestamp)
-  val (bottomUiState, _) = tagApps(bundle.bottomTag ?: "", bundle.timestamp)
+  val (uiState, _) = rememberAppsByTag(bundle.tag, bundle.timestamp)
+  val (bottomUiState, _) = rememberAppsByTag(bundle.bottomTag ?: "", bundle.timestamp)
 
   Box {
     AptoideAsyncImage(

--- a/app/src/main/java/cm/aptoide/pt/home/BundlesView.kt
+++ b/app/src/main/java/cm/aptoide/pt/home/BundlesView.kt
@@ -36,7 +36,7 @@ import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
 import cm.aptoide.pt.feature_apps.presentation.rememberAppsByTag
-import cm.aptoide.pt.feature_editorial.presentation.rememberEditorialsCardViewModel
+import cm.aptoide.pt.feature_editorial.presentation.rememberEditorialsCardState
 import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.Type
 import cm.aptoide.pt.feature_home.presentation.BundlesViewUiState
@@ -223,7 +223,7 @@ fun EditorialMetaView(
   tag: String,
   navigate: (String) -> Unit,
 ) {
-  val (items, _) = rememberEditorialsCardViewModel(tag = tag)
+  val (items, _) = rememberEditorialsCardState(tag = tag)
 
   if (items == null) {
     LoadingBundleView(height = 240.dp)

--- a/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/presentation/ViewModelProvider.kt
+++ b/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/presentation/ViewModelProvider.kt
@@ -19,7 +19,7 @@ class InjectionsProvider @Inject constructor(
 ) : ViewModel()
 
 @Composable
-fun rememberCategoriesViewModel(requestUrl: String): CategoriesViewUiState =
+fun rememberCategoriesState(requestUrl: String): CategoriesViewUiState =
   runPreviewable(
     preview = {
     CategoriesViewUiState(

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
@@ -24,7 +24,7 @@ class InjectionsProvider @Inject constructor(
 ) : ViewModel()
 
 @Composable
-fun rememberEditorialsCardViewModel(
+fun rememberEditorialsCardState(
   tag: String,
   subtype: String? = null,
   salt: String? = null


### PR DESCRIPTION
**What does this PR do?**

   - Renames editorial and categories state fetching composable
   - Fixes errors in app games imports related to the BundleView preview changes

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-589](https://aptoide.atlassian.net/browse/DT-589)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-589](https://aptoide.atlassian.net/browse/DT-589)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-589]: https://aptoide.atlassian.net/browse/DT-589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-589]: https://aptoide.atlassian.net/browse/DT-589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ