### PR TITLE
[APP-2442] Implement circular loading progress icon

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/AptoideGamesCircularLoading.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/AptoideGamesCircularLoading.kt
@@ -1,0 +1,92 @@
+package com.aptoide.android.aptoidegames.drawables.icons
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.aptoide.android.aptoidegames.theme.primary
+import kotlinx.coroutines.delay
+
+@Preview
+@Composable
+fun IndeterminateCircularLoadingPreview() {
+  IndeterminateCircularLoading()
+}
+
+@Composable
+fun IndeterminateCircularLoading(
+  size: Dp = 74.dp,
+) {
+  var startAngle by remember { mutableFloatStateOf(0f) }
+  var sweepAngle by remember { mutableFloatStateOf(0f) }
+  var progress by remember { mutableFloatStateOf(45f) }
+
+  var fillCircle by remember { mutableStateOf(false) }
+
+  LaunchedEffect(Unit) {
+    while (true) {
+      delay(180L)
+      if (progress + 45f > 360f) {
+        progress = 45f
+        fillCircle = !fillCircle
+      } else {
+        progress += 45f
+      }
+    }
+  }
+
+  LaunchedEffect(progress) {
+    if (fillCircle) {
+      startAngle = -90f + (progress)
+      sweepAngle = 360f - (progress)
+    } else {
+      startAngle = -90f
+      sweepAngle = progress
+    }
+  }
+
+  CircularLoading(
+    size = size,
+    startAngle = startAngle,
+    sweepAngle = sweepAngle
+  )
+}
+
+@Composable
+private fun CircularLoading(
+  size: Dp,
+  startAngle: Float,
+  sweepAngle: Float,
+) {
+  Canvas(modifier = Modifier.size(size)) {
+    val strokeWidth = (size / 9).toPx()
+    val arcSize = size.toPx() - strokeWidth
+    drawArc(
+      color = primary,
+      startAngle = 0f,
+      sweepAngle = 360f,
+      useCenter = false,
+      topLeft = Offset(strokeWidth / 2, strokeWidth / 2),
+      size = Size(arcSize, arcSize),
+      style = Stroke(strokeWidth)
+    )
+    drawArc(
+      color = primary,
+      startAngle = startAngle,
+      sweepAngle = sweepAngle,
+      useCenter = true,
+    )
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

   - Implements the new circular progress icons for aptoide games

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AptoideGamesCircularLoading.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2442](https://aptoide.atlassian.net/browse/APP-2442)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2442](https://aptoide.atlassian.net/browse/APP-2442)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2442]: https://aptoide.atlassian.net/browse/APP-2442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2442]: https://aptoide.atlassian.net/browse/APP-2442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ