### PR TITLE
[APP-2709] Add app links support

### DIFF
--- a/app-games/src/main/AndroidManifest.xml
+++ b/app-games/src/main/AndroidManifest.xml
@@ -48,6 +48,7 @@
         <data android:scheme="https" />
         <data android:host="*.aptoide.com" />
         <data android:path="/app" />
+        <data android:pathPattern="/editorial/.*" />
       </intent-filter>
     </activity>
 

--- a/app-games/src/main/AndroidManifest.xml
+++ b/app-games/src/main/AndroidManifest.xml
@@ -37,7 +37,18 @@
 
         <data android:scheme="ag" />
       </intent-filter>
-      <!-- ${dataPlaceholder} -->
+
+      <intent-filter android:autoVerify="true">
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.BROWSABLE" />
+        <category android:name="android.intent.category.DEFAULT" />
+
+        <data android:scheme="http" />
+        <data android:scheme="https" />
+        <data android:host="*.aptoide.com" />
+        <data android:path="/app" />
+      </intent-filter>
     </activity>
 
     <activity
@@ -51,9 +62,16 @@
         android:name="com.aptoide.android.aptoidegames.SupportActivity"
         android:configChanges="orientation|keyboardHidden"
         android:exported="true"
-        android:windowSoftInputMode="adjustResize"
-        android:screenOrientation="portrait" />
+        android:screenOrientation="portrait"
+        android:windowSoftInputMode="adjustResize" />
 
+    <meta-data
+        android:name="com.google.firebase.messaging.default_notification_icon"
+        android:resource="@drawable/ic_notification_icon" />
+
+    <meta-data
+        android:name="com.google.firebase.messaging.default_notification_color"
+        android:resource="@color/ic_launcher_background" />
     <service
         android:name=".notifications.AptoideGamesNotificationsService"
         android:exported="false">

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/LaunchIntentExtensions.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/LaunchIntentExtensions.kt
@@ -9,6 +9,10 @@ private const val DEEPLINK_KEY = "dti.link"
 
 val Intent?.hasDeepLink get() = this?.extras?.containsKey(DEEPLINK_KEY) ?: false
 
+//App link
+const val APP_LINK_SCHEMA = "https://"
+const val APP_LINK_HOST = "{LANG}.aptoide.com"
+
 fun Intent.putDeeplink(deepLink: String): Intent = putExtra(DEEPLINK_KEY, deepLink)
 
 // Ahab

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -69,6 +69,8 @@ import cm.aptoide.pt.feature_apps.presentation.rememberApp
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
 import cm.aptoide.pt.feature_editorial.presentation.relatedEditorialsCardViewModel
 import cm.aptoide.pt.feature_editorial.presentation.rememberRelatedEditorials
+import com.aptoide.android.aptoidegames.APP_LINK_HOST
+import com.aptoide.android.aptoidegames.APP_LINK_SCHEMA
 import com.aptoide.android.aptoidegames.AppIconImage
 import com.aptoide.android.aptoidegames.AptoideAsyncImageWithFullscreen
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
@@ -105,18 +107,29 @@ private val tabsList = listOf(
   AppViewTab.RELATED,
   AppViewTab.INFO
 )
+private const val PACKAGE_UNAME = "package_uname"
+
+private const val PATH = "path"
+private const val APP_PATH = "app"
 
 private const val SOURCE = "source"
 
-const val appViewRoute = "app/{$SOURCE}?"
+const val appViewRoute = "${APP_PATH}/{$SOURCE}?"
 
 fun appViewScreen() = ScreenData.withAnalytics(
   route = appViewRoute,
   screenAnalyticsName = "AppView",
-  deepLinks = listOf(navDeepLink { uriPattern = BuildConfig.DEEP_LINK_SCHEMA + appViewRoute })
+  deepLinks = listOf(
+    navDeepLink { uriPattern = BuildConfig.DEEP_LINK_SCHEMA + appViewRoute },
+    navDeepLink { uriPattern = "$APP_LINK_SCHEMA{$SOURCE}.$APP_LINK_HOST/{$PATH}" },
+  ),
 ) { arguments, navigate, navigateBack ->
-  val source = arguments?.getString(SOURCE)!!
+  val path = arguments?.getString(PATH)
 
+  val source = when (path) {
+    "app" -> "$PACKAGE_UNAME=${arguments.getString(SOURCE)}"
+    else -> arguments?.getString(SOURCE)!!
+  }
   AppViewScreen(
     source = source.appendIfRequired(BuildConfig.MARKET_NAME),
     navigate = navigate,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialViewScreen.kt
@@ -46,6 +46,8 @@ import cm.aptoide.pt.feature_home.domain.Type.EDITORIAL
 import cm.aptoide.pt.feature_home.domain.WidgetAction
 import cm.aptoide.pt.feature_home.domain.WidgetActionType.BUTTON
 import com.aptoide.android.aptoidegames.AptoideAsyncImageWithFullscreen
+import com.aptoide.android.aptoidegames.APP_LINK_HOST
+import com.aptoide.android.aptoidegames.APP_LINK_SCHEMA
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
 import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.R
@@ -65,16 +67,26 @@ import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.theme.Palette
 
-const val editorialRoute = "editorial/{articleId}"
+private const val ARTICLE_ID = "id"
+private const val PATH = "editorial"
+private const val SLUG = "slug"
+
+const val editorialRoute = "editorial/{$ARTICLE_ID}"
 
 fun editorialScreen() = ScreenData.withAnalytics(
   route = editorialRoute,
   screenAnalyticsName = "Editorial",
-  deepLinks = listOf(navDeepLink { uriPattern = BuildConfig.DEEP_LINK_SCHEMA + editorialRoute })
+  deepLinks = listOf(
+    navDeepLink { uriPattern = BuildConfig.DEEP_LINK_SCHEMA + editorialRoute },
+    navDeepLink { uriPattern = "$APP_LINK_SCHEMA$APP_LINK_HOST/$PATH/{$SLUG}" }
+  )
 ) { arguments, navigate, navigateBack ->
-  val articleId = arguments?.getString("articleId")!!
+  val source = arguments?.getString(ARTICLE_ID)
+    ?.let { "$ARTICLE_ID=$it" }
+    ?: arguments?.getString(SLUG)!!
+      .let { "$SLUG=$it" }
 
-  val viewModel = editorialViewModel(articleId)
+  val viewModel = editorialViewModel(source)
   val analyticsContext = AnalyticsContext.current
   val genericAnalytics = rememberGenericAnalytics()
   val uiState by viewModel.uiState.collectAsState()
@@ -91,7 +103,7 @@ fun editorialScreen() = ScreenData.withAnalytics(
   )
 }
 
-fun buildEditorialRoute(articleId: String): String = "editorial/$articleId"
+fun buildEditorialRoute(articleId: String): String = "$PATH/$articleId"
 
 @Composable
 private fun EditorialViewScreen(

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/usecase/ArticleUseCase.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/domain/usecase/ArticleUseCase.kt
@@ -14,9 +14,9 @@ class ArticleUseCase @Inject constructor(
   private val urlsCache: UrlsCache,
   @StoreName private val storeName: String,
 ) {
-  suspend fun getDetails(articleId: String): Article {
-    val editorialUrl = urlsCache.get(id = ARTICLE_CACHE_ID_PREFIX + articleId)
-      ?: "card/get/id=$articleId/store_name=$storeName"
+  suspend fun getDetails(source: String): Article {
+    val editorialUrl = urlsCache.get(id = ARTICLE_CACHE_ID_PREFIX + source)
+      ?: "card/get/$source/store_name=$storeName"
     return editorialRepository.getArticle(editorialUrl)
   }
 }

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/EditorialViewModel.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/EditorialViewModel.kt
@@ -12,7 +12,7 @@ import timber.log.Timber
 import java.io.IOException
 
 class EditorialViewModel(
-  private val articleId: String,
+  private val source: String,
   private val articleUseCase: ArticleUseCase,
 ) :
   ViewModel() {
@@ -33,7 +33,7 @@ class EditorialViewModel(
     viewModelScope.launch {
       viewModelState.update { EditorialUiState.Loading }
       try {
-        val result = articleUseCase.getDetails(articleId)
+        val result = articleUseCase.getDetails(source)
         viewModelState.update { EditorialUiState.Idle(article = result) }
       } catch (t: Throwable) {
         Timber.w(t)

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/presentation/ViewModelProvider.kt
@@ -119,15 +119,15 @@ fun rememberRelatedEditorials(packageName: String): List<ArticleMeta>? = runPrev
 )
 
 @Composable
-fun editorialViewModel(articleId: String): EditorialViewModel {
+fun editorialViewModel(source: String): EditorialViewModel {
   val injectionsProvider = hiltViewModel<InjectionsProvider>()
   return viewModel(
-    key = articleId,
+    key = source,
     factory = object : ViewModelProvider.Factory {
       override fun <T : ViewModel> create(modelClass: Class<T>): T {
         @Suppress("UNCHECKED_CAST")
         return EditorialViewModel(
-          articleId = articleId,
+          source = source,
           articleUseCase = injectionsProvider.articleUseCase,
         ) as T
       }


### PR DESCRIPTION
**What does this PR do?**

 This PR aims to support app links so when the web user clicks on an App or downloads it gets redirected to Aptoide Games

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AndroidManifest.xml
- [ ] AppViewScreen.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2709](https://aptoide.atlassian.net/browse/APP-2709)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2709](https://aptoide.atlassian.net/browse/APP-2709)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2709]: https://aptoide.atlassian.net/browse/APP-2709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2709]: https://aptoide.atlassian.net/browse/APP-2709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ