### PR TITLE
[APP-2867] - Fix "%" encoding and decoding 

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/UrlActivity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/UrlActivity.kt
@@ -15,9 +15,6 @@ import com.aptoide.android.aptoidegames.home.AppThemeViewModel
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.toolbar.SimpleAppGamesToolbar
 import dagger.hilt.android.AndroidEntryPoint
-import java.net.URLDecoder
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets.UTF_8
 
 @AndroidEntryPoint
 class UrlActivity : AppCompatActivity() {
@@ -35,7 +32,7 @@ class UrlActivity : AppCompatActivity() {
           topBar = { SimpleAppGamesToolbar() }
         ) {
           url?.let {
-            UrlView(url = URLDecoder.decode(it, UTF_8.toString()))
+            UrlView(url = it)
           }
         }
       }
@@ -45,7 +42,7 @@ class UrlActivity : AppCompatActivity() {
   companion object {
     fun open(context: Context, url: String) {
       val intent = Intent(context, UrlActivity::class.java)
-        .apply { putExtra("url", URLEncoder.encode(url, UTF_8.toString())) }
+        .apply { putExtra("url", url) }
       context.startActivity(intent)
     }
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/dto/AnalyticsData.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/dto/AnalyticsData.kt
@@ -1,8 +1,7 @@
 package com.aptoide.android.aptoidegames.analytics.dto
 
+import android.net.Uri.encode
 import androidx.annotation.Keep
-import java.net.URLDecoder
-import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 @Keep
@@ -65,17 +64,16 @@ data class SearchMeta(
   val searchTerm get() = searchKeyword
   val searchTermSource get() = searchType
 
-  override fun toString(): String = listOf(
-    URLEncoder.encode(insertedKeyword, StandardCharsets.UTF_8.toString()),
-    URLEncoder.encode(searchKeyword, StandardCharsets.UTF_8.toString()),
-    searchType
-  ).joinToString("~")
+  override fun toString(): String = encode(
+    "$insertedKeyword~$searchKeyword~$searchType",
+    StandardCharsets.UTF_8.toString()
+  )
 
   companion object {
     fun fromString(source: String) = source.split("~").let {
       SearchMeta(
-        insertedKeyword = URLDecoder.decode(it[0], StandardCharsets.UTF_8.toString()),
-        searchKeyword = URLDecoder.decode(it[1], StandardCharsets.UTF_8.toString()),
+        insertedKeyword = it[0],
+        searchKeyword = it[1],
         searchType = it[2]
       )
     }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/BonusBundleMoreView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/BonusBundleMoreView.kt
@@ -69,7 +69,7 @@ fun seeMoreBonusScreen() = ScreenData.withAnalytics(
   screenAnalyticsName = "SeeAll",
   deepLinks = listOf(navDeepLink { uriPattern = BuildConfig.DEEP_LINK_SCHEMA + seeMoreRoute })
 ) { arguments, navigate, navigateBack ->
-  val bundleTitle = arguments?.getString("title")!!.replace(".", "%")
+  val bundleTitle = arguments?.getString("title")!!
   val bundleTag = arguments.getString("tag")!!
 
   MoreBonusBundleView(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -1,6 +1,7 @@
 package com.aptoide.android.aptoidegames.home
 
 import android.content.Context
+import android.net.Uri.encode
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -440,7 +441,7 @@ fun getSeeMoreRouteNavigation(
   val genericAnalytics = rememberGenericAnalytics()
 
   val context = LocalContext.current
-  val title = bundle.title.translateOrKeep(context)
+  val title = encode(bundle.title.translateOrKeep(context))
   return {
     genericAnalytics.sendSeeAllClick(analyticsContext)
     navigate(
@@ -455,7 +456,7 @@ fun getSeeMoreBonusRouteNavigation(
   bundle: Bundle,
   navigate: (String) -> Unit,
 ): () -> Unit {
-  val title = bundle.title.replace("%", ".")
+  val title = encode(bundle.title)
   return {
     navigate(
       buildSeeMoreBonusRoute(title, "${bundle.tag}-more")


### PR DESCRIPTION
**What does this PR do?**

Fixes two bugs:
 - When we searched for an app putting a % in the search keyword, clicking on an app from search results would crash the app.
 - When we had a % sign in a bundle/section title, it's see more section wouldn't decode the symbol correctly.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] See by commit

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2867](https://aptoide.atlassian.net/browse/APP-2867)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2867](https://aptoide.atlassian.net/browse/APP-2867)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2867]: https://aptoide.atlassian.net/browse/APP-2867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2867]: https://aptoide.atlassian.net/browse/APP-2867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ