### PR TITLE
[APP-2904] - Fix YoutubePlayer video errors

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -50,6 +50,7 @@ import androidx.navigation.navDeepLink
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.ScreenData
+import cm.aptoide.pt.extensions.extractVideoId
 import cm.aptoide.pt.extensions.formatDownloads
 import cm.aptoide.pt.extensions.isYoutubeURL
 import cm.aptoide.pt.extensions.openUrlInBrowser
@@ -231,7 +232,7 @@ fun AppViewContent(
     }
 
     if (showYoutubeVideo) {
-      val videoId = app.videos[0].split("embed/").getOrElse(1) { "" }
+      val videoId = app.videos[0].extractVideoId()
       val videoHeightPx = with(localDensity) { VIDEO_HEIGHT.dp.toPx() }
       val contentDesc = String.format("Video of %1s", app.name)
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/videos/presentation/YoutubePlayer.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/videos/presentation/YoutubePlayer.kt
@@ -3,6 +3,9 @@ package com.aptoide.android.aptoidegames.videos.presentation
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -79,6 +82,7 @@ fun AppViewYoutubePlayer(
     val videoSettingsViewModel = hiltViewModel<VideoSettingsViewModel>()
     val shouldMute by videoSettingsViewModel.uiState.collectAsState()
 
+    var showVideo by remember { mutableStateOf(false) }
     var showFullscreen by remember { mutableStateOf(false) }
     var userPaused by remember { mutableStateOf(false) }
 
@@ -152,34 +156,51 @@ fun AppViewYoutubePlayer(
         state: PlayerConstants.PlayerState,
       ) {
         when (state) {
+          PlayerConstants.PlayerState.VIDEO_CUED -> showVideo = true
+
           PlayerConstants.PlayerState.PAUSED -> {
             if (showFullscreen) {
               userPaused = true
+            } else {
+              youtubePlayer?.hidePlayerControls()
+              youtubePlayer?.hideVideoTitle()
             }
+            showVideo = true
           }
 
           PlayerConstants.PlayerState.PLAYING -> {
             if (showFullscreen) {
               userPaused = false
+            } else {
+              youtubePlayer?.hidePlayerControls()
+              youtubePlayer?.hideVideoTitle()
             }
+            showVideo = true
           }
 
           else -> {}
         }
       }
     })
-
-    if (youtubePlayerView != null) {
+    val show = youtubePlayerView != null && showVideo
+    AnimatedVisibility(
+      visible = show,
+      enter = fadeIn(),
+    ) {
       AppViewYoutubePlayerContent(
         modifier = modifier,
-        youtubePlayerView = youtubePlayerView,
+        youtubePlayerView = youtubePlayerView!!, //check on visible already
         youtubePlayer = youtubePlayer,
         showFullscreen = showFullscreen,
         toggleFullscreen = { showFullscreen = !showFullscreen },
         shouldMute = shouldMute,
         contentDescription = contentDesc
       )
-    } else {
+    }
+    AnimatedVisibility(
+      visible = !show,
+      exit = fadeOut()
+    ) {
       onErrorContent()
     }
   }

--- a/extensions/src/main/java/cm/aptoide/pt/extensions/StringExtensions.kt
+++ b/extensions/src/main/java/cm/aptoide/pt/extensions/StringExtensions.kt
@@ -5,6 +5,7 @@ import android.text.Spanned
 import android.text.style.StrikethroughSpan
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.core.net.toUri
 import androidx.core.text.HtmlCompat
 import androidx.core.text.getSpans
 import java.text.SimpleDateFormat
@@ -21,6 +22,24 @@ fun String.parseDate(pattern: String = "yyyy-MM-dd HH:mm:ss"): Date? = try {
 fun String.isYoutubeURL(): Boolean {
   val pattern = "^(http(s)?://)?((w){3}.)?youtu(be|.be)?(\\.com)?/.+"
   return matches(Regex(pattern))
+}
+
+fun String.extractVideoId(): String {
+  // Ensure the URL starts with a valid scheme
+  val url = if (this.lowercase().startsWith("http")) {
+    this.toUri()
+  } else {
+    "https://$this".toUri()
+  }
+
+  // Try to extract the video ID from the query parameters (removes / for the video to work if needed)
+  if (url.query != null) {
+    if (url.getQueryParameter("v") != null)
+      return url.getQueryParameter("v")!!.replace("/", "")
+  }
+
+  // If not found in query parameters, try the path component
+  return url.lastPathSegment ?: ""
 }
 
 fun String.getTextSpans(): Pair<Spanned, List<TextSpan>> {


### PR DESCRIPTION
**What does this PR do?**

It implements a new function extractVideoId in StringExtensions to support different youtube url formats. It also assures that the video is only played if it reaches the supposed state to play, otherwise it shows the FG.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AppViewScreen.kt
- [ ] YoutubePlayer.kt
- [ ] StringExtensions.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2904](https://aptoide.atlassian.net/browse/APP-2904)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2904](https://aptoide.atlassian.net/browse/APP-2904)




**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2904]: https://aptoide.atlassian.net/browse/APP-2904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2904]: https://aptoide.atlassian.net/browse/APP-2904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ