### PR TITLE
[APP-2392] Filtering apps Q parameter

### DIFF
--- a/app-games/build.gradle.kts
+++ b/app-games/build.gradle.kts
@@ -129,7 +129,6 @@ dependencies {
   implementation(project(ModuleDependency.FEATURE_OOS))
   implementation(project(ModuleDependency.DOWNLOAD_VIEW))
   implementation(project(ModuleDependency.APTOIDE_INSTALLER))
-  implementation(project(ModuleDependency.FEATURE_SETTINGS))
   implementation(project(ModuleDependency.APTOIDE_NETWORK))
   implementation(project(ModuleDependency.FEATURE_CAMPAIGNS))
   implementation(project(ModuleDependency.ENVIRONMENT_INFO))

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/AptoideApplication.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/AptoideApplication.kt
@@ -2,9 +2,7 @@ package cm.aptoide.pt.app_games
 
 import android.app.Application
 import android.content.Context
-import android.preference.PreferenceManager
 import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.SharedPreferencesMigration
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import cm.aptoide.pt.app_games.installer.notifications.InstallerNotificationsManager
@@ -15,13 +13,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
-
-val Context.userPreferencesDataStore: DataStore<Preferences> by preferencesDataStore(
-  name = "userPreferences",
-  produceMigrations = { context ->
-    listOf(SharedPreferencesMigration({ PreferenceManager.getDefaultSharedPreferences(context) }))
-  }
-)
 
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "permissions")
 val Context.userFeatureFlagsDataStore: DataStore<Preferences> by preferencesDataStore(name = "userFeatureFlags")

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/di/RepositoryModule.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/di/RepositoryModule.kt
@@ -4,21 +4,15 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import cm.aptoide.pt.app_games.BuildConfig
-import cm.aptoide.pt.app_games.appLaunchDataStore
 import cm.aptoide.pt.app_games.feature_flags.AptoideFeatureFlagsRepository
 import cm.aptoide.pt.app_games.home.repository.ThemePreferencesManager
-import cm.aptoide.pt.app_games.launch.AppLaunchPreferencesManager
 import cm.aptoide.pt.app_games.network.AptoideGetUserAgent
 import cm.aptoide.pt.app_games.network.AptoideQLogicInterceptor
-import cm.aptoide.pt.app_games.networkPreferencesDataStore
-import cm.aptoide.pt.app_games.notifications.NotificationsPermissionManager
 import cm.aptoide.pt.app_games.search.repository.AppGamesAutoCompleteSuggestionsRepository
 import cm.aptoide.pt.app_games.search.repository.AppGamesAutoCompleteSuggestionsRepository.AutoCompleteSearchRetrofitService
 import cm.aptoide.pt.app_games.search.repository.AppGamesSearchStoreManager
 import cm.aptoide.pt.app_games.themeDataStore
-import cm.aptoide.pt.app_games.dataStore
 import cm.aptoide.pt.app_games.userFeatureFlagsDataStore
-import cm.aptoide.pt.app_games.userPreferencesDataStore
 import cm.aptoide.pt.aptoide_network.data.network.GetUserAgent
 import cm.aptoide.pt.aptoide_network.data.network.QLogicInterceptor
 import cm.aptoide.pt.aptoide_network.di.BaseOkHttp
@@ -32,11 +26,8 @@ import cm.aptoide.pt.feature_editorial.di.DefaultEditorialUrl
 import cm.aptoide.pt.feature_flags.data.FeatureFlagsRepository
 import cm.aptoide.pt.feature_flags.di.FeatureFlagsDataStore
 import cm.aptoide.pt.feature_home.di.WidgetsUrl
-import cm.aptoide.pt.feature_oos.di.UninstallPackagesFilter
 import cm.aptoide.pt.feature_search.data.AutoCompleteSuggestionsRepository
 import cm.aptoide.pt.feature_search.domain.repository.SearchStoreManager
-import cm.aptoide.pt.settings.di.UserPreferencesDataStore
-import cm.aptoide.pt.settings.repository.UserPreferencesRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -48,6 +39,12 @@ import retrofit2.converter.gson.GsonConverterFactory
 import java.util.*
 import javax.inject.Qualifier
 import javax.inject.Singleton
+import cm.aptoide.pt.app_games.appLaunchDataStore
+import cm.aptoide.pt.app_games.launch.AppLaunchPreferencesManager
+import cm.aptoide.pt.app_games.networkPreferencesDataStore
+import cm.aptoide.pt.app_games.notifications.NotificationsPermissionManager
+import cm.aptoide.pt.app_games.dataStore
+import cm.aptoide.pt.feature_oos.di.UninstallPackagesFilter
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -78,13 +75,6 @@ class RepositoryModule {
   @Singleton
   fun providesUserAgentInterceptor(aptoideGetUserAgent: AptoideGetUserAgent): GetUserAgent =
     aptoideGetUserAgent
-
-  @Singleton
-  @Provides
-  @UserPreferencesDataStore
-  fun provideUserPreferencesDataStore(@ApplicationContext appContext: Context): DataStore<Preferences> {
-    return appContext.userPreferencesDataStore
-  }
 
   @Singleton
   @Provides
@@ -142,14 +132,6 @@ class RepositoryModule {
 
   @Singleton
   @Provides
-  fun provideUserPreferencesRepository(
-    @UserPreferencesDataStore dataStore: DataStore<Preferences>,
-  ): UserPreferencesRepository {
-    return UserPreferencesRepository(dataStore)
-  }
-
-  @Singleton
-  @Provides
   fun provideSearchStoreManager(): SearchStoreManager = AppGamesSearchStoreManager()
 
   @RetrofitBuzz
@@ -186,11 +168,9 @@ class RepositoryModule {
   @Provides
   @Singleton
   fun providesQLogicInterceptor(
-    userPreferencesRepository: UserPreferencesRepository,
     deviceInfo: DeviceInfo,
   ): QLogicInterceptor {
     return AptoideQLogicInterceptor(
-      userPreferencesRepository = userPreferencesRepository,
       deviceInfo = deviceInfo,
     )
   }

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/network/AptoideQLogicInterceptor.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/network/AptoideQLogicInterceptor.kt
@@ -3,28 +3,22 @@ package cm.aptoide.pt.app_games.network
 import android.util.Base64
 import cm.aptoide.pt.aptoide_network.data.network.QLogicInterceptor
 import cm.aptoide.pt.environment_info.DeviceInfo
-import cm.aptoide.pt.settings.repository.UserPreferencesRepository
-import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor.Chain
 import okhttp3.Response
 import javax.inject.Inject
 
 class AptoideQLogicInterceptor @Inject constructor(
-  private val userPreferencesRepository: UserPreferencesRepository,
   private val deviceInfo: DeviceInfo
 ) : QLogicInterceptor {
 
   private val cachedFilters: String by lazy { computeFilters() }
 
-  override fun buildQValue(): String? =
-    runBlocking { userPreferencesRepository.isShowCompatibleApps() }
-      .takeIf { it }
-      ?.let { cachedFilters }
+  override fun buildQValue(): String = cachedFilters
 
   override fun intercept(chain: Chain): Response {
     val originalRequest = chain.request()
     val newUrl = originalRequest.url.newBuilder()
-    buildQValue()?.let {
+    buildQValue().let {
       newUrl.addQueryParameter("q", buildQValue())
     }
     val newRequest = originalRequest.newBuilder().url(newUrl.build()).build()


### PR DESCRIPTION
**What does this PR do?**

 This PR aims to fix the filter app's q parameter that now doesn't take into account if the user has that option selected like in v10

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AptoideQLogicInterceptor.kt
- [ ] RepositoryModule.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2392](https://aptoide.atlassian.net/browse/APP-2392)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2392](https://aptoide.atlassian.net/browse/APP-2392)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2392]: https://aptoide.atlassian.net/browse/APP-2392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2392]: https://aptoide.atlassian.net/browse/APP-2392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ