### PR TITLE
[APP-3028] 1st installation permissions session and obbs

### DIFF
--- a/app-games/build.gradle.kts
+++ b/app-games/build.gradle.kts
@@ -245,6 +245,9 @@ dependencies {
   implementation(LibraryDependency.ACCOMPANIST_WEBVIEW)
   implementation(LibraryDependency.ACCOMPANIST_PERMISSIONS)
 
+  //WorkManager
+  implementation(LibraryDependency.WORK_MANAGER)
+  implementation(LibraryDependency.HILT_WORK)
 }
 
 fun BaseFlavor.buildConfigFieldFromGradleProperty(gradlePropertyName: String) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/di/InstallerModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/di/InstallerModule.kt
@@ -10,6 +10,7 @@ import cm.aptoide.pt.install_manager.environment.NetworkConnection
 import cm.aptoide.pt.installer.AptoideDownloader
 import cm.aptoide.pt.installer.AptoideInstallPackageInfoMapper
 import cm.aptoide.pt.installer.AptoideInstaller
+import cm.aptoide.pt.installer.obb.OBBInstallManager
 import cm.aptoide.pt.task_info.AptoideTaskInfoRepository
 import com.aptoide.android.aptoidegames.installer.analytics.AnalyticsInstallPackageInfoMapper
 import com.aptoide.android.aptoidegames.installer.analytics.DownloadProbe
@@ -45,18 +46,21 @@ interface InstallerModule {
       installer: AptoideInstaller,
       installAnalytics: InstallAnalytics,
       networkConnection: NetworkConnection,
-    ): InstallManager = InstallManager.with(
+    ): InstallManager = OBBInstallManager(
       context = appContext,
-      taskInfoRepository = taskInfoRepository,
-      packageDownloader = DownloadProbe(
-        packageDownloader = downloader,
-        analytics = installAnalytics,
-      ),
-      packageInstaller = InstallProbe(
-        packageInstaller = installer,
-        analytics = installAnalytics,
-      ),
-      networkConnection = networkConnection
+      installManager = InstallManager.with(
+        context = appContext,
+        taskInfoRepository = taskInfoRepository,
+        packageDownloader = DownloadProbe(
+          packageDownloader = downloader,
+          analytics = installAnalytics,
+        ),
+        packageInstaller = InstallProbe(
+          packageInstaller = installer,
+          analytics = installAnalytics,
+        ),
+        networkConnection = networkConnection
+      )
     )
 
     @Singleton

--- a/aptoide-installer/src/main/AndroidManifest.xml
+++ b/aptoide-installer/src/main/AndroidManifest.xml
@@ -5,10 +5,16 @@
   <uses-permission android:name="android.permission.ENFORCE_UPDATE_OWNERSHIP" />
   <uses-permission android:name="android.permission.UPDATE_PACKAGES_WITHOUT_USER_ACTION" />
   <!--Permissions for the Android below 11 (R)-->
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
   <application
       android:allowBackup="true"
-      android:requestLegacyExternalStorage="true" />
+      android:requestLegacyExternalStorage="true">
+
+    <service
+        android:name="cm.aptoide.pt.installer.obb.ObbService"
+        android:process=":obbMoverProcess"
+        android:exported="false" />
+  </application>
 </manifest>

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/obb/OBBInstallManager.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/obb/OBBInstallManager.kt
@@ -1,0 +1,50 @@
+package cm.aptoide.pt.installer.obb
+
+import android.app.ActivityManager
+import android.app.Application.ACTIVITY_SERVICE
+import android.content.Context
+import android.os.Process
+import cm.aptoide.pt.install_manager.App
+import cm.aptoide.pt.install_manager.InstallManager
+import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
+import kotlinx.coroutines.flow.Flow
+
+class OBBInstallManager(
+  private val context: Context,
+  private val installManager: InstallManager
+) : InstallManager {
+  override fun getApp(packageName: String) = installManager.getApp(packageName)
+
+  override val installedApps: Set<App>
+    get() = installManager.installedApps
+  override val workingAppInstallers: Flow<App?>
+    get() = installManager.workingAppInstallers
+  override val scheduledApps: List<App>
+    get() = installManager.scheduledApps
+  override val appsChanges: Flow<App>
+    get() = installManager.appsChanges
+
+  override fun getMissingFreeSpaceFor(installPackageInfo: InstallPackageInfo) =
+    installManager.getMissingFreeSpaceFor(installPackageInfo)
+
+  override suspend fun restore() {
+    if (getProcessName(
+        context,
+        Process.myPid()
+      ) != "${context.packageName}:obbMoverProcess"
+    ) {
+      installManager.restore()
+    }
+  }
+}
+
+fun getProcessName(cxt: Context, pid: Int): String? {
+  val am = cxt.getSystemService(ACTIVITY_SERVICE) as ActivityManager
+  val runningApps = am.runningAppProcesses ?: return null
+  for (procInfo in runningApps) {
+    if (procInfo.pid == pid) {
+      return procInfo.processName
+    }
+  }
+  return null
+}

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/obb/OBBInstaller.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/obb/OBBInstaller.kt
@@ -1,0 +1,41 @@
+package cm.aptoide.pt.installer.obb
+
+import android.os.Environment
+import cm.aptoide.pt.installer.platform.copyWithProgressTo
+import java.io.File
+
+private val OBB_FOLDER = Environment.getExternalStorageDirectory().absolutePath + "/Android/obb/"
+
+internal suspend fun Collection<File>.installOBBs(
+  packageName: String,
+  progress: suspend (Long) -> Unit,
+) {
+  val outputPath = "$OBB_FOLDER$packageName/"
+  val prepared = File(outputPath).run {
+    deleteRecursively()
+    mkdirs()
+  }
+  if (!prepared) throw IllegalStateException("Can't create OBB folder: $outputPath")
+
+  var processedSize: Long = 0
+  forEach { file ->
+    val size = file.length()
+    val destinationFile = File(outputPath + file.name)
+    // Try to move first
+    file.renameTo(destinationFile)
+      .takeUnless { it }
+      ?.also {
+        file.inputStream().use { inputStream ->
+          destinationFile.createNewFile()
+          destinationFile.outputStream().use { outputStream ->
+            inputStream
+              .copyWithProgressTo(outputStream)
+              .collect {
+                progress(processedSize + it)
+              }
+          }
+        }
+      }
+    processedSize += size
+  }
+}

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/obb/ObbService.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/obb/ObbService.kt
@@ -1,0 +1,144 @@
+package cm.aptoide.pt.installer.obb
+
+import android.app.Service
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Bundle
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.os.Message
+import android.os.Messenger
+import cm.aptoide.pt.installer.obb.ObbService.Companion.OBB_MOVE_FAIL
+import cm.aptoide.pt.installer.obb.ObbService.Companion.OBB_MOVE_SUCCESS
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.io.File
+import kotlin.coroutines.resume
+
+internal interface OBBServiceCallback {
+  fun onSuccess()
+  fun onError()
+}
+
+internal class ObbService : Service() {
+  override fun onBind(intent: Intent): IBinder {
+    return Messenger(OBBDataHandler()).binder
+  }
+
+  private class OBBDataHandler : Handler(Looper.getMainLooper()) {
+    override fun handleMessage(msg: Message) {
+      val replyMessenger = msg.replyTo
+
+      try {
+        when (msg.what) {
+          MSG_OBB_DATA -> {
+            val filePaths = msg.data.getStringArrayList(OBB_FILE_PATHS_EXTRA)
+            val packageName = msg.data.getString(PACKAGE_NAME_EXTRA)
+
+            if (!filePaths.isNullOrEmpty() && !packageName.isNullOrBlank()) {
+              val files = filePaths.map(::File)
+
+              CoroutineScope(Dispatchers.IO).launch {
+                val obbResultMsg = try {
+                  files.installOBBs(packageName = packageName, progress = {})
+                  Message.obtain(null, OBB_MOVE_SUCCESS)
+                } catch (e: Throwable) {
+                  e.printStackTrace()
+                  Message.obtain(null, OBB_MOVE_FAIL)
+                }
+
+                replyMessenger.send(obbResultMsg)
+              }
+            } else {
+              throw IllegalStateException("Error moving OBB files: wrong input")
+            }
+          }
+
+          else -> {
+            super.handleMessage(msg)
+            throw IllegalStateException("Error moving OBB files: wrong message type")
+          }
+        }
+      } catch (e: Throwable) {
+        e.printStackTrace()
+        replyMessenger.send(Message.obtain(null, OBB_MOVE_FAIL))
+      }
+    }
+  }
+
+  companion object {
+    const val OBB_FILE_PATHS_EXTRA = "obb_file_paths"
+    const val PACKAGE_NAME_EXTRA = "package_name"
+
+    const val MSG_OBB_DATA = 1
+
+    const val OBB_MOVE_SUCCESS = 0
+    const val OBB_MOVE_FAIL = -1
+
+    internal suspend fun bindServiceAndWaitForResult(
+      context: Context,
+      packageName: String,
+      obbFilePaths: List<String>,
+    ): Boolean = suspendCancellableCoroutine { continuation ->
+      val serviceIntent = Intent(context, ObbService::class.java)
+
+      //Callback to handle OBB service results
+      val obbServiceCallback = object : OBBServiceCallback {
+        override fun onSuccess() = continuation.resume(true)
+        override fun onError() = continuation.resume(false)
+      }
+
+      val connection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName, service: IBinder) {
+          val serviceMessenger = Messenger(service)
+
+          val obbDataMsg = Message.obtain(null, MSG_OBB_DATA)
+          obbDataMsg.data = Bundle().apply {
+            this.putStringArrayList(OBB_FILE_PATHS_EXTRA, ArrayList(obbFilePaths))
+            this.putString(PACKAGE_NAME_EXTRA, packageName)
+          }
+
+          obbDataMsg.replyTo = Messenger(OBBServiceResponseHandler(obbServiceCallback))
+          serviceMessenger.send(obbDataMsg)
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+          if (!continuation.isCompleted) {
+            continuation.cancel(
+              cause = IllegalStateException("Error moving OBB files: service disconnected")
+            )
+          }
+        }
+      }
+
+      // Bind to the service
+      context.bindService(serviceIntent, connection, Context.BIND_AUTO_CREATE)
+
+      // Handle cancellation of coroutine
+      continuation.invokeOnCancellation {
+        context.unbindService(connection)
+      }
+    }
+  }
+}
+
+private class OBBServiceResponseHandler(
+  val obbServiceCallback: OBBServiceCallback
+) : Handler(Looper.getMainLooper()) {
+  override fun handleMessage(msg: Message) {
+    when (msg.what) {
+      OBB_MOVE_FAIL -> obbServiceCallback.onError()
+      OBB_MOVE_SUCCESS -> obbServiceCallback.onSuccess()
+
+      else -> {
+        super.handleMessage(msg)
+        obbServiceCallback.onError()
+      }
+    }
+  }
+}

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/InstallPermissions.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/InstallPermissions.kt
@@ -48,8 +48,8 @@ class InstallPermissionsImpl @Inject constructor(
   }
 
   override suspend fun checkIfCanWriteExternal() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-      //Android is below 11
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+      //Android is below 13
       if (!context.hasWriteExternalStoragePermission()) {
         when (userActionLauncher.checkPermissionState(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
           //Requested permission

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/InstallPermissions.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/InstallPermissions.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
+import cm.aptoide.pt.extensions.hasPackageInstallsPermission
 import cm.aptoide.pt.extensions.hasWriteExternalStoragePermission
 import cm.aptoide.pt.install_manager.AbortException
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -32,7 +33,7 @@ class InstallPermissionsImpl @Inject constructor(
 ) : InstallPermissions {
 
   override suspend fun checkIfCanInstall() {
-    if (!areInstallationsAllowed()) {
+    if (!context.hasPackageInstallsPermission()) {
       if (userActionLauncher.confirm(UserConfirmation.INSTALL_SOURCE)) {
         userActionLauncher.launchIntent(
           Intent(
@@ -43,7 +44,7 @@ class InstallPermissionsImpl @Inject constructor(
       } else {
         throw AbortException("Not allowed")
       }
-      if (!areInstallationsAllowed()) throw AbortException("Not allowed")
+      if (!context.hasPackageInstallsPermission()) throw AbortException("Not allowed")
     }
   }
 
@@ -90,7 +91,4 @@ class InstallPermissionsImpl @Inject constructor(
       }
     }
   }
-
-  private fun areInstallationsAllowed(): Boolean =
-    context.packageManager.canRequestPackageInstalls()
 }

--- a/extensions/src/main/java/cm/aptoide/pt/extensions/ContextExtensions.kt
+++ b/extensions/src/main/java/cm/aptoide/pt/extensions/ContextExtensions.kt
@@ -24,6 +24,8 @@ fun Context.hasNotificationsPermission(): Boolean =
 fun Context.hasWriteExternalStoragePermission(): Boolean =
   isAllowed(Manifest.permission.WRITE_EXTERNAL_STORAGE)
 
+fun Context.hasPackageInstallsPermission(): Boolean = packageManager.canRequestPackageInstalls()
+
 @SuppressLint("InlinedApi")
 fun Context.isAllowed(permission: String): Boolean =
   ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED


### PR DESCRIPTION
**What does this PR do?**

   - Fixes the issue of not being able to move OBB files to the obb folder on the first session that the user allows the necessary permissions to install apps.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-3028](https://aptoide.atlassian.net/browse/APP-3028)

- Install an app with OBBs on the first session when the install permissions (unknown sources and external storage, if necessary) are accepted and check if the app installs successfully and the OBB files are moved to the device's storage Android/obb folder.
- Check for the following versions: < 11; 11; 12; 13; 14

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-3028](https://aptoide.atlassian.net/browse/APP-3028)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-3028]: https://aptoide.atlassian.net/browse/APP-3028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-3028]: https://aptoide.atlassian.net/browse/APP-3028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ