### PR TITLE
[APP-2893] - Force 2 Decimals in AG Purchase Info

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/AppGamesPurchaseInfo.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/AppGamesPurchaseInfo.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.PreviewLandscapeDark
+import cm.aptoide.pt.extensions.format
 import cm.aptoide.pt.extensions.getAppIconDrawable
 import cm.aptoide.pt.extensions.getAppName
 import cm.aptoide.pt.extensions.runPreviewable
@@ -71,7 +72,7 @@ fun PurchaseInfoRow(
         modifier = modifier,
         buyingPackage = buyingPackage,
         productName = productInfo?.title,
-        price = productInfo?.run { "$priceValue $priceCurrency" },
+        price = productInfo?.run { "${priceValue.format(2)} $priceCurrency" },
       )
     }
 
@@ -80,7 +81,7 @@ fun PurchaseInfoRow(
         modifier = modifier,
         buyingPackage = buyingPackage,
         productName = productInfo?.title,
-        price = productInfo?.run { "$priceValue $priceCurrency" },
+        price = productInfo?.run { "${priceValue.format(2)} $priceCurrency" },
       )
     }
   }


### PR DESCRIPTION
**What does this PR do?**

Makes every purchase info in AG have 2 decimal places

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AppGamesPurchaseInfo.kt
- [ ] TextFormatter.kt 

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2893](https://aptoide.atlassian.net/browse/APP-2893)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2893](https://aptoide.atlassian.net/browse/APP-2893)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2893]: https://aptoide.atlassian.net/browse/APP-2893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2893]: https://aptoide.atlassian.net/browse/APP-2893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ