### PR TITLE
[APP-2619] - Send AppPromoClick on Categories & See All Views

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/CategoryDetailView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/CategoryDetailView.kt
@@ -118,14 +118,26 @@ fun CategoryDetailView(
           if (index == 0) {
             LargeAppItem(
               app = app,
-              onClick = { navigateToApp(app, index) }
+              onClick = {
+                genericAnalytics.sendAppPromoClick(
+                  app = app,
+                  analyticsContext = analyticsContext.copy(itemPosition = index)
+                )
+                navigateToApp(app, index)
+              }
             ) {
               installViewShort()
             }
           } else {
             AppItem(
               app = app,
-              onClick = { navigateToApp(app, index) },
+              onClick = {
+                genericAnalytics.sendAppPromoClick(
+                  app = app,
+                  analyticsContext = analyticsContext.copy(itemPosition = index)
+                )
+                navigateToApp(app, index)
+              },
             ) {
               installViewShort()
             }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MoreBundleView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MoreBundleView.kt
@@ -124,6 +124,9 @@ private fun AppsList(
   appList: List<App>,
   navigate: (String) -> Unit,
 ) {
+  val analyticsContext = AnalyticsContext.current
+  val genericAnalytics = rememberGenericAnalytics()
+
   Spacer(modifier = Modifier.fillMaxWidth())
   LazyColumn(
     modifier = Modifier
@@ -135,6 +138,10 @@ private fun AppsList(
       AppItem(
         app = app,
         onClick = {
+          genericAnalytics.sendAppPromoClick(
+            app = app,
+            analyticsContext = analyticsContext.copy(itemPosition = index)
+          )
           navigate(
             buildAppViewRoute(app.packageName)
               .withItemPosition(index)


### PR DESCRIPTION
**What does this PR do?**

 It adds the analytics event app_promo_click to the MoreBundleView and to the CategoryDetailView


**Database changed?**

No

**Where should the reviewer start?**

- [ ]  MoreBundleView.kt
- [ ]  CategoryDetailView.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2619](https://aptoide.atlassian.net/browse/APP-2619)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2619](https://aptoide.atlassian.net/browse/APP-2619)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2619]: https://aptoide.atlassian.net/browse/APP-2619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2619]: https://aptoide.atlassian.net/browse/APP-2619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ