### PR TITLE
[APP-2991] - Upgrade Compose version and replace ripple

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/design_system/AptoideGamesSwitch.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/design_system/AptoideGamesSwitch.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.FractionalThreshold
 import androidx.compose.material.rememberSwipeableState
-import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material.ripple
 import androidx.compose.material.swipeable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -123,7 +123,7 @@ fun AptoideGamesSwitch(
         .clip(RoundedCornerShape(50))
         .indication(
           interactionSource = interactionSource,
-          indication = rememberRipple(bounded = false, radius = 90.dp)
+          indication = ripple(bounded = false, radius = 90.dp)
         )
         .background(color)
     )

--- a/buildSrc/src/main/kotlin/LibraryDependency.kt
+++ b/buildSrc/src/main/kotlin/LibraryDependency.kt
@@ -51,7 +51,7 @@ object LibraryVersion {
   const val COIL = "2.4.0"
   const val ROOM = "2.5.1"
   const val ACTIVITY_COMPOSE = "1.7.1"
-  const val COMPOSE = "1.5.4"
+  const val COMPOSE = "1.7.3"
   const val COMPOSE_LIFECYCLE = "2.7.0"
   const val VIEWMODEL_COMPOSE = "2.6.1"
   const val NAVIGATION_COMPOSE = "2.7.5"


### PR DESCRIPTION
**What does this PR do?**

Aims to fix the crash that occurs when changing perspective (portrait/landscape) returning negative values for width/height.

This seems to be related to an [issue](https://issuetracker.google.com/issues/314008560) fixed on a [later version of compose](https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.7.0-beta01) , so I updated the compose version to the latest one (1.7.3) and replaced `rememberRipple` with `ripple` since the first didn't work on this new compose version

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AptoideGamesSwitch.kt
- [ ] LibraryDependency.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2991](https://aptoide.atlassian.net/browse/APP-2991)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2991](https://aptoide.atlassian.net/browse/APP-2991)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2991]: https://aptoide.atlassian.net/browse/APP-2991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2991]: https://aptoide.atlassian.net/browse/APP-2991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ