### PR TITLE
[APP-2450] - Update bundles headers

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/CategoriesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/CategoriesView.kt
@@ -53,7 +53,9 @@ fun CategoriesBundle(
       .padding(bottom = 16.dp)
   ) {
     BundleHeader(
-      bundle = bundle,
+      title = bundle.title,
+      icon = bundle.bundleIcon,
+      hasMoreAction = bundle.hasMoreAction,
       onClick = { navigate(buildAllCategoriesRoute(bundle.title, "${bundle.tag}-more")) }
     )
     CategoriesListView(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/Forward.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/Forward.kt
@@ -1,0 +1,49 @@
+package com.aptoide.android.aptoidegames.drawables.icons
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.aptoide.android.aptoidegames.theme.primary
+
+@Preview
+@Composable
+fun TestForward() {
+  Image(
+    imageVector = getForward(primary),
+    contentDescription = null,
+    modifier = Modifier.size(240.dp)
+  )
+}
+
+fun getForward(iconColor: Color): ImageVector = ImageVector.Builder(
+  name = "Forward",
+  defaultWidth = 24.dp,
+  defaultHeight = 24.dp,
+  viewportWidth = 24f,
+  viewportHeight = 24f,
+).apply {
+  path(
+    pathFillType = PathFillType.EvenOdd,
+    fill = SolidColor(iconColor),
+  ) {
+    moveTo(21f, 3f)
+    lineTo(3f, 3f)
+    lineTo(3f, 21f)
+    lineTo(21f, 21f)
+    lineTo(21f, 3f)
+    close()
+    moveTo(14.6474f, 12.3526f)
+    lineTo(11f, 8.70526f)
+    lineTo(11f, 16f)
+    lineTo(14.6474f, 12.3526f)
+    close()
+  }
+}.build()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialView.kt
@@ -67,7 +67,9 @@ fun EditorialBundle(
       .padding(bottom = 16.dp)
   ) {
     BundleHeader(
-      bundle = bundle,
+      title = bundle.title,
+      icon = bundle.bundleIcon,
+      hasMoreAction = bundle.hasMoreAction,
       onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate),
     )
     if (items == null) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
@@ -51,9 +51,10 @@ fun AppsGridBundle(
     modifier = Modifier.padding(bottom = 28.dp)
   ) {
     BundleHeader(
-      bundle = bundle,
+      title = bundle.title,
+      icon = bundle.bundleIcon,
+      hasMoreAction = bundle.hasMoreAction,
       onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate)
-
     )
     when (uiState) {
       is AppsListUiState.Idle -> AppsRowView(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselAppView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselAppView.kt
@@ -54,7 +54,9 @@ fun CarouselBundle(
     modifier = Modifier.padding(bottom = 16.dp)
   ) {
     BundleHeader(
-      bundle = bundle,
+      title = bundle.title,
+      icon = bundle.bundleIcon,
+      hasMoreAction = bundle.hasMoreAction,
       onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate),
     )
     when (uiState) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselLargeAppView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselLargeAppView.kt
@@ -78,10 +78,11 @@ fun CarouselLargeBundle(
           .padding(bottom = 24.dp)
       ) {
         BundleHeader(
-          bundle = bundle,
+          title = bundle.title,
+          icon = bundle.bundleIcon,
+          hasMoreAction = bundle.hasMoreAction,
           onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate),
           titleColor = pureWhite,
-          actionColor = pureWhite
         )
         when (uiState) {
           is Idle -> CarouselLargeListView(
@@ -104,7 +105,9 @@ fun CarouselLargeBundle(
       modifier = Modifier.padding(bottom = 24.dp)
     ) {
       BundleHeader(
-        bundle = bundle,
+        title = bundle.title,
+        icon = bundle.bundleIcon,
+        hasMoreAction = bundle.hasMoreAction,
         onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate)
       )
       when (uiState) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MyGamesBundleView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MyGamesBundleView.kt
@@ -380,7 +380,7 @@ fun MyGamesBundleHeader(
       )
     }
     onSeeMoreClick?.let {
-      SeeMoreView(onClick = it, actionColor = AppTheme.colors.myGamesSeeAllViewColor)
+      SeeMoreView(onClick = it)
     }
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MyGamesBundleView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MyGamesBundleView.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -45,9 +44,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CollectionInfo
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.collectionInfo
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.heading
-import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -60,7 +56,7 @@ import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.feature_apps.data.MyGamesApp
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.R
-import com.aptoide.android.aptoidegames.home.SeeMoreView
+import com.aptoide.android.aptoidegames.home.BundleHeader
 import com.aptoide.android.aptoidegames.theme.AppTheme
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 
@@ -98,7 +94,7 @@ fun MyGamesBundleViewContent(
   val localContext = LocalContext.current
   when (uiState) {
     MyGamesBundleUiState.Empty -> MyGamesEmptyView {
-      MyGamesBundleHeader(title, icon)
+      BundleHeader(title = title, icon = icon, hasMoreAction = false)
       MyGamesEmptyListView(onRetryClick = onRetryClick)
     }
 
@@ -107,12 +103,18 @@ fun MyGamesBundleViewContent(
     }
 
     is MyGamesBundleUiState.AppsList -> MyGamesAppsListView {
-      MyGamesBundleHeader(title, icon, onSeeMoreClick)
+      BundleHeader(
+        title = title,
+        icon = icon,
+        hasMoreAction = true,
+        onClick = onSeeMoreClick,
+        iconColor = AppTheme.colors.onSurface,
+      )
       MyGamesListView(size = uiState.installedAppsList.size) {
         itemsIndexed(
           items = uiState.installedAppsList,
           key = { _, it -> it.packageName }
-        ) { index, it ->
+        ) { _, it ->
           val appIcon = rememberAppIconDrawable(packageName = it.packageName, localContext)
           MyGameView(
             icon = appIcon,
@@ -330,57 +332,6 @@ fun MyGamesEmptyListView(onRetryClick: () -> Unit) {
         maxLines = 1,
         style = AppTheme.typography.buttonTextMedium
       )
-    }
-  }
-}
-
-@Composable
-fun MyGamesBundleHeader(
-  title: String,
-  icon: String?,
-  onSeeMoreClick: (() -> Unit)? = null,
-) {
-  val label = stringResource(R.string.button_see_all_title)
-  Row(
-    modifier = Modifier
-      .clearAndSetSemantics {
-        heading()
-        contentDescription = "$title bundle"
-        onSeeMoreClick?.let {
-          onClick(label = label) {
-            it()
-            true
-          }
-        }
-      }
-      .fillMaxWidth()
-      .wrapContentHeight()
-      .padding(top = 24.dp, start = 32.dp, end = 16.dp),
-    horizontalArrangement = Arrangement.SpaceBetween,
-    verticalAlignment = Alignment.CenterVertically
-  ) {
-    Row(
-      verticalAlignment = Alignment.CenterVertically,
-      modifier = Modifier.weight(1f, fill = false)
-    ) {
-      icon?.let {
-        AptoideAsyncImage(
-          modifier = Modifier
-            .padding(end = 8.dp)
-            .size(24.dp),
-          data = it,
-          contentDescription = null,
-        )
-      }
-      Text(
-        modifier = Modifier.clearAndSetSemantics { },
-        text = title,
-        style = AppTheme.typography.headlineTitleText,
-        maxLines = 2
-      )
-    }
-    onSeeMoreClick?.let {
-      SeeMoreView(onClick = it)
     }
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/PublisherTakeOverBundle.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/PublisherTakeOverBundle.kt
@@ -91,7 +91,6 @@ fun PublisherTakeOverBundle(
         )
         if (bundle.hasMoreAction) {
           SeeMoreView(
-            actionColor = pureWhite,
             onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate),
             modifier = Modifier.padding(top = 4.dp)
           )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -23,10 +23,7 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Icon
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
@@ -65,6 +62,7 @@ import cm.aptoide.pt.feature_home.presentation.bundlesList
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.categories.presentation.CategoriesBundle
+import com.aptoide.android.aptoidegames.drawables.icons.getForward
 import com.aptoide.android.aptoidegames.editorial.EditorialBundle
 import com.aptoide.android.aptoidegames.feature_apps.presentation.AppsGridBundle
 import com.aptoide.android.aptoidegames.feature_apps.presentation.CarouselBundle
@@ -261,19 +259,20 @@ fun EmptyBundleView(height: Dp) {
 
 @Composable
 fun BundleHeader(
-  bundle: Bundle,
-  onClick: () -> Unit,
+  title: String,
+  icon: String?,
+  hasMoreAction: Boolean,
+  onClick: () -> Unit = {},
   titleColor: Color = Color.Unspecified,
-  actionColor: Color = AppTheme.colors.moreAppsViewBackColor,
+  iconColor: Color? = null,
 ) {
-  val title = bundle.title
   val label = stringResource(R.string.button_see_all_title)
   Row(
     modifier = Modifier
       .clearAndSetSemantics {
         heading()
         contentDescription = "$title bundle"
-        if (bundle.hasMoreAction) {
+        if (hasMoreAction) {
           onClick(label = label) {
             onClick()
             true
@@ -289,12 +288,12 @@ fun BundleHeader(
       verticalAlignment = Alignment.CenterVertically,
       modifier = Modifier.weight(1f, fill = false)
     ) {
-      bundle.bundleIcon?.let {
+      icon?.let {
         AptoideAsyncImage(
           modifier = Modifier
             .padding(end = 8.dp)
             .size(24.dp),
-          data = bundle.bundleIcon,
+          data = icon,
           contentDescription = null,
         )
       }
@@ -303,15 +302,15 @@ fun BundleHeader(
         maxLines = 2,
         modifier = Modifier
           .clearAndSetSemantics { },
-        style = AppTheme.typography.headlineTitleText,
+        style = AppTheme.typography.title,
         color = titleColor,
         overflow = TextOverflow.Ellipsis
       )
     }
-    if (bundle.hasMoreAction) {
+    if (hasMoreAction) {
       SeeMoreView(
         onClick = onClick,
-        actionColor = actionColor
+        iconColor = iconColor,
       )
     }
   }
@@ -321,7 +320,7 @@ fun BundleHeader(
 fun SeeMoreView(
   modifier: Modifier = Modifier,
   onClick: () -> Unit,
-  actionColor: Color = AppTheme.colors.moreAppsViewBackColor,
+  iconColor: Color? = null,
 ) {
   Row(
     modifier = modifier
@@ -333,19 +332,17 @@ fun SeeMoreView(
   ) {
     Text(
       text = stringResource(R.string.button_see_all_title),
-      color = actionColor,
       modifier = Modifier.padding(end = 4.dp),
-      style = AppTheme.typography.headlineTitleText,
+      style = AppTheme.typography.inputs_M,
       overflow = TextOverflow.Ellipsis,
       maxLines = 2,
     )
-    Icon(
+    Image(
       modifier = Modifier
-        .size(18.dp)
-        .requiredSize(18.dp),
-      imageVector = Icons.Default.ArrowForward,
+        .size(24.dp)
+        .requiredSize(24.dp),
+      imageVector = getForward(iconColor?: AppTheme.colors.primary),
       contentDescription = null,
-      tint = actionColor
     )
   }
 }


### PR DESCRIPTION
**What does this PR do?**

 Refactors BundleHeader to uniformize and remove MyGamesBundleHeader and updates it according to the new design.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] CategoriesView.kt
- [ ] Forward.kt
- [ ] EditorialView.kt
- [ ] AppGridView.kt
- [ ] CarouselAppView.kt
- [ ] CarouselLargeAppView.kt
- [ ] MyGamesBundleView.kt
- [ ] PublisherTakeOverBundle.kt
- [ ] BundlesView.kt

**How should this be manually tested?**

Test different bundles headers, including My Games and PTO

  Flow on how to test this or QA Tickets related to this use-case: [APP-2450](https://aptoide.atlassian.net/browse/APP-2450)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2450](https://aptoide.atlassian.net/browse/APP-2450)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2450]: https://aptoide.atlassian.net/browse/APP-2450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2450]: https://aptoide.atlassian.net/browse/APP-2450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ