### PR TITLE
[APP-3008] - Ready To Install Notification

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/UserActionDialog.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/UserActionDialog.kt
@@ -52,6 +52,7 @@ import com.aptoide.android.aptoidegames.design_system.PrimaryTextButton
 import com.aptoide.android.aptoidegames.drawables.icons.getAptoideGamesToolbarLogo
 import com.aptoide.android.aptoidegames.installer.analytics.rememberInstallAnalytics
 import com.aptoide.android.aptoidegames.installer.analytics.toAnalyticsPayload
+import com.aptoide.android.aptoidegames.installer.notifications.rememberInstallerNotifications
 import com.aptoide.android.aptoidegames.permissions.AppPermissionsViewModel
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
@@ -103,6 +104,7 @@ fun UserActionDialog() {
   )
 
   val installAnalytics = rememberInstallAnalytics()
+  val installerNotifications = rememberInstallerNotifications()
   LaunchedEffect(
     key1 = state,
     key2 = isOnForeground,
@@ -141,6 +143,21 @@ fun UserActionDialog() {
               permissionsViewModel.setPermissionRequested(it.permission)
             } else {
               viewModel.onResult(false)
+            }
+          }
+
+          else -> Unit
+        }
+      } else {
+        when (val it = state) {
+          is InstallationAction -> {
+            if (!installationActionLaunched) {
+              //System action, we cannot access it any other way
+              if (it.intent.action == "android.content.pm.action.CONFIRM_INSTALL") {
+                val packageName = it.intent
+                  .getStringExtra("${BuildConfig.APPLICATION_ID}.pn") ?: "NaN"
+                installerNotifications.onReadyToInstall(packageName)
+              }
             }
           }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/FakeInstallerNotificationsManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/FakeInstallerNotificationsManager.kt
@@ -3,4 +3,5 @@ package com.aptoide.android.aptoidegames.installer.notifications
 class FakeInstallerNotificationsManager : InstallerNotificationsManager {
   override suspend fun initialize() {}
   override fun onInstallationQueued(packageName: String) {}
+  override fun onReadyToInstall(packageName: String) {}
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/InstallerNotificationsManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/InstallerNotificationsManager.kt
@@ -4,4 +4,5 @@ interface InstallerNotificationsManager {
 
   suspend fun initialize()
   fun onInstallationQueued(packageName: String)
+  fun onReadyToInstall(packageName: String)
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/RealInstallerNotificationsManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/RealInstallerNotificationsManager.kt
@@ -44,6 +44,22 @@ class RealInstallerNotificationsManager @Inject constructor(
     }
   }
 
+  override fun onReadyToInstall(packageName: String) {
+    launch {
+      onReadyToInstall(installManager.getApp(packageName))
+    }
+  }
+
+  private suspend fun onReadyToInstall(app: App) {
+    app.task?.let {
+      val appDetails = appDetailsUseCase.getAppDetails(app)
+      installerNotificationsManager.showReadyToInstallNotification(
+        packageName = app.packageName,
+        appDetails = appDetails
+      )
+    }
+  }
+
   @OptIn(ExperimentalCoroutinesApi::class)
   private suspend fun onInstallationQueued(app: App) {
     app.task?.let {


### PR DESCRIPTION
**What does this PR do?**

It implements the Ready To Install notification for when AG is downloading on background. 
It also changes the copy of the installing notification from "Installing" to "Preparing".

**Database changed?**

No

**Where should the reviewer start?**

- [ ] FakeInstallerNotificationsManager.kt
- [ ] InstallerNotificationsBuilder.kt
- [ ] InstallerNotificationsManager.kt
- [ ] RealInstallerNotificationsManager.kt
- [ ] UserActionDialog.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-3008](https://aptoide.atlassian.net/browse/APP-3008)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-3008](https://aptoide.atlassian.net/browse/APP-3008)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-3008]: https://aptoide.atlassian.net/browse/APP-3008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-3008]: https://aptoide.atlassian.net/browse/APP-3008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ