### PR TITLE
[DT-1134] Add way to fetch apps by tag with defined limit (for widget purposes)

### DIFF
--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppsByTagUseCase.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppsByTagUseCase.kt
@@ -1,5 +1,6 @@
 package cm.aptoide.pt.feature_apps.domain
 
+import android.net.Uri
 import cm.aptoide.pt.aptoide_network.domain.UrlsCache
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.AppsRepository
@@ -7,7 +8,7 @@ import javax.inject.Inject
 
 class AppsByTagUseCase @Inject constructor(
   private val appsRepository: AppsRepository,
-  private val urlsCache: UrlsCache
+  private val urlsCache: UrlsCache,
 ) : AppsListUseCase {
 
   /**
@@ -21,4 +22,19 @@ class AppsByTagUseCase @Inject constructor(
       )
     }
     ?: throw IllegalStateException("No url cached")
+
+  suspend fun getAppsListWithLimit(
+    source: String,
+    limit: Int,
+  ): List<App> {
+    return urlsCache.get(id = source)
+      ?.let {
+        val newUrl = Uri.parse(it).buildUpon().appendPath("limit=$limit").build().toString()
+        appsRepository.getAppsList(
+          url = newUrl,
+          bypassCache = urlsCache.isInvalid(id = source)
+        )
+      }
+      ?: throw IllegalStateException("No url cached")
+  }
 }


### PR DESCRIPTION
**What does this PR do?**

   - Creates a new method in the Apps by tag use case that allows to define a new limit on the number of apps fetched.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppsByTagUseCase.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-1134](https://aptoide.atlassian.net/browse/DT-1134)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1134](https://aptoide.atlassian.net/browse/DT-1134)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-1134]: https://aptoide.atlassian.net/browse/DT-1134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1134]: https://aptoide.atlassian.net/browse/DT-1134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ