### PR TITLE
[APP-2471] Update aptoide games app view UI

### DIFF
--- a/app-games/build.gradle.kts
+++ b/app-games/build.gradle.kts
@@ -150,6 +150,7 @@ dependencies {
   implementation(project(ModuleDependency.APTOIDE_TASK_INFO))
   implementation(project(ModuleDependency.NETWORK_LISTENER))
   implementation(project(ModuleDependency.FEATURE_SEARCH))
+  implementation(project(ModuleDependency.YOUTUBE_VIDEO_PLAYER))
 
   //room
   implementation(LibraryDependency.ROOM)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -43,6 +43,12 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.navDeepLink
+import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
+import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_apps.presentation.AppUiState
+import cm.aptoide.pt.feature_apps.presentation.appViewModel
+import cm.aptoide.pt.feature_appview.presentation.AppViewTab
+import coil.transform.RoundedCornersTransformation
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
 import com.aptoide.android.aptoidegames.BuildConfig
@@ -53,12 +59,6 @@ import com.aptoide.android.aptoidegames.home.NoConnectionView
 import com.aptoide.android.aptoidegames.installer.presentation.AppIcon
 import com.aptoide.android.aptoidegames.installer.presentation.InstallView
 import com.aptoide.android.aptoidegames.theme.AppTheme
-import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
-import cm.aptoide.pt.feature_apps.data.App
-import cm.aptoide.pt.feature_apps.presentation.AppUiState
-import cm.aptoide.pt.feature_apps.presentation.appViewModel
-import cm.aptoide.pt.feature_appview.presentation.AppViewTab
-import coil.transform.RoundedCornersTransformation
 
 private val tabsList = listOf(
   AppViewTab.DETAILS,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -65,6 +65,7 @@ import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.appview.AppViewHeaderConstants.FEATURE_GRAPHIC_HEIGHT
 import com.aptoide.android.aptoidegames.appview.AppViewHeaderConstants.VIDEO_HEIGHT
+import com.aptoide.android.aptoidegames.appview.permissions.buildAppPermissionsRoute
 import com.aptoide.android.aptoidegames.drawables.icons.getForward
 import com.aptoide.android.aptoidegames.editorial.RelatedEditorialViewCard
 import com.aptoide.android.aptoidegames.editorial.buildEditorialRoute
@@ -294,7 +295,10 @@ fun ViewPagerContent(
       navigate = navigate
     )
 
-    AppViewTab.INFO -> AppInfoSection(app = app)
+    AppViewTab.INFO -> AppInfoSection(
+      app = app,
+      navigate = navigate
+    )
   }
 }
 
@@ -344,6 +348,7 @@ fun ScreenshotsList(screenshots: List<String>) {
 @Composable
 fun AppInfoSection(
   app: App,
+  navigate: (String) -> Unit,
 ) {
   val context = LocalContext.current
   Column(
@@ -395,7 +400,9 @@ fun AppInfoSection(
     app.permissions?.let {
       AppInfoRowWithAction(
         infoCategory = "Permissions",
-        onClick = {}
+        onClick = {
+          navigate(buildAppPermissionsRoute(app.packageName))
+        }
       )
     }
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -11,14 +11,12 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
@@ -29,7 +27,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
@@ -48,17 +45,17 @@ import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.presentation.AppUiState
 import cm.aptoide.pt.feature_apps.presentation.appViewModel
 import cm.aptoide.pt.feature_appview.presentation.AppViewTab
-import coil.transform.RoundedCornersTransformation
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
 import com.aptoide.android.aptoidegames.BuildConfig
-import com.aptoide.android.aptoidegames.R.string
+import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.appview.AppViewVideoConstants.FEATURE_GRAPHIC_HEIGHT
 import com.aptoide.android.aptoidegames.home.GenericErrorView
 import com.aptoide.android.aptoidegames.home.NoConnectionView
 import com.aptoide.android.aptoidegames.installer.presentation.AppIcon
 import com.aptoide.android.aptoidegames.installer.presentation.InstallView
 import com.aptoide.android.aptoidegames.theme.AppTheme
+import com.aptoide.android.aptoidegames.theme.agWhite
 
 private val tabsList = listOf(
   AppViewTab.DETAILS,
@@ -144,7 +141,7 @@ fun AppViewContent(
   navigateBack: () -> Unit,
 ) {
   val selectedTab by rememberSaveable { mutableIntStateOf(0) }
-  val appImageString = stringResource(id = string.app_view_image_description_body, app.name)
+  val appImageString = stringResource(id = R.string.app_view_image_description_body, app.name)
 
   val scrollState = rememberScrollState()
 
@@ -165,21 +162,23 @@ fun AppViewContent(
       )
       Image(
         imageVector = AppTheme.icons.LeftArrow,
-        contentDescription = stringResource(id = string.button_back_title),
+        contentDescription = stringResource(id = R.string.button_back_title),
         contentScale = ContentScale.Crop,
         modifier = Modifier
           .clickable(onClick = navigateBack)
-          .padding(horizontal = 16.dp, vertical = 12.dp)
+          .padding(top = 4.dp, start = 16.dp)
           .size(32.dp)
       )
     }
     Column(
       modifier = Modifier.background(AppTheme.colors.background)
     ) {
-
       AppPresentationView(app)
 
-      InstallButton(app)
+      InstallView(
+        modifier = Modifier.padding(top = 24.dp, start = 16.dp, end = 16.dp),
+        app = app
+      )
 
       ViewPagerContent(
         app = app,
@@ -209,9 +208,9 @@ fun DetailsView(app: App) {
     app.description?.let {
       Text(
         text = it,
-        modifier = Modifier.padding(top = 12.dp, bottom = 26.dp, start = 16.dp, end = 16.dp),
-        style = AppTheme.typography.bodyCopyXS,
-        color = AppTheme.colors.greyText
+        modifier = Modifier.padding(top = 24.dp, bottom = 32.dp, start = 16.dp, end = 16.dp),
+        style = AppTheme.typography.articleText,
+        color = agWhite
       )
     }
   }
@@ -225,21 +224,19 @@ fun ScreenshotsList(screenshots: List<String>) {
       .semantics {
         collectionInfo = CollectionInfo(1, screenshots.size)
       },
-    horizontalArrangement = Arrangement.spacedBy(8.dp),
-    contentPadding = PaddingValues(start = 18.dp)
+    horizontalArrangement = Arrangement.spacedBy(16.dp),
+    contentPadding = PaddingValues(horizontal = 16.dp)
   ) {
     itemsIndexed(screenshots) { index, screenshot ->
-      val stringResource = stringResource(id = string.app_view_screenshot_number, index + 1)
+      val stringResource = stringResource(id = R.string.app_view_screenshot_number, index + 1)
       AptoideAsyncImage(
         modifier = Modifier
           .clearAndSetSemantics {
             contentDescription = stringResource
           }
-          .size(268.dp, 152.dp)
-          .clip(RoundedCornerShape(24.dp)),
+          .size(268.dp, 152.dp),
         data = screenshot,
         contentDescription = null,
-        transformations = RoundedCornersTransformation(24f)
       )
     }
   }
@@ -252,71 +249,47 @@ fun buildAppViewDeepLinkUri(packageName: String) =
 
 @Composable
 fun AppPresentationView(app: App) {
-  Box(
+  Row(
     modifier = Modifier
+      .padding(start = 16.dp, top = 16.dp)
       .fillMaxWidth()
-      .offset(0.dp, (-24).dp)
-      .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
-      .background(AppTheme.colors.background)
+      .wrapContentHeight(),
+    verticalAlignment = Alignment.CenterVertically,
   ) {
-    Row(
+    val appIconString = stringResource(id = R.string.app_view_icon_description_body, app.name)
+    AppIcon(
       modifier = Modifier
-        .padding(start = 16.dp, top = 16.dp, bottom = 24.dp)
-        .fillMaxWidth()
-        .wrapContentHeight(),
-      verticalAlignment = Alignment.CenterVertically,
+        .clearAndSetSemantics { contentDescription = appIconString }
+        .padding(end = 16.dp)
+        .size(88.dp),
+      app = app,
+      contentDescription = null,
+    )
+    Column(
+      modifier = Modifier
+        .padding(end = 16.dp)
+        .weight(1f),
+      horizontalAlignment = Alignment.Start,
     ) {
-      val appIconString = stringResource(id = string.app_view_icon_description_body, app.name)
-      AppIcon(
-        modifier = Modifier
-          .clearAndSetSemantics { contentDescription = appIconString }
-          .padding(end = 16.dp)
-          .size(88.dp)
-          .clip(RoundedCornerShape(16.dp)),
-        app = app,
-        contentDescription = null,
+      Text(
+        text = app.name,
+        maxLines = 2,
+        style = AppTheme.typography.titleGames,
+        fontWeight = FontWeight.Bold,
+        overflow = TextOverflow.Ellipsis,
       )
-      Column(
-        modifier = Modifier
-          .padding(end = 16.dp)
-          .weight(1f),
-        horizontalAlignment = Alignment.Start,
-      ) {
+      app.developerName?.let {
         Text(
-          text = app.name,
-          maxLines = 2,
-          style = AppTheme.typography.gameTitleTextCondensed,
-          fontWeight = FontWeight.Bold,
+          text = it,
+          maxLines = 1,
+          style = AppTheme.typography.smallGames,
           overflow = TextOverflow.Ellipsis,
-          modifier = Modifier.padding(bottom = 4.dp)
         )
-        app.developerName?.let {
-          Text(
-            text = it,
-            maxLines = 1,
-            style = AppTheme.typography.gameTitleTextCondensed,
-            overflow = TextOverflow.Ellipsis,
-          )
-        }
       }
     }
   }
 }
 
-@Composable
-fun InstallButton(app: App) {
-  Box(
-    modifier = Modifier
-      .fillMaxWidth()
-      .padding(horizontal = 16.dp)
-      .wrapContentHeight()
-      .offset(0.dp, (-24).dp)
-      .background(AppTheme.colors.background)
-  ) {
-    InstallView(app = app)
-  }
-}
-
 private object AppViewVideoConstants {
-  const val FEATURE_GRAPHIC_HEIGHT = 208
+  const val FEATURE_GRAPHIC_HEIGHT = 200
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/CustomScrollableTabRow.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/CustomScrollableTabRow.kt
@@ -1,0 +1,142 @@
+package com.aptoide.android.aptoidegames.appview
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.ScrollableTabRow
+import androidx.compose.material.Tab
+import androidx.compose.material.TabPosition
+import androidx.compose.material.TabRowDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import cm.aptoide.pt.extensions.PreviewDark
+import com.aptoide.android.aptoidegames.theme.AppTheme
+import com.aptoide.android.aptoidegames.theme.AptoideTheme
+import com.aptoide.android.aptoidegames.theme.agWhite
+import com.aptoide.android.aptoidegames.theme.primary
+import kotlin.random.Random
+import kotlin.random.nextInt
+
+@Composable
+fun CustomScrollableTabRow(
+  tabs: List<AppViewTab>,
+  selectedTabIndex: Int,
+  onTabClick: (Int) -> Unit,
+  contentColor: Color,
+  backgroundColor: Color,
+) {
+  val density = LocalDensity.current
+  val indicatorWidths = remember(key1 = tabs.size) { MutableList(tabs.size) { 0.dp } }
+
+  ScrollableTabRow(
+    selectedTabIndex = selectedTabIndex,
+    contentColor = contentColor,
+    backgroundColor = backgroundColor,
+    modifier = Modifier
+      .padding(top = 24.dp)
+      .height(40.dp),
+    edgePadding = 0.dp,
+    indicator = { tabPositions ->
+      TabRowDefaults.Indicator(
+        modifier = Modifier.customTabIndicatorOffset(
+          currentTabPosition = tabPositions[selectedTabIndex],
+          tabWidth = indicatorWidths[selectedTabIndex]
+        )
+      )
+    },
+    divider = {
+      Box {}
+    }
+  ) {
+    tabs.forEachIndexed { tabIndex, tab ->
+      Tab(
+        selected = selectedTabIndex == tabIndex,
+        onClick = { onTabClick(tabIndex) },
+        text = {
+          Text(
+            text = tab.getTabName(),
+            style = AppTheme.typography.inputs_L,
+            color = if (selectedTabIndex == tabIndex) {
+              primary
+            } else {
+              agWhite
+            },
+            onTextLayout = { textLayoutResult ->
+              indicatorWidths[tabIndex] =
+                with(density) { textLayoutResult.size.width.toDp() }
+            }
+          )
+        }
+      )
+    }
+  }
+}
+
+private fun Modifier.customTabIndicatorOffset(
+  currentTabPosition: TabPosition,
+  tabWidth: Dp,
+): Modifier = composed(
+  inspectorInfo = debugInspectorInfo {
+    name = "customTabIndicatorOffset"
+    value = currentTabPosition
+  }
+) {
+  val currentTabWidth by animateDpAsState(
+    targetValue = tabWidth,
+    animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing)
+  )
+  val indicatorOffset by animateDpAsState(
+    targetValue = ((currentTabPosition.left + currentTabPosition.right - tabWidth) / 2),
+    animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing)
+  )
+  fillMaxWidth()
+    .wrapContentSize(Alignment.BottomStart)
+    .offset(x = indicatorOffset)
+    .width(currentTabWidth)
+}
+
+@Composable
+fun AppViewTab.getTabName(): String = when (this) {
+  AppViewTab.DETAILS -> "Details"
+  AppViewTab.RELATED -> "Related"
+  AppViewTab.INFO -> "Info"
+}
+
+enum class AppViewTab {
+  DETAILS,
+  RELATED,
+  INFO
+}
+
+@PreviewDark
+@Composable
+fun CustomScrollableTabRowPreview() {
+  val tabsList = List(Random.nextInt(1..3)) { AppViewTab.values()[it] }
+
+  AptoideTheme {
+    CustomScrollableTabRow(
+      tabs = tabsList,
+      selectedTabIndex = Random.nextInt(tabsList.size),
+      onTabClick = {},
+      contentColor = primary,
+      backgroundColor = Color.Transparent
+    )
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/permissions/AppPermissionsView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/permissions/AppPermissionsView.kt
@@ -1,0 +1,174 @@
+package com.aptoide.android.aptoidegames.appview.permissions
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavGraphBuilder
+import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
+import cm.aptoide.pt.extensions.PreviewDark
+import cm.aptoide.pt.feature_apps.presentation.AppUiState
+import cm.aptoide.pt.feature_apps.presentation.AppUiStateProvider
+import cm.aptoide.pt.feature_apps.presentation.appViewModel
+import com.aptoide.android.aptoidegames.AppIconImage
+import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.drawables.icons.IndeterminateCircularLoading
+import com.aptoide.android.aptoidegames.theme.AppTheme
+import com.aptoide.android.aptoidegames.theme.agWhite
+import com.aptoide.android.aptoidegames.theme.greyLight
+import com.aptoide.android.aptoidegames.toolbar.AppGamesTopBar
+
+const val appPermissionsRoute = "appInfoPermissions/{packageName}"
+
+fun NavGraphBuilder.appPermissionsScreen(
+  navigateBack: () -> Unit,
+) = animatedComposable(appPermissionsRoute) {
+  val packageName = it.arguments?.getString("packageName")!!
+
+  AppInfoPermissionsView(
+    navigateBack = navigateBack,
+    packageName = packageName
+  )
+}
+
+fun buildAppPermissionsRoute(packageName: String): String = "appInfoPermissions/$packageName"
+
+@Composable
+fun AppInfoPermissionsView(
+  navigateBack: () -> Unit,
+  packageName: String,
+) {
+  val appViewModel = appViewModel(packageName = packageName, adListId = "")
+  val uiState by appViewModel.uiState.collectAsState()
+
+  (uiState as? AppUiState.Idle)?.app?.run {
+    AppInfoPermissionsViewContent(
+      navigateBack = navigateBack,
+      uiState = uiState
+    )
+  }
+}
+
+@Composable
+fun AppInfoPermissionsViewContent(
+  navigateBack: () -> Unit,
+  uiState: AppUiState,
+) {
+  Column(
+    modifier = Modifier.fillMaxSize(),
+    horizontalAlignment = Alignment.CenterHorizontally
+  ) {
+    AppGamesTopBar(
+      navigateBack = navigateBack,
+      title = "Permissions"
+    )
+
+    when (uiState) {
+      is AppUiState.Idle -> uiState.app.run {
+        AppPresentationRow(icon, name, developerName)
+        permissions?.let { PermissionsList(it) }
+      }
+
+      else -> Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+      ) {
+        IndeterminateCircularLoading()
+      }
+    }
+  }
+}
+
+@Composable
+fun AppPresentationRow(
+  appIcon: String,
+  appName: String,
+  appDeveloper: String?,
+) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(all = 16.dp)
+  ) {
+    AppIconImage(
+      modifier = Modifier
+        .padding(end = 16.dp)
+        .size(88.dp),
+      data = appIcon,
+      contentDescription = "App icon",
+    )
+    Column(
+      horizontalAlignment = Alignment.Start,
+      verticalArrangement = Arrangement.Center
+    ) {
+      Text(
+        text = appName,
+        maxLines = 2,
+        style = AppTheme.typography.titleGames,
+        color = agWhite,
+        overflow = TextOverflow.Ellipsis,
+      )
+      appDeveloper?.let {
+        Text(
+          text = it,
+          maxLines = 1,
+          style = AppTheme.typography.smallGames,
+          color = agWhite,
+          overflow = TextOverflow.Ellipsis,
+        )
+      }
+    }
+  }
+}
+
+@Composable
+fun PermissionsList(permissionsList: List<String>) {
+  LazyColumn(
+    modifier = Modifier.fillMaxWidth(),
+    contentPadding = PaddingValues(top = 16.dp, start = 16.dp, end = 16.dp, bottom = 24.dp),
+    verticalArrangement = Arrangement.spacedBy(16.dp)
+  ) {
+    items(permissionsList) {
+      PermissionItem(it)
+    }
+  }
+}
+
+@Composable
+fun PermissionItem(permission: String) {
+  Text(
+    text = permission.trim(),
+    style = AppTheme.typography.inputs_M,
+    color = greyLight,
+    maxLines = 2,
+    overflow = TextOverflow.Ellipsis
+  )
+}
+
+@PreviewDark
+@Composable
+fun AppPermissionsViewPreview(
+  @PreviewParameter(AppUiStateProvider::class) uiState: AppUiState,
+) {
+  AppInfoPermissionsViewContent(
+    navigateBack = {},
+    uiState = uiState
+  )
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/CategoriesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/CategoriesView.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -32,8 +33,8 @@ import cm.aptoide.pt.feature_categories.presentation.rememberCategoriesState
 import cm.aptoide.pt.feature_home.domain.Bundle
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.feature_apps.presentation.SmallEmptyView
 import com.aptoide.android.aptoidegames.home.BundleHeader
-import com.aptoide.android.aptoidegames.home.EmptyBundleView
 import com.aptoide.android.aptoidegames.home.LoadingBundleView
 import com.aptoide.android.aptoidegames.theme.AppTheme
 
@@ -75,7 +76,7 @@ fun CategoriesListView(
   if (loading) {
     LoadingBundleView(height = 132.dp)
   } else if (categories.isEmpty()) {
-    EmptyBundleView(height = 132.dp)
+    SmallEmptyView(modifier = Modifier.height(132.dp))
   } else {
     LazyRow(
       modifier = Modifier

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/Muted.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/Muted.kt
@@ -1,0 +1,51 @@
+package com.aptoide.android.aptoidegames.drawables.icons
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.aptoide.android.aptoidegames.theme.pureWhite
+
+@Preview
+@Composable
+fun TestMuted() {
+  Image(
+    imageVector = getMuted(),
+    contentDescription = null,
+    modifier = Modifier.size(240.dp)
+  )
+}
+
+fun getMuted(): ImageVector = ImageVector.Builder(
+  name = "Muted",
+  defaultWidth = 10.dp,
+  defaultHeight = 14.dp,
+  viewportWidth = 10f,
+  viewportHeight = 14f,
+).apply {
+  path(
+    fill = SolidColor(pureWhite),
+  ) {
+    moveTo(0.759874f, 10.0194f)
+    curveTo(0.543486f, 10.0194f, 0.362324f, 9.94891f, 0.216388f, 9.80298f)
+    curveTo(0.0754841f, 9.66207f, 0f, 9.48091f, 0f, 9.25949f)
+    verticalLineTo(4.73044f)
+    curveTo(0f, 4.51406f, 0.0704519f, 4.33289f, 0.216388f, 4.18696f)
+    curveTo(0.357292f, 4.04605f, 0.538454f, 3.97057f, 0.759874f, 3.97057f)
+    horizontalLineTo(4.03085f)
+    lineTo(7.7799f, 0.23159f)
+    curveTo(8.01642f, -0.00492742f, 8.28816f, -0.0602825f, 8.60016f, 0.0655244f)
+    curveTo(8.91216f, 0.191331f, 9.06816f, 0.422816f, 9.06816f, 0.759978f)
+    verticalLineTo(13.24f)
+    curveTo(9.06816f, 13.5772f, 8.91216f, 13.8087f, 8.60016f, 13.9345f)
+    curveTo(8.28816f, 14.0603f, 8.01642f, 14.0049f, 7.7799f, 13.7684f)
+    lineTo(4.03085f, 10.0194f)
+    horizontalLineTo(0.759874f)
+    close()
+  }
+}.build()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/Unmuted.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/Unmuted.kt
@@ -1,0 +1,79 @@
+package com.aptoide.android.aptoidegames.drawables.icons
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.aptoide.android.aptoidegames.theme.pureWhite
+
+@Preview
+@Composable
+fun TestUnmuted() {
+  Image(
+    imageVector = getUnmuted(),
+    contentDescription = null,
+    modifier = Modifier.size(240.dp)
+  )
+}
+
+fun getUnmuted(): ImageVector = ImageVector.Builder(
+  name = "Unmuted",
+  defaultWidth = 17.dp,
+  defaultHeight = 14.dp,
+  viewportWidth = 17f,
+  viewportHeight = 14f,
+).apply {
+  path(
+    fill = SolidColor(pureWhite),
+  ) {
+    moveTo(11.8812f, 13.7332f)
+    curveTo(11.6698f, 13.7986f, 11.4736f, 13.7684f, 11.3025f, 13.6325f)
+    curveTo(11.1314f, 13.4967f, 11.0458f, 13.3205f, 11.0458f, 13.0941f)
+    curveTo(11.0458f, 12.9884f, 11.076f, 12.8928f, 11.1364f, 12.8072f)
+    curveTo(11.1968f, 12.7217f, 11.2773f, 12.6663f, 11.383f, 12.6361f)
+    curveTo(12.5908f, 12.2134f, 13.567f, 11.4888f, 14.3118f, 10.4622f)
+    curveTo(15.0566f, 9.43562f, 15.429f, 8.28323f, 15.429f, 6.99497f)
+    curveTo(15.429f, 5.70671f, 15.0566f, 4.54928f, 14.3118f, 3.51767f)
+    curveTo(13.567f, 2.48605f, 12.5908f, 1.76643f, 11.383f, 1.35379f)
+    curveTo(11.2773f, 1.32863f, 11.1918f, 1.26824f, 11.1364f, 1.17262f)
+    curveTo(11.0811f, 1.07701f, 11.0458f, 0.981399f, 11.0458f, 0.875721f)
+    curveTo(11.0458f, 0.649268f, 11.1364f, 0.473139f, 11.3126f, 0.347332f)
+    curveTo(11.4887f, 0.221525f, 11.6799f, 0.191331f, 11.8812f, 0.256751f)
+    curveTo(13.3003f, 0.759978f, 14.4477f, 1.63056f, 15.3182f, 2.85844f)
+    curveTo(16.1888f, 4.08631f, 16.6216f, 5.46516f, 16.6216f, 6.99497f)
+    curveTo(16.6216f, 8.52478f, 16.1888f, 9.89859f, 15.3182f, 11.1315f)
+    curveTo(14.4477f, 12.3644f, 13.3003f, 13.2249f, 11.8812f, 13.7332f)
+    close()
+    moveTo(0.759874f, 10.0194f)
+    curveTo(0.543486f, 10.0194f, 0.362324f, 9.94891f, 0.216388f, 9.80298f)
+    curveTo(0.0754841f, 9.66207f, 0f, 9.48091f, 0f, 9.25949f)
+    verticalLineTo(4.73044f)
+    curveTo(0f, 4.51406f, 0.0704519f, 4.33289f, 0.216388f, 4.18696f)
+    curveTo(0.357292f, 4.04605f, 0.538454f, 3.97057f, 0.759874f, 3.97057f)
+    horizontalLineTo(4.03085f)
+    lineTo(7.7799f, 0.23159f)
+    curveTo(8.01642f, -0.00492742f, 8.28816f, -0.0602825f, 8.60016f, 0.0655244f)
+    curveTo(8.91216f, 0.191331f, 9.06816f, 0.422816f, 9.06816f, 0.759978f)
+    verticalLineTo(13.24f)
+    curveTo(9.06816f, 13.5772f, 8.91216f, 13.8087f, 8.60016f, 13.9345f)
+    curveTo(8.28816f, 14.0603f, 8.01642f, 14.0049f, 7.7799f, 13.7684f)
+    lineTo(4.03085f, 10.0194f)
+    horizontalLineTo(0.759874f)
+    close()
+    moveTo(10.6483f, 10.0747f)
+    verticalLineTo(3.94038f)
+    curveTo(10.6483f, 3.79947f, 10.7892f, 3.69379f, 10.92f, 3.74915f)
+    curveTo(11.5138f, 3.9907f, 11.9969f, 4.38322f, 12.3794f, 4.9267f)
+    curveTo(12.8172f, 5.5507f, 13.0386f, 6.25019f, 13.0386f, 7.02013f)
+    curveTo(13.0386f, 7.79007f, 12.8172f, 8.49962f, 12.3794f, 9.11355f)
+    curveTo(11.9969f, 9.64194f, 11.5138f, 10.0294f, 10.92f, 10.271f)
+    curveTo(10.7892f, 10.3263f, 10.6433f, 10.2207f, 10.6433f, 10.0798f)
+    lineTo(10.6483f, 10.0747f)
+    close()
+  }
+}.build()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialView.kt
@@ -33,8 +33,8 @@ import cm.aptoide.pt.feature_editorial.domain.randomArticleMeta
 import cm.aptoide.pt.feature_editorial.presentation.rememberEditorialsCardState
 import cm.aptoide.pt.feature_home.domain.Bundle
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
+import com.aptoide.android.aptoidegames.feature_apps.presentation.SmallEmptyView
 import com.aptoide.android.aptoidegames.home.BundleHeader
-import com.aptoide.android.aptoidegames.home.EmptyBundleView
 import com.aptoide.android.aptoidegames.home.LoadingBundleView
 import com.aptoide.android.aptoidegames.home.getSeeMoreRouteNavigation
 import com.aptoide.android.aptoidegames.theme.AppTheme
@@ -72,7 +72,7 @@ fun EditorialBundle(
     if (items == null) {
       LoadingBundleView(height = 240.dp)
     } else if (items.isEmpty()) {
-      EmptyBundleView(height = 240.dp)
+      SmallEmptyView(modifier = Modifier.height(240.dp))
     } else {
       LazyRow(
         modifier = Modifier

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -32,7 +33,6 @@ import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.randomBundle
 import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
 import com.aptoide.android.aptoidegames.home.BundleHeader
-import com.aptoide.android.aptoidegames.home.EmptyBundleView
 import com.aptoide.android.aptoidegames.home.LoadingBundleView
 import com.aptoide.android.aptoidegames.home.getSeeMoreRouteNavigation
 import com.aptoide.android.aptoidegames.installer.presentation.AppIconWProgress
@@ -78,7 +78,7 @@ private fun RealAppsGridBundle(
       AppsListUiState.Empty,
       AppsListUiState.Error,
       AppsListUiState.NoConnection,
-      -> EmptyBundleView(height = 184.dp)
+      -> SmallEmptyView(modifier = Modifier.height(184.dp))
 
       AppsListUiState.Loading -> LoadingBundleView(height = 184.dp)
     }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselAppView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselAppView.kt
@@ -31,7 +31,6 @@ import cm.aptoide.pt.feature_home.domain.randomBundle
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
 import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
 import com.aptoide.android.aptoidegames.home.BundleHeader
-import com.aptoide.android.aptoidegames.home.EmptyBundleView
 import com.aptoide.android.aptoidegames.home.HorizontalPagerView
 import com.aptoide.android.aptoidegames.home.LoadingBundleView
 import com.aptoide.android.aptoidegames.home.getSeeMoreRouteNavigation
@@ -81,7 +80,7 @@ private fun RealCarouselBundle(
       AppsListUiState.Empty,
       AppsListUiState.Error,
       AppsListUiState.NoConnection,
-      -> EmptyBundleView(height = 184.dp)
+      -> SmallEmptyView(modifier = Modifier.height(184.dp))
 
       AppsListUiState.Loading -> LoadingBundleView(height = 184.dp)
     }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselLargeAppView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselLargeAppView.kt
@@ -41,7 +41,6 @@ import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
 import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
 import com.aptoide.android.aptoidegames.home.BundleHeader
-import com.aptoide.android.aptoidegames.home.EmptyBundleView
 import com.aptoide.android.aptoidegames.home.LoadingBundleView
 import com.aptoide.android.aptoidegames.home.getSeeMoreRouteNavigation
 import com.aptoide.android.aptoidegames.installer.presentation.AppIconWProgress
@@ -102,7 +101,7 @@ private fun RealCarouselLargeBundle(
         Empty,
         Error,
         NoConnection,
-        -> EmptyBundleView(height = 184.dp)
+        -> SmallEmptyView(modifier = Modifier.height(184.dp))
 
         Loading -> LoadingBundleView(height = 184.dp)
       }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/SmallEmptyView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/SmallEmptyView.kt
@@ -1,0 +1,57 @@
+package com.aptoide.android.aptoidegames.feature_apps.presentation
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import cm.aptoide.pt.extensions.PreviewDark
+import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.theme.AppTheme
+import com.aptoide.android.aptoidegames.theme.AptoideTheme
+import com.aptoide.android.aptoidegames.theme.agWhite
+import com.aptoide.android.aptoidegames.theme.grey
+
+@Composable
+fun SmallEmptyView(
+  modifier: Modifier = Modifier,
+  padding: PaddingValues = PaddingValues(horizontal = 48.dp),
+  title: String = stringResource(id = R.string.editorials_view_no_content_message),
+) {
+  Column(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(padding),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.Center
+  ) {
+    Image(
+      imageVector = AppTheme.icons.SingleGamepad,
+      contentDescription = null,
+      colorFilter = ColorFilter.tint(grey)
+    )
+    Text(
+      text = title,
+      style = AppTheme.typography.subHeading_S,
+      textAlign = TextAlign.Center,
+      color = agWhite,
+    )
+  }
+}
+
+@PreviewDark
+@Composable
+fun SmallEmptyViewPreview() {
+  AptoideTheme {
+    SmallEmptyView()
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -72,7 +71,6 @@ import com.aptoide.android.aptoidegames.feature_apps.presentation.PublisherTakeO
 import com.aptoide.android.aptoidegames.feature_apps.presentation.buildSeeMoreRoute
 import com.aptoide.android.aptoidegames.feature_apps.presentation.perCarouselViewModel
 import com.aptoide.android.aptoidegames.theme.AppTheme
-import com.aptoide.android.aptoidegames.theme.gray5
 import kotlinx.coroutines.launch
 import kotlin.math.absoluteValue
 
@@ -231,29 +229,6 @@ fun LoadingBundleView(height: Dp) {
     contentAlignment = Alignment.Center,
   ) {
     CircularProgressIndicator()
-  }
-}
-
-@Composable
-fun EmptyBundleView(height: Dp) {
-  Column(
-    modifier = Modifier
-      .fillMaxWidth()
-      .height(height),
-    horizontalAlignment = Alignment.CenterHorizontally,
-    verticalArrangement = Arrangement.Center
-  ) {
-    Image(
-      imageVector = AppTheme.icons.PlanetSearch,
-      contentDescription = null
-    )
-    Text(
-      modifier = Modifier.padding(all = 24.dp),
-      text = stringResource(R.string.editorials_view_no_content_message),
-      style = AppTheme.typography.headlineTitleText,
-      textAlign = TextAlign.Center,
-      color = gray5,
-    )
   }
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
@@ -99,6 +99,7 @@ private fun NavigationGraph(
     )
 
     appViewScreen(
+      navigate = navController::navigate,
       navigateBack = navController::popBackStack,
     )
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
@@ -16,6 +16,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import com.aptoide.android.aptoidegames.appview.appViewScreen
+import com.aptoide.android.aptoidegames.appview.permissions.appPermissionsScreen
 import com.aptoide.android.aptoidegames.bottom_bar.AppGamesBottomBar
 import com.aptoide.android.aptoidegames.categories.presentation.allCategoriesScreen
 import com.aptoide.android.aptoidegames.categories.presentation.categoryDetailScreen
@@ -129,5 +130,8 @@ private fun NavigationGraph(
       navigate = navController::navigate
     )
 
+    appPermissionsScreen(
+      navigateBack = navController::navigateUp
+    )
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/theme/AppIcons.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/theme/AppIcons.kt
@@ -33,4 +33,6 @@ data class AppIcons(
   var PopularSearches: ImageVector,
   var SearchLens: ImageVector,
   var MoreVert: ImageVector,
+  val Muted: ImageVector,
+  val Unmuted: ImageVector,
 )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/theme/Theme.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/theme/Theme.kt
@@ -41,6 +41,7 @@ import com.aptoide.android.aptoidegames.drawables.icons.getHistoryOutlined
 import com.aptoide.android.aptoidegames.drawables.icons.getLeftArrow
 import com.aptoide.android.aptoidegames.drawables.icons.getLogout
 import com.aptoide.android.aptoidegames.drawables.icons.getMoreVert
+import com.aptoide.android.aptoidegames.drawables.icons.getMuted
 import com.aptoide.android.aptoidegames.drawables.icons.getNoConnection
 import com.aptoide.android.aptoidegames.drawables.icons.getNoConnectionSmall
 import com.aptoide.android.aptoidegames.drawables.icons.getNoWifi
@@ -48,6 +49,7 @@ import com.aptoide.android.aptoidegames.drawables.icons.getNotificationBell
 import com.aptoide.android.aptoidegames.drawables.icons.getPlanetSearch
 import com.aptoide.android.aptoidegames.drawables.icons.getSearch
 import com.aptoide.android.aptoidegames.drawables.icons.getSingleGamepad
+import com.aptoide.android.aptoidegames.drawables.icons.getUnmuted
 import com.aptoide.android.aptoidegames.drawables.icons.getWifi
 
 private val darkMaterialColorPalette = darkColors(
@@ -409,9 +411,11 @@ private val darkIcons = AppIcons(
   Search = getSearch(agWhite),
   Wifi = getWifi(),
   RecentSearches = getAsterisk(grey),
-  PopularSearches = getGames(grey , agBlack),
+  PopularSearches = getGames(grey, agBlack),
   SearchLens = getSearch(grey),
   MoreVert = getMoreVert(),
+  Muted = getMuted(),
+  Unmuted = getUnmuted(),
 )
 
 private val lightIcons = darkIcons

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/videos/presentation/VideoSettingsViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/videos/presentation/VideoSettingsViewModel.kt
@@ -1,0 +1,42 @@
+package com.dti.hub.videos.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.dti.hub.videos.repository.VideoSettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class VideoSettingsViewModel @Inject constructor(
+  private val videoSettingsRepository: VideoSettingsRepository,
+) : ViewModel() {
+
+  private val viewModelState = MutableStateFlow(false)
+
+  val uiState = viewModelState
+    .stateIn(
+      viewModelScope,
+      SharingStarted.Eagerly,
+      viewModelState.value
+    )
+
+  init {
+    viewModelScope.launch {
+      videoSettingsRepository.shouldVideosMute()
+        .catch { throwable -> throwable.printStackTrace() }
+        .collect { shouldMute -> viewModelState.update { shouldMute } }
+    }
+  }
+
+  fun setShouldMute(shouldMute: Boolean) {
+    viewModelScope.launch {
+      videoSettingsRepository.setShouldVideosMute(shouldMute)
+    }
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/videos/presentation/YoutubePlayer.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/videos/presentation/YoutubePlayer.kt
@@ -1,0 +1,288 @@
+package com.dti.hub.videos.presentation
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import cm.aptoide.pt.extensions.isActiveNetworkMetered
+import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.theme.AppTheme
+import com.aptoide.android.aptoidegames.theme.agBlack
+import com.aptoide.android.aptoidegames.theme.greyLight
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.PlayerConstants
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.YouTubePlayer
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.listeners.AbstractYouTubePlayerListener
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.listeners.YouTubePlayerCallback
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.options.IFramePlayerOptions
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.utils.YouTubePlayerTracker
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views.YouTubePlayerView
+
+@Composable
+fun AppViewYoutubePlayer(
+  modifier: Modifier,
+  videoId: String,
+  shouldPause: Boolean = false,
+  contentDesc: String = "",
+) {
+  val context = LocalContext.current
+  val lifecycleOwner = LocalLifecycleOwner.current
+
+  val youtubePlayerTracker = remember { YouTubePlayerTracker() }
+  var youtubePlayer: YouTubePlayer? by remember { mutableStateOf(null) }
+
+  val videoSettingsViewModel = hiltViewModel<VideoSettingsViewModel>()
+  val shouldMute by videoSettingsViewModel.uiState.collectAsState()
+
+  var showFullscreen by remember { mutableStateOf(false) }
+  var userPaused by remember { mutableStateOf(false) }
+
+  val meteredConnection = isActiveNetworkMetered()
+
+  val autoplayAllowed = !meteredConnection
+  val shouldAutoplay by remember { derivedStateOf { !userPaused && autoplayAllowed } }
+
+  val youtubePlayerView = remember {
+    buildYoutubePlayerView(
+      context,
+      lifecycleOwner.lifecycle,
+      videoId,
+      youtubePlayerTracker,
+      shouldMute,
+      autoplayAllowed
+    )
+  }
+
+  LaunchedEffect(shouldPause) {
+    if (shouldPause) {
+      youtubePlayer?.pause()
+    } else {
+      if (shouldAutoplay) {
+        youtubePlayer?.play()
+      }
+    }
+  }
+
+  DisposableEffect(lifecycleOwner) {
+    val observer = LifecycleEventObserver { _, event ->
+      when (event) {
+        Lifecycle.Event.ON_STOP -> {
+          //This condition is used to fix an issue where the video appears to
+          //restart when the app goes to background and returns to foreground
+          if (youtubePlayerTracker.currentSecond > 0f)
+            youtubePlayer?.seekTo(youtubePlayerTracker.currentSecond)
+        }
+
+        Lifecycle.Event.ON_RESUME -> {
+          if (shouldAutoplay) {
+            youtubePlayer?.play()
+          }
+        }
+
+        else -> {}
+      }
+    }
+
+    lifecycleOwner.lifecycle.addObserver(observer)
+
+    onDispose {
+      lifecycleOwner.lifecycle.removeObserver(observer)
+      youtubePlayerView.release()
+    }
+  }
+
+  youtubePlayerView.addYouTubePlayerListener(object : AbstractYouTubePlayerListener() {
+    override fun onReady(youTubePlayer: YouTubePlayer) {
+      youtubePlayer = youTubePlayer
+    }
+
+    override fun onMuteChanged(
+      youTubePlayer: YouTubePlayer,
+      isMuted: Boolean,
+    ) {
+      videoSettingsViewModel.setShouldMute(isMuted)
+    }
+
+    override fun onStateChange(
+      youTubePlayer: YouTubePlayer,
+      state: PlayerConstants.PlayerState,
+    ) {
+      when (state) {
+        PlayerConstants.PlayerState.PAUSED -> {
+          if (showFullscreen) {
+            userPaused = true
+          }
+        }
+
+        PlayerConstants.PlayerState.PLAYING -> {
+          if (showFullscreen) {
+            userPaused = false
+          }
+        }
+
+        else -> {}
+      }
+    }
+  })
+
+  if (!showFullscreen) {
+    Box {
+      AndroidView(
+        modifier = modifier,
+        factory = {
+          youtubePlayerView.removeSelf()
+          youtubePlayerView.toggleAccessibility(false)
+          youtubePlayerView
+        },
+        update = {
+          youtubePlayerView.getYouTubePlayerWhenReady(object : YouTubePlayerCallback {
+            override fun onYouTubePlayer(youTubePlayer: YouTubePlayer) {
+              youTubePlayer.hideVideoTitle()
+              youTubePlayer.hidePlayerControls()
+            }
+          })
+        }
+      )
+      Box(
+        modifier = modifier.clickable {
+          showFullscreen = true
+        }
+      )
+      IconButton(
+        modifier = Modifier
+          .padding(top = 4.dp, end = 16.dp)
+          .clip(CircleShape)
+          .size(32.dp)
+          .background(greyLight.copy(alpha = 0.4f))
+          .align(Alignment.TopEnd),
+        onClick = {
+          if (shouldMute) youtubePlayer?.unMute() else youtubePlayer?.mute()
+        }
+      ) {
+        Icon(
+          imageVector = if (shouldMute) AppTheme.icons.Muted else AppTheme.icons.Unmuted,
+          contentDescription = if (shouldMute) "Muted" else "Unmuted",
+          tint = Color.Unspecified
+        )
+      }
+    }
+  } else {
+    Dialog(
+      onDismissRequest = {
+        showFullscreen = false
+      },
+      properties = DialogProperties(
+        usePlatformDefaultWidth = false
+      )
+    ) {
+      Box(
+        modifier = Modifier
+          .fillMaxSize()
+          .background(agBlack)
+      ) {
+        AndroidView(
+          modifier = Modifier.fillMaxSize(),
+          factory = {
+            youtubePlayerView.contentDescription = contentDesc
+            youtubePlayerView.toggleAccessibility(true)
+            youtubePlayerView
+          },
+          update = {
+            youtubePlayerView.getYouTubePlayerWhenReady(object : YouTubePlayerCallback {
+              override fun onYouTubePlayer(youTubePlayer: YouTubePlayer) {
+                youTubePlayer.showPlayerControls()
+                youTubePlayer.showVideoTitle()
+              }
+            })
+          }
+        )
+        Image(
+          imageVector = AppTheme.icons.LeftArrow,
+          contentDescription = stringResource(id = R.string.button_back_title),
+          contentScale = ContentScale.Crop,
+          modifier = Modifier
+            .clickable { showFullscreen = false }
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .size(32.dp)
+        )
+      }
+    }
+  }
+}
+
+fun buildYoutubePlayerView(
+  context: Context,
+  lifecycle: Lifecycle,
+  videoId: String,
+  youtubePlayerTracker: YouTubePlayerTracker,
+  startMuted: Boolean,
+  autoplay: Boolean,
+): YouTubePlayerView {
+  val youtubePlayerView = YouTubePlayerView(context)
+  lifecycle.addObserver(youtubePlayerView)
+  youtubePlayerView.enableAutomaticInitialization = false
+
+  val youtubeListener = object : AbstractYouTubePlayerListener() {
+    override fun onReady(youTubePlayer: YouTubePlayer) {
+      youTubePlayer.addListener(youtubePlayerTracker)
+
+      if (autoplay)
+        youTubePlayer.loadVideo(videoId, youtubePlayerTracker.currentSecond)
+      else
+        youTubePlayer.cueVideo(videoId, youtubePlayerTracker.currentSecond)
+    }
+  }
+
+  val iFramePlayerOptions = IFramePlayerOptions.Builder()
+    .apply {
+      rel(0)
+      controls(1)
+      ivLoadPolicy(3)
+      ccLoadPolicy(1)
+      modestBranding(0)
+      langPref(context.resources?.configuration?.locale?.language ?: "en")
+      if (startMuted) mute(1)
+    }.build()
+
+  youtubePlayerView.initialize(youtubeListener, iFramePlayerOptions)
+
+  return youtubePlayerView
+}
+
+fun View?.removeSelf() {
+  this ?: return
+  val parentView = parent as? ViewGroup ?: return
+  parentView.removeView(this)
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/videos/repository/VideoSettingsRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/videos/repository/VideoSettingsRepository.kt
@@ -1,0 +1,18 @@
+package com.dti.hub.videos.repository
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class VideoSettingsRepository @Inject constructor() {
+
+  private val shouldVideosMute = MutableStateFlow(true)
+
+  suspend fun setShouldVideosMute(shouldMute: Boolean) {
+    shouldVideosMute.emit(shouldMute)
+  }
+
+  fun shouldVideosMute(): Flow<Boolean> = shouldVideosMute
+}

--- a/extensions/src/main/java/cm/aptoide/pt/extensions/DateExtensions.kt
+++ b/extensions/src/main/java/cm/aptoide/pt/extensions/DateExtensions.kt
@@ -1,8 +1,8 @@
 package cm.aptoide.pt.extensions
 
-import android.icu.text.DateFormat
+import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-fun Date.getPatternFormat(skeleton: String = "dd MMMM") =
-  DateFormat.getPatternInstance(skeleton, Locale.getDefault()).format(this)!!
+fun Date.toFormattedString(pattern: String = "dd MMMM") =
+  SimpleDateFormat(pattern, Locale.getDefault()).format(this) ?: ""

--- a/extensions/src/main/java/cm/aptoide/pt/extensions/StringExtensions.kt
+++ b/extensions/src/main/java/cm/aptoide/pt/extensions/StringExtensions.kt
@@ -7,3 +7,8 @@ import java.util.Locale
 fun String.parseDate(pattern: String = "yyyy-MM-dd HH:mm:ss"): Date {
   return SimpleDateFormat(pattern, Locale.getDefault()).parse(this)!!
 }
+
+fun String.isYoutubeURL(): Boolean {
+  val pattern = "^(http(s)?://)?((w){3}.)?youtu(be|.be)?(\\.com)?/.+"
+  return matches(Regex(pattern))
+}

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/AppUiState.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/AppUiState.kt
@@ -1,10 +1,21 @@
 package cm.aptoide.pt.feature_apps.presentation
 
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_apps.data.randomApp
 
 sealed class AppUiState {
   data class Idle(val app: App) : AppUiState()
   object Loading : AppUiState()
   object NoConnection : AppUiState()
   object Error : AppUiState()
+}
+
+class AppUiStateProvider : PreviewParameterProvider<AppUiState> {
+  override val values: Sequence<AppUiState> = sequenceOf(
+    AppUiState.Idle(randomApp),
+    AppUiState.Loading,
+    AppUiState.NoConnection,
+    AppUiState.Error
+  )
 }


### PR DESCRIPTION
**What does this PR do?**

**PR in draft, waiting for the permissions view UI and the editorials card design updates.**

   - Updates the app view UI to match the design.
   - Adds the missing Related and Info tabs, including the tab row to access them.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2471](https://aptoide.atlassian.net/browse/APP-2471)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2471](https://aptoide.atlassian.net/browse/APP-2471)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2471]: https://aptoide.atlassian.net/browse/APP-2471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2471]: https://aptoide.atlassian.net/browse/APP-2471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ