### PR TITLE
[APP-2607] Fix text colors in aptoide games payment error views

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/AGPaymentScreenContentProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/AGPaymentScreenContentProvider.kt
@@ -31,7 +31,7 @@ class AGPaymentScreenContentProvider : PaymentScreenContentProvider {
       context.setContent {
         val navController = rememberNavController()
 
-        AptoideTheme(darkTheme = true) {
+        AptoideTheme(darkTheme = false) {
           purchaseRequest
             ?.also {
               NavigationGraph(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/ErrorViews.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/ErrorViews.kt
@@ -66,6 +66,7 @@ fun PortraitPaymentErrorView(
           .clickable(onClick = onContactUsClick),
         text = stringResource(R.string.contact_support_title),
         textAlign = TextAlign.Center,
+        color = Palette.Black,
         style = AGTypography.InputsL,
         textDecoration = TextDecoration.Underline,
       )
@@ -111,6 +112,7 @@ fun LandscapePaymentErrorView(
           .clickable(onClick = onContactUsClick),
         text = stringResource(R.string.contact_support_title),
         textAlign = TextAlign.Center,
+        color = Palette.Black,
         style = AGTypography.InputsL,
         textDecoration = TextDecoration.Underline,
       )
@@ -191,6 +193,7 @@ private fun ErrorViewContent(
     Text(
       modifier = Modifier.padding(top = 16.dp),
       text = message,
+      color = Palette.Black,
       style = AGTypography.Title,
       textAlign = TextAlign.Center,
     )
@@ -198,6 +201,7 @@ private fun ErrorViewContent(
       Text(
         modifier = Modifier.padding(top = 8.dp),
         text = description,
+        color = Palette.Black,
         style = AGTypography.DescriptionGames,
         textAlign = TextAlign.Center,
       )


### PR DESCRIPTION
**What does this PR do?**

   - Fixes missing text colors in aptoide games payment error views.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AGPaymentScreenContentProvider.kt
- [ ] ErrorViews.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2607](https://aptoide.atlassian.net/browse/APP-2607)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2607](https://aptoide.atlassian.net/browse/APP-2607)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2607]: https://aptoide.atlassian.net/browse/APP-2607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2607]: https://aptoide.atlassian.net/browse/APP-2607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ