### PR TITLE
[APP-2667] Replace getApp requests with getMeta

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -57,7 +57,7 @@ import cm.aptoide.pt.extensions.toFormattedString
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppUiState
-import cm.aptoide.pt.feature_apps.presentation.appViewModel
+import cm.aptoide.pt.feature_apps.presentation.rememberApp
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
 import cm.aptoide.pt.feature_editorial.presentation.relatedEditorialsCardViewModel
 import com.aptoide.android.aptoidegames.AppIconImage
@@ -118,10 +118,9 @@ fun AppViewScreen(
   navigate: (String) -> Unit,
   navigateBack: () -> Unit,
 ) {
-  val appViewModel = appViewModel(packageName = packageName, adListId = "")
+  val (uiState, reload) = rememberApp(packageName = packageName, adListId = "")
   val analyticsContext = AnalyticsContext.current
   val genericAnalytics = rememberGenericAnalytics()
-  val uiState by appViewModel.uiState.collectAsState()
 
   val editorialsCardViewModel = relatedEditorialsCardViewModel(packageName = packageName)
   val relatedEditorialsUiState by editorialsCardViewModel.uiState.collectAsState()
@@ -137,10 +136,8 @@ fun AppViewScreen(
 
   MainAppViewView(
     uiState = uiState,
-    reload = appViewModel::reload,
-    noNetworkReload = {
-      appViewModel.reload()
-    },
+    reload = reload,
+    noNetworkReload = reload,
     navigate = navigate,
     navigateBack = {
       genericAnalytics.sendBackButtonClick(analyticsContext)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/permissions/AppPermissionsView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/permissions/AppPermissionsView.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
@@ -24,7 +22,7 @@ import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.ScreenData
 import cm.aptoide.pt.feature_apps.presentation.AppUiState
 import cm.aptoide.pt.feature_apps.presentation.AppUiStateProvider
-import cm.aptoide.pt.feature_apps.presentation.appViewModel
+import cm.aptoide.pt.feature_apps.presentation.rememberApp
 import com.aptoide.android.aptoidegames.AppIconImage
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
 import com.aptoide.android.aptoidegames.design_system.IndeterminateCircularLoading
@@ -53,8 +51,7 @@ fun AppInfoPermissionsView(
   navigateBack: () -> Unit,
   packageName: String,
 ) {
-  val appViewModel = appViewModel(packageName = packageName, adListId = "")
-  val uiState by appViewModel.uiState.collectAsState()
+  val (uiState, _) = rememberApp(packageName = packageName, adListId = "")
 
   (uiState as? AppUiState.Idle)?.app?.run {
     AppInfoPermissionsViewContent(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/wallet/WalletInstallationScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/wallet/WalletInstallationScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,7 +33,7 @@ import cm.aptoide.pt.extensions.ScreenData
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.presentation.AppUiState
 import cm.aptoide.pt.feature_apps.presentation.AppUiStateProvider
-import cm.aptoide.pt.feature_apps.presentation.appViewModel
+import cm.aptoide.pt.feature_apps.presentation.rememberApp
 import cm.aptoide.pt.feature_home.domain.BundleSource
 import com.appcoins.payments.arch.PurchaseRequest
 import com.appcoins.payments.arch.emptyPurchaseRequest
@@ -52,8 +51,8 @@ import com.aptoide.android.aptoidegames.feature_payments.LoadingView
 import com.aptoide.android.aptoidegames.feature_payments.PortraitPaymentErrorView
 import com.aptoide.android.aptoidegames.feature_payments.PortraitPaymentsNoConnectionView
 import com.aptoide.android.aptoidegames.feature_payments.PurchaseInfoRow
-import com.aptoide.android.aptoidegames.installer.UserActionDialog
 import com.aptoide.android.aptoidegames.feature_payments.analytics.PaymentContext
+import com.aptoide.android.aptoidegames.installer.UserActionDialog
 import com.aptoide.android.aptoidegames.installer.analytics.AnalyticsInstallPackageInfoMapper
 import com.aptoide.android.aptoidegames.installer.forceInstallConstraints
 import com.aptoide.android.aptoidegames.installer.notifications.rememberInstallerNotifications
@@ -126,8 +125,7 @@ private fun PaymentsWalletInstallationBottomSheetView(
 ) {
   val genericAnalytics = rememberGenericAnalytics()
   val walletPaymentMethod = rememberWalletPaymentMethod(purchaseRequest)
-  val walletViewModel = appViewModel(packageName = "com.appcoins.wallet", adListId = "")
-  val uiState by walletViewModel.uiState.collectAsState()
+  val (uiState, _) = rememberApp(packageName = "com.appcoins.wallet", adListId = "")
 
   PaymentsWalletInstallationView(
     purchaseRequest = purchaseRequest,

--- a/app/src/main/java/cm/aptoide/pt/appview/AppViewScreen.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/AppViewScreen.kt
@@ -101,7 +101,7 @@ fun AppViewScreen(
   packageName: String = "",
   navigateBack: () -> Unit = {},
   navigate: (String) -> Unit = {},
-){
+) {
   val appViewModel = appViewModel(packageName = packageName, adListId = "")
   val uiState by appViewModel.uiState.collectAsState()
 
@@ -133,6 +133,7 @@ fun AppViewScreen(
     tabsList = tabsList
   )
 }
+
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @Composable
 fun MainAppViewView(
@@ -251,7 +252,7 @@ fun ViewPagerContent(
   selectedTab: AppViewTab,
   onSelectReportApp: (App) -> Unit,
   onAppClick: (String) -> Unit,
-  onRelatedContentClick: (String) -> Unit
+  onRelatedContentClick: (String) -> Unit,
 ) {
   when (selectedTab) {
     AppViewTab.DETAILS -> DetailsView(

--- a/app/src/main/java/cm/aptoide/pt/appview/AppViewScreen.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/AppViewScreen.kt
@@ -62,7 +62,7 @@ import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
 import cm.aptoide.pt.editorial.buildEditorialRoute
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.presentation.AppUiState
-import cm.aptoide.pt.feature_apps.presentation.appViewModel
+import cm.aptoide.pt.feature_apps.presentation.rememberApp
 import cm.aptoide.pt.feature_appview.presentation.AppViewTab
 import cm.aptoide.pt.feature_editorial.presentation.relatedEditorialsCardViewModel
 import cm.aptoide.pt.theme.AppTheme
@@ -102,8 +102,7 @@ fun AppViewScreen(
   navigateBack: () -> Unit = {},
   navigate: (String) -> Unit = {},
 ) {
-  val appViewModel = appViewModel(packageName = packageName, adListId = "")
-  val uiState by appViewModel.uiState.collectAsState()
+  val (uiState, _) = rememberApp(packageName = packageName, adListId = "")
 
   val editorialsCardViewModel = relatedEditorialsCardViewModel(packageName = packageName)
   val relatedEditorialsUiState by editorialsCardViewModel.uiState.collectAsState()

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppInfoUseCase.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppInfoUseCase.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.scopes.ViewModelScoped
 import javax.inject.Inject
 
 @ViewModelScoped
+@Suppress("unused")
 class AppInfoUseCase @Inject constructor(private val appsRepository: AppsRepository) {
 
   suspend fun getAppInfo(packageName: String): App =

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/AppViewModel.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/AppViewModel.kt
@@ -2,7 +2,7 @@ package cm.aptoide.pt.feature_apps.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import cm.aptoide.pt.feature_apps.domain.AppInfoUseCase
+import cm.aptoide.pt.feature_apps.domain.AppMetaUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
@@ -11,8 +11,8 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.IOException
 
-class AppViewModel constructor(
-  private val appInfoUseCase: AppInfoUseCase,
+class AppViewModel(
+  private val appMetaUseCase: AppMetaUseCase,
   private val packageName: String,
   private val adListId: String?,
 ) : ViewModel() {
@@ -34,7 +34,7 @@ class AppViewModel constructor(
     viewModelScope.launch {
       viewModelState.update { AppUiState.Loading }
       try {
-        val app = appInfoUseCase.getAppInfo(packageName)
+        val app = appMetaUseCase.getMetaInfo(packageName)
         app.campaigns?.adListId = adListId
         app.campaigns?.sendImpressionEvent()
         viewModelState.update { AppUiState.Idle(app) }

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/ViewModelProvider.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/ViewModelProvider.kt
@@ -30,7 +30,10 @@ class InjectionsProvider @Inject constructor(
 ) : ViewModel()
 
 @Composable
-fun appViewModel(packageName: String, adListId: String?): AppViewModel {
+fun appViewModel(
+  packageName: String,
+  adListId: String?,
+): AppViewModel {
   val injectionsProvider = hiltViewModel<InjectionsProvider>()
   return viewModel(
     viewModelStoreOwner = LocalContext.current as ViewModelStoreOwner,
@@ -72,7 +75,7 @@ fun appVersions(packageName: String): Pair<AppsListUiState, KFunction0<Unit>> {
 @Composable
 fun rememberAppsByTag(
   tag: String,
-  salt: String? = null
+  salt: String? = null,
 ): Pair<AppsListUiState, () -> Unit> = runPreviewable(
   preview = {
     AppsListUiState.Idle(List((0..50).random()) { randomApp }) to {}
@@ -99,7 +102,7 @@ fun rememberAppsByTag(
 @Composable
 fun eSkillsApps(
   tag: String,
-  salt: String? = null
+  salt: String? = null,
 ): Pair<AppsListUiState, KFunction0<Unit>> {
   val injectionsProvider = hiltViewModel<InjectionsProvider>()
   val vm: AppsListViewModel = viewModel(
@@ -122,7 +125,7 @@ fun eSkillsApps(
 @Composable
 fun categoryApps(
   categoryName: String,
-  salt: String? = null
+  salt: String? = null,
 ): Pair<AppsListUiState, KFunction0<Unit>> {
   val injectionsProvider = hiltViewModel<InjectionsProvider>()
   val vm: AppsListViewModel = viewModel(

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/ViewModelProvider.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/ViewModelProvider.kt
@@ -11,7 +11,7 @@ import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
 import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.feature_apps.data.randomApp
-import cm.aptoide.pt.feature_apps.domain.AppInfoUseCase
+import cm.aptoide.pt.feature_apps.domain.AppMetaUseCase
 import cm.aptoide.pt.feature_apps.domain.AppVersionsUseCase
 import cm.aptoide.pt.feature_apps.domain.AppsByTagUseCase
 import cm.aptoide.pt.feature_apps.domain.CategoryAppsUseCase
@@ -22,7 +22,7 @@ import kotlin.reflect.KFunction0
 
 @HiltViewModel
 class InjectionsProvider @Inject constructor(
-  val appInfoUseCase: AppInfoUseCase,
+  val appMetaUseCase: AppMetaUseCase,
   val appVersionsUseCase: AppVersionsUseCase,
   val appsByTagUseCase: AppsByTagUseCase,
   val eSkillsAppsUseCase: ESkillsAppsUseCase,
@@ -42,7 +42,7 @@ fun appViewModel(
       override fun <T : ViewModel> create(modelClass: Class<T>): T {
         @Suppress("UNCHECKED_CAST")
         return AppViewModel(
-          appInfoUseCase = injectionsProvider.appInfoUseCase,
+          appMetaUseCase = injectionsProvider.appMetaUseCase,
           packageName = packageName,
           adListId = adListId
         ) as T


### PR DESCRIPTION
**What does this PR do?**

   - Replaces getApp requests with getMeta in the AppViewModel.
   - Refactors the composable used to fetch the AppViewModel to be previewable. It now returns the ui state and the reload function instead of returning the ViewModel directly.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2667](https://aptoide.atlassian.net/browse/APP-2667)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2667](https://aptoide.atlassian.net/browse/APP-2667)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2667]: https://aptoide.atlassian.net/browse/APP-2667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2667]: https://aptoide.atlassian.net/browse/APP-2667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ