### PR TITLE
[APP-2733] - Remove AdListId and CampaignUrlNormalizer from v10

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/appview/AppViewScreen.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/AppViewScreen.kt
@@ -102,7 +102,7 @@ fun AppViewScreen(
   navigateBack: () -> Unit = {},
   navigate: (String) -> Unit = {},
 ) {
-  val (uiState, _) = rememberApp(packageName = packageName, adListId = "")
+  val (uiState, _) = rememberApp(packageName = packageName)
 
   val editorialsCardViewModel = relatedEditorialsCardViewModel(packageName = packageName)
   val relatedEditorialsUiState by editorialsCardViewModel.uiState.collectAsState()

--- a/app/src/main/java/cm/aptoide/pt/di/RepositoryModule.kt
+++ b/app/src/main/java/cm/aptoide/pt/di/RepositoryModule.kt
@@ -14,7 +14,6 @@ import cm.aptoide.pt.aptoide_network.di.StoreDomain
 import cm.aptoide.pt.aptoide_network.di.StoreName
 import cm.aptoide.pt.aptoide_network.di.VersionCode
 import cm.aptoide.pt.environment_info.DeviceInfo
-import cm.aptoide.pt.feature_campaigns.data.CampaignUrlNormalizer
 import cm.aptoide.pt.feature_editorial.di.DefaultEditorialUrl
 import cm.aptoide.pt.feature_flags.AptoideFeatureFlagsRepository
 import cm.aptoide.pt.feature_flags.data.FeatureFlagsRepository
@@ -44,7 +43,7 @@ import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import java.util.*
+import java.util.Locale
 import javax.inject.Singleton
 
 @Module
@@ -82,10 +81,6 @@ class RepositoryModule {
   @APIChainBDSDomain
   fun provideAPIChainBDSDomain(): String = BuildConfig.APTOIDE_WEB_SERVICES_APICHAIN_BDS_HOST
 
-  @Provides
-  @Singleton
-  fun providesCampaignUrlNormalizer(@ApplicationContext context: Context): CampaignUrlNormalizer =
-    CampaignUrlNormalizer(context)
 
   @Singleton
   @Provides


### PR DESCRIPTION
**What does this PR do?**

As the feature campaign was refactored and the AppData changed, we don't have AdListId in v10 anymore, nor CampaignUrlNormalizer exists.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AppViewScreen.kt
- [ ] RepositoryModule.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2733](https://aptoide.atlassian.net/browse/APP-2733)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2733](https://aptoide.atlassian.net/browse/APP-2733)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2733]: https://aptoide.atlassian.net/browse/APP-2733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2733]: https://aptoide.atlassian.net/browse/APP-2733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ