### PR TITLE
[APP-2709] Add app links support

### DIFF
--- a/app-games/src/main/AndroidManifest.xml
+++ b/app-games/src/main/AndroidManifest.xml
@@ -35,6 +35,17 @@
 
         <data android:scheme="ag" />
       </intent-filter>
+
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <data android:path="/download"/>
+        <data android:path="/app"/>
+        <data android:scheme="http"/>
+        <data android:scheme="https"/>
+        <data android:host="*.aptoide.com"/>
+      </intent-filter>
       <!-- ${dataPlaceholder} -->
     </activity>
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -60,6 +60,7 @@ import cm.aptoide.pt.feature_apps.presentation.AppUiState
 import cm.aptoide.pt.feature_apps.presentation.rememberApp
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
 import cm.aptoide.pt.feature_editorial.presentation.relatedEditorialsCardViewModel
+import cm.aptoide.pt.feature_editorial.presentation.rememberRelatedEditorials
 import com.aptoide.android.aptoidegames.AppIconImage
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
@@ -122,9 +123,8 @@ fun AppViewScreen(
   val analyticsContext = AnalyticsContext.current
   val genericAnalytics = rememberGenericAnalytics()
 
-  val editorialsCardViewModel = relatedEditorialsCardViewModel(packageName = packageName)
-  val relatedEditorialsUiState by editorialsCardViewModel.uiState.collectAsState()
-  val tabsList by remember {
+  val relatedEditorialsUiState = rememberRelatedEditorials(packageName = packageName)
+  val tabsList by remember(relatedEditorialsUiState) {
     derivedStateOf {
       if (relatedEditorialsUiState.isNullOrEmpty()) {
         tabsList.filter { it != AppViewTab.RELATED }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -98,9 +98,20 @@ const val appViewRoute = "app/{source}"
 fun appViewScreen() = ScreenData.withAnalytics(
   route = appViewRoute,
   screenAnalyticsName = "AppView",
-  deepLinks = listOf(navDeepLink { uriPattern = BuildConfig.DEEP_LINK_SCHEMA + appViewRoute })
+  deepLinks = listOf(
+    navDeepLink { uriPattern = BuildConfig.DEEP_LINK_SCHEMA + appViewRoute },
+    navDeepLink { uriPattern = "https://{source}.{lang}.aptoide.com/{path}" },
+    navDeepLink { uriPattern = "https://{lang}.aptoide.com/{path}?{source}" }
+  )
 ) { arguments, navigate, navigateBack ->
-  val source = arguments?.getString("source")!!
+  val path = arguments?.getString("path") ?: ""
+
+  val source = when (path) {
+    "download" -> arguments?.getString("source")!!.split("&").first()
+    "app" -> "package_uname=${arguments?.getString("source")}"
+    else -> arguments?.getString("source")!!
+  }
+
   AppViewScreen(
     source = source,
     navigate = navigate,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/InstallerNotificationsBuilder.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/InstallerNotificationsBuilder.kt
@@ -14,6 +14,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
 import cm.aptoide.pt.extensions.isAllowed
+import cm.aptoide.pt.feature_apps.presentation.toPackageNameParam
 import cm.aptoide.pt.install_manager.Task.State
 import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.MainActivity
@@ -169,7 +170,7 @@ class InstallerNotificationsBuilder @Inject constructor(
     contentText: String,
     hasAction: Boolean = false,
   ): Notification {
-    val deepLink = buildAppViewDeepLinkUri(packageName)
+    val deepLink = buildAppViewDeepLinkUri(packageName.toPackageNameParam())
 
     val clickIntent = PendingIntent.getActivity(
       context,

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AppsRepository.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AppsRepository.kt
@@ -8,7 +8,7 @@ interface AppsRepository {
 
   suspend fun getApp(packageName: String, bypassCache: Boolean = false): App
 
-  suspend fun getMeta(packageName: String, bypassCache: Boolean = false): App
+  suspend fun getMetaBySource(source: String, bypassCache: Boolean = false): App
 
   suspend fun getRecommended(path: String, bypassCache: Boolean = false): List<App>
 

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AptoideAppsRepository.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AptoideAppsRepository.kt
@@ -99,15 +99,15 @@ internal class AptoideAppsRepository @Inject constructor(
         )
     }
 
-  override suspend fun getMeta(
-    packageName: String,
+  override suspend fun getMetaBySource(
+    source: String,
     bypassCache: Boolean,
   ): App =
     withContext(scope.coroutineContext) {
 
-      appsRemoteDataSource.getMeta(
-        path = packageName,
-        storeName = if (packageName != "com.appcoins.wallet") storeName else null,
+      appsRemoteDataSource.getMetaBySource(
+        path = source,
+        storeName = storeName,
         bypassCache = if (bypassCache) CacheConstants.NO_CACHE else null
       ).data
         .toDomainModel(
@@ -228,9 +228,9 @@ internal class AptoideAppsRepository @Inject constructor(
       @Header(CacheConstants.CACHE_CONTROL_HEADER) bypassCache: String?,
     ): GetAppResponse
 
-    @GET("app/getMeta/")
-    suspend fun getMeta(
-      @Query(value = "package_name", encoded = true) path: String,
+    @GET("app/getMeta/{source}")
+    suspend fun getMetaBySource(
+      @Path(value = "source", encoded = true) path: String,
       @Query("store_name") storeName: String? = null,
       @Query("aab") aab: Int = 1,
       @Header(CacheConstants.CACHE_CONTROL_HEADER) bypassCache: String?,

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
@@ -2,6 +2,7 @@ package cm.aptoide.pt.feature_apps.domain
 
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.AppsRepository
+import cm.aptoide.pt.feature_apps.presentation.toPackageNameParam
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -9,5 +10,8 @@ import javax.inject.Singleton
 class AppMetaUseCase @Inject constructor(private val appsRepository: AppsRepository) {
 
   suspend fun getMetaInfo(packageName: String): App =
-    appsRepository.getMeta(packageName = packageName)
+    appsRepository.getMetaBySource(source = packageName.toPackageNameParam())
+
+  suspend fun getMetaInfoBySource(source: String): App =
+    appsRepository.getMetaBySource(source = source)
 }

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/AppViewModel.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/AppViewModel.kt
@@ -13,7 +13,7 @@ import java.io.IOException
 
 class AppViewModel(
   private val appMetaUseCase: AppMetaUseCase,
-  private val packageName: String,
+  private val source: String,
   private val adListId: String?,
 ) : ViewModel() {
 
@@ -34,7 +34,7 @@ class AppViewModel(
     viewModelScope.launch {
       viewModelState.update { AppUiState.Loading }
       try {
-        val app = appMetaUseCase.getMetaInfo(packageName)
+        val app = appMetaUseCase.getMetaInfoBySource(source)
         app.campaigns?.adListId = adListId
         app.campaigns?.sendImpressionEvent()
         viewModelState.update { AppUiState.Idle(app) }

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/ViewModelProvider.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/ViewModelProvider.kt
@@ -45,7 +45,35 @@ fun rememberApp(
           @Suppress("UNCHECKED_CAST")
           return AppViewModel(
             appMetaUseCase = injectionsProvider.appMetaUseCase,
-            packageName = packageName,
+            source = packageName.toPackageNameParam(),
+            adListId = adListId
+          ) as T
+        }
+      }
+    )
+
+    val uiState by vm.uiState.collectAsState()
+    uiState to vm::reload
+  }
+)
+
+@Composable
+fun rememberAppBySource(
+  source: String,
+  adListId: String?,
+): Pair<AppUiState, () -> Unit> = runPreviewable(
+  preview = { AppUiStateProvider().values.toSet().random() to {} },
+  real = {
+    val injectionsProvider = hiltViewModel<InjectionsProvider>()
+    val vm: AppViewModel = viewModel(
+      viewModelStoreOwner = LocalContext.current as ViewModelStoreOwner,
+      key = "appView/$source",
+      factory = object : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+          @Suppress("UNCHECKED_CAST")
+          return AppViewModel(
+            appMetaUseCase = injectionsProvider.appMetaUseCase,
+            source = source,
             adListId = adListId
           ) as T
         }
@@ -150,3 +178,5 @@ fun categoryApps(
 
   return uiState to vm::reload
 }
+
+fun String.toPackageNameParam() = "package_name=$this"

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
@@ -69,6 +69,28 @@ fun relatedEditorialsCardViewModel(packageName: String): RelatedEditorialsCardVi
 }
 
 @Composable
+fun rememberRelatedEditorials(packageName: String): List<ArticleMeta>? = runPreviewable(
+  preview = { List((0..20).random()) { randomArticleMeta } },
+  real = {
+    val injectionsProvider = hiltViewModel<InjectionsProvider>()
+    val vm: RelatedEditorialsCardViewModel = viewModel(
+      key = "relatedEditorials/$packageName",
+      factory = object : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+          @Suppress("UNCHECKED_CAST")
+          return RelatedEditorialsCardViewModel(
+            packageName = packageName,
+            relatedArticlesMetaUseCase = injectionsProvider.relatedArticlesMetaUseCase,
+          ) as T
+        }
+      }
+    )
+    val uiState by vm.uiState.collectAsState()
+    uiState
+  }
+)
+
+@Composable
 fun editorialViewModel(articleId: String): EditorialViewModel {
   val injectionsProvider = hiltViewModel<InjectionsProvider>()
   return viewModel(


### PR DESCRIPTION
**What does this PR do?**
This PR aims to support app links so when the web user clicks on an App or downloads it gets redirected to Aptoide Games

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AndroidManifest.xml
- [ ] AppViewScreen

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2709](https://aptoide.atlassian.net/browse/APP-2709)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2709](https://aptoide.atlassian.net/browse/APP-2709)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2709]: https://aptoide.atlassian.net/browse/APP-2709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2709]: https://aptoide.atlassian.net/browse/APP-2709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ