### PR TITLE
[APP-2519] Improve app item lists previews

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/CategoryDetailView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/CategoryDetailView.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CollectionInfo
 import androidx.compose.ui.semantics.collectionInfo
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraphBuilder
 import com.aptoide.android.aptoidegames.R
@@ -31,10 +32,9 @@ import com.aptoide.android.aptoidegames.toolbar.AppGamesTopBar
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
-import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
+import cm.aptoide.pt.feature_apps.presentation.AppsListUiStateProvider
 import cm.aptoide.pt.feature_apps.presentation.categoryApps
-import kotlin.random.Random
 
 const val categoryDetailRoute = "category/{title}/{name}"
 
@@ -154,14 +154,13 @@ fun CategoryAppsList(
 
 @PreviewDark
 @Composable
-fun CategoryDetailViewPreview() {
-  val uiStateFake = AppsListUiState.Idle(List(Random.nextInt(until = 20)) {
-    randomApp
-  })
+fun CategoryDetailViewPreview(
+  @PreviewParameter(AppsListUiStateProvider::class) uiState: AppsListUiState,
+) {
   CategoryDetailView(
     title = "Action",
     categoryName = "Action",
-    uiState = uiStateFake,
+    uiState = uiState,
     onError = {},
     navigateBack = {},
     navigate = {},

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
@@ -28,6 +28,7 @@ import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
+import cm.aptoide.pt.feature_apps.presentation.previewAppsListIdleState
 import cm.aptoide.pt.feature_apps.presentation.rememberAppsByTag
 import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.randomBundle
@@ -169,7 +170,7 @@ private fun RealAppsGridBundlePreview() {
 private fun AppsRowViewPreview() {
   AptoideTheme {
     AppsRowView(
-      appsList = listOf(randomApp, randomApp, randomApp, randomApp),
+      appsList = previewAppsListIdleState.apps,
       navigate = {},
     )
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselAppView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselAppView.kt
@@ -23,8 +23,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
-import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
+import cm.aptoide.pt.feature_apps.presentation.previewAppsListIdleState
 import cm.aptoide.pt.feature_apps.presentation.rememberAppsByTag
 import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.randomBundle
@@ -173,9 +173,7 @@ private fun RealCarouselBundlePreview() {
   AptoideTheme {
     RealCarouselBundle(
       bundle = randomBundle,
-      uiState = AppsListUiState.Idle(
-        apps = listOf(randomApp, randomApp, randomApp),
-      ),
+      uiState = previewAppsListIdleState,
       navigate = {}
     )
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselLargeAppView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselLargeAppView.kt
@@ -27,13 +27,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
-import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState.Empty
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState.Error
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState.Idle
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState.Loading
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState.NoConnection
+import cm.aptoide.pt.feature_apps.presentation.previewAppsListIdleState
 import cm.aptoide.pt.feature_apps.presentation.rememberAppsByTag
 import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.randomBundle
@@ -203,9 +203,7 @@ fun RealCarouselLargeBundlePreview() {
   AptoideTheme {
     RealCarouselLargeBundle(
       bundle = randomBundle,
-      uiState = Idle(
-        apps = listOf(randomApp, randomApp, randomApp)
-      ),
+      uiState = previewAppsListIdleState,
       navigate = {},
     )
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MoreBundleView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MoreBundleView.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.semantics.CollectionInfo
 import androidx.compose.ui.semantics.collectionInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.navArgument
@@ -24,8 +23,8 @@ import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.getRandomString
 import cm.aptoide.pt.feature_apps.data.App
-import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
+import cm.aptoide.pt.feature_apps.presentation.AppsListUiStateProvider
 import cm.aptoide.pt.feature_apps.presentation.rememberAppsByTag
 import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
@@ -35,7 +34,6 @@ import com.aptoide.android.aptoidegames.home.NoConnectionView
 import com.aptoide.android.aptoidegames.installer.presentation.InstallViewShort
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.toolbar.AppGamesTopBar
-import kotlin.random.Random
 
 const val seeMoreRoute =
   "seeMore/{title}/{tag}?originSection={originSection}&bundleSource={bundleSource}"
@@ -150,21 +148,6 @@ private fun AppsList(
 
 @PreviewDark
 @Composable
-private fun MoreBundleViewIdlePreview() {
-  AptoideTheme {
-    MoreBundleViewContent(
-      uiState = AppsListUiState.Idle(List(size = Random.nextInt(15)) { randomApp }),
-      title = getRandomString(range = 1..5, capitalize = true),
-      reload = {},
-      noNetworkReload = {},
-      navigateBack = {},
-      navigate = {},
-    )
-  }
-}
-
-@PreviewDark
-@Composable
 private fun MoreBundleViewPreview(
   @PreviewParameter(AppsListUiStateProvider::class) uiState: AppsListUiState,
 ) {
@@ -178,14 +161,4 @@ private fun MoreBundleViewPreview(
       navigate = {},
     )
   }
-}
-
-class AppsListUiStateProvider : PreviewParameterProvider<AppsListUiState> {
-  override val values: Sequence<AppsListUiState> = sequenceOf(
-    AppsListUiState.Idle(List(size = Random.nextInt(15)) { randomApp }),
-    AppsListUiState.Loading,
-    AppsListUiState.Empty,
-    AppsListUiState.NoConnection,
-    AppsListUiState.Error
-  )
 }

--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadUiState.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadUiState.kt
@@ -1,7 +1,11 @@
 package cm.aptoide.pt.download_view.presentation
 
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import cm.aptoide.pt.install_manager.dto.Constraints
 import cm.aptoide.pt.install_manager.dto.Constraints.NetworkType.ANY
+import kotlin.random.Random
+import kotlin.random.nextInt
+import kotlin.random.nextLong
 
 val defaultResolver: ConstraintsResolver = { _, onResult ->
   onResult(
@@ -71,4 +75,28 @@ enum class ExecutionBlocker {
   QUEUE,
   CONNECTION,
   UNMETERED,
+}
+
+class DownloadUiStateProvider : PreviewParameterProvider<DownloadUiState> {
+  override val values: Sequence<DownloadUiState> = sequenceOf(
+    DownloadUiState.Install(installWith = {}),
+    DownloadUiState.Waiting(action = null),
+    DownloadUiState.Downloading(
+      size = Random.nextLong(5000000L..300000000L),
+      downloadProgress = Random.nextInt(0..100),
+      cancel = {}
+    ),
+    DownloadUiState.Installing(
+      size = Random.nextLong(5000000L..300000000L),
+      installProgress = Random.nextInt(0..100),
+    ),
+    DownloadUiState.Uninstalling,
+    DownloadUiState.Installed(
+      open = {},
+      uninstall = {}
+    ),
+    DownloadUiState.Outdated(open = {}, updateWith = {}, uninstall = {}),
+    DownloadUiState.Error(retryWith = {}),
+    DownloadUiState.ReadyToInstall(cancel = {})
+  )
 }

--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/ViewModelProvider.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/ViewModelProvider.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import cm.aptoide.pt.download_view.domain.model.PayloadMapper
-import cm.aptoide.pt.download_view.presentation.DownloadUiState.Install
 import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.install_manager.InstallManager
@@ -31,7 +30,7 @@ class InjectionsProvider @Inject constructor(
 @Composable
 fun rememberDownloadState(app: App): DownloadUiState? = runPreviewable(
   preview = {
-    Install(installWith = {})
+    DownloadUiStateProvider().values.toList().random()
   },
   real = {
     val injectionsProvider = hiltViewModel<InjectionsProvider>()

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/AppsListUiState.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/AppsListUiState.kt
@@ -1,6 +1,10 @@
 package cm.aptoide.pt.feature_apps.presentation
 
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_apps.data.randomApp
+import kotlin.random.Random
+import kotlin.random.nextInt
 
 sealed class AppsListUiState {
   data class Idle(val apps: List<App>) : AppsListUiState()
@@ -9,3 +13,16 @@ sealed class AppsListUiState {
   object NoConnection : AppsListUiState()
   object Error : AppsListUiState()
 }
+
+class AppsListUiStateProvider : PreviewParameterProvider<AppsListUiState> {
+  override val values: Sequence<AppsListUiState> = sequenceOf(
+    AppsListUiState.Idle(List(Random.nextInt(1..12)) { randomApp }),
+    AppsListUiState.Loading,
+    AppsListUiState.Empty,
+    AppsListUiState.NoConnection,
+    AppsListUiState.Error
+  )
+}
+
+val previewAppsListIdleState
+  get() = AppsListUiState.Idle(List(Random.nextInt(1..12)) { randomApp })


### PR DESCRIPTION
**What does this PR do?**

   - Improves app items lists previews by adding more PreviewParameterProvider's for uistates and adding a random state for the rememberDownloadState previewable. 

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2519](https://aptoide.atlassian.net/browse/APP-2519)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2519](https://aptoide.atlassian.net/browse/APP-2519)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2519]: https://aptoide.atlassian.net/browse/APP-2519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2519]: https://aptoide.atlassian.net/browse/APP-2519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ