### PR TITLE
[APP-2454] Make install view short work

### DIFF
--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/InstallPackageInfoMapperImpl.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/InstallPackageInfoMapperImpl.kt
@@ -2,17 +2,22 @@ package cm.aptoide.pt.installer
 
 import android.os.Environment
 import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_apps.domain.AppMetaUseCase
 import cm.aptoide.pt.install_info_mapper.domain.InstallPackageInfoMapper
 import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import cm.aptoide.pt.install_manager.dto.InstallationFile
 import cm.aptoide.pt.install_manager.dto.InstallationFile.Type.OBB_PATCH
 
-class InstallPackageInfoMapperImpl : InstallPackageInfoMapper {
+class InstallPackageInfoMapperImpl(private val appMetaUseCase: AppMetaUseCase) :
+  InstallPackageInfoMapper {
   override suspend fun map(app: App): InstallPackageInfo = InstallPackageInfo(
     versionCode = app.versionCode.toLong(),
     installationFiles = mutableSetOf<InstallationFile>()
       .apply {
-        with(app.file) {
+        with(
+          app.file.takeIf { it.path.isNotEmpty() }
+            ?: appMetaUseCase.getMetaInfo(app.packageName).file
+        ) {
           add(
             InstallationFile(
               name = fileName,

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/di/AptoideInstallerModule.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/di/AptoideInstallerModule.kt
@@ -1,6 +1,7 @@
 package cm.aptoide.pt.installer.di
 
 import android.content.Context
+import cm.aptoide.pt.feature_apps.domain.AppMetaUseCase
 import cm.aptoide.pt.install_info_mapper.domain.InstallPackageInfoMapper
 import cm.aptoide.pt.installer.InstallPackageInfoMapperImpl
 import cm.aptoide.pt.installer.platform.InstallEvents
@@ -50,7 +51,8 @@ object AptoideInstallerModule {
 
   @Singleton
   @Provides
-  fun providePayloadMapper(): InstallPackageInfoMapper = InstallPackageInfoMapperImpl()
+  fun providePayloadMapper(appMetaUseCase: AppMetaUseCase): InstallPackageInfoMapper =
+    InstallPackageInfoMapperImpl(appMetaUseCase)
 }
 
 @Qualifier

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AppsRepository.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AppsRepository.kt
@@ -8,6 +8,8 @@ interface AppsRepository {
 
   suspend fun getApp(packageName: String, bypassCache: Boolean = false): App
 
+  suspend fun getMeta(packageName: String, bypassCache: Boolean = false): App
+
   suspend fun getRecommended(path: String, bypassCache: Boolean = false): List<App>
 
   suspend fun getCategoryAppsList(categoryName: String): List<App>

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AptoideAppsRepository.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AptoideAppsRepository.kt
@@ -6,6 +6,7 @@ import cm.aptoide.pt.aptoide_network.data.network.base_response.BaseV7ListRespon
 import cm.aptoide.pt.feature_apps.data.model.AppJSON
 import cm.aptoide.pt.feature_apps.data.model.CampaignUrls
 import cm.aptoide.pt.feature_apps.data.model.GetAppResponse
+import cm.aptoide.pt.feature_apps.data.model.GetMetaResponse
 import cm.aptoide.pt.feature_apps.data.model.VideoTypeJSON
 import cm.aptoide.pt.feature_apps.domain.Rating
 import cm.aptoide.pt.feature_apps.domain.Store
@@ -84,6 +85,21 @@ internal class AptoideAppsRepository @Inject constructor(
         bypassCache = if (bypassCache) CacheConstants.NO_CACHE else null
       )
         .nodes.meta.data
+        .toDomainModel(
+          campaignRepository = campaignRepository,
+          campaignUrlNormalizer = campaignUrlNormalizer,
+          adListId = UUID.randomUUID().toString()
+        )
+    }
+
+  override suspend fun getMeta(packageName: String, bypassCache: Boolean): App =
+    withContext(scope.coroutineContext) {
+
+      appsRemoteDataSource.getMeta(
+        path = packageName,
+        storeName = if (packageName != "com.appcoins.wallet") storeName else null,
+        bypassCache = if (bypassCache) CacheConstants.NO_CACHE else null
+      ).data
         .toDomainModel(
           campaignRepository = campaignRepository,
           campaignUrlNormalizer = campaignUrlNormalizer,
@@ -191,6 +207,14 @@ internal class AptoideAppsRepository @Inject constructor(
       @Query("aab") aab: Int = 1,
       @Header(CacheConstants.CACHE_CONTROL_HEADER) bypassCache: String?,
     ): GetAppResponse
+
+    @GET("app/getMeta/")
+    suspend fun getMeta(
+      @Query(value = "package_name", encoded = true) path: String,
+      @Query("store_name") storeName: String? = null,
+      @Query("aab") aab: Int = 1,
+      @Header(CacheConstants.CACHE_CONTROL_HEADER) bypassCache: String?,
+    ): GetMetaResponse
 
     @GET("apps/getRecommended/{query}")
     suspend fun getRecommendedAppsList(

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/model/GetMetaResponse.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/model/GetMetaResponse.kt
@@ -1,0 +1,7 @@
+package cm.aptoide.pt.feature_apps.data.model
+
+import androidx.annotation.Keep
+import cm.aptoide.pt.aptoide_network.data.network.base_response.BaseV7Response
+
+@Keep
+internal data class GetMetaResponse(var data: AppJSON) : BaseV7Response()

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
@@ -1,0 +1,11 @@
+package cm.aptoide.pt.feature_apps.domain
+
+import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_apps.data.AppsRepository
+import javax.inject.Inject
+
+class AppMetaUseCase @Inject constructor(private val appsRepository: AppsRepository) {
+
+  suspend fun getMetaInfo(packageName: String): App =
+    appsRepository.getMeta(packageName = packageName)
+}


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix an issue with the InstallViewShorts. When the install button is clicked, it now includes a check to see if the app has a path. If the path is empty, the AppMetaUseCase will be called to retrieve the app's path.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] See by commit

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2454](https://aptoide.atlassian.net/browse/APP-2454)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2454](https://aptoide.atlassian.net/browse/APP-2454)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2454]: https://aptoide.atlassian.net/browse/APP-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2454]: https://aptoide.atlassian.net/browse/APP-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ