### PR TITLE
[APP-2831] - Implement correct Legal Urls

### DIFF
--- a/app-games/build.gradle.kts
+++ b/app-games/build.gradle.kts
@@ -44,17 +44,17 @@ android {
     buildConfigField(
       type = "String",
       name = "TC_URL",
-      value = "\"https://en.aptoide.com/company/legal\""
+      value = "\"https://aptoide.com/legal\""
     )
     buildConfigField(
       type = "String",
       name = "BT_URL",
-      value = "\"https://en.aptoide.com/company/legal?section=aptoidegamesbilling\""
+      value = "\"https://aptoide.com/legal?section=aptoidegamesbilling\""
     )
     buildConfigField(
       type = "String",
       name = "PP_URL",
-      value = "\"https://en.aptoide.com/company/legal?section=privacy\""
+      value = "\"https://aptoide.com/legal?section=privacy\""
     )
 
     buildConfigField(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -83,8 +83,8 @@ fun settingsScreen(showSnack: (String) -> Unit) = ScreenData(
         genericAnalytics.sendDownloadOverWifiDisabled()
       }
     },
-    onPrivacyPolicyClick = { UrlActivity.open(context, context.ppUrl) },
-    onTermsConditionsClick = { UrlActivity.open(context, context.tcUrl) },
+    onPrivacyPolicyClick = { UrlActivity.open(context, ppUrl) },
+    onTermsConditionsClick = { UrlActivity.open(context, tcUrl) },
     onContactSupportClick = {
       genericAnalytics.sendPaymentSupportClicked()
       SupportActivity.openForSupport(context)
@@ -93,7 +93,7 @@ fun settingsScreen(showSnack: (String) -> Unit) = ScreenData(
       genericAnalytics.sendSendFeedbackClicked()
       SupportActivity.openForFeedBack(context)
     },
-    onBillingTermsClick = { UrlActivity.open(context, context.btUrl) },
+    onBillingTermsClick = { UrlActivity.open(context, btUrl) },
     copyInfo = {
       clipboardManager.setText(deviceInfo)
       showSnack(copiedMessage)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/terms_and_conditions/LegalUrls.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/terms_and_conditions/LegalUrls.kt
@@ -1,22 +1,9 @@
 package com.aptoide.android.aptoidegames.terms_and_conditions
 
-import android.content.Context
-import android.net.Uri
 import com.aptoide.android.aptoidegames.BuildConfig
 
-val Context.tcUrl get() = BuildConfig.TC_URL.addLanguage(this)
+const val tcUrl = BuildConfig.TC_URL
 
-val Context.btUrl get() = BuildConfig.BT_URL.addLanguage(this)
+const val btUrl = BuildConfig.BT_URL
 
-val Context.ppUrl get() = BuildConfig.PP_URL.addLanguage(this)
-
-val paymentsTermsOfUseUrl get() = ""
-
-private fun String.addLanguage(context: Context): String {
-  val resources = context.resources
-  return Uri.parse(this).buildUpon().appendQueryParameter(
-    "lang", resources.configuration.locales.get(0).language
-      + "-"
-      + resources.configuration.locales.get(0).country
-  ).build().toString()
-}
+const val ppUrl = BuildConfig.PP_URL

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/toolbar/AppGamesToolBar.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/toolbar/AppGamesToolBar.kt
@@ -60,12 +60,12 @@ fun AppGamesToolBar(
   val onDropDownTermsConditionsClick = {
     showMenu = false
     genericAnalytics.sendMenuClick("terms & conditions")
-    UrlActivity.open(context, context.tcUrl)
+    UrlActivity.open(context, tcUrl)
   }
   val onDropDownPrivacyPolicyClick = {
     showMenu = false
     genericAnalytics.sendMenuClick("privacy policy")
-    UrlActivity.open(context, context.ppUrl)
+    UrlActivity.open(context, ppUrl)
   }
   val onDropDownDismissRequest = { showMenu = false }
 


### PR DESCRIPTION
**What does this PR do?**

It fixes the redirect logic for the Aptoide Games legal urls. We have automatic redirects without subdomain and lang parameter for aptoide.com/legal 

**Database changed?**

No

**Where should the reviewer start?**

- [ ] build.gradle.kts
- [ ] SettingsScreen.kt
- [ ] LegalUrls.kt
- [ ] AppGamesToolBar.kt

**How should this be manually tested?**
 Change your device's language and open the links from the AG app (with cache cleared)

  Flow on how to test this or QA Tickets related to this use-case: [APP-2831](https://aptoide.atlassian.net/browse/APP-2831)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2831](https://aptoide.atlassian.net/browse/APP-2831)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2831]: https://aptoide.atlassian.net/browse/APP-2831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2831]: https://aptoide.atlassian.net/browse/APP-2831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ