### PR TITLE
[APP-2835] Implement applinks support and updated some url handles

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,6 @@ android {
     testProguardFile 'proguard-rules-test.pro'
     testInstrumentationRunner "cm.aptoide.pt.MultidexAndroidJunitRunner"
     // vectorDrawables.useSupportLibrary = true
-    manifestPlaceholders = [dataPlaceholder: generateData()]
   }
 
   lintOptions {
@@ -189,8 +188,7 @@ android {
         [toolboxProviderAuthority: "${toolboxProviderAuthority}",
             suggestionProviderAuthority: "${searchSuggestionProviderAuthority}",
             storeSuggestionProviderAuthority: "${storeSuggestionProviderAuthority}",
-            adMobApiKey: "${project.AD_MOB_APPLICATION_ID}",
-            dataPlaceholder: generateData()]
+            adMobApiKey: "${project.AD_MOB_APPLICATION_ID}"]
 
     variant.resValue "string", "authenticator_account_type", applicationId
     variant.resValue "string", "search_suggestion_provider_authority",
@@ -518,114 +516,4 @@ String getDate() {
   def date = new Date()
   def formattedDate = date.format('yyyyMMdd')
   return formattedDate
-}
-
-static def generateData() {
-  return data("app.aptoide.com") + data("market.android.com") +
-      dataWithPathPrefix("webservices.aptoide.com", "/apkinstall") +
-      data("play.google.com") +
-      aptoideSubdomainDataWithWildCardPrefix() +
-      aptoideSubdomainData("/store/..*") +
-      aptoideSubdomainData("/thank-you*") +
-      aptoideSubdomainData("/appcoins") +
-      data("community.aptoide.com", "/using-appcoins*") +
-      data("become-a-power-gamer.aptoide.com", "/using-appcoins*") +
-      aptoideSubdomainData("/download*") +
-      aptoideSubdomainData("/editorial/..*") +
-      aptoideSubdomainData("/app") +
-      aptoideSubdomainData()
-}
-
-static def getAptoideSubdomainsList() {
-  def subdomainList = ["en", "pt", "br", "fr", "es", "mx", "de", "it", "ru", "sa", "id", "in", "bd", "mr", "pa",
-      "my", "th", "vn", "tr", "cn", "ro", "mm", "pl", "rs", "hu", "gr", "bg", "nl", "ir", "jp", "kr", "ua"]
-  return new ArrayList<>(subdomainList)
-}
-
-static def aptoideSubdomainDataWithWildCardPrefix() {
-  def subdomainData = ""
-  List<String> subdomainList = getAptoideSubdomainsList()
-  for (subdomain in subdomainList) {
-    subdomainData = subdomainData + data("*." + subdomain + ".aptoide.com")
-  }
-  return subdomainData
-}
-
-static def aptoideSubdomainData() {
-  def subdomainData = ""
-  List<String> subdomainList = getAptoideSubdomainsList()
-  for (subdomain in subdomainList) {
-    subdomainData = subdomainData + data(subdomain + ".aptoide.com")
-  }
-  return subdomainData
-}
-
-static def aptoideSubdomainData(String pathPattern) {
-  def subdomainData = ""
-  List<String> subdomainList = getAptoideSubdomainsList()
-  for (subdomain in subdomainList) {
-    subdomainData = subdomainData + data(subdomain + ".aptoide.com", pathPattern)
-  }
-  return subdomainData
-}
-
-static def data(String host, String pathPattern) {
-  return generateIntentFilter(http(host, pathPattern) + https(host, pathPattern))
-}
-
-static def data(String host) {
-  return generateIntentFilter(http(host, "") + https(host, ""))
-}
-
-static def dataWithPathPrefix(String host, String pathPrefix) {
-  return generateIntentFilter(
-      createDataTagWithPathPrefix(host, "http", pathPrefix) + createDataTagWithPathPrefix(host,
-          "https", pathPrefix))
-}
-
-static def http(String host, String pathPattern) {
-  if (pathPattern != null && !pathPattern.isEmpty()) {
-    createDataTagWithPathPattern(host, "http", pathPattern)
-  } else {
-    createDataTagWithNoPathPattern(host, "http")
-  }
-}
-
-static def https(String host, String pathPattern) {
-  if (pathPattern != null && !pathPattern.isEmpty()) {
-    createDataTagWithPathPattern(host, "https", pathPattern)
-  } else {
-    createDataTagWithNoPathPattern(host, "https")
-  }
-}
-
-static def createDataTagWithNoPathPattern(String host, String scheme) {
-  return "\n" + "               <data\n" +
-      "                   android:host=\"$host\"\n" +
-      "                   android:scheme=\"$scheme\"/>\n"
-}
-
-static def createDataTagWithPathPattern(String host, String scheme, String pathPattern) {
-  return "\n" + "               <data\n" +
-      "                   android:host=\"$host\"\n" +
-      "                   android:pathPattern=\"$pathPattern\"\n" +
-      "                   android:scheme=\"$scheme\"/>\n"
-}
-
-static def createDataTagWithPathPrefix(String host, String scheme, String pathPrefix) {
-  return "\n" + "               <data\n" +
-      "                   android:host=\"$host\"\n" +
-      "                   android:pathPrefix=\"$pathPrefix\"\n" +
-      "                   android:scheme=\"$scheme\"/>\n"
-}
-
-static def generateIntentFilter(String data) {
-  return "\n            <intent-filter>\n" +
-      "                <action android:name=\"android.intent.action.VIEW\"/>\n" +
-      "\n" +
-      "                <category android:name=\"android.intent.category.DEFAULT\"/>\n" +
-      "                <category android:name=\"android.intent.category.BROWSABLE\"/>\n" +
-      "\n" +
-      data +
-      "            </intent-filter>\n"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -189,8 +189,79 @@
         <data android:scheme="market" />
       </intent-filter>
 
-      <!-- ${dataPlaceholder} -->
 
+<!--      <intent-filter-->
+<!--          android:autoVerify="true"-->
+<!--          android:priority="100">-->
+<!--        <action android:name="android.intent.action.VIEW" />-->
+
+<!--        <category android:name="android.intent.category.BROWSABLE" />-->
+<!--        <category android:name="android.intent.category.DEFAULT" />-->
+
+<!--        <data android:scheme="http" />-->
+<!--        <data android:scheme="https" />-->
+<!--        <data android:host="en.aptoide.com" />-->
+<!--        <data android:host="es.aptoide.com" />-->
+<!--        <data android:host="br.aptoide.com" />-->
+<!--        <data android:host="ar.aptoide.com" />-->
+<!--        <data android:host="fr.aptoide.com" />-->
+<!--        <data android:host="id.aptoide.com" />-->
+<!--        <data android:host="ru.aptoide.com" />-->
+<!--        <data android:host="it.aptoide.com" />-->
+<!--        <data android:host="ro.aptoide.com" />-->
+<!--        <data android:host="in.aptoide.com" />-->
+<!--        <data android:host="mr.aptoide.com" />-->
+<!--        <data android:host="pa.aptoide.com" />-->
+<!--        <data android:host="cn.aptoide.com" />-->
+<!--        <data android:host="mm.aptoide.com" />-->
+<!--        <data android:host="th.aptoide.com" />-->
+<!--        <data android:host="pt.aptoide.com" />-->
+<!--        <data android:host="my.aptoide.com" />-->
+<!--        <data android:host="vn.aptoide.com" />-->
+<!--        <data android:host="pl.aptoide.com" />-->
+<!--        <data android:host="tr.aptoide.com" />-->
+<!--        <data android:host="nl.aptoide.com" />-->
+<!--        <data android:host="de.aptoide.com" />-->
+<!--        <data android:host="hu.aptoide.com" />-->
+<!--        <data android:host="rs.aptoide.com" />-->
+<!--        <data android:host="gr.aptoide.com" />-->
+<!--        <data android:host="jp.aptoide.com" />-->
+<!--        <data android:host="ua.aptoide.com" />-->
+<!--        <data android:host="ir.aptoide.com" />-->
+<!--        <data android:host="kr.aptoide.com" />-->
+<!--        <data android:pathPattern="^/$"/>-->
+<!--      </intent-filter>-->
+
+
+      <intent-filter
+          android:autoVerify="true"
+          android:priority="100">
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.BROWSABLE" />
+        <category android:name="android.intent.category.DEFAULT" />
+
+        <data android:scheme="http" />
+        <data android:scheme="https" />
+        <data android:host="*.aptoide.com" />
+        <data android:pathPrefix="/download" />
+        <data android:path="/appcoins" />
+        <data android:path="/app" />
+        <data android:pathPattern="/editorial/.*" />
+      </intent-filter>
+
+      <intent-filter
+          android:autoVerify="true"
+          android:priority="100">
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.BROWSABLE" />
+        <category android:name="android.intent.category.DEFAULT" />
+
+        <data android:scheme="http" />
+        <data android:scheme="https" />
+        <data android:host="app.aptoide.com" />
+      </intent-filter>
 
     </activity>
 

--- a/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
+++ b/app/src/main/java/cm/aptoide/pt/DeepLinkIntentReceiver.java
@@ -285,7 +285,7 @@ public class DeepLinkIntentReceiver extends ActivityView {
         if (!TextUtils.isEmpty(uname)) {
           return parseAptoideInstallUri("uname=" + uname);
         } else {
-          String packageName = u.getQueryParameter("package");
+          String packageName = u.getQueryParameter("package_name");
           if (!TextUtils.isEmpty(packageName)) {
             return parseAptoideInstallUri("package=" + packageName);
           } else {
@@ -358,8 +358,7 @@ public class DeepLinkIntentReceiver extends ActivityView {
       String slug = u.getPath()
           .split("/")[2];
       return startEditorialFromSlug(slug);
-    } else if (u.getPath() != null && u.getPath()
-        .contains("using-appcoins")) {
+    } else if (u.getPath() != null && u.getPath().contains("appcoins")) {
       return startAppcInfoView();
     } else {
       String[] appName = u.getHost()


### PR DESCRIPTION
**What does this PR do?**

This PR aims at implementing the applinks in vanilla.
Note: We are still not supporting the homepage (eventhough we are supporting everything else), but we have all subdomains  commented on purpose in the manifest, as it might get fixed after.
Also fixed some url handling as the url tags changed on the web since the last time we worked on it.


**Database changed?**

 No

**Where should the reviewer start?**

- [ ] AndroidManifest.xml

**How should this be manually tested?**

Generate a signed apk, test the different applinks while navigating on the web.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2835](https://aptoide.atlassian.net/browse/APP-2835)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2835]: https://aptoide.atlassian.net/browse/APP-2835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ