### PR TITLE
[APP-2443] - Add Notifications Icons

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/InstallerNotificationsBuilder.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/InstallerNotificationsBuilder.kt
@@ -8,19 +8,23 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
+import cm.aptoide.pt.extensions.isAllowed
+import cm.aptoide.pt.install_manager.Task.State
+import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.MainActivity
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.appview.buildAppViewDeepLinkUri
 import com.aptoide.android.aptoidegames.installer.AppDetails
+import com.aptoide.android.aptoidegames.notifications.getNotificationIcon
 import com.aptoide.android.aptoidegames.putDeeplink
 import com.aptoide.android.aptoidegames.putNotificationSource
-import com.aptoide.android.aptoidegames.theme.pinkishOrange
-import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
-import cm.aptoide.pt.extensions.isAllowed
-import cm.aptoide.pt.install_manager.Task.State
+import com.aptoide.android.aptoidegames.theme.agBlack
+import com.aptoide.android.aptoidegames.theme.primary
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -178,12 +182,17 @@ class InstallerNotificationsBuilder @Inject constructor(
       PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     )
 
-    val notificationIcon = R.drawable.ic_notification_icon
+    val notificationIcon = BuildConfig.FLAVOR.getNotificationIcon()
+
+    val resources = context.resources
+    val uiMode = resources.configuration.uiMode
+    val isNightMode = (uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+    val colorToUse = if (isNightMode) primary.toArgb() else agBlack.toArgb()
 
     return NotificationCompat.Builder(context, INSTALLER_NOTIFICATION_CHANNEL_ID)
       .setShowWhen(true)
       .setSmallIcon(notificationIcon)
-      .setColor(pinkishOrange.toArgb())
+      .setColor(colorToUse)
       .setContentTitle(appDetails?.name)
       .setContentText(contentText)
       .setLargeIcon(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/NotificationUtils.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/NotificationUtils.kt
@@ -1,0 +1,9 @@
+package com.aptoide.android.aptoidegames.notifications
+
+import com.aptoide.android.aptoidegames.R
+
+fun String.getNotificationIcon() =
+  when (this) {
+    "dev" -> R.drawable.notification_icon_dev
+    else -> R.drawable.notification_icon
+  }

--- a/app-games/src/main/res/drawable/notification_icon.xml
+++ b/app-games/src/main/res/drawable/notification_icon.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="58dp"
+    android:height="58dp"
+    android:viewportWidth="58"
+    android:viewportHeight="58">
+  <path
+      android:pathData="M45.5,7H40V12.5H34.5V19.1H29V23.5H23.5V18H18V12.5H12.5V7H7V34.5H12.5V40H18V45.5H23.5V51H34.5V45.5H40V40H45.5V34.5H51V12.5H45.5V7ZM18,29V34.5H12.5V29H18ZM18,29H23.5V23.5H18V29Z"
+      android:fillColor="#1E1E26"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app-games/src/main/res/drawable/notification_icon_dev.xml
+++ b/app-games/src/main/res/drawable/notification_icon_dev.xml
@@ -1,0 +1,23 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="72dp"
+    android:height="72dp"
+    android:viewportWidth="72"
+    android:viewportHeight="72">
+  <group>
+    <clip-path
+        android:pathData="M0,0h72v72h-72z"/>
+    <path
+        android:pathData="M10,52.714H22.629L26.012,56.02V68.694L22.629,72H10V52.714ZM20.741,68.804L22.178,67.399V57.315L20.741,55.91H13.834V68.804H20.741Z"
+        android:fillColor="#1E1E26"/>
+    <path
+        android:pathData="M29.409,52.714H43.673V55.883H33.243V60.759H42.855V63.873H33.243V68.832H43.673V72H29.409V52.714Z"
+        android:fillColor="#1E1E26"/>
+    <path
+        android:pathData="M44.954,52.714H48.901L53.806,67.537H53.862L58.768,52.714H62.714L55.695,72H51.974L44.954,52.714Z"
+        android:fillColor="#1E1E26"/>
+    <path
+        android:pathData="M51.143,0H45.816V5.327H40.49V11.718H35.163V15.98H29.837V10.653H24.51V5.327H19.184V0H13.857V26.633H19.184V31.959H24.51V37.286H29.837V42.612H40.49V37.286H45.816V31.959H51.143V26.633H56.469V5.327H51.143V0ZM24.51,21.306V26.633H19.184V21.306H24.51ZM24.51,21.306H29.837V15.98H24.51V21.306Z"
+        android:fillColor="#1E1E26"
+        android:fillType="evenOdd"/>
+  </group>
+</vector>


### PR DESCRIPTION
**What does this PR do?**

There's not much notification customization we can do since Android 12, so (for now) I just added the new notifications icons and made the color change according to the system theme. For Android 11 and below it's a bit different but they seem okay as well, I think.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] InstallerNotificationsBuilder.kt
- [ ] NotificationUtils.kt
- [ ] notification_icon.xml
- [ ] notification_icon_dev.xml

**How should this be manually tested?**

 Test the install notifications flow in both light and dark theme (system-level). See if it seems okay for both and different Android devices as well.

  Flow on how to test this or QA Tickets related to this use-case: [APP-2443](https://aptoide.atlassian.net/browse/APP-2443)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2443](https://aptoide.atlassian.net/browse/APP-2443)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2443]: https://aptoide.atlassian.net/browse/APP-2443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2443]: https://aptoide.atlassian.net/browse/APP-2443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ