### PR TITLE
[APP-2614] Change apkfy app fetching logic

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/ApkfyBottomSheetContent.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/ApkfyBottomSheetContent.kt
@@ -12,7 +12,7 @@ import com.aptoide.android.aptoidegames.BottomSheetContent
 import com.aptoide.android.aptoidegames.BottomSheetHeader
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.presentation.OverrideAnalyticsAPKFY
-import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
+import com.aptoide.android.aptoidegames.appview.buildAppViewRouteByAppId
 import com.aptoide.android.aptoidegames.feature_apps.presentation.AppItem
 import com.aptoide.android.aptoidegames.installer.presentation.InstallViewShort
 import com.aptoide.android.aptoidegames.theme.AGTypography
@@ -37,7 +37,9 @@ class ApkfyBottomSheetContent(private val app: App) : BottomSheetContent {
         AppItem(
           app = app,
           onClick = {
-            navigateTo(buildAppViewRoute(app.packageName))
+            navigateTo(
+              buildAppViewRouteByAppId(appId = app.id, useStoreName = false)
+            )
             dismiss()
           }
         ) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -60,6 +60,7 @@ import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppUiState
 import cm.aptoide.pt.feature_apps.presentation.rememberAppBySource
+import cm.aptoide.pt.feature_apps.presentation.toAppIdParam
 import cm.aptoide.pt.feature_apps.presentation.toPackageNameParam
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
 import cm.aptoide.pt.feature_editorial.presentation.relatedEditorialsCardViewModel
@@ -127,6 +128,11 @@ fun appViewScreen() = ScreenData.withAnalytics(
 
 fun buildAppViewRoute(packageName: String): String =
   buildAppViewRouteBySource(packageName.toPackageNameParam())
+
+fun buildAppViewRouteByAppId(
+  appId: Long,
+  useStoreName: Boolean = true,
+): String = buildAppViewRouteBySource(appId.toAppIdParam(), useStoreName)
 
 fun buildAppViewRouteBySource(
   source: String,

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstallPackageInfoMapper.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstallPackageInfoMapper.kt
@@ -20,7 +20,7 @@ class AptoideInstallPackageInfoMapper @Inject constructor(
   private val dynamicSplitsUseCase: DynamicSplitsUseCase,
 ) : InstallPackageInfoMapper {
   override suspend fun map(app: App): InstallPackageInfo {
-    val appMeta = appMetaUseCase.getMetaInfo(app.packageName)
+    val appMeta = appMetaUseCase.getMetaInfoByAppId(appId = app.id, useStoreName = false)
 
     return InstallPackageInfo(
       versionCode = app.versionCode.toLong(),

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/App.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/App.kt
@@ -12,6 +12,7 @@ import kotlin.random.Random
 import kotlin.random.nextLong
 
 data class App(
+  val id: Long,
   val name: String,
   val packageName: String,
   val md5: String,
@@ -72,6 +73,7 @@ data class Obb(
 )
 
 val emptyApp = App(
+  id = 0,
   name = "",
   packageName = "",
   md5 = "",
@@ -126,6 +128,7 @@ val emptyApp = App(
 val randomApp
   get() =
     emptyApp.copy(
+      id = Random.nextLong(),
       name = getRandomString(range = 2..5, capitalize = true),
       packageName = getRandomString(range = 3..5, separator = "."),
       appSize = Random.nextLong(1_000_000L..1_000_000_000L),

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AptoideAppsRepository.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AptoideAppsRepository.kt
@@ -264,6 +264,7 @@ fun AppJSON.toDomainModel(
   campaignRepository: CampaignRepository,
   adListId: String,
 ) = App(
+  id = this.id!!,
   name = this.name!!,
   packageName = this.packageName!!,
   appSize = this.file.filesize + (this.obb?.main?.filesize ?: 0) + (this.obb?.patch?.filesize ?: 0),

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
@@ -16,5 +16,8 @@ class AppMetaUseCase @Inject constructor(private val appsRepository: AppsReposit
     )
 
   suspend fun getMetaInfoBySource(source: String): App =
-    appsRepository.getMetaBySource(source = source)
+    appsRepository.getMetaBySource(
+      source = source,
+      useStoreName = !source.contains("com.appcoins.wallet".toPackageNameParam())
+    )
 }

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
@@ -2,6 +2,7 @@ package cm.aptoide.pt.feature_apps.domain
 
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.AppsRepository
+import cm.aptoide.pt.feature_apps.presentation.toAppIdParam
 import cm.aptoide.pt.feature_apps.presentation.toPackageNameParam
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -13,6 +14,15 @@ class AppMetaUseCase @Inject constructor(private val appsRepository: AppsReposit
     appsRepository.getMetaBySource(
       source = packageName.toPackageNameParam(),
       useStoreName = packageName != "com.appcoins.wallet"
+    )
+
+  suspend fun getMetaInfoByAppId(
+    appId: Long,
+    useStoreName: Boolean = true,
+  ): App =
+    appsRepository.getMetaBySource(
+      source = appId.toAppIdParam(),
+      useStoreName = useStoreName
     )
 
   suspend fun getMetaInfoBySource(

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
@@ -10,12 +10,6 @@ import javax.inject.Singleton
 @Singleton
 class AppMetaUseCase @Inject constructor(private val appsRepository: AppsRepository) {
 
-  suspend fun getMetaInfo(packageName: String): App =
-    appsRepository.getMetaBySource(
-      source = packageName.toPackageNameParam(),
-      useStoreName = packageName != "com.appcoins.wallet"
-    )
-
   suspend fun getMetaInfoByAppId(
     appId: Long,
     useStoreName: Boolean = true,

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
@@ -15,9 +15,12 @@ class AppMetaUseCase @Inject constructor(private val appsRepository: AppsReposit
       useStoreName = packageName != "com.appcoins.wallet"
     )
 
-  suspend fun getMetaInfoBySource(source: String): App =
+  suspend fun getMetaInfoBySource(
+    source: String,
+    useStoreName: Boolean = true,
+  ): App =
     appsRepository.getMetaBySource(
       source = source,
-      useStoreName = !source.contains("com.appcoins.wallet".toPackageNameParam())
+      useStoreName = useStoreName && !source.contains("com.appcoins.wallet".toPackageNameParam())
     )
 }

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/AppViewModel.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/AppViewModel.kt
@@ -14,6 +14,7 @@ import java.io.IOException
 class AppViewModel(
   private val appMetaUseCase: AppMetaUseCase,
   private val source: String,
+  private val useStoreName: Boolean = true,
 ) : ViewModel() {
 
   private val viewModelState = MutableStateFlow<AppUiState>(AppUiState.Loading)
@@ -33,7 +34,7 @@ class AppViewModel(
     viewModelScope.launch {
       viewModelState.update { AppUiState.Loading }
       try {
-        val app = appMetaUseCase.getMetaInfoBySource(source)
+        val app = appMetaUseCase.getMetaInfoBySource(source = source, useStoreName = useStoreName)
         viewModelState.update { AppUiState.Idle(app) }
       } catch (e: Throwable) {
         Timber.w(e)

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/ViewModelProvider.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/ViewModelProvider.kt
@@ -180,3 +180,5 @@ fun categoryApps(
 }
 
 fun String.toPackageNameParam() = "package_name=$this"
+
+fun Long.toAppIdParam() = "app_id=$this"

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/ViewModelProvider.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/ViewModelProvider.kt
@@ -32,6 +32,7 @@ class InjectionsProvider @Inject constructor(
 @Composable
 fun rememberApp(
   packageName: String,
+  useStoreName: Boolean = true,
 ): Pair<AppUiState, () -> Unit> = runPreviewable(
   preview = { AppUiStateProvider().values.toSet().random() to {} },
   real = {
@@ -45,6 +46,7 @@ fun rememberApp(
           return AppViewModel(
             appMetaUseCase = injectionsProvider.appMetaUseCase,
             source = packageName.toPackageNameParam(),
+            useStoreName = useStoreName,
           ) as T
         }
       }
@@ -58,6 +60,7 @@ fun rememberApp(
 @Composable
 fun rememberAppBySource(
   source: String,
+  useStoreName: Boolean = true,
 ): Pair<AppUiState, () -> Unit> = runPreviewable(
   preview = { AppUiStateProvider().values.toSet().random() to {} },
   real = {
@@ -71,6 +74,7 @@ fun rememberAppBySource(
           return AppViewModel(
             appMetaUseCase = injectionsProvider.appMetaUseCase,
             source = source,
+            useStoreName = useStoreName,
           ) as T
         }
       }


### PR DESCRIPTION
**What does this PR do?**

   - Adds a method to getMeta by app id in the apps repository.
   - Changes the conditions logic to fetch the app in the ApkfyViewModel. It prioritizes app id over package name and it does not fetch if the package name is the same as the AptoideGames,.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppsRepository.kt
- [ ] AptoideAppsRepository.kt
- [ ] AppMetaStorelessUseCase.kt
- [ ] ApkfyViewModel.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2614](https://aptoide.atlassian.net/browse/APP-2614)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2614](https://aptoide.atlassian.net/browse/APP-2614)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2614]: https://aptoide.atlassian.net/browse/APP-2614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2614]: https://aptoide.atlassian.net/browse/APP-2614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ