### PR TITLE
[APP-2446] Update aptoide games PTO

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/DownloadView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/DownloadView.kt
@@ -35,11 +35,11 @@ import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
 import cm.aptoide.pt.download_view.presentation.DownloadUiState
 import cm.aptoide.pt.download_view.presentation.rememberDownloadState
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun DownloadPreview() {
   // A contrast divider to highlight items boundaries
@@ -84,7 +84,7 @@ fun DownloadPreview() {
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun DownloadAppcPreview() {
   // A contrast divider to highlight items boundaries

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
@@ -21,12 +21,12 @@ import com.aptoide.android.aptoidegames.home.BottomBarMenus.Games
 import com.aptoide.android.aptoidegames.home.BottomBarMenus.Search
 import com.aptoide.android.aptoidegames.theme.AppTheme
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.runPreviewable
 import kotlin.random.Random
 
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
-@PreviewAll
+@PreviewDark
 @Composable
 fun AppGamesBottomBarPreview() {
   AptoideTheme(darkTheme = isSystemInDarkTheme()) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/AllCategoriesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/AllCategoriesView.kt
@@ -46,7 +46,7 @@ import com.aptoide.android.aptoidegames.theme.AppTheme
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.toolbar.AppGamesTopBar
 import cm.aptoide.pt.aptoide_ui.animations.staticComposable
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_categories.domain.randomCategory
 import cm.aptoide.pt.feature_categories.presentation.AllCategoriesUiState
 import cm.aptoide.pt.feature_categories.presentation.AllCategoriesUiStateType
@@ -214,7 +214,7 @@ fun CategoryLargeItem(
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun LandscapePaymentView() {
   val uiStateFake =

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/CategoriesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/CategoriesView.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.semantics.collectionInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_categories.domain.Category
 import cm.aptoide.pt.feature_categories.presentation.rememberCategoriesState
 import cm.aptoide.pt.feature_home.domain.Bundle
@@ -145,7 +145,7 @@ fun CategoryGridView(
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun CategoriesViewPreview() {
   CategoryGridView(title = "Action", icon = "", onClick = {})

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/CategoryDetailView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/CategoryDetailView.kt
@@ -29,7 +29,7 @@ import com.aptoide.android.aptoidegames.home.NoConnectionView
 import com.aptoide.android.aptoidegames.installer.presentation.InstallViewShort
 import com.aptoide.android.aptoidegames.toolbar.AppGamesTopBar
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
@@ -152,7 +152,7 @@ fun CategoryAppsList(
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun CategoryDetailViewPreview() {
   val uiStateFake = AppsListUiState.Idle(List(Random.nextInt(until = 20)) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/banners/ChessPatternBanner.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/banners/ChessPatternBanner.kt
@@ -1,0 +1,69 @@
+package com.aptoide.android.aptoidegames.drawables.banners
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.aptoide.android.aptoidegames.theme.AppTheme
+import com.aptoide.android.aptoidegames.theme.secondary
+
+@Preview
+@Composable
+fun TestChessPatternBanner() {
+  Column(
+    verticalArrangement = Arrangement.spacedBy(20.dp)
+  ) {
+    Image(
+      imageVector = getChessPatternBanner(),
+      contentDescription = null,
+    )
+    Image(
+      imageVector = getChessPatternBanner(
+        color = secondary,
+        blockOffset = 1
+      ),
+      contentDescription = null,
+    )
+  }
+}
+
+@Composable
+fun getChessPatternBanner(
+  color: Color = AppTheme.colors.primary,
+  blockOffset: Int = 0,
+): ImageVector = ImageVector.Builder(
+  name = "ChessPatternBanner",
+  defaultWidth = 360.dp,
+  defaultHeight = 32.dp,
+  viewportWidth = 360f,
+  viewportHeight = 32f,
+).apply {
+  for (i in 0..10) {
+    path(
+      fill = SolidColor(color),
+    ) {
+      moveTo(blockOffset * 16.73f + i * 32.7268f, 0f)
+      horizontalLineToRelative(16f)
+      verticalLineToRelative(16f)
+      horizontalLineToRelative(-16f)
+      close()
+    }
+  }
+  for (i in 0..10) {
+    path(
+      fill = SolidColor(color),
+    ) {
+      moveTo((blockOffset + 1) * 16.73f + i * 32.7268f, 16f)
+      horizontalLineToRelative(16f)
+      verticalLineToRelative(16f)
+      horizontalLineToRelative(-16f)
+      close()
+    }
+  }
+}.build()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.semantics.collectionInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
@@ -140,7 +140,7 @@ internal fun AppGridView(
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun AppGridViewPreview() {
   AptoideTheme {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppItems.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppItems.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
@@ -118,7 +118,7 @@ fun LargeAppItem(
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun AppItemPreview() {
   AptoideTheme {
@@ -136,7 +136,7 @@ fun AppItemPreview() {
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun LargeAppItemPreview() {
   AptoideTheme {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselAppView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselAppView.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
@@ -167,7 +167,7 @@ fun CarouselAppView(
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun CarouselAppViewPreview() {
   AptoideTheme {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselLargeAppView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselLargeAppView.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.semantics.collectionInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState.Empty
@@ -221,7 +221,7 @@ fun CarouselLargeAppView(
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun CarouselLargeAppViewPreview() {
   AptoideTheme {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MyGamesBundleView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MyGamesBundleView.kt
@@ -50,7 +50,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.getAppIconDrawable
 import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.feature_apps.data.MyGamesApp
@@ -336,7 +336,7 @@ fun MyGamesEmptyListView(onRetryClick: () -> Unit) {
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun GMInstallationPreview(
   @PreviewParameter(GamesMatchInstallationUiStateProvider::class)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/PublisherTakeOverBundle.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/PublisherTakeOverBundle.kt
@@ -1,5 +1,6 @@
 package com.aptoide.android.aptoidegames.feature_apps.presentation
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -20,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
@@ -37,6 +39,7 @@ import cm.aptoide.pt.feature_home.domain.randomBundle
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
 import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
+import com.aptoide.android.aptoidegames.drawables.banners.getChessPatternBanner
 import com.aptoide.android.aptoidegames.home.HorizontalPagerView
 import com.aptoide.android.aptoidegames.home.LoadingBundleView
 import com.aptoide.android.aptoidegames.home.SeeMoreView
@@ -47,6 +50,7 @@ import com.aptoide.android.aptoidegames.theme.AppGamesButton
 import com.aptoide.android.aptoidegames.theme.AppTheme
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.theme.ButtonStyle.Default
+import com.aptoide.android.aptoidegames.theme.agWhite
 import com.aptoide.android.aptoidegames.theme.pureBlack
 import com.aptoide.android.aptoidegames.theme.pureWhite
 import kotlin.random.Random
@@ -75,80 +79,87 @@ fun PublisherTakeOverContent(
   bottomUiState: AppsListUiState,
   navigate: (String) -> Unit,
 ) {
-  Box {
-    AptoideAsyncImage(
-      modifier = Modifier.matchParentSize(),
-      data = bundle.background,
-      contentDescription = null
-    )
-    Column(
-      modifier = Modifier
-        .background(color = pureBlack.copy(0.7f))
-        .padding(bottom = 24.dp)
-    ) {
-      Row(
-        modifier = Modifier
-          .wrapContentHeight()
-          .fillMaxWidth()
-          .padding(start = 24.dp, top = 16.dp, end = 16.dp, bottom = 8.dp),
-        verticalAlignment = Alignment.Top,
-        horizontalArrangement = Arrangement.SpaceBetween
-      ) {
-        AptoideAsyncImage(
-          modifier = Modifier
-            .size(64.dp)
-            .clip(RoundedCornerShape(16.dp))
-            .background(color = Color.Transparent),
-          data = bundle.bundleIcon,
-          contentDescription = null,
-        )
-        if (bundle.hasMoreAction) {
-          SeeMoreView(
-            onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate),
-            modifier = Modifier.padding(top = 4.dp)
-          )
-        }
-      }
-      Text(
-        text = bundle.title.translateOrKeep(LocalContext.current),
-        modifier = Modifier
-          .semantics { heading() }
-          .padding(start = 24.dp, end = 24.dp, bottom = 24.dp),
-        overflow = TextOverflow.Ellipsis,
-        maxLines = 2,
-        color = pureWhite,
-        style = AppTheme.typography.headlineTitleText
+  Column {
+    Box {
+      AptoideAsyncImage(
+        modifier = Modifier.matchParentSize(),
+        data = bundle.background,
+        contentDescription = null
       )
-      when (uiState) {
-        is AppsListUiState.Idle -> PublisherTakeOverListView(
-          appsList = uiState.apps,
-          navigate = navigate,
-        )
-
-        AppsListUiState.Empty,
-        AppsListUiState.Error,
-        AppsListUiState.NoConnection,
-        -> { /*nothing to show*/
+      Column(
+        modifier = Modifier
+          .background(color = pureBlack.copy(0.7f))
+          .padding(bottom = 28.dp)
+      ) {
+        Row(
+          modifier = Modifier
+            .wrapContentHeight()
+            .fillMaxWidth()
+            .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 8.dp),
+          verticalAlignment = Alignment.Top,
+          horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+          AptoideAsyncImage(
+            modifier = Modifier
+              .size(64.dp)
+              .background(color = Color.Transparent),
+            data = bundle.bundleIcon,
+            contentDescription = null,
+          )
+          if (bundle.hasMoreAction) {
+            SeeMoreView(
+              onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate),
+              modifier = Modifier.padding(top = 4.dp)
+            )
+          }
         }
-
-        AppsListUiState.Loading -> LoadingBundleView(height = 184.dp)
-      }
-      when (bottomUiState) {
-        is AppsListUiState.Idle -> AppsRowView(
-          appsList = bottomUiState.apps,
-          navigate = navigate,
-          appsNameColor = Color.White,
+        Text(
+          text = bundle.title.translateOrKeep(LocalContext.current),
+          modifier = Modifier
+            .semantics { heading() }
+            .padding(start = 16.dp, end = 16.dp, bottom = 24.dp),
+          overflow = TextOverflow.Ellipsis,
+          maxLines = 2,
+          color = agWhite,
+          style = AppTheme.typography.title
         )
+        when (uiState) {
+          is AppsListUiState.Idle -> PublisherTakeOverListView(
+            appsList = uiState.apps,
+            navigate = navigate,
+          )
 
-        AppsListUiState.Empty,
-        AppsListUiState.Error,
-        AppsListUiState.NoConnection,
-        -> { /*nothing to show*/
+          AppsListUiState.Empty,
+          AppsListUiState.Error,
+          AppsListUiState.NoConnection,
+          -> { /*nothing to show*/
+          }
+
+          AppsListUiState.Loading -> LoadingBundleView(height = 184.dp)
         }
+        when (bottomUiState) {
+          is AppsListUiState.Idle -> AppsRowView(
+            appsList = bottomUiState.apps,
+            navigate = navigate,
+            appsNameColor = Color.White,
+          )
 
-        AppsListUiState.Loading -> LoadingBundleView(height = 184.dp)
+          AppsListUiState.Empty,
+          AppsListUiState.Error,
+          AppsListUiState.NoConnection,
+          -> { /*nothing to show*/
+          }
+
+          AppsListUiState.Loading -> LoadingBundleView(height = 184.dp)
+        }
       }
     }
+    Image(
+      imageVector = getChessPatternBanner(),
+      contentDescription = null,
+      modifier = Modifier.fillMaxWidth(),
+      contentScale = ContentScale.FillWidth
+    )
   }
 }
 
@@ -157,7 +168,6 @@ fun PublisherTakeOverListView(
   appsList: List<App>,
   navigate: (String) -> Unit,
 ) {
-
   HorizontalPagerView(
     appsList = appsList,
     modifier = Modifier.padding(bottom = 24.dp)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/EmptyView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/EmptyView.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.unit.dp
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.theme.AppTheme
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 
 @Composable
 fun EmptyView(text: String) {
@@ -39,7 +39,7 @@ fun EmptyView(text: String) {
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun EmptyViewPreview() {
   AptoideTheme {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/GenericErrorView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/GenericErrorView.kt
@@ -20,7 +20,7 @@ import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.theme.ButtonStyle.Default
 import com.aptoide.android.aptoidegames.theme.blueGradient
 import com.aptoide.android.aptoidegames.theme.lightGradient
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 
 @Composable
 fun GenericErrorView(
@@ -100,7 +100,7 @@ fun RetryButton(
   )
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun GenericErrorPreview() {
   AptoideTheme {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/NoConnectionView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/NoConnectionView.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.text.style.TextAlign
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.theme.AppTheme
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 
 @Composable
 fun NoConnectionView(
@@ -81,7 +81,7 @@ fun PaddedRow(
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun NoConnectionPreview() {
   AptoideTheme {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/UserActionDialog.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/UserActionDialog.kt
@@ -36,7 +36,7 @@ import androidx.core.app.ActivityCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.aptoide.android.aptoidegames.theme.AppTheme
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.installer.platform.UserActionRequest.ConfirmationAction
 import cm.aptoide.pt.installer.platform.UserActionRequest.InstallationAction
 import cm.aptoide.pt.installer.platform.UserActionRequest.PermissionAction
@@ -165,7 +165,7 @@ private fun DialogButton(title: String, onClick: () -> Unit) {
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 private fun PermissionsContentPreview() {
   AptoideTheme(isSystemInDarkTheme()) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallView.kt
@@ -38,11 +38,11 @@ import cm.aptoide.pt.download_view.presentation.DownloadUiState
 import cm.aptoide.pt.download_view.presentation.ExecutionBlocker.CONNECTION
 import cm.aptoide.pt.download_view.presentation.ExecutionBlocker.QUEUE
 import cm.aptoide.pt.download_view.presentation.ExecutionBlocker.UNMETERED
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun InstallViewProcessingPreview() {
   // A contrast divider to highlight items boundaries

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewShort.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewShort.kt
@@ -17,11 +17,11 @@ import cm.aptoide.pt.download_view.presentation.DownloadUiState
 import cm.aptoide.pt.download_view.presentation.ExecutionBlocker.CONNECTION
 import cm.aptoide.pt.download_view.presentation.ExecutionBlocker.QUEUE
 import cm.aptoide.pt.download_view.presentation.ExecutionBlocker.UNMETERED
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun InstallViewShortPreview() {
   // A contrast divider to highlight items boundaries

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/network/presentation/WifiPromptDialog.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/network/presentation/WifiPromptDialog.kt
@@ -35,7 +35,7 @@ import com.aptoide.android.aptoidegames.theme.AppTheme
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.theme.richOrange
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter.Companion.formatBytes
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 
 @Composable
 fun WifiPromptDialog(
@@ -150,7 +150,7 @@ enum class WifiPromptType {
   UNMETERED_LARGE_FILE,
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun WifiPromptDialogPreview(
   @PreviewParameter(WifiPromptInfoProvider::class) info: Pair<WifiPromptType, Long>,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -59,7 +59,7 @@ import com.aptoide.android.aptoidegames.theme.pinkishOrangeLight
 import com.aptoide.android.aptoidegames.theme.richOrange
 import com.aptoide.android.aptoidegames.toolbar.AppGamesTopBar
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.UrlActivity
 import com.aptoide.android.aptoidegames.terms_and_conditions.ppUrl
@@ -328,7 +328,7 @@ fun SettingsCaretItem(
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun SettingsScreenPreview(
   @PreviewParameter(SettingsScreenStateProvider::class)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/support/SupportScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/support/SupportScreen.kt
@@ -45,7 +45,7 @@ import com.aptoide.android.aptoidegames.theme.ButtonStyle
 import com.aptoide.android.aptoidegames.theme.shapes
 import com.aptoide.android.aptoidegames.toolbar.AppGamesTopBar
 import com.aptoide.android.aptoidegames.toolbar.SimpleAppGamesToolbar
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.getRandomString
 import cm.aptoide.pt.extensions.sendMail
 
@@ -183,7 +183,7 @@ fun keyboardAsState(): State<Keyboard> {
   return keyboardState
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun SupportScreenPreview() {
   AptoideTheme {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/terms_and_conditions/TermsAndConditions.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/terms_and_conditions/TermsAndConditions.kt
@@ -18,7 +18,7 @@ import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.UrlActivity
 import com.aptoide.android.aptoidegames.theme.AppTheme
 import com.aptoide.android.aptoidegames.theme.richOrange
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 
 @Composable
 fun TermsAndConditions(
@@ -101,7 +101,7 @@ fun TermsAndConditions(
   )
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun TermsAndConditionsPreview() {
   TermsAndConditions(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/theme/AppGamesButton.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/theme/AppGamesButton.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.getRandomString
 import com.aptoide.android.aptoidegames.theme.ButtonStyle.Default
 import com.aptoide.android.aptoidegames.theme.ButtonStyle.Gray
@@ -35,7 +35,7 @@ sealed class ButtonStyle {
   data class Gray(override val fillWidth: Boolean) : ButtonStyle()
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun AppGamesButtonPreview() {
   AptoideTheme {
@@ -95,7 +95,7 @@ fun AppGamesButtonPreview() {
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun AppGamesOutlinedButtonPreview() {
   AptoideTheme {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/toolbar/AppGamesToolBar.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/toolbar/AppGamesToolBar.kt
@@ -25,12 +25,12 @@ import com.aptoide.android.aptoidegames.settings.settingsRoute
 import com.aptoide.android.aptoidegames.terms_and_conditions.ppUrl
 import com.aptoide.android.aptoidegames.terms_and_conditions.tcUrl
 import com.aptoide.android.aptoidegames.theme.AppTheme
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 
-@PreviewAll
+@PreviewDark
 @Composable
 private fun AppGamesToolBarPreview() {
   AppGamesToolBar(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/toolbar/AppGamesTopBar.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/toolbar/AppGamesTopBar.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.unit.dp
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.theme.AppTheme
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
-import cm.aptoide.pt.extensions.PreviewAll
+import cm.aptoide.pt.extensions.PreviewDark
 
 @Composable
 fun AppGamesTopBar(
@@ -91,7 +91,7 @@ private fun TopBar(
   }
 }
 
-@PreviewAll
+@PreviewDark
 @Composable
 fun AppGamesTopBarPreview() {
   AptoideTheme {


### PR DESCRIPTION
**What does this PR do?**

   - Refactors all aptoide games composable previews to be in dark mode only
   - Adds PTO composable preview
   - Adds the chess pattern banner from the design
   - Updates the PTO to match the design

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2446](https://aptoide.atlassian.net/browse/APP-2446)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2446](https://aptoide.atlassian.net/browse/APP-2446)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2446]: https://aptoide.atlassian.net/browse/APP-2446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2446]: https://aptoide.atlassian.net/browse/APP-2446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ