### PR TITLE
[DT-1034] Fix myCPU Q-logic

### DIFF
--- a/environment-info/src/main/java/cm/aptoide/pt/environment_info/DeviceInfo.kt
+++ b/environment-info/src/main/java/cm/aptoide/pt/environment_info/DeviceInfo.kt
@@ -80,7 +80,7 @@ class DeviceInfo @Inject constructor(
 
   fun getArchitecture() = deviceInfoRepository.architecture
 
-  fun getSupportedABIs() = Build.SUPPORTED_ABIS.joinToString()
+  fun getSupportedABIs() = Build.SUPPORTED_ABIS.joinToString(separator = ",")
 
   fun getScreenDimensions() =
     "${deviceInfoRepository.screenWidth}x${deviceInfoRepository.screenHeight}"


### PR DESCRIPTION
**What does this PR do?**

`joinToString` function parameter `separator` is by default `separator=", "` making it have a space between CPU configurations, which we don't want and it's not supported by the backend, now we send `separator=","` in order to fix this issue
 
**Database changed?**

No

**Where should the reviewer start?**

- [ ] DeviceInfo.kt

**How should this be manually tested?**

Open the app and test different flows, to see if the q is being correctly sent and in the right places. Try with a device with multiple CPU confs (might need an emulator for that) to see if the myCPU q parameter is not coming with spaces.

  Flow on how to test this or QA Tickets related to this use-case: [DT-1034](https://aptoide.atlassian.net/browse/DT-1034)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1034](https://aptoide.atlassian.net/browse/DT-1034)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-1034]: https://aptoide.atlassian.net/browse/DT-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1034]: https://aptoide.atlassian.net/browse/DT-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ