### PR TITLE
[APP-2910] Refactor padding logic on screens with Bottom bar

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/AllCategoriesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/AllCategoriesView.kt
@@ -159,7 +159,7 @@ fun CategoryList(
       .semantics { collectionInfo = CollectionInfo(size, GRID_COLUMNS) }
       .wrapContentSize(Alignment.TopCenter),
     columns = GridCells.Fixed(2),
-    contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 28.dp),
+    contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 72.dp),
     horizontalArrangement = Arrangement.spacedBy(8.dp),
     verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -185,7 +185,7 @@ fun BundlesView(
         .fillMaxSize()
         .wrapContentSize(Alignment.TopCenter),
       verticalArrangement = Arrangement.spacedBy(32.dp),
-      contentPadding = PaddingValues(bottom = 32.dp)
+      contentPadding = PaddingValues(bottom = 72.dp)
     ) {
       items(viewState.bundles) { bundle ->
         OverrideAnalyticsBundleMeta(bundle.meta, navigate) { navigateTo ->

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/search/presentation/SearchView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/search/presentation/SearchView.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
@@ -609,7 +610,8 @@ fun EmptySearchView(
 ) {
   LazyColumn(
     modifier = Modifier.padding(start = 16.dp, end = 16.dp),
-  ) {
+    contentPadding = PaddingValues(bottom = 72.dp),
+    ) {
     itemsIndexed(
       items = searchResults,
     ) { index, app ->

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -190,8 +191,9 @@ private fun AppsList(
       modifier = Modifier
         .semantics { collectionInfo = CollectionInfo(appList.size, 1) }
         .padding(start = 16.dp, end = 16.dp)
-        .wrapContentSize(Alignment.TopCenter)
-    ) {
+        .wrapContentSize(Alignment.TopCenter),
+      contentPadding = PaddingValues(bottom = 72.dp)
+      ) {
       itemsIndexed(appList) { index, app ->
         AppItemUpdates(
           app = app,


### PR DESCRIPTION
**What does this PR do?**

This PR addresses the issue of the last item on the list being cut off. While this solution resolves the visibility issue of the last item, it does not yet address the problem of the scroll jump.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2910](https://aptoide.atlassian.net/browse/APP-2910)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2910](https://aptoide.atlassian.net/browse/APP-2910)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2910]: https://aptoide.atlassian.net/browse/APP-2910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2910]: https://aptoide.atlassian.net/browse/APP-2910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ