### PR TITLE
[APP-2827] Remove the blinking from the credit card screen

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/credit_card/AdyenCreditCardScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/credit_card/AdyenCreditCardScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -32,7 +33,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.view.isVisible
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
@@ -369,23 +369,42 @@ private fun AdyenCreditCardScreenPortrait(
 private fun AdyenCreditCardView(
   cardComponent: CardComponent,
   modifier: Modifier = Modifier,
+  delayMillis: Long = 100L,
 ) {
+  val context = LocalContext.current
   val lifecycleOwner = LocalLifecycleOwner.current
-  AndroidView(
-    factory = {
-      CardView(it).apply {
-        attach(cardComponent, lifecycleOwner)
-      }
-    },
-    update = {
-      it.findViewById<SwitchCompat>(com.adyen.checkout.card.R.id.switch_storePaymentMethod)?.run {
-        if (isVisible) {
-          isChecked = true
+  var isVisible by remember { mutableStateOf(false) }
+
+  LaunchedEffect(Unit) {
+    delay(delayMillis)
+    isVisible = true
+  }
+
+  val cardView = remember(
+    key1 = context,
+    key2 = cardComponent,
+    key3 = lifecycleOwner
+  ) {
+    CardView(context).apply {
+      attach(cardComponent, lifecycleOwner)
+    }
+  }
+
+  if (isVisible) {
+    AndroidView(
+      factory = { cardView },
+      update = {
+        it.findViewById<SwitchCompat>(com.adyen.checkout.card.R.id.switch_storePaymentMethod)?.run {
+          if (isVisible) {
+            isChecked = true
+          }
         }
-      }
-    },
-    modifier = modifier.fillMaxWidth(),
-  )
+      },
+      modifier = modifier.fillMaxWidth()
+    )
+  } else {
+    Spacer(modifier = Modifier.height(200.dp))
+  }
 }
 
 @PreviewLight


### PR DESCRIPTION
**What does this PR do?**

   This PR aims to remove the blinking in the credit card screen by adding a delay so the card only turns visible after the correct form fields are drawn


**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AdyenCreditCardScreen.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2827](https://aptoide.atlassian.net/browse/APP-2827)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1340](https://aptoide.atlassian.net/browse/DT-1340)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2827]: https://aptoide.atlassian.net/browse/APP-2827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2827]: https://aptoide.atlassian.net/browse/APP-2827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DT-1340]: https://aptoide.atlassian.net/browse/DT-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ