### PR TITLE
[APP-2643] Add download numbers to app view

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -50,6 +50,7 @@ import androidx.navigation.navDeepLink
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.ScreenData
+import cm.aptoide.pt.extensions.formatDownloads
 import cm.aptoide.pt.extensions.isYoutubeURL
 import cm.aptoide.pt.extensions.openUrlInBrowser
 import cm.aptoide.pt.extensions.parseDate
@@ -621,15 +622,19 @@ fun AppPresentationView(app: App) {
           overflow = TextOverflow.Ellipsis,
         )
       }
-      AppRating(rating = app.pRating)
+      AppRatingAndDownloads(
+        rating = app.pRating,
+        downloads = app.pDownloads
+      )
     }
   }
 }
 
 @Composable
-fun AppRating(
+fun AppRatingAndDownloads(
   modifier: Modifier = Modifier,
   rating: Rating,
+  downloads: Int? = null
 ) {
   Row(
     modifier = modifier
@@ -647,6 +652,8 @@ fun AppRating(
         .size(12.dp),
     )
     Text(
+      modifier = modifier
+        .padding(end = 8.dp),
       text = if (rating.avgRating == 0.0) {
         "--"
       } else {
@@ -656,6 +663,14 @@ fun AppRating(
       style = AGTypography.InputsXS,
       overflow = TextOverflow.Ellipsis,
     )
+    downloads?.let {
+      Text(
+        text = "${it.formatDownloads()} downloads",
+        maxLines = 1,
+        style = AGTypography.InputsXS,
+        overflow = TextOverflow.Ellipsis,
+      )
+    }
   }
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
@@ -39,7 +39,7 @@ import com.aptoide.android.aptoidegames.analytics.presentation.AnalyticsContext
 import com.aptoide.android.aptoidegames.analytics.presentation.SwipeListener
 import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
 import com.aptoide.android.aptoidegames.analytics.presentation.withItemPosition
-import com.aptoide.android.aptoidegames.appview.AppRating
+import com.aptoide.android.aptoidegames.appview.AppRatingAndDownloads
 import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
 import com.aptoide.android.aptoidegames.drawables.icons.getBonusIconRight
 import com.aptoide.android.aptoidegames.home.BundleHeader
@@ -175,7 +175,7 @@ private fun AppGridView(
         .defaultMinSize(minHeight = 36.dp),
       style = AGTypography.DescriptionGames
     )
-    AppRating(rating = app.pRating)
+    AppRatingAndDownloads(rating = app.pRating)
   }
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/ProgressText.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/ProgressText.kt
@@ -20,7 +20,7 @@ import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 import com.aptoide.android.aptoidegames.R.string
-import com.aptoide.android.aptoidegames.appview.AppRating
+import com.aptoide.android.aptoidegames.appview.AppRatingAndDownloads
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.theme.Palette
@@ -79,7 +79,7 @@ private fun ProgressTextContent(
         maxLines = 1
       )
     } else {
-      AppRating(rating = app.pRating)
+      AppRatingAndDownloads(rating = app.pRating)
     }
 
     is Waiting,

--- a/extensions/src/main/java/cm/aptoide/pt/extensions/IntExtensions.kt
+++ b/extensions/src/main/java/cm/aptoide/pt/extensions/IntExtensions.kt
@@ -4,6 +4,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.sp
+import java.util.Locale
 
 @Composable
 fun Int.spAsDp(): Dp = with(LocalDensity.current) { sp.toDp() }
+
+fun Int.formatDownloads(): String {
+  val suffixes = listOf("", "K", "M", "B", "T")
+  var value = this.toDouble()
+  var index = 0
+
+  while (value >= 1000 && index < suffixes.size - 1) {
+    value /= 1000
+    index++
+  }
+
+  return String.format(Locale.ENGLISH, "%.1f%s+", value, suffixes[index])
+}

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/App.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/App.kt
@@ -23,6 +23,7 @@ data class App(
   val rating: Rating,
   val pRating: Rating,
   val downloads: Int,
+  val pDownloads: Int,
   val versionName: String,
   val versionCode: Int,
   val featureGraphic: String,
@@ -92,6 +93,7 @@ val emptyApp = App(
     votes = emptyList()
   ),
   downloads = 0,
+  pDownloads = 0,
   versionName = "",
   versionCode = 0,
   featureGraphic = "",

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AptoideAppsRepository.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AptoideAppsRepository.kt
@@ -283,6 +283,7 @@ fun AppJSON.toDomainModel(
     votes = this.stats.prating.votes?.map { Votes(it.value, it.count) }
   ),
   downloads = this.stats.downloads,
+  pDownloads = this.stats.pdownloads,
   versionName = this.file.vername,
   versionCode = this.file.vercode,
   screenshots = this.media?.screenshots?.map { it.url },


### PR DESCRIPTION
**What does this PR do?**

   This PR aims to add the download numbers to the app view screen

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2643](https://aptoide.atlassian.net/browse/APP-2643)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2643](https://aptoide.atlassian.net/browse/APP-2643)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2643]: https://aptoide.atlassian.net/browse/APP-2643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2643]: https://aptoide.atlassian.net/browse/APP-2643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ