### PR TITLE
[APP-2837] - Fix cache on getWidgets request on pull to refresh

### DIFF
--- a/feature-home/src/main/java/cm/aptoide/pt/feature_home/domain/BundlesUseCase.kt
+++ b/feature-home/src/main/java/cm/aptoide/pt/feature_home/domain/BundlesUseCase.kt
@@ -13,6 +13,7 @@ class BundlesUseCase @Inject constructor(
     widgetsRepository.getStoreWidgets(
       context = context,
       bypassCache = urlsCache.isInvalid(WIDGETS_TAG)
+        .also { urlsCache.putAll(mapOf(WIDGETS_TAG to "")) }
     )
       .also { urlsCache.putAll(it.tagsUrls) }
       .map {
@@ -59,6 +60,7 @@ class BundlesUseCase @Inject constructor(
         WidgetLayout.BRICK,
         WidgetLayout.GRAPHIC,
         WidgetLayout.CAROUSEL_LARGE -> Type.CAROUSEL_LARGE
+
         WidgetLayout.LIST -> Type.APP_GRID
         WidgetLayout.CURATION_1,
         WidgetLayout.UNDEFINED,


### PR DESCRIPTION
**What does this PR do?**

Pull to refresh had clean cache for every request except on getWidgets (meaning that the content inside each section would get updated but not the sections list itself.). This PR fixes that part, now when we pull to refresh we also perform the getWidgets request with no cache

**Database changed?**

 No

**Where should the reviewer start?**

- [ ] BundlesUseCase.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2837](https://aptoide.atlassian.net/browse/APP-2837)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2837](https://aptoide.atlassian.net/browse/APP-2837)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2837]: https://aptoide.atlassian.net/browse/APP-2837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2837]: https://aptoide.atlassian.net/browse/APP-2837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ