### PR TITLE
[APP-2844] - Implement Notifications Dialog

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/NotificationBell.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/NotificationBell.kt
@@ -1,0 +1,77 @@
+package com.aptoide.android.aptoidegames.drawables.icons
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Preview
+@Composable
+fun TestNotificationBell() {
+  Image(
+    imageVector = getNotificationBell(Color.White, Color.Red),
+    contentDescription = null,
+    modifier = Modifier.size(240.dp)
+  )
+}
+
+fun getNotificationBell(
+  bellColor: Color,
+  notificationColor: Color
+): ImageVector = ImageVector.Builder(
+  name = "NotificationBell",
+  defaultWidth = 24.dp,
+  defaultHeight = 24.dp,
+  viewportWidth = 24f,
+  viewportHeight = 24f,
+).apply {
+  path(
+    fill = SolidColor(bellColor),
+  ) {
+    moveTo(12f, 22f)
+    curveTo(11.45f, 22f, 10.9792f, 21.8042f, 10.5875f, 21.4125f)
+    curveTo(10.1958f, 21.0208f, 10f, 20.55f, 10f, 20f)
+    horizontalLineTo(14f)
+    curveTo(14f, 20.55f, 13.8042f, 21.0208f, 13.4125f, 21.4125f)
+    curveTo(13.0208f, 21.8042f, 12.55f, 22f, 12f, 22f)
+    close()
+    moveTo(4f, 19f)
+    verticalLineTo(17f)
+    horizontalLineTo(6f)
+    verticalLineTo(10f)
+    curveTo(6f, 8.61667f, 6.41667f, 7.3875f, 7.25f, 6.3125f)
+    curveTo(8.08333f, 5.2375f, 9.16667f, 4.53333f, 10.5f, 4.2f)
+    verticalLineTo(2f)
+    horizontalLineTo(13.5f)
+    verticalLineTo(3.825f)
+    curveTo(13.3333f, 4.15833f, 13.2083f, 4.50833f, 13.125f, 4.875f)
+    curveTo(13.0417f, 5.24167f, 13f, 5.61667f, 13f, 6f)
+    curveTo(13f, 7.38333f, 13.4875f, 8.5625f, 14.4625f, 9.5375f)
+    curveTo(15.4375f, 10.5125f, 16.6167f, 11f, 18f, 11f)
+    verticalLineTo(17f)
+    horizontalLineTo(20f)
+    verticalLineTo(19f)
+    horizontalLineTo(4f)
+    close()
+  }
+  path(
+    fill = SolidColor(notificationColor),
+  ) {
+    moveTo(15.875f, 8.125f)
+    curveTo(16.4583f, 8.70833f, 17.1667f, 9f, 18f, 9f)
+    curveTo(18.8333f, 9f, 19.5417f, 8.70833f, 20.125f, 8.125f)
+    curveTo(20.7083f, 7.54167f, 21f, 6.83333f, 21f, 6f)
+    curveTo(21f, 5.16667f, 20.7083f, 4.45833f, 20.125f, 3.875f)
+    curveTo(19.5417f, 3.29167f, 18.8333f, 3f, 18f, 3f)
+    curveTo(17.1667f, 3f, 16.4583f, 3.29167f, 15.875f, 3.875f)
+    curveTo(15.2917f, 4.45833f, 15f, 5.16667f, 15f, 6f)
+    curveTo(15f, 6.83333f, 15.2917f, 7.54167f, 15.875f, 8.125f)
+    close()
+  }
+}.build()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/NotificationsPermissionIcon.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/NotificationsPermissionIcon.kt
@@ -1,0 +1,227 @@
+package com.aptoide.android.aptoidegames.drawables.icons
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.aptoide.android.aptoidegames.theme.Palette
+
+@Preview
+@Composable
+fun testGetNotificationsPermissionIcon() {
+  Image(
+    imageVector = getNotificationsPermissionIcon(Color.Green, Color.White, Color.Red),
+    contentDescription = null,
+    modifier = Modifier
+      .size(240.dp)
+      .background(Palette.Black)
+  )
+}
+
+fun getNotificationsPermissionIcon(
+  controllerColor: Color,
+  bellColor: Color,
+  notificationColor: Color,
+): ImageVector =
+  ImageVector.Builder(
+    name = "NotificationsPermissionIcon",
+    defaultWidth = 280.0.dp,
+    defaultHeight = 120.0.dp,
+    viewportWidth = 280.0f,
+    viewportHeight = 120.0f
+  ).apply {
+    path(
+      fill = SolidColor(bellColor),
+      stroke = null,
+      strokeLineWidth = 0.0f,
+      strokeLineCap = Butt,
+      strokeLineJoin = Miter,
+      strokeLineMiter = 4.0f,
+      pathFillType = NonZero
+    ) {
+      moveTo(24.0f, 28.0f)
+      horizontalLineToRelative(16.0f)
+      verticalLineToRelative(8.0f)
+      horizontalLineToRelative(-16.0f)
+      close()
+    }
+    path(
+      fill = SolidColor(controllerColor),
+      stroke = null,
+      strokeLineWidth = 0.0f,
+      strokeLineCap = Butt,
+      strokeLineJoin = Miter,
+      strokeLineMiter = 4.0f,
+      pathFillType = NonZero
+    ) {
+      moveTo(198.0f, 16.0f)
+      horizontalLineToRelative(58.0f)
+      verticalLineToRelative(16.0f)
+      horizontalLineToRelative(-58.0f)
+      close()
+    }
+    path(
+      fill = SolidColor(bellColor),
+      stroke = null,
+      strokeLineWidth = 0.0f,
+      strokeLineCap = Butt,
+      strokeLineJoin = Miter,
+      strokeLineMiter = 4.0f,
+      pathFillType = NonZero
+    ) {
+      moveTo(233.0f, 64.0f)
+      horizontalLineToRelative(23.0f)
+      verticalLineToRelative(16.0f)
+      horizontalLineToRelative(-23.0f)
+      close()
+    }
+    path(
+      fill = SolidColor(notificationColor),
+      stroke = null,
+      strokeLineWidth = 0.0f,
+      strokeLineCap = Butt,
+      strokeLineJoin = Miter,
+      strokeLineMiter = 4.0f,
+      pathFillType = NonZero
+    ) {
+      moveTo(40.0f, 0.0f)
+      horizontalLineToRelative(23.0f)
+      verticalLineToRelative(16.0f)
+      horizontalLineToRelative(-23.0f)
+      close()
+    }
+    path(
+      fill = SolidColor(controllerColor),
+      stroke = null,
+      strokeLineWidth = 0.0f,
+      strokeLineCap = Butt,
+      strokeLineJoin = Miter,
+      strokeLineMiter = 4.0f,
+      pathFillType = NonZero
+    ) {
+      moveTo(56.0f, 104.0f)
+      horizontalLineToRelative(16.0f)
+      verticalLineToRelative(16.0f)
+      horizontalLineToRelative(-16.0f)
+      close()
+    }
+    path(
+      fill = SolidColor(controllerColor),
+      stroke = null,
+      strokeLineWidth = 0.0f,
+      strokeLineCap = Butt,
+      strokeLineJoin = Miter,
+      strokeLineMiter = 4.0f,
+      pathFillType = NonZero
+    ) {
+      moveTo(101.958f, 93.667f)
+      lineTo(109.108f, 42.333f)
+      horizontalLineTo(170.891f)
+      lineTo(178.041f, 93.667f)
+      horizontalLineTo(163.466f)
+      lineTo(152.466f, 82.667f)
+      horizontalLineTo(127.533f)
+      lineTo(116.533f, 93.667f)
+      horizontalLineTo(101.958f)
+      close()
+      moveTo(158.333f, 71.667f)
+      curveTo(159.372f, 71.667f, 160.243f, 71.315f, 160.946f, 70.613f)
+      curveTo(161.648f, 69.91f, 162.0f, 69.039f, 162.0f, 68.0f)
+      curveTo(162.0f, 66.961f, 161.648f, 66.09f, 160.946f, 65.387f)
+      curveTo(160.243f, 64.685f, 159.372f, 64.333f, 158.333f, 64.333f)
+      curveTo(157.294f, 64.333f, 156.423f, 64.685f, 155.721f, 65.387f)
+      curveTo(155.018f, 66.09f, 154.666f, 66.961f, 154.666f, 68.0f)
+      curveTo(154.666f, 69.039f, 155.018f, 69.91f, 155.721f, 70.613f)
+      curveTo(156.423f, 71.315f, 157.294f, 71.667f, 158.333f, 71.667f)
+      close()
+      moveTo(151.0f, 60.667f)
+      curveTo(152.039f, 60.667f, 152.909f, 60.315f, 153.612f, 59.612f)
+      curveTo(154.315f, 58.91f, 154.666f, 58.039f, 154.666f, 57.0f)
+      curveTo(154.666f, 55.961f, 154.315f, 55.09f, 153.612f, 54.388f)
+      curveTo(152.909f, 53.685f, 152.039f, 53.333f, 151.0f, 53.333f)
+      curveTo(149.961f, 53.333f, 149.09f, 53.685f, 148.387f, 54.388f)
+      curveTo(147.684f, 55.09f, 147.333f, 55.961f, 147.333f, 57.0f)
+      curveTo(147.333f, 58.039f, 147.684f, 58.91f, 148.387f, 59.612f)
+      curveTo(149.09f, 60.315f, 149.961f, 60.667f, 151.0f, 60.667f)
+      close()
+      moveTo(124.416f, 71.667f)
+      horizontalLineTo(129.916f)
+      verticalLineTo(65.25f)
+      horizontalLineTo(136.333f)
+      verticalLineTo(59.75f)
+      horizontalLineTo(129.916f)
+      verticalLineTo(53.333f)
+      horizontalLineTo(124.416f)
+      verticalLineTo(59.75f)
+      horizontalLineTo(118.0f)
+      verticalLineTo(65.25f)
+      horizontalLineTo(124.416f)
+      verticalLineTo(71.667f)
+      close()
+    }
+    path(
+      fill = SolidColor(bellColor),
+      stroke = null,
+      strokeLineWidth = 0.0f,
+      strokeLineCap = Butt,
+      strokeLineJoin = Miter,
+      strokeLineMiter = 4.0f,
+      pathFillType = NonZero
+    ) {
+      moveTo(177.0f, 108.333f)
+      curveTo(175.716f, 108.333f, 174.618f, 107.876f, 173.704f, 106.962f)
+      curveTo(172.79f, 106.049f, 172.333f, 104.95f, 172.333f, 103.667f)
+      horizontalLineTo(181.666f)
+      curveTo(181.666f, 104.95f, 181.209f, 106.049f, 180.296f, 106.962f)
+      curveTo(179.382f, 107.876f, 178.283f, 108.333f, 177.0f, 108.333f)
+      close()
+      moveTo(158.333f, 101.333f)
+      verticalLineTo(96.667f)
+      horizontalLineTo(163.0f)
+      verticalLineTo(80.333f)
+      curveTo(163.0f, 77.105f, 163.972f, 74.238f, 165.916f, 71.729f)
+      curveTo(167.861f, 69.221f, 170.389f, 67.578f, 173.5f, 66.8f)
+      verticalLineTo(61.667f)
+      horizontalLineTo(180.5f)
+      verticalLineTo(65.925f)
+      curveTo(180.111f, 66.703f, 179.819f, 67.519f, 179.625f, 68.375f)
+      curveTo(179.43f, 69.23f, 179.333f, 70.105f, 179.333f, 71.0f)
+      curveTo(179.333f, 74.228f, 180.471f, 76.979f, 182.746f, 79.254f)
+      curveTo(185.021f, 81.529f, 187.772f, 82.667f, 191.0f, 82.667f)
+      verticalLineTo(96.667f)
+      horizontalLineTo(195.666f)
+      verticalLineTo(101.333f)
+      horizontalLineTo(158.333f)
+      close()
+    }
+    path(
+      fill = SolidColor(notificationColor),
+      stroke = null,
+      strokeLineWidth = 0.0f,
+      strokeLineCap = Butt,
+      strokeLineJoin = Miter,
+      strokeLineMiter = 4.0f,
+      pathFillType = NonZero
+    ) {
+      moveTo(185.042f, 75.958f)
+      curveTo(186.403f, 77.319f, 188.056f, 78.0f, 190.0f, 78.0f)
+      curveTo(191.944f, 78.0f, 193.597f, 77.319f, 194.958f, 75.958f)
+      curveTo(196.319f, 74.597f, 197.0f, 72.944f, 197.0f, 71.0f)
+      curveTo(197.0f, 69.056f, 196.319f, 67.403f, 194.958f, 66.042f)
+      curveTo(193.597f, 64.681f, 191.944f, 64.0f, 190.0f, 64.0f)
+      curveTo(188.056f, 64.0f, 186.403f, 64.681f, 185.042f, 66.042f)
+      curveTo(183.681f, 67.403f, 183.0f, 69.056f, 183.0f, 71.0f)
+      curveTo(183.0f, 72.944f, 183.681f, 74.597f, 185.042f, 75.958f)
+      close()
+    }
+  }.build()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/launch/AppLaunchPreferencesManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/launch/AppLaunchPreferencesManager.kt
@@ -32,6 +32,8 @@ class AppLaunchPreferencesManager @Inject constructor(private val dataStore: Dat
   }
 
   suspend fun shouldShowNotificationsDialog(): Boolean = dataStore.data
-    .map { it[SHOULD_SHOW_NOTIFICATIONS_DIALOG] ?: true }
-    .first()
+    .map { preferences ->
+      (preferences[IS_FIRST_LAUNCH] == false) && (preferences[SHOULD_SHOW_NOTIFICATIONS_DIALOG]
+        ?: true)
+    }.first()
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/NotificationsPermissionRequester.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/NotificationsPermissionRequester.kt
@@ -2,10 +2,11 @@ package com.aptoide.android.aptoidegames.notifications
 
 import android.Manifest
 import android.annotation.SuppressLint
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -13,11 +14,9 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.paint
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -26,7 +25,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.aptoide.android.aptoidegames.MainActivity
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
-import com.aptoide.android.aptoidegames.design_system.PrimarySmallButton
+import com.aptoide.android.aptoidegames.design_system.PrimaryButton
+import com.aptoide.android.aptoidegames.design_system.PrimaryTextButton
+import com.aptoide.android.aptoidegames.drawables.icons.getNotificationsPermissionIcon
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.Palette
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -81,51 +82,76 @@ fun NotificationPermissionDialog(
       genericAnalytics.sendGetNotifiedContinueClick()
       onDismissDialog(true)
     }
-    DialogContent(onContinueClick)
+    val onCancelClick: () -> Unit = { onDismissDialog(false) }
+    DialogContent(onContinueClick, onCancelClick)
   }
 }
 
 @Preview
 @Composable
 fun DialogContentPreview() {
-  DialogContent {}
+  DialogContent({}, {})
 }
 
 @Composable
-fun DialogContent(onContinueClick: () -> Unit) {
+fun DialogContent(
+  onContinueClick: () -> Unit,
+  onCancelClick: () -> Unit
+) {
   Box(
     modifier = Modifier
-      .padding(horizontal = 24.dp)
+      .padding(horizontal = 16.dp)
       .fillMaxWidth()
       .wrapContentHeight()
-      .defaultMinSize(minHeight = 261.dp)
-      .paint(
-        painter = painterResource(id = R.drawable.notification_permission_bg),
-        contentScale = ContentScale.Crop,
-      ),
+      .background(color = Palette.GreyDark),
     contentAlignment = Alignment.Center
   ) {
     Column(
       verticalArrangement = Arrangement.SpaceEvenly,
+      horizontalAlignment = Alignment.CenterHorizontally,
       modifier = Modifier
         .wrapContentHeight()
+        .padding(horizontal = 24.dp)
     ) {
+      Image(
+        imageVector = getNotificationsPermissionIcon(
+          controllerColor = Palette.Primary,
+          bellColor = Palette.White,
+          notificationColor = Palette.Secondary
+        ),
+        contentDescription = null,
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(vertical = 40.dp)
+      )
       Text(
         text = stringResource(R.string.notifications_context_title),
         style = AGTypography.Title,
         color = Palette.White,
-        modifier = Modifier.padding(top = 35.dp, start = 24.dp, bottom = 16.dp, end = 24.dp)
+        modifier = Modifier.padding(bottom = 8.dp)
       )
       Text(
         text = stringResource(R.string.notifications_context_body),
-        style = AGTypography.Body,
+        style = AGTypography.SubHeadingS,
         color = Palette.White,
-        modifier = Modifier.padding(start = 24.dp, bottom = 24.dp, end = 32.dp)
+        textAlign = TextAlign.Center,
+        modifier = Modifier
+          .padding(bottom = 24.dp)
+          .fillMaxWidth()
       )
-      PrimarySmallButton(
+      PrimaryButton(
         onClick = onContinueClick,
-        modifier = Modifier.padding(start = 24.dp, end = 8.dp, bottom = 40.dp),
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(),
         title = stringResource(R.string.continue_button)
+      )
+      PrimaryTextButton(
+        onClick = onCancelClick,
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(bottom = 8.dp),
+        text = stringResource(id = R.string.cancel_button)
       )
     }
   }


### PR DESCRIPTION
**What does this PR do?**

It implements the new Notifications Dialog design and specific logic -> Bell on toolbar always appears and notification dialog on launch only appears if it isn't first launch.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] NotificationBell.kt
- [ ] NotificationsPermissionIcon.kt
- [ ] AppLaunchPreferencesManager.kt
- [ ] NotificationsPermissionRequester.kt
- [ ] AppGamesToolBar.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2844](https://aptoide.atlassian.net/browse/APP-2844)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2844](https://aptoide.atlassian.net/browse/APP-2844)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2844]: https://aptoide.atlassian.net/browse/APP-2844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2844]: https://aptoide.atlassian.net/browse/APP-2844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ