### PR TITLE
[APP-3048] Add sending HTTP error code for failed downloads

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
@@ -5,6 +5,7 @@ import cm.aptoide.pt.install_manager.workers.PackageDownloader
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
+import retrofit2.HttpException
 import java.util.concurrent.CancellationException
 
 class DownloadProbe(
@@ -40,7 +41,8 @@ class DownloadProbe(
             packageName = packageName,
             analyticsPayload = analyticsPayload,
             errorMessage = it.message,
-            errorType = it::class.simpleName
+            errorType = it::class.simpleName,
+            errorCode = (it as? HttpException)?.code()
           )
         }
       }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -113,6 +113,7 @@ class InstallAnalytics(
     analyticsPayload: AnalyticsPayload?,
     errorMessage: String?,
     errorType: String?,
+    errorCode: Int?,
   ) {
     genericAnalytics.sendDownloadErrorEvent(
       packageName = packageName,
@@ -130,6 +131,7 @@ class InstallAnalytics(
             P_CONTEXT to it?.context,
             P_ERROR_MESSAGE to errorMessage,
             P_ERROR_TYPE to errorType,
+            P_ERROR_HTTP_CODE to errorCode,
             P_PREVIOUS_CONTEXT to it?.previousContext,
             P_STORE to it?.store,
             P_TAG to it?.bundleMeta?.tag,
@@ -313,5 +315,6 @@ class InstallAnalytics(
     private const val P_TRUSTED_BADGE = "trusted_badge"
     private const val P_ERROR_MESSAGE = "error_message"
     private const val P_ERROR_TYPE = "error_type"
+    private const val P_ERROR_HTTP_CODE = "error_http_code"
   }
 }


### PR DESCRIPTION
**What does this PR do?**

   Adds sending HTTP error code for failed downloads Indicative events. 

   Had to recreate a HttpException mapping to pass down the code.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] DownloadProbe.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-3048](https://aptoide.atlassian.net/browse/APP-3048)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-3048](https://aptoide.atlassian.net/browse/APP-3048)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-3048]: https://aptoide.atlassian.net/browse/APP-3048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-3048]: https://aptoide.atlassian.net/browse/APP-3048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ