### PR TITLE
[APP-2426] Update aptoide games domains

### DIFF
--- a/app-games/build.gradle.kts
+++ b/app-games/build.gradle.kts
@@ -23,7 +23,7 @@ android {
     versionName = AndroidConfig.VERSION_NAME
 
     buildConfigField("String", "MARKET_NAME", "\"aptoide-games\"")
-    buildConfigField("String", "STORE_DOMAIN", "\"https://ws75.aptoide.com/api/7.20221201/\"")
+    buildConfigField("String", "STORE_DOMAIN", "\"https://ws75.aptoide.com/api/7/\"")
     buildConfigField("String", "SEARCH_BUZZ_DOMAIN", "\"https://buzz.aptoide.com:10002\"")
     buildConfigField(
       type = "String",

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/di/RepositoryModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/di/RepositoryModule.kt
@@ -59,7 +59,7 @@ class RepositoryModule {
   @Provides
   @DefaultEditorialUrl
   fun provideDefaultEditorialUrl(): String =
-    "${BuildConfig.STORE_DOMAIN}user/action/item/cards/get/type=CURATION_1/limit=10/store_name=${BuildConfig.MARKET_NAME}/aptoide_uid=0/?subtype=COLLECTION&aab=1&aptoide_vercode=${BuildConfig.VERSION_CODE}"
+    "${BuildConfig.STORE_DOMAIN}user/action/item/cards/get/type=CURATION_1/limit=10/store_name=${BuildConfig.MARKET_NAME}/aptoide_uid=1/?subtype=COLLECTION&aab=1&aptoide_vercode=${BuildConfig.VERSION_CODE}"
 
   @Singleton
   @Provides

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/di/RepositoryModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/di/RepositoryModule.kt
@@ -53,7 +53,7 @@ class RepositoryModule {
   @Singleton
   @Provides
   @WidgetsUrl
-  fun provideWidgetsUrl(): String = "getStoreWidgets?limit=25"
+  fun provideWidgetsUrl(): String = "dt/getWidgets?limit=25"
 
   @Singleton
   @Provides

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -99,7 +99,7 @@ fun NavGraphBuilder.gamesScreen(
 fun BundlesScreen(
   navigate: (String) -> Unit,
 ) {
-  val (viewState, loadFreshHomeBundles) = bundlesList(context = "home_games")
+  val (viewState, loadFreshHomeBundles) = bundlesList()
 
   val isRefreshing = (viewState.type == BundlesViewUiStateType.RELOADING)
 


### PR DESCRIPTION
**What does this PR do?**

   - Updates the getWidgets endpoint and removes the context filter from the request.
   - Updates the editorials URL by changing te aptoide_uid query parameter.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2426](https://aptoide.atlassian.net/browse/APP-2426)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2426](https://aptoide.atlassian.net/browse/APP-2426)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2426]: https://aptoide.atlassian.net/browse/APP-2426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2426]: https://aptoide.atlassian.net/browse/APP-2426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ