### PR TITLE
[APP-2415] Refactor aptoide games settings

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -57,34 +58,29 @@ import com.aptoide.android.aptoidegames.toolbar.AppGamesTopBar
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
 import cm.aptoide.pt.extensions.PreviewAll
 import com.aptoide.android.aptoidegames.BuildConfig
+import com.aptoide.android.aptoidegames.UrlActivity
+import com.aptoide.android.aptoidegames.terms_and_conditions.ppUrl
+import com.aptoide.android.aptoidegames.terms_and_conditions.tcUrl
 
 const val settingsRoute = "settings"
 
 fun NavGraphBuilder.settingsScreen(
   navigateBack: () -> Unit,
 ) = animatedComposable(settingsRoute) {
+  val context = LocalContext.current
   val networkPreferencesViewModel = hiltViewModel<NetworkPreferencesViewModel>()
   val downloadOnlyOverWifi by networkPreferencesViewModel.downloadOnlyOverWifi.collectAsState()
-
-  var showOptOutDialog by remember { mutableStateOf(false) }
-  var acceptedPPAndTC by remember { mutableStateOf(true) } //Radio button state - Used for UI/UX purposes
-
 
   SettingsViewContent(
     title = stringResource(R.string.settings_title),
     downloadOnlyOverWifi = downloadOnlyOverWifi,
-    acceptedPPAndTC = acceptedPPAndTC,
     verName = BuildConfig.VERSION_NAME,
     verCode = BuildConfig.VERSION_CODE,
     toggleDownloadOnlyOverWifi = { isChecked ->
       networkPreferencesViewModel.setDownloadOnlyOverWifi(isChecked)
     },
-    togglePPAndTC = { isChecked ->
-      if (!isChecked) {
-        acceptedPPAndTC = false //Turn false for UX purposes
-        showOptOutDialog = true
-      }
-    },
+    onPrivacyPolicyClick = { UrlActivity.open(context, context.ppUrl) },
+    onTermsConditionsClick = { UrlActivity.open(context, context.tcUrl) },
     navigateBack = navigateBack,
   )
 }
@@ -93,13 +89,13 @@ fun NavGraphBuilder.settingsScreen(
 fun SettingsViewContent(
   title: String = "Settings",
   downloadOnlyOverWifi: Boolean = true,
-  acceptedPPAndTC: Boolean = true,
   verName: String = "1.2.3",
   verCode: Int = 123,
   toggleDownloadOnlyOverWifi: (Boolean) -> Unit = {},
   sendFeedback: () -> Unit = {},
   copyInfo: () -> Unit = {},
-  togglePPAndTC: (Boolean) -> Unit = {},
+  onPrivacyPolicyClick: () -> Unit = {},
+  onTermsConditionsClick: () -> Unit = {},
   navigateBack: () -> Unit = {},
 ) {
   Column(
@@ -181,26 +177,14 @@ fun SettingsViewContent(
         title = stringResource(R.string.settings_legal_title)
       ) {
         Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-          Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(26.dp),
-            modifier = Modifier
-              .defaultMinSize(minHeight = 48.dp)
-              .fillMaxWidth()
-              .padding(start = 8.dp)
-          ) {
-            Switch(
-              modifier = Modifier.clearAndSetSemantics { },
-              checked = acceptedPPAndTC,
-              onCheckedChange = togglePPAndTC,
-              colors = SwitchDefaults.colors(
-                checkedThumbColor = pinkishOrange,
-                checkedTrackColor = pinkishOrangeLight,
-                uncheckedThumbColor = gray7,
-                uncheckedTrackColor = gray2
-              )
-            )
-          }
+          SettingsCaretItem(
+            title = stringResource(R.string.overflow_menu_privacy_policy),
+            onClick = onPrivacyPolicyClick
+          )
+          SettingsCaretItem(
+            title = stringResource(R.string.overflow_menu_terms_conditions),
+            onClick = onTermsConditionsClick
+          )
         }
       }
     }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -56,6 +56,7 @@ import com.aptoide.android.aptoidegames.theme.richOrange
 import com.aptoide.android.aptoidegames.toolbar.AppGamesTopBar
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
 import cm.aptoide.pt.extensions.PreviewAll
+import com.aptoide.android.aptoidegames.BuildConfig
 
 const val settingsRoute = "settings"
 
@@ -76,6 +77,8 @@ fun NavGraphBuilder.settingsScreen(
     downloadOnlyOverWifi = downloadOnlyOverWifi,
     isDarkTheme = isDarkTheme,
     acceptedPPAndTC = acceptedPPAndTC,
+    verName = BuildConfig.VERSION_NAME,
+    verCode = BuildConfig.VERSION_CODE,
     selectSystemDefault = themeViewModel::setSystem,
     selectLight = themeViewModel::setLight,
     selectDark = themeViewModel::setDark,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -63,8 +63,6 @@ const val settingsRoute = "settings"
 fun NavGraphBuilder.settingsScreen(
   navigateBack: () -> Unit,
 ) = animatedComposable(settingsRoute) {
-  val themeViewModel = hiltViewModel<AppThemeViewModel>()
-  val isDarkTheme by themeViewModel.uiState.collectAsState()
   val networkPreferencesViewModel = hiltViewModel<NetworkPreferencesViewModel>()
   val downloadOnlyOverWifi by networkPreferencesViewModel.downloadOnlyOverWifi.collectAsState()
 
@@ -75,13 +73,9 @@ fun NavGraphBuilder.settingsScreen(
   SettingsViewContent(
     title = stringResource(R.string.settings_title),
     downloadOnlyOverWifi = downloadOnlyOverWifi,
-    isDarkTheme = isDarkTheme,
     acceptedPPAndTC = acceptedPPAndTC,
     verName = BuildConfig.VERSION_NAME,
     verCode = BuildConfig.VERSION_CODE,
-    selectSystemDefault = themeViewModel::setSystem,
-    selectLight = themeViewModel::setLight,
-    selectDark = themeViewModel::setDark,
     toggleDownloadOnlyOverWifi = { isChecked ->
       networkPreferencesViewModel.setDownloadOnlyOverWifi(isChecked)
     },
@@ -99,14 +93,10 @@ fun NavGraphBuilder.settingsScreen(
 fun SettingsViewContent(
   title: String = "Settings",
   downloadOnlyOverWifi: Boolean = true,
-  isDarkTheme: Boolean? = null,
   acceptedPPAndTC: Boolean = true,
   verName: String = "1.2.3",
   verCode: Int = 123,
   toggleDownloadOnlyOverWifi: (Boolean) -> Unit = {},
-  selectSystemDefault: () -> Unit = {},
-  selectLight: () -> Unit = {},
-  selectDark: () -> Unit = {},
   sendFeedback: () -> Unit = {},
   copyInfo: () -> Unit = {},
   togglePPAndTC: (Boolean) -> Unit = {},
@@ -131,26 +121,6 @@ fun SettingsViewContent(
             title = stringResource(R.string.wifi_settings_title),
             enabled = downloadOnlyOverWifi,
             onToggle = toggleDownloadOnlyOverWifi
-          )
-          Text(
-            text = stringResource(R.string.settings_theme_options_title),
-            style = AppTheme.typography.headlineTitleTextSecondary,
-            modifier = Modifier.padding(start = 8.dp, top = 8.dp)
-          )
-          ThemeOption(
-            title = stringResource(R.string.settings_theme_option_system),
-            selected = isDarkTheme == null,
-            onClick = selectSystemDefault
-          )
-          ThemeOption(
-            title = stringResource(R.string.settings_theme_option_light),
-            selected = isDarkTheme == false,
-            onClick = selectLight
-          )
-          ThemeOption(
-            title = stringResource(R.string.settings_theme_option_dark),
-            selected = isDarkTheme == true,
-            onClick = selectDark
           )
         }
       }
@@ -357,39 +327,6 @@ fun SettingsCaretItem(
   }
 }
 
-@Composable
-fun ThemeOption(
-  title: String,
-  selected: Boolean,
-  onClick: () -> Unit,
-) {
-
-  val themeText = stringResource(R.string.settings_theme_options_title)
-
-  Row(
-    verticalAlignment = Alignment.CenterVertically,
-    modifier = Modifier
-      .clickable(onClick = onClick)
-      .fillMaxWidth()
-      .padding(end = 16.dp)
-      .clearAndSetSemantics {
-        contentDescription = "$title $themeText"
-        role = Role.RadioButton
-        toggleableState = ToggleableState(selected)
-      }
-  ) {
-    RadioButton(
-      selected = selected,
-      onClick = onClick,
-      enabled = true
-    )
-    Text(
-      text = title,
-      style = AppTheme.typography.bodyCopySmall
-    )
-  }
-}
-
 @PreviewAll
 @Composable
 fun SettingsScreenPreview(
@@ -399,12 +336,8 @@ fun SettingsScreenPreview(
   AptoideTheme(darkTheme = isSystemInDarkTheme()) {
     SettingsViewContent(
       title = "Settings",
-      isDarkTheme = isSystemInDarkTheme(),
       verName = "1.2.3",
       verCode = 123,
-      selectSystemDefault = {},
-      selectLight = {},
-      selectDark = {},
       sendFeedback = {},
       copyInfo = {},
       navigateBack = {},

--- a/app-games/src/main/res/values/strings.xml
+++ b/app-games/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
   <!-- Settings -->
   <string name="overflow_menu_settings">Settings</string>
   <string name="overflow_menu_terms_conditions">Terms &amp; Conditions</string>
+  <string name="overflow_menu_privacy_policy">Privacy Policy</string>
   <string name="settings_about_hardware_title">Hardware specs</string>
   <string name="settings_about_title">About Us</string>
   <string name="settings_about_version">Version %1$s (%2$s)</string>
@@ -28,8 +29,6 @@
   <string name="my_games_empty">We couldn\'t find any games installed on your device!</string>
   <string name="my_games_progress_message">Organizing your games</string>
   <string name="empty_category_body">There\'re no apps in this category... Yet!</string>
-  <string name="overflow_menu_privacy_policy">Privacy Policy</string>
-
 
   <!-- Notifications -->
   <string name="notifications_context_title">Get notified!</string>


### PR DESCRIPTION
**What does this PR do?**

   - Adds the specific version name and version code to the settings screen.
   - Removes UI theme options from the settings screen.
   - Refactors the legal section in the settings: removes the opt in/opt out toggle and adds Privacy Policy and Terms & Condition redirect buttons.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2415](https://aptoide.atlassian.net/browse/APP-2415)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2415](https://aptoide.atlassian.net/browse/APP-2415)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2415]: https://aptoide.atlassian.net/browse/APP-2415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2415]: https://aptoide.atlassian.net/browse/APP-2415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ