### PR TITLE
[DT-1280] - Update gradle and gradle plugin versions

### DIFF
--- a/aptoide-account-manager/build.gradle
+++ b/aptoide-account-manager/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion Integer.parseInt(project.COMPILE_SDK_VERSION)
-  buildToolsVersion AndroidConfig.BUILD_TOOLS
 
   defaultConfig {
     minSdkVersion project.MINIMUM_SDK_VERSION

--- a/aptoide-analytics-core/build.gradle
+++ b/aptoide-analytics-core/build.gradle
@@ -16,7 +16,6 @@ buildscript{
 
 android {
   compileSdkVersion Integer.parseInt(project.COMPILE_SDK_VERSION)
-  buildToolsVersion AndroidConfig.BUILD_TOOLS
 
   defaultConfig {
     minSdkVersion project.MINIMUM_SDK_VERSION

--- a/aptoide-analytics-default-implementation/build.gradle
+++ b/aptoide-analytics-default-implementation/build.gradle
@@ -17,7 +17,6 @@ buildscript{
 
 android {
   compileSdkVersion Integer.parseInt(project.COMPILE_SDK_VERSION)
-  buildToolsVersion AndroidConfig.BUILD_TOOLS
 
   defaultConfig {
     minSdkVersion project.MINIMUM_SDK_VERSION

--- a/aptoide-views/build.gradle
+++ b/aptoide-views/build.gradle
@@ -5,7 +5,6 @@ apply plugin: 'kotlin-kapt'
 android {
 
   compileSdkVersion Integer.parseInt(project.COMPILE_SDK_VERSION)
-  buildToolsVersion AndroidConfig.BUILD_TOOLS
 
   defaultConfig {
     minSdkVersion project.LIB_MINIMUM_SDK_VERSION

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 dependencies {
   implementation("org.jetbrains.kotlin:kotlin-stdlib:1.8.22")
   // Android gradle plugin will allow us to access Android specific features
-  implementation("com.android.tools.build:gradle:8.1.1")
+  implementation("com.android.tools.build:gradle:8.4.1")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22")
   // Required by HILT. To override older version pushed by gradle plugin
   implementation("com.squareup:javapoet:1.13.0")

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -2,7 +2,6 @@ object AndroidConfig {
   const val COMPILE_SDK = 34
   const val MIN_SDK = 26
   const val TARGET_SDK = 33
-  const val BUILD_TOOLS = "33.0.2"
 
   const val VERSION_CODE = 10000
   const val VERSION_NAME = "10.0.0.0-alpha01"

--- a/buildSrc/src/main/kotlin/GradleDependency.kt
+++ b/buildSrc/src/main/kotlin/GradleDependency.kt
@@ -1,7 +1,6 @@
 object GradlePluginVersion {
-  const val ANDROID_GRADLE = "8.1.1"
+  const val ANDROID_GRADLE = "8.4.1"
   const val KOTLIN = CoreVersion.KOTLIN
-  const val KOTLIN_JVM = "1.8"
   const val HILT = "2.46.1"
   const val GMS = "4.3.15"
   const val CRASHLYTICS = "2.9.5"
@@ -18,7 +17,6 @@ object GradlePluginId {
   const val ANDROID_LIBRARY = "com.android.library"
   const val KOTLIN_KAPT = "kotlin-kapt"
   const val KOTLIN_KSP = "com.google.devtools.ksp"
-  const val KOTLIN_JVM = "org.jetbrains.kotlin.jvm"
   const val KOTLIN_ANDROID = "org.jetbrains.kotlin.android"
   const val KOTLIN_SERIALIZATION = "org.jetbrains.kotlin.plugin.serialization"
   const val HILT_PLUGIN = "dagger.hilt.android.plugin"

--- a/buildSrc/src/main/kotlin/plugin/AndroidModulePlugin.kt
+++ b/buildSrc/src/main/kotlin/plugin/AndroidModulePlugin.kt
@@ -3,7 +3,6 @@ package plugin
 import AndroidConfig
 import GradlePluginId
 import JavaLibrary
-import KeyHelper
 import LibraryDependency
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.LibraryExtension
@@ -25,7 +24,6 @@ class AndroidModulePlugin : Plugin<Project> {
         compileSdk = AndroidConfig.COMPILE_SDK
 
         defaultConfig {
-          buildToolsVersion = AndroidConfig.BUILD_TOOLS
           minSdk = AndroidConfig.MIN_SDK
           targetSdk = AndroidConfig.TARGET_SDK
         }

--- a/crashreports/build.gradle
+++ b/crashreports/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion Integer.parseInt(project.COMPILE_SDK_VERSION)
-  buildToolsVersion AndroidConfig.BUILD_TOOLS
 
   defaultConfig {
     minSdkVersion project.LIB_MINIMUM_SDK_VERSION

--- a/dataprovider/build.gradle
+++ b/dataprovider/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion Integer.parseInt(project.COMPILE_SDK_VERSION)
-  buildToolsVersion AndroidConfig.BUILD_TOOLS
 
   defaultConfig {
     minSdkVersion project.MINIMUM_SDK_VERSION

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 19 14:22:12 WEST 2023
+#Thu Jun 06 12:23:10 WEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion Integer.parseInt(project.COMPILE_SDK_VERSION)
-  buildToolsVersion AndroidConfig.BUILD_TOOLS
 
   defaultConfig {
     minSdkVersion project.MINIMUM_SDK_VERSION


### PR DESCRIPTION
**What does this PR do?**

It updates AGP and Gradle versions, from 8.1.1 to 8.2.2 and from 8.0 to 8.2, respectively.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] gradle-wrapper.properties
- [ ] aptoide-client-v8.buildSrc/build.gradle.kts
- [ ] GradleDependency.kt

**How should this be manually tested?**

  See if no build is broken and everything's working accordingly.
  Flow on how to test this or QA Tickets related to this use-case: [DT-1280](https://aptoide.atlassian.net/browse/DT-1280)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1280](https://aptoide.atlassian.net/browse/DT-1280)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-1280]: https://aptoide.atlassian.net/browse/DT-1280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1280]: https://aptoide.atlassian.net/browse/DT-1280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ