### PR TITLE
[APP-2551] Add exception handling in date parsing

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -363,15 +363,15 @@ fun AppInfoSection(
     )
     AppInfoRow(
       infoCategory = "Release",
-      infoContent = app.releaseDate.orEmpty()
-        .parseDate()
-        .toFormattedString(pattern = "d MMM yyyy")
+      infoContent = app.releaseDate
+        ?.parseDate()
+        ?.toFormattedString(pattern = "d MMM yyyy") ?: ""
     )
     AppInfoRow(
       infoCategory = "Updated on",
-      infoContent = app.releaseUpdateDate.orEmpty()
-        .parseDate(pattern = "yyyy-MM-dd")
-        .toFormattedString(pattern = "d MMM yyyy")
+      infoContent = app.updateDate
+        ?.parseDate(pattern = "yyyy-MM-dd")
+        ?.toFormattedString(pattern = "d MMM yyyy") ?: ""
     )
     AppInfoRow(
       infoCategory = "Download size",

--- a/extensions/src/main/java/cm/aptoide/pt/extensions/StringExtensions.kt
+++ b/extensions/src/main/java/cm/aptoide/pt/extensions/StringExtensions.kt
@@ -4,8 +4,11 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-fun String.parseDate(pattern: String = "yyyy-MM-dd HH:mm:ss"): Date {
-  return SimpleDateFormat(pattern, Locale.getDefault()).parse(this)!!
+fun String.parseDate(pattern: String = "yyyy-MM-dd HH:mm:ss"): Date? = try {
+  SimpleDateFormat(pattern, Locale.getDefault()).parse(this)!!
+} catch (t: Throwable) {
+  t.printStackTrace()
+  null
 }
 
 fun String.isYoutubeURL(): Boolean {


### PR DESCRIPTION
**What does this PR do?**

   - Adds exception handling to date parsing, since it could cause crashes in the app in case the original date string was null.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppViewScreen.kt
- [ ] StringExtensions.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2551](https://aptoide.atlassian.net/browse/APP-2551)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2551](https://aptoide.atlassian.net/browse/APP-2551)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2551]: https://aptoide.atlassian.net/browse/APP-2551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2551]: https://aptoide.atlassian.net/browse/APP-2551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ