### PR TITLE
[APP-2347] Add links to privacy policy and terms & conditions

### DIFF
--- a/app-games/build.gradle.kts
+++ b/app-games/build.gradle.kts
@@ -35,6 +35,17 @@ android {
       value = "\"ag://\""
     )
 
+    buildConfigField(
+      type = "String",
+      name = "TC_URL",
+      value = "\"https://en.aptoide.com/company/legal\""
+    )
+    buildConfigField(
+      type = "String",
+      name = "PP_URL",
+      value = "\"https://en.aptoide.com/company/legal?section=privacy\""
+    )
+
     testInstrumentationRunner = AndroidConfig.TEST_INSTRUMENTATION_RUNNER
 
     manifestPlaceholders["dataPlaceholder"] = generateData()
@@ -150,7 +161,9 @@ dependencies {
   implementation(LibraryDependency.GMS_PLAY_SERVICES_ADS)
 
   //Accompanist
+  implementation(LibraryDependency.ACCOMPANIST_WEBVIEW)
   implementation(LibraryDependency.ACCOMPANIST_PERMISSIONS)
+
 }
 
 fun BaseFlavor.buildConfigFieldFromGradleProperty(gradlePropertyName: String) {

--- a/app-games/src/main/AndroidManifest.xml
+++ b/app-games/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+  <uses-permission android:name="android.permission.INTERNET" />
+
   <application
       android:name=".AptoideApplication"
       android:allowBackup="true"
@@ -33,9 +36,13 @@
       </intent-filter>
       <!-- ${dataPlaceholder} -->
     </activity>
+
+    <activity
+        android:name="cm.aptoide.pt.app_games.UrlActivity"
+        android:configChanges="orientation|keyboardHidden"
+        android:exported="false"
+        android:launchMode="standard"
+        android:screenOrientation="portrait" />
+
   </application>
-
-  <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-
-  <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/UrlActivity.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/UrlActivity.kt
@@ -1,0 +1,52 @@
+package cm.aptoide.pt.app_games
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import cm.aptoide.pt.app_games.home.AppThemeViewModel
+import cm.aptoide.pt.app_games.theme.AptoideTheme
+import cm.aptoide.pt.app_games.toolbar.SimpleAppGamesToolbar
+import dagger.hilt.android.AndroidEntryPoint
+import java.net.URLDecoder
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
+
+@AndroidEntryPoint
+class UrlActivity : AppCompatActivity() {
+
+  @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    val url = intent.getStringExtra("url")
+    setContent {
+      val themeViewModel = hiltViewModel<AppThemeViewModel>()
+      val isDarkTheme by themeViewModel.uiState.collectAsState()
+      AptoideTheme(darkTheme = isDarkTheme ?: isSystemInDarkTheme()) {
+        Scaffold(
+          topBar = { SimpleAppGamesToolbar() }
+        ) {
+          url?.let {
+            UrlView(url = URLDecoder.decode(it, UTF_8.toString()))
+          }
+        }
+      }
+    }
+  }
+
+  companion object {
+    fun open(context: Context, url: String) {
+      val intent = Intent(context, UrlActivity::class.java)
+        .apply { putExtra("url", URLEncoder.encode(url, UTF_8.toString())) }
+      context.startActivity(intent)
+    }
+  }
+}

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/UrlView.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/UrlView.kt
@@ -1,0 +1,109 @@
+package cm.aptoide.pt.app_games
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.graphics.Bitmap
+import android.net.Uri
+import android.webkit.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.accompanist.web.AccompanistWebViewClient
+import com.google.accompanist.web.WebView
+import com.google.accompanist.web.rememberWebViewState
+import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_SHORT
+import com.google.android.material.snackbar.Snackbar
+import timber.log.Timber
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+fun UrlView(url: String) {
+  val loading = remember { mutableStateOf(false) }
+  val onLoaded: (Boolean) -> Unit = { loading.value = !it }
+
+  val webViewState = rememberWebViewState(url)
+
+  Box(contentAlignment = Alignment.Center) {
+    WebView(
+      modifier = Modifier.fillMaxSize(),
+      state = webViewState,
+      onCreated = {
+        it.settings.javaScriptEnabled = true
+        it.settings.apply {
+          safeBrowsingEnabled = true
+          javaScriptEnabled = true
+          loadWithOverviewMode = true
+          cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
+          domStorageEnabled = true
+        }
+      },
+      client = AppWebViewClients(onLoaded)
+    )
+    if (loading.value) {
+      CircularProgressIndicator()
+    }
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DefaultPreview() = UrlView(url = "https://google.com")
+
+class AppWebViewClients(
+  private val onLoaded: (Boolean) -> Unit,
+) : AccompanistWebViewClient() {
+
+  override fun shouldOverrideUrlLoading(
+    view: WebView?,
+    request: WebResourceRequest?,
+  ): Boolean {
+    val uri: Uri? = request?.url
+    return when (uri?.scheme) {
+      "http",
+      "https",
+      -> false
+
+      "tel" -> {
+        try {
+          view?.context?.startActivity(Intent(Intent.ACTION_DIAL, uri))
+        } catch (t: Throwable) {
+          Timber.e(t)
+          view?.let { Snackbar.make(it, "Phone app not found", LENGTH_SHORT).show() }
+        }
+        true
+      }
+
+      else -> {
+        try {
+          view?.context?.startActivity(Intent(Intent.ACTION_VIEW, uri))
+        } catch (t: Throwable) {
+          Timber.w(t)
+          view?.let { Snackbar.make(it, "Handling app not found", LENGTH_SHORT).show() }
+        }
+        true
+      }
+    }
+  }
+
+  override fun onPageStarted(
+    view: WebView,
+    url: String?,
+    favicon: Bitmap?,
+  ) {
+    onLoaded(false)
+    super.onPageStarted(view, url, favicon)
+  }
+
+  override fun onPageFinished(
+    view: WebView,
+    url: String?,
+  ) {
+    super.onPageFinished(view, url)
+    onLoaded(true)
+  }
+}

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/terms_and_conditions/LegalUrls.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/terms_and_conditions/LegalUrls.kt
@@ -1,0 +1,20 @@
+package cm.aptoide.pt.app_games.terms_and_conditions
+
+import android.content.Context
+import android.net.Uri
+import cm.aptoide.pt.app_games.BuildConfig
+
+val Context.tcUrl get() = BuildConfig.TC_URL.addLanguage(this)
+
+val Context.ppUrl get() = BuildConfig.PP_URL.addLanguage(this)
+
+val paymentsTermsOfUseUrl get() = ""
+
+private fun String.addLanguage(context: Context): String {
+  val resources = context.resources
+  return Uri.parse(this).buildUpon().appendQueryParameter(
+    "lang", resources.configuration.locales.get(0).language
+      + "-"
+      + resources.configuration.locales.get(0).country
+  ).build().toString()
+}

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/terms_and_conditions/TermsAndConditions.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/terms_and_conditions/TermsAndConditions.kt
@@ -1,0 +1,112 @@
+package cm.aptoide.pt.app_games.terms_and_conditions
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import cm.aptoide.pt.app_games.R
+import cm.aptoide.pt.app_games.UrlActivity
+import cm.aptoide.pt.app_games.theme.AppTheme
+import cm.aptoide.pt.app_games.theme.richOrange
+import cm.aptoide.pt.extensions.PreviewAll
+
+@Composable
+fun TermsAndConditions(
+  modifier: Modifier = Modifier,
+  textStyle: TextStyle,
+  @StringRes textID: Int,
+) {
+  val context = LocalContext.current
+  val open = stringResource(id = R.string.button_open_app_title)
+
+  val privacyPolicyText = stringResource(id = R.string.notice_at_collection_and_privacy_policy)
+  val termsText = stringResource(id = R.string.terms_and_conditions)
+  val termsAndConditionsText: String = stringResource(id = textID, privacyPolicyText, termsText)
+
+  val privacyPolicyStartIndex = termsAndConditionsText.indexOf(privacyPolicyText)
+  val privacyPolicyEndIndex = privacyPolicyStartIndex + privacyPolicyText.length
+
+  val termsStartIndex = termsAndConditionsText.indexOf(termsText)
+  val termsEndIndex = termsStartIndex + termsText.length
+
+  val annotatedString = buildAnnotatedString {
+    append(termsAndConditionsText)
+    addStyle(
+      SpanStyle(
+        color = richOrange,
+        textDecoration = TextDecoration.Underline
+      ),
+      start = privacyPolicyStartIndex,
+      end = privacyPolicyEndIndex
+    )
+    addStringAnnotation(
+      tag = "policy",
+      annotation = context.ppUrl,
+      start = privacyPolicyStartIndex,
+      end = privacyPolicyEndIndex
+    )
+    addStyle(
+      SpanStyle(
+        color = richOrange,
+        textDecoration = TextDecoration.Underline
+      ),
+      start = termsStartIndex,
+      end = termsEndIndex
+    )
+    addStringAnnotation(
+      tag = "terms",
+      annotation = context.tcUrl,
+      start = termsStartIndex,
+      end = termsEndIndex
+    )
+  }
+  ClickableText(
+    text = annotatedString,
+    style = textStyle,
+    modifier = modifier
+      .semantics {
+        customActions = listOf(
+          CustomAccessibilityAction(
+            label = "$open $privacyPolicyText",
+            action = {
+              UrlActivity.open(context, context.ppUrl)
+              true
+            }
+          ),
+          CustomAccessibilityAction(
+            label = "$open $termsText",
+            action = {
+              UrlActivity.open(context, context.tcUrl)
+              true
+            }
+          )
+        )
+      },
+    onClick = { offset ->
+      annotatedString
+        .getStringAnnotations(offset, offset)
+        .firstOrNull()
+        ?.let { UrlActivity.open(context, it.item) }
+    }
+  )
+}
+
+@PreviewAll
+@Composable
+fun TermsAndConditionsPreview() {
+  TermsAndConditions(
+    modifier = Modifier,
+    textStyle = AppTheme.typography.bodyCopyXS.copy(textAlign = TextAlign.Center),
+    textID = R.string.continue_to_accept_tandc_and_pp_disclaimer
+  )
+}

--- a/app-games/src/main/java/cm/aptoide/pt/app_games/toolbar/AppGamesToolBar.kt
+++ b/app-games/src/main/java/cm/aptoide/pt/app_games/toolbar/AppGamesToolBar.kt
@@ -13,12 +13,17 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.app_games.R
 import cm.aptoide.pt.app_games.notifications.NotificationsPermissionRequester
+import cm.aptoide.pt.app_games.UrlActivity
 import cm.aptoide.pt.app_games.settings.settingsRoute
+import cm.aptoide.pt.app_games.terms_and_conditions.ppUrl
+import cm.aptoide.pt.app_games.terms_and_conditions.tcUrl
 import cm.aptoide.pt.app_games.theme.AppTheme
 import cm.aptoide.pt.extensions.PreviewAll
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -51,6 +56,7 @@ fun AppGamesToolBar(
   goBackHome: () -> Unit,
 ) {
   var showMenu by remember { mutableStateOf(false) }
+  val context = LocalContext.current
 
   var showNotificationsDialog by remember { mutableStateOf(false) }
 
@@ -66,9 +72,11 @@ fun AppGamesToolBar(
   }
   val onDropDownTermsConditionsClick = {
     showMenu = false
+    UrlActivity.open(context, context.tcUrl)
   }
   val onDropDownPrivacyPolicyClick = {
     showMenu = false
+    UrlActivity.open(context, context.ppUrl)
   }
   val onDropDownDismissRequest = { showMenu = false }
 
@@ -181,5 +189,37 @@ private fun AppGamesToolBar(
   )
   if (showNotificationsDialog) {
     NotificationsPermissionRequester(onDismissPermissionRequesterDialog)
+  }
+}
+
+@Composable
+fun SimpleAppGamesToolbar() {
+  TopAppBar(
+    backgroundColor = AppTheme.colors.background,
+    elevation = Dp(0f),
+  ) {
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier
+        .fillMaxHeight()
+        .fillMaxWidth()
+    ) {
+      Spacer(modifier = Modifier.weight(1f))
+      Image(
+        imageVector = AppTheme.icons.ToolBarLogo,
+        contentDescription = null
+      )
+      @Suppress("KotlinConstantConditions")
+      Text(
+        text = "Dev",
+        modifier = Modifier
+          .clearAndSetSemantics { }
+          .weight(1f)
+          .fillMaxHeight()
+          .padding(vertical = 12.dp, horizontal = 4.dp),
+        style = AppTheme.typography.buttonTextLight,
+        color = AppTheme.colors.dividerColor
+      )
+    }
   }
 }

--- a/app-games/src/main/res/values/strings.xml
+++ b/app-games/src/main/res/values/strings.xml
@@ -70,6 +70,7 @@
   <string name="install_installing_message">Installing</string>
   <string name="install_error_short_message">Oops, an error occurred.</string>
 
+
   <string name="button_copy_title">Copy</string>
   <string name="button_back_title">Back</string>
   <string name="button_see_all_title">See All</string>
@@ -114,6 +115,12 @@
 
   <!-- Install -->
   <string name="button_install_title">Install</string>
+
+  <!-- Common -->
+  <string name="notice_at_collection_and_privacy_policy">Notice at Collection &amp; Privacy Policy</string>
+  <string name="terms_and_conditions">Terms</string>
+  <string name="continue_to_accept_tandc_and_pp_disclaimer">By continuing you accept the %1$s and %2$s.</string>
+
 
 
 </resources>


### PR DESCRIPTION
**What does this PR do?**

This PR aims to add links to privacy policy and terms & conditions so the user can click them and be redirected to their pages

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2347](https://aptoide.atlassian.net/browse/APP-2347)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2347](https://aptoide.atlassian.net/browse/APP-2347)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2347]: https://aptoide.atlassian.net/browse/APP-2347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2347]: https://aptoide.atlassian.net/browse/APP-2347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ