### PR TITLE
[APP-2859] - Update dialogs width according to the design

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_oos/OutOfSpaceDialog.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_oos/OutOfSpaceDialog.kt
@@ -56,7 +56,7 @@ fun OutOfSpaceDialog(
     Box(
       modifier = Modifier
         .padding(horizontal = 16.dp, vertical = 24.dp)
-        .fillMaxWidth()
+        .width(328.dp)
         .defaultMinSize(minHeight = 520.dp)
         .background(Palette.GreyDark),
       contentAlignment = Alignment.Center

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/network/presentation/WifiPromptDialog.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/network/presentation/WifiPromptDialog.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -64,7 +65,7 @@ fun WifiPromptDialog(
     Box(
       modifier = Modifier
         .padding(horizontal = 16.dp)
-        .fillMaxWidth()
+        .width(328.dp)
         .wrapContentHeight()
         .background(Palette.GreyDark),
     ) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/NotificationsPermissionRequester.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/NotificationsPermissionRequester.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -101,7 +102,7 @@ fun DialogContent(
   Box(
     modifier = Modifier
       .padding(horizontal = 16.dp)
-      .fillMaxWidth()
+      .width(328.dp)
       .wrapContentHeight()
       .background(color = Palette.GreyDark),
     contentAlignment = Alignment.Center


### PR DESCRIPTION
**What does this PR do?**

Replaces the fillMaxWidth on the dialogs with the correct design width

**Database changed?**

No

**Where should the reviewer start?**

- [ ] OutOfSpaceDialog.kt
- [ ] WifiPromptDialog.kt
- [ ] NotificationsPermissionRequester.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2859](https://aptoide.atlassian.net/browse/APP-2859)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2859](https://aptoide.atlassian.net/browse/APP-2859)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2859]: https://aptoide.atlassian.net/browse/APP-2859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2859]: https://aptoide.atlassian.net/browse/APP-2859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ