### PR TITLE
[App-2580] Bottom navigation items spacing

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.selection.selectableGroup
@@ -85,16 +84,13 @@ fun RowScope.AddBottomNavigationItem(
   onItemClicked: () -> Unit,
 ) {
   BottomNavigationItem(
-    modifier = Modifier
-      .defaultMinSize(minWidth = 74.dp)
-      .weight(1f, fill = false),
     selected = isSelected,
     onClick = onItemClicked,
     alwaysShowLabel = true,
     icon = {
       Icon(
         imageVector = item.icon,
-        contentDescription = null
+        contentDescription = null,
       )
     },
     label = {


### PR DESCRIPTION
**What does this PR do?**

   Fix the bottom navigation icons spacing

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppGamesBottomBar.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2580](https://aptoide.atlassian.net/browse/APP-2580)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2580](https://aptoide.atlassian.net/browse/APP-2580)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2580]: https://aptoide.atlassian.net/browse/APP-2580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2580]: https://aptoide.atlassian.net/browse/APP-2580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ