### PR TITLE
[DT-1351] - Disable Edge to Edge enforcement

### DIFF
--- a/app-games/src/main/AndroidManifest.xml
+++ b/app-games/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
       android:networkSecurityConfig="@xml/network_security_config"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:supportsRtl="true"
-      android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
+      android:theme="@style/AptoideGames.Theme.OptOutEdgeToEdgeEnforcement"
       tools:replace="android:allowBackup">
     <uses-library android:name="org.apache.http.legacy" android:required="false" />
 

--- a/app-games/src/main/res/values/themes.xml
+++ b/app-games/src/main/res/values/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+  <style name="AptoideGames.Theme.OptOutEdgeToEdgeEnforcement" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
+  </style>
+</resources>


### PR DESCRIPTION
**What does this PR do?**

It disables the edge to edge enforcement imposed on Android 15.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] themes.xml
- [ ] AndroidManifest.xml

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [DT-1351](https://aptoide.atlassian.net/browse/DT-1351)

**What are the relevant tickets?**

  Tickets related to this pull-request: [DT-1351](https://aptoide.atlassian.net/browse/DT-1351)

  PRs related to this one: 
[#560](https://github.com/Aptoide/aptoide-client-dt/pull/560)
[#9](https://github.com/Catappult/appcoins-payments-android/pull/9)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[DT-1351]: https://aptoide.atlassian.net/browse/DT-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1351]: https://aptoide.atlassian.net/browse/DT-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ