### PR TITLE
[APP-2877] Fix notifications permission

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/notification/SystemNotificationShower.java
+++ b/app/src/main/java/cm/aptoide/pt/notification/SystemNotificationShower.java
@@ -86,7 +86,6 @@ public class SystemNotificationShower implements Presenter {
   }
 
   @Override public void present() {
-    setupChannels();
     setNotificationPressSubscribe();
     setNotificationDismissSubscribe();
     setNotificationBootCompletedSubscribe();
@@ -105,6 +104,7 @@ public class SystemNotificationShower implements Presenter {
   private void showNewNotification() {
     subscriptions.add(notificationCenter.getNewNotifications()
         .flatMapCompletable(aptoideNotification -> {
+          setupChannels();
           int notificationId =
               notificationIdsMapper.getNotificationId(aptoideNotification.getType());
           if (aptoideNotification.getType() != AptoideNotification.APPC_PROMOTION


### PR DESCRIPTION
**What does this PR do?**

   A few sentences describing the overall goals of the pull request's commits. 

   Explain any technical decisions that were made and why (when it makes sense).

**Database changed?**

No

**Where should the reviewer start?**

- [ ] SystemNotificationShower.java

**How should this be manually tested?**

Open app check that you dont get the permission prompt unless you really need it (have a permission to show).
Before, we would be showing it always.
We think this is happening because this permission is mandatory above android 13. But our target is 12, which means we dont have a way to request it, so we think the system itself is handling the permission request when we create the notification channels. If we commented the notification channel creation, it would not show the permission dialog.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2877](https://aptoide.atlassian.net/browse/APP-2877)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2877]: https://aptoide.atlassian.net/browse/APP-2877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ