### PR TITLE
[APP-2890] - Add PID to DeviceInfoViewModel

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/DeviceInfoViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/DeviceInfoViewModel.kt
@@ -10,10 +10,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider.Factory
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.aptoide.android.aptoidegames.BuildConfig
 import cm.aptoide.pt.aptoide_network.di.StoreName
 import cm.aptoide.pt.environment_info.DeviceInfo
 import cm.aptoide.pt.extensions.runPreviewable
+import com.appcoins.payments.arch.WalletProvider
+import com.appcoins.payments.di.Payments
+import com.appcoins.payments.di.walletProvider
+import com.aptoide.android.aptoidegames.BuildConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -30,6 +33,7 @@ class InjectionsProvider @Inject constructor(
 
 class DeviceInfoViewModel(
   private val deviceInfo: DeviceInfo,
+  private val walletProvider: WalletProvider,
   private val storeName: String,
 ) : ViewModel() {
 
@@ -44,9 +48,11 @@ class DeviceInfoViewModel(
 
   init {
     viewModelScope.launch {
+      val pid = runCatching { walletProvider.getWallet() }.getOrNull()?.address ?: "-"
       viewModelState.update {
         "${deviceInfo.getDeviceInfoSummary()}\n" +
           "AptoideGames: ${Integer.toHexString(storeName.hashCode())}\n" +
+          "PID: $pid\n" +
           "AptoideGames version: ${BuildConfig.VERSION_NAME}(${BuildConfig.VERSION_CODE})\n"
       }
     }
@@ -64,6 +70,7 @@ fun rememberDeviceInfo(): String = runPreviewable(
           @Suppress("UNCHECKED_CAST")
           return DeviceInfoViewModel(
             deviceInfo = injectionsProvider.deviceInfo,
+            walletProvider = Payments.walletProvider,
             storeName = injectionsProvider.storeName
           ) as T
         }


### PR DESCRIPTION
**What does this PR do?**

Feedback emails were coming without PID (Wallet Address), it was added to the device info so it comes on emails as well, just like in GH.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] DeviceInfoViewModel.kt

**How should this be manually tested?**

Go to the Contact Us after a payment fail, go through the flow and see if the PID now appears as expected.

  Flow on how to test this or QA Tickets related to this use-case: [APP-2890](https://aptoide.atlassian.net/browse/APP-2890)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2890](https://aptoide.atlassian.net/browse/APP-2890)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2890]: https://aptoide.atlassian.net/browse/APP-2890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2890]: https://aptoide.atlassian.net/browse/APP-2890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ