### PR TITLE
[APP-2614] Aptoide games APKFY flow implementation

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideGamesBottomSheet.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideGamesBottomSheet.kt
@@ -1,0 +1,71 @@
+package com.aptoide.android.aptoidegames
+
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun AptoideGamesBottomSheet(
+  navigate: (String) -> Unit = {},
+  content: @Composable (show: (BottomSheetContent?) -> Unit) -> Unit,
+) {
+  val coroutineScope = rememberCoroutineScope()
+  var bottomSheetContent: BottomSheetContent? by remember { mutableStateOf(null) }
+
+  val sheetState = rememberModalBottomSheetState(
+    initialValue = ModalBottomSheetValue.Hidden,
+  )
+
+  val onCloseBottomSheetClick: () -> Unit = {
+    coroutineScope.launch {
+      sheetState.hide()
+      bottomSheetContent = null
+    }
+  }
+
+  if (sheetState.currentValue != ModalBottomSheetValue.Hidden) {
+    DisposableEffect(Unit) {
+      onDispose {
+        bottomSheetContent = null
+      }
+    }
+  }
+
+  ModalBottomSheetLayout(
+    sheetState = sheetState,
+    scrimColor = Color.Black.copy(alpha = 0.60f),
+    sheetContent = {
+      bottomSheetContent?.Draw(
+        dismiss = onCloseBottomSheetClick,
+        navigate = navigate,
+      )
+    },
+    content = {
+      content {
+        bottomSheetContent = it
+        coroutineScope.launch {
+          sheetState.show()
+        }
+      }
+    }
+  )
+}
+
+interface BottomSheetContent {
+  @Composable
+  fun Draw(
+    dismiss: () -> Unit,
+    navigate: (String) -> Unit,
+  )
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideGamesBottomSheet.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideGamesBottomSheet.kt
@@ -1,5 +1,11 @@
 package com.aptoide.android.aptoidegames
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
@@ -11,8 +17,21 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.aptoide.android.aptoidegames.theme.Palette
 import kotlinx.coroutines.launch
+
+interface BottomSheetContent {
+  @Composable
+  fun Draw(
+    dismiss: () -> Unit,
+    navigate: (String) -> Unit,
+  )
+}
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -45,6 +64,8 @@ fun AptoideGamesBottomSheet(
   ModalBottomSheetLayout(
     sheetState = sheetState,
     scrimColor = Color.Black.copy(alpha = 0.60f),
+    sheetBackgroundColor = Palette.Black,
+    sheetElevation = 0.dp,
     sheetContent = {
       bottomSheetContent?.Draw(
         dismiss = onCloseBottomSheetClick,
@@ -62,10 +83,19 @@ fun AptoideGamesBottomSheet(
   )
 }
 
-interface BottomSheetContent {
-  @Composable
-  fun Draw(
-    dismiss: () -> Unit,
-    navigate: (String) -> Unit,
-  )
+@Composable
+fun BottomSheetHeader() {
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .height(36.dp),
+    contentAlignment = Alignment.Center
+  ) {
+    Box(
+      modifier = Modifier
+        .size(width = 32.dp, height = 4.dp)
+        .clip(RoundedCornerShape(100.dp))
+        .background(Palette.Grey)
+    )
+  }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/ApkfyBottomSheetContent.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/ApkfyBottomSheetContent.kt
@@ -1,0 +1,46 @@
+package com.aptoide.android.aptoidegames.apkfy
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import cm.aptoide.pt.feature_apps.data.App
+import com.aptoide.android.aptoidegames.BottomSheetContent
+import com.aptoide.android.aptoidegames.BottomSheetHeader
+import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
+import com.aptoide.android.aptoidegames.feature_apps.presentation.AppItem
+import com.aptoide.android.aptoidegames.installer.presentation.InstallViewShort
+import com.aptoide.android.aptoidegames.theme.AGTypography
+import com.aptoide.android.aptoidegames.theme.Palette
+
+class ApkfyBottomSheetContent(private val app: App) : BottomSheetContent {
+  @Composable override fun Draw(
+    dismiss: () -> Unit,
+    navigate: (String) -> Unit,
+  ) {
+    Column(
+      modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 50.dp)
+    ) {
+      BottomSheetHeader()
+      Text(
+        modifier = Modifier.padding(top = 11.dp, bottom = 22.dp),
+        text = stringResource(id = R.string.apkfy_install_title),
+        color = Palette.White,
+        style = AGTypography.Title
+      )
+      AppItem(
+        app = app,
+        onClick = {
+          navigate(buildAppViewRoute(app.packageName))
+          dismiss()
+        }
+      ) {
+        InstallViewShort(app)
+      }
+    }
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/ApkfyViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/ApkfyViewModel.kt
@@ -1,0 +1,73 @@
+package com.aptoide.android.aptoidegames.apkfy
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cm.aptoide.pt.extensions.runPreviewable
+import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_apps.domain.AppMetaUseCase
+import cm.aptoide.pt.feature_mmp.apkfy.domain.ApkfyManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ApkfyViewModel @Inject constructor(
+  private val apkfyManager: ApkfyManager,
+  private val appMetaUseCase: AppMetaUseCase,
+) : ViewModel() {
+
+  private val viewModelState = MutableStateFlow<App?>(value = null)
+
+  val uiState = viewModelState
+    .stateIn(
+      viewModelScope,
+      SharingStarted.Eagerly,
+      viewModelState.value
+    )
+
+  init {
+    viewModelScope.launch {
+      try {
+        apkfyManager.getApkfy()?.run {
+          packageName?.let {
+            var app = appMetaUseCase.getMetaInfo(it)
+
+            if (oemId != null) {
+              val oemIdQuery = "?oemid=${oemId}"
+              app = app.copy(
+                file = app.file.run {
+                  copy(
+                    path = path + oemIdQuery,
+                    path_alt = path_alt + oemIdQuery
+                  )
+                }
+              )
+            }
+
+            viewModelState.update { app }
+          }
+        }
+      } catch (e: Throwable) {
+        e.printStackTrace()
+      }
+    }
+  }
+}
+
+@Composable
+fun rememberApkfyApp() = runPreviewable(
+  preview = { null },
+  real = {
+    val vm = hiltViewModel<ApkfyViewModel>()
+    val app by vm.uiState.collectAsState()
+    app
+  }
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
@@ -17,6 +17,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import cm.aptoide.pt.extensions.animatedComposable
 import cm.aptoide.pt.extensions.staticComposable
+import com.aptoide.android.aptoidegames.AptoideGamesBottomSheet
 import com.aptoide.android.aptoidegames.appview.appViewScreen
 import com.aptoide.android.aptoidegames.appview.permissions.appPermissionsScreen
 import com.aptoide.android.aptoidegames.bottom_bar.AppGamesBottomBar
@@ -48,35 +49,37 @@ fun MainView(navController: NavHostController) {
     { navController.popBackStack(navController.graph.startDestinationId, false) }
   //Forced theme do be dark to always apply dark background, for now.
   AptoideTheme(darkTheme = true) {
-    Scaffold(
-      snackbarHost = {
-        SnackbarHost(
-          hostState = snackBarHostState,
-          snackbar = { AptoideSnackBar(it) }
-        )
-      },
-      bottomBar = {
-        AppGamesBottomBar(navController = navController)
-      },
-      topBar = {
-        AppGamesToolBar(navigate = navController::navigateTo, goBackHome)
-      }
-    ) { padding ->
-      if (showNotificationsRationaleDialog) {
-        NotificationsPermissionRequester(
-          onDismiss = notificationsPermissionViewModel::dismissDialog
-        )
-      }
+    AptoideGamesBottomSheet { showBottomSheet ->
+      Scaffold(
+        snackbarHost = {
+          SnackbarHost(
+            hostState = snackBarHostState,
+            snackbar = { AptoideSnackBar(it) }
+          )
+        },
+        bottomBar = {
+          AppGamesBottomBar(navController = navController)
+        },
+        topBar = {
+          AppGamesToolBar(navigate = navController::navigateTo, goBackHome)
+        }
+      ) { padding ->
+        if (showNotificationsRationaleDialog) {
+          NotificationsPermissionRequester(
+            onDismiss = notificationsPermissionViewModel::dismissDialog
+          )
+        }
 
-      Box(modifier = Modifier.padding(padding)) {
-        NavigationGraph(
-          navController,
-          showSnack = {
-            coroutineScope.launch {
-              snackBarHostState.showSnackbar(message = it)
+        Box(modifier = Modifier.padding(padding)) {
+          NavigationGraph(
+            navController,
+            showSnack = {
+              coroutineScope.launch {
+                snackBarHostState.showSnackbar(message = it)
+              }
             }
-          }
-        )
+          )
+        }
       }
     }
     UserActionDialog()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
@@ -9,8 +9,10 @@ import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
@@ -18,6 +20,8 @@ import androidx.navigation.compose.NavHost
 import cm.aptoide.pt.extensions.animatedComposable
 import cm.aptoide.pt.extensions.staticComposable
 import com.aptoide.android.aptoidegames.AptoideGamesBottomSheet
+import com.aptoide.android.aptoidegames.apkfy.ApkfyBottomSheetContent
+import com.aptoide.android.aptoidegames.apkfy.rememberApkfyApp
 import com.aptoide.android.aptoidegames.appview.appViewScreen
 import com.aptoide.android.aptoidegames.appview.permissions.appPermissionsScreen
 import com.aptoide.android.aptoidegames.bottom_bar.AppGamesBottomBar
@@ -47,9 +51,15 @@ fun MainView(navController: NavHostController) {
   val coroutineScope = rememberCoroutineScope()
   val goBackHome: () -> Unit =
     { navController.popBackStack(navController.graph.startDestinationId, false) }
+
+  val apkfyApp = rememberApkfyApp()
+  var apkfyShown by remember { mutableStateOf(false) }
+
   //Forced theme do be dark to always apply dark background, for now.
   AptoideTheme(darkTheme = true) {
-    AptoideGamesBottomSheet { showBottomSheet ->
+    AptoideGamesBottomSheet(
+      navigate = navController::navigateTo
+    ) { showBottomSheet ->
       Scaffold(
         snackbarHost = {
           SnackbarHost(
@@ -79,6 +89,11 @@ fun MainView(navController: NavHostController) {
               }
             }
           )
+        }
+
+        if(apkfyApp != null && !apkfyShown) {
+          showBottomSheet(ApkfyBottomSheetContent(apkfyApp))
+          apkfyShown = true
         }
       }
     }

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AptoideAppsRepository.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AptoideAppsRepository.kt
@@ -32,7 +32,10 @@ internal class AptoideAppsRepository @Inject constructor(
   private val scope: CoroutineScope,
 ) : AppsRepository {
 
-  override suspend fun getAppsList(url: String, bypassCache: Boolean): List<App> =
+  override suspend fun getAppsList(
+    url: String,
+    bypassCache: Boolean,
+  ): List<App> =
     withContext(scope.coroutineContext) {
       if (url.isEmpty()) {
         throw IllegalStateException()
@@ -78,7 +81,10 @@ internal class AptoideAppsRepository @Inject constructor(
         ?: throw IllegalStateException()
     }
 
-  override suspend fun getApp(packageName: String, bypassCache: Boolean): App =
+  override suspend fun getApp(
+    packageName: String,
+    bypassCache: Boolean,
+  ): App =
     withContext(scope.coroutineContext) {
       appsRemoteDataSource.getApp(
         path = packageName,
@@ -93,7 +99,10 @@ internal class AptoideAppsRepository @Inject constructor(
         )
     }
 
-  override suspend fun getMeta(packageName: String, bypassCache: Boolean): App =
+  override suspend fun getMeta(
+    packageName: String,
+    bypassCache: Boolean,
+  ): App =
     withContext(scope.coroutineContext) {
 
       appsRemoteDataSource.getMeta(
@@ -108,7 +117,10 @@ internal class AptoideAppsRepository @Inject constructor(
         )
     }
 
-  override suspend fun getRecommended(path: String, bypassCache: Boolean): List<App> =
+  override suspend fun getRecommended(
+    path: String,
+    bypassCache: Boolean,
+  ): List<App> =
     withContext(scope.coroutineContext) {
       val randomAdListId = UUID.randomUUID().toString()
       appsRemoteDataSource.getRecommendedAppsList(


### PR DESCRIPTION
**What does this PR do?**

   - Adds the AptoideGames APKFY flow implementation, including the bottom sheet that follows the design.
   - Changes the getMeta call to be able to fetch an app by app id.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  1.   Run the /download endpoint in the Aptoide MMP OpenAPI, with the package name of the app you want to test and an oemID.
  2. Perform a clean install on the app and check if the apkfy flow starts correctly and the bottom sheet shows up.

  Flow on how to test this or QA Tickets related to this use-case: [APP-2614](https://aptoide.atlassian.net/browse/APP-2614)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2614](https://aptoide.atlassian.net/browse/APP-2614)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2614]: https://aptoide.atlassian.net/browse/APP-2614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2614]: https://aptoide.atlassian.net/browse/APP-2614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ