### PR TITLE
[APP-2905] Control icon progress based on state class type

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/AppIconWProgress.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/AppIconWProgress.kt
@@ -54,20 +54,22 @@ fun AppIconWProgress(
         }
       }
     }
-    LaunchedEffect(key1 = state) {
-      animation.snapTo(0f)
+    LaunchedEffect(key1 = state?.javaClass?.simpleName) {
       when (state) {
         is Waiting,
         is ReadyToInstall,
         is Installing,
         is Uninstalling,
-        -> animation.animateTo(
-          targetValue = 1f,
-          animationSpec = infiniteRepeatable(
-            animation = tween(1000, easing = LinearEasing),
-            repeatMode = Restart
+        -> {
+          animation.snapTo(0f)
+          animation.animateTo(
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+              animation = tween(1000, easing = LinearEasing),
+              repeatMode = Restart
+            )
           )
-        )
+        }
 
         else -> animation.stop()
       }


### PR DESCRIPTION
**What does this PR do?**

   - Changes the LaunchedEffect that controls the anamitation for indeterminate progresses to be triggered based on the download state object type and not the object itself. Since the progress in the Installing state is constantly being updated, the object reference changes and the LaunchedEffect is triggered each time.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AppIconWProgress.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2905](https://aptoide.atlassian.net/browse/APP-2905)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2905](https://aptoide.atlassian.net/browse/APP-2905)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2905]: https://aptoide.atlassian.net/browse/APP-2905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2905]: https://aptoide.atlassian.net/browse/APP-2905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ