### PR TITLE
[APP-2965] Add support for different store names and signatures

### DIFF
--- a/app-games/build.gradle.kts
+++ b/app-games/build.gradle.kts
@@ -20,7 +20,15 @@ android {
     versionCode = Integer.parseInt(project.property("VERSION_CODE_APTOIDEGAMES").toString())
     versionName = "0.9.0"
 
-    buildConfigField("String", "MARKET_NAME", "\"aptoide-games\"")
+    System.getenv("STORE_NAME")
+      .also {
+        buildConfigField(
+          type = "String",
+          name = "MARKET_NAME",
+          value = "\"${it ?: "aptoide-games"}\""
+        )
+      }
+
     buildConfigField("String", "STORE_DOMAIN", "\"https://ws75.aptoide.com/api/7.20240701/\"")
     buildConfigField("String", "SEARCH_BUZZ_DOMAIN", "\"https://buzz.aptoide.com:10002\"")
     buildConfigField(
@@ -76,10 +84,18 @@ android {
 
   signingConfigs {
     create("signingConfigRelease") {
-      storeFile = project.file(project.properties[KeyHelper.KEY_STORE_FILE].toString())
-      storePassword = project.properties[KeyHelper.KEY_STORE_PASS].toString()
-      keyAlias = project.properties[KeyHelper.KEY_ALIAS].toString()
-      keyPassword = project.properties[KeyHelper.KEY_PASS].toString()
+      storeFile = project.file(
+        project.properties[
+          System.getenv("KEY_STORE_FILE") ?: KeyHelper.KEY_STORE_FILE
+        ].toString()
+      )
+      storePassword = project.properties[
+        System.getenv("KEY_STORE_PASS") ?: KeyHelper.KEY_STORE_PASS
+      ].toString()
+      keyAlias =
+        project.properties[System.getenv("KEY_ALIAS") ?: KeyHelper.KEY_ALIAS].toString()
+      keyPassword =
+        project.properties[System.getenv("KEY_PASS") ?: KeyHelper.KEY_PASS].toString()
     }
   }
 


### PR DESCRIPTION
**What does this PR do?**

   - Adds support for different store names and signatures in the build process through environment variables.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] build.gradle.kts (app-games)

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2965](https://aptoide.atlassian.net/browse/APP-2965)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2965](https://aptoide.atlassian.net/browse/APP-2965)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2965]: https://aptoide.atlassian.net/browse/APP-2965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2965]: https://aptoide.atlassian.net/browse/APP-2965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ