### PR TITLE
[APP-2887] Delete cached files after successful installations

### DIFF
--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstaller.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstaller.kt
@@ -111,7 +111,11 @@ class AptoideInstaller @Inject constructor(
           when (val result = installEvents.events.filter { it.sessionId == sessionId }.first()) {
             is InstallResult.Fail -> throw Exception(result.message)
             is InstallResult.Abort -> throw AbortException(result.message)
-            is InstallResult.Success -> emit(100)
+            is InstallResult.Success -> {
+              emit(100)
+              apkFiles.deleteFromCache()
+              obbFiles.deleteFromCache()
+            }
           }
         }
           .onFailure { abandon() }
@@ -222,6 +226,8 @@ class AptoideInstaller @Inject constructor(
       processedSize += size
     }
   }
+
+  private fun Collection<File>.deleteFromCache() = forEach(File::delete)
 
   companion object {
     private const val SESSION_INSTALL_REQUEST_CODE = 18


### PR DESCRIPTION
**What does this PR do?**

   - Makes the AptoideInstaller delete the downloaded files of the installation that remained in the cache path used.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AptoideInstaller.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2887](https://aptoide.atlassian.net/browse/APP-2887)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2887](https://aptoide.atlassian.net/browse/APP-2887)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass