### PR TITLE
[APP-2445] Fix app name in carousels

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselAppView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselAppView.kt
@@ -2,6 +2,7 @@ package com.aptoide.android.aptoidegames.feature_apps.presentation
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -21,6 +22,8 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import cm.aptoide.pt.download_view.presentation.DownloadUiState
+import cm.aptoide.pt.download_view.presentation.rememberDownloadState
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
@@ -96,7 +99,6 @@ private fun CarouselListView(
     Box(
       modifier
         .width(280.dp)
-        .height(184.dp)
         .background(color = Color.Transparent)
     ) {
       CarouselAppView(
@@ -116,6 +118,16 @@ private fun CarouselAppView(
   app: App,
   onClick: () -> Unit,
 ) {
+  val downloadUiState = rememberDownloadState(app = app)
+
+  val appNameMaxLines = if (
+    !(downloadUiState is DownloadUiState.Install
+      || downloadUiState is DownloadUiState.Outdated
+      || downloadUiState is DownloadUiState.Installed)
+  ) {
+    1
+  } else 2
+
   Column(
     modifier = Modifier
       .requiredWidth(280.dp)
@@ -145,24 +157,25 @@ private fun CarouselAppView(
         modifier = Modifier
           .padding(start = 8.dp, end = 8.dp)
           .weight(1f),
+        verticalArrangement = Arrangement.Center
       ) {
         Text(
           text = app.name,
           modifier = Modifier
-            .wrapContentHeight()
-            .weight(1f)
-            .clearAndSetSemantics { },
+            .clearAndSetSemantics { }
+            .wrapContentHeight(unbounded = true),
           color = Palette.White,
-          maxLines = 2,
+          maxLines = appNameMaxLines,
           overflow = TextOverflow.Ellipsis,
           style = AGTypography.DescriptionGames
         )
-        ProgressText(app = app, showVersionName = false)
+        ProgressText(
+          modifier = Modifier.wrapContentHeight(unbounded = true, align = Alignment.Top),
+          app = app,
+          showVersionName = false
+        )
       }
-      InstallViewShort(
-        app = app,
-        cancelable = false
-      )
+      InstallViewShort(app = app)
     }
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselLargeAppView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselLargeAppView.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.semantics.collectionInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import cm.aptoide.pt.download_view.presentation.DownloadUiState
+import cm.aptoide.pt.download_view.presentation.rememberDownloadState
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
@@ -121,8 +123,7 @@ private fun CarouselLargeListView(
       .semantics {
         collectionInfo = CollectionInfo(1, appsList.size)
       }
-      .fillMaxWidth()
-      .wrapContentHeight(),
+      .fillMaxWidth(),
     state = lazyListState,
     horizontalArrangement = Arrangement.spacedBy(16.dp),
     contentPadding = PaddingValues(horizontal = 16.dp)
@@ -145,6 +146,16 @@ private fun CarouselLargeAppView(
   app: App,
   onClick: () -> Unit,
 ) {
+  val downloadUiState = rememberDownloadState(app = app)
+
+  val appNameMaxLines = if (
+    !(downloadUiState is DownloadUiState.Install
+      || downloadUiState is DownloadUiState.Outdated
+      || downloadUiState is DownloadUiState.Installed)
+  ) {
+    1
+  } else 2
+
   Column(
     modifier = Modifier
       .semantics(mergeDescendants = true) { }
@@ -173,26 +184,23 @@ private fun CarouselLargeAppView(
         modifier = Modifier
           .padding(start = 8.dp, end = 8.dp)
           .weight(1f),
+        verticalArrangement = Arrangement.Center
       ) {
         Text(
+          modifier = Modifier.wrapContentHeight(unbounded = true),
           text = app.name,
-          modifier = Modifier
-            .wrapContentHeight()
-            .weight(1f),
           color = Palette.White,
-          maxLines = 2,
+          maxLines = appNameMaxLines,
           overflow = TextOverflow.Ellipsis,
           style = AGTypography.DescriptionGames
         )
         ProgressText(
+          modifier = Modifier.wrapContentHeight(unbounded = true, align = Alignment.Top),
           app = app,
           showVersionName = false
         )
       }
-      InstallViewShort(
-        app = app,
-        cancelable = false
-      )
+      InstallViewShort(app = app)
     }
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/PublisherTakeOverBundle.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/PublisherTakeOverBundle.kt
@@ -14,16 +14,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
@@ -39,9 +36,7 @@ import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.randomBundle
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
-import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
-import com.aptoide.android.aptoidegames.design_system.PrimarySmallButton
 import com.aptoide.android.aptoidegames.drawables.banners.getChessPatternBanner
 import com.aptoide.android.aptoidegames.home.HorizontalPagerView
 import com.aptoide.android.aptoidegames.home.LoadingBundleView
@@ -49,6 +44,8 @@ import com.aptoide.android.aptoidegames.home.SeeMoreView
 import com.aptoide.android.aptoidegames.home.getSeeMoreRouteNavigation
 import com.aptoide.android.aptoidegames.home.translateOrKeep
 import com.aptoide.android.aptoidegames.installer.presentation.AppIconWProgress
+import com.aptoide.android.aptoidegames.installer.presentation.InstallViewShort
+import com.aptoide.android.aptoidegames.installer.presentation.ProgressText
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.theme.Palette
@@ -190,8 +187,7 @@ fun PublisherTakeOverListView(
           modifier = Modifier
             .padding(bottom = 8.dp)
             .width(280.dp)
-            .height(136.dp)
-            .clip(RoundedCornerShape(16.dp)),
+            .height(136.dp),
           data = app.featureGraphic,
           contentDescription = null,
         )
@@ -217,11 +213,12 @@ fun PublisherTakeOverListView(
               overflow = TextOverflow.Ellipsis,
               style = AGTypography.DescriptionGames
             )
+            ProgressText(
+              app = app,
+              showVersionName = false
+            )
           }
-          PrimarySmallButton(
-            onClick = {},
-            title = stringResource(id = R.string.button_install_title),
-          )
+          InstallViewShort(app = app)
         }
       }
     }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/PublisherTakeOverBundle.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/PublisherTakeOverBundle.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import cm.aptoide.pt.download_view.presentation.DownloadUiState
+import cm.aptoide.pt.download_view.presentation.rememberDownloadState
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
@@ -167,6 +169,16 @@ fun PublisherTakeOverListView(
     appsList = appsList,
     modifier = Modifier.padding(bottom = 24.dp)
   ) { modifier, page, app ->
+    val downloadUiState = rememberDownloadState(app = app)
+
+    val appNameMaxLines = if (
+      !(downloadUiState is DownloadUiState.Install
+        || downloadUiState is DownloadUiState.Outdated
+        || downloadUiState is DownloadUiState.Installed)
+    ) {
+      1
+    } else 2
+
     Box(
       modifier
         .width(280.dp)
@@ -204,16 +216,18 @@ fun PublisherTakeOverListView(
             modifier = Modifier
               .padding(start = 8.dp, end = 8.dp)
               .weight(1f),
+            verticalArrangement = Arrangement.Center
           ) {
             Text(
               text = app.name,
-              modifier = Modifier.wrapContentHeight(),
-              maxLines = 1,
+              modifier = Modifier.wrapContentHeight(unbounded = true),
+              maxLines = appNameMaxLines,
               color = Palette.White,
               overflow = TextOverflow.Ellipsis,
               style = AGTypography.DescriptionGames
             )
             ProgressText(
+              modifier = Modifier.wrapContentHeight(unbounded = true, align = Alignment.Top),
               app = app,
               showVersionName = false
             )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/ProgressText.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/ProgressText.kt
@@ -27,12 +27,14 @@ import kotlin.random.Random
 
 @Composable
 fun ProgressText(
+  modifier: Modifier = Modifier,
   app: App,
   showVersionName: Boolean = true,
 ) {
   val state = rememberDownloadState(app = app)
 
   ProgressTextContent(
+    modifier = modifier,
     app = app,
     state = state,
     showVersionName = showVersionName
@@ -41,6 +43,7 @@ fun ProgressText(
 
 @Composable
 private fun ProgressTextContent(
+  modifier: Modifier = Modifier,
   app: App,
   state: DownloadUiState?,
   showVersionName: Boolean,
@@ -67,6 +70,7 @@ private fun ProgressTextContent(
     is Installed,
     -> if (showVersionName) {
       Text(
+        modifier = modifier,
         text = text,
         style = AGTypography.InputsS,
         color = Palette.GreyLight,
@@ -81,6 +85,7 @@ private fun ProgressTextContent(
     is Installing,
     Uninstalling,
     -> Text(
+      modifier = modifier,
       text = text,
       style = AGTypography.InputsS,
       color = Palette.Primary,
@@ -89,7 +94,7 @@ private fun ProgressTextContent(
     )
 
     is Error,
-    -> GenericErrorLabel()
+    -> GenericErrorLabel(modifier = modifier)
   }
 }
 


### PR DESCRIPTION
**What does this PR do?**

   - Fixes the app name in carousels to have two lines when there is no download progress, and only one line if there is.
   - Also fixes some accessibility issues with the progress text in these items if the device's font is slightly larger.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] CarouselAppView.kt
- [ ] CarouselLargeAppView.kt
- [ ] ProgressText.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2445](https://aptoide.atlassian.net/browse/APP-2445)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2445](https://aptoide.atlassian.net/browse/APP-2445)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2445]: https://aptoide.atlassian.net/browse/APP-2445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2445]: https://aptoide.atlassian.net/browse/APP-2445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ