### PR TITLE
[APP-3022] Add utm_package_name as an Indicative user property

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
@@ -87,12 +87,14 @@ class BIAnalytics(private val analyticsSender: AnalyticsSender) {
     utmCampaign: String?,
     utmTerm: String?,
     utmContent: String?,
+    utmPackageName: String?,
   ) = analyticsSender.setUserProperties(
     "utm_source" to utmSource,
     "utm_medium" to utmMedium,
     "utm_campaign" to utmCampaign,
     "utm_term" to utmTerm,
-    "utm_content" to utmContent
+    "utm_content" to utmContent,
+    "utm_package_name" to utmPackageName,
   )
 
   fun sendFirstLaunchEvent() = analyticsSender.logEvent(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyManagerProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyManagerProbe.kt
@@ -35,7 +35,8 @@ class ApkfyManagerProbe(
           utmMedium = utmMedium,
           utmCampaign = utmCampaign,
           utmTerm = utmTerm,
-          utmContent = utmContent
+          utmContent = utmContent,
+          utmPackageName = packageName
         )
       } else if (packageName == null && oemId == null) {
         //Safe to assume there are no utms, so no need to check
@@ -44,7 +45,8 @@ class ApkfyManagerProbe(
           utmMedium = UTM_PROPERTY_NO_APKFY,
           utmCampaign = UTM_PROPERTY_NO_APKFY,
           utmTerm = UTM_PROPERTY_NO_APKFY,
-          utmContent = UTM_PROPERTY_NO_APKFY
+          utmContent = UTM_PROPERTY_NO_APKFY,
+          utmPackageName = UTM_PROPERTY_NO_APKFY
         )
       } else {
         biAnalytics.setUTMProperties(
@@ -52,7 +54,8 @@ class ApkfyManagerProbe(
           utmMedium = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
           utmCampaign = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
           utmTerm = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-          utmContent = UTM_PROPERTY_APKFY_WITHOUT_UTMS
+          utmContent = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
+          utmPackageName = packageName
         )
       }
     }


### PR DESCRIPTION
**What does this PR do?**

   - Adds the Indicative user property 'utm_package_name', which is the package name that comes in the Apkfy flow.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] BIAnalytics.kt
- [ ] ApkfyManagerProbe.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-3022](https://aptoide.atlassian.net/browse/APP-3022)

 - Start APKFY and check if the property is set and sent to indicative.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-3022](https://aptoide.atlassian.net/browse/APP-3022)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-3022]: https://aptoide.atlassian.net/browse/APP-3022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-3022]: https://aptoide.atlassian.net/browse/APP-3022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ