### PR TITLE
[APP-2347] Settings billing terms of use url

### DIFF
--- a/app-games/build.gradle.kts
+++ b/app-games/build.gradle.kts
@@ -42,6 +42,11 @@ android {
     )
     buildConfigField(
       type = "String",
+      name = "BT_URL",
+      value = "\"https://en.aptoide.com/company/legal?section=aptoidegamesbilling\""
+    )
+    buildConfigField(
+      type = "String",
       name = "PP_URL",
       value = "\"https://en.aptoide.com/company/legal?section=privacy\""
     )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -49,6 +49,7 @@ import com.aptoide.android.aptoidegames.design_system.PrimarySmallOutlinedButton
 import com.aptoide.android.aptoidegames.drawables.icons.getAptoideLogo
 import com.aptoide.android.aptoidegames.drawables.icons.getForward
 import com.aptoide.android.aptoidegames.network.presentation.NetworkPreferencesViewModel
+import com.aptoide.android.aptoidegames.terms_and_conditions.btUrl
 import com.aptoide.android.aptoidegames.terms_and_conditions.ppUrl
 import com.aptoide.android.aptoidegames.terms_and_conditions.tcUrl
 import com.aptoide.android.aptoidegames.theme.AGTypography
@@ -79,6 +80,7 @@ fun NavGraphBuilder.settingsScreen(
     },
     onPrivacyPolicyClick = { UrlActivity.open(context, context.ppUrl) },
     onTermsConditionsClick = { UrlActivity.open(context, context.tcUrl) },
+    onBillingTermsClick = { UrlActivity.open(context, context.btUrl) },
     sendFeedback = {
       SupportActivity.open(context, "feedback")
     },

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/terms_and_conditions/LegalUrls.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/terms_and_conditions/LegalUrls.kt
@@ -6,6 +6,8 @@ import com.aptoide.android.aptoidegames.BuildConfig
 
 val Context.tcUrl get() = BuildConfig.TC_URL.addLanguage(this)
 
+val Context.btUrl get() = BuildConfig.BT_URL.addLanguage(this)
+
 val Context.ppUrl get() = BuildConfig.PP_URL.addLanguage(this)
 
 val paymentsTermsOfUseUrl get() = ""


### PR DESCRIPTION
**What does this PR do?**

This PR aims to add a URL to billing terms on settings

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] LegalUrls.kt
- [ ] build.gradle.kts
- [ ] SettingsScreen.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2347](https://aptoide.atlassian.net/browse/APP-2347)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2347](https://aptoide.atlassian.net/browse/APP-2347)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2347]: https://aptoide.atlassian.net/browse/APP-2347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2347]: https://aptoide.atlassian.net/browse/APP-2347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ