### PR TITLE
[DT-1291] Fix network connection detection logic

### DIFF
--- a/network-listener/src/main/java/cm/aptoide/pt/network_listener/NetworkConnectionImpl.kt
+++ b/network-listener/src/main/java/cm/aptoide/pt/network_listener/NetworkConnectionImpl.kt
@@ -35,14 +35,16 @@ class NetworkConnectionImpl @Inject constructor(
       networkCapabilities: NetworkCapabilities,
     ) {
       super.onCapabilitiesChanged(network, networkCapabilities)
-      if (networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)) {
-        listener?.invoke(UNMETERED)
-        _states.tryEmit(UNMETERED)
-        WifiWorker.cancel(context)
-      } else {
-        listener?.invoke(METERED)
-        _states.tryEmit(METERED)
-        WifiWorker.enqueue(context)
+      if (networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)) {
+        if (networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)) {
+          listener?.invoke(UNMETERED)
+          _states.tryEmit(UNMETERED)
+          WifiWorker.cancel(context)
+        } else {
+          listener?.invoke(METERED)
+          _states.tryEmit(METERED)
+          WifiWorker.enqueue(context)
+        }
       }
     }
 
@@ -68,7 +70,7 @@ val Context.networkState
     Context.CONNECTIVITY_SERVICE
   ) as ConnectivityManager).run {
     getNetworkCapabilities(activeNetwork)
-      ?.takeIf { it.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) }
+      ?.takeIf { it.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) }
       ?.let {
         if (it.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)) {
           UNMETERED


### PR DESCRIPTION
**What does this PR do?**

   Adds check for validated network connection. 

   To make sure the network is actually available when emitting the event.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] NetworkConnectionImpl.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-1291](https://aptoide.atlassian.net/browse/DT-1291)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1291](https://aptoide.atlassian.net/browse/DT-1291)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[DT-1291]: https://aptoide.atlassian.net/browse/DT-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1291]: https://aptoide.atlassian.net/browse/DT-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ