### PR TITLE
[APP-3057] - Set manifest backup flags to false

### DIFF
--- a/app-games/src/main/AndroidManifest.xml
+++ b/app-games/src/main/AndroidManifest.xml
@@ -8,8 +8,8 @@
 
   <application
       android:name=".AptoideApplication"
-      android:allowBackup="true"
-      android:fullBackupContent="true"
+      android:allowBackup="false"
+      android:fullBackupContent="false"
       android:icon="@mipmap/ic_launcher"
       android:label="@string/app_name"
       android:networkSecurityConfig="@xml/network_security_config"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,8 +5,8 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <application
       android:name=".AptoideApplication"
-      android:allowBackup="true"
-      android:fullBackupContent="true"
+      android:allowBackup="false"
+      android:fullBackupContent="false"
       android:icon="@mipmap/ic_launcher"
       android:label="@string/app_name"
       android:roundIcon="@mipmap/ic_launcher_round"

--- a/aptoide-installer/src/main/AndroidManifest.xml
+++ b/aptoide-installer/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
   <application
-      android:allowBackup="true"
+      android:allowBackup="false"
       android:requestLegacyExternalStorage="true">
 
     <service

--- a/aptoide-network/src/main/AndroidManifest.xml
+++ b/aptoide-network/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
   <application
-      android:allowBackup="true"
-      android:fullBackupContent="true"
+      android:allowBackup="false"
+      android:fullBackupContent="false"
       android:label="@string/app_name"
       android:supportsRtl="true"
       tools:ignore="MissingApplicationIcon" />

--- a/download-view/src/main/AndroidManifest.xml
+++ b/download-view/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application
-      android:allowBackup="true"/>
+      android:allowBackup="false"/>
 
 
 </manifest>

--- a/environment-info/src/main/AndroidManifest.xml
+++ b/environment-info/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
   <application
-      android:allowBackup="true"
+      android:allowBackup="false"
       android:label="@string/app_name"
       android:supportsRtl="true"
       tools:ignore="MissingApplicationIcon">

--- a/extensions/src/main/AndroidManifest.xml
+++ b/extensions/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <application
-      android:allowBackup="true"
+      android:allowBackup="false"
       android:label="@string/app_name"
       android:supportsRtl="true"
       tools:ignore="MissingApplicationIcon">

--- a/feature-appcoins/src/main/AndroidManifest.xml
+++ b/feature-appcoins/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
   <application
-      android:allowBackup="true"
+      android:allowBackup="false"
       android:label="@string/app_name"
       android:supportsRtl="true"
       tools:ignore="MissingApplicationIcon">

--- a/feature-home/src/main/AndroidManifest.xml
+++ b/feature-home/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
   <application
-      android:allowBackup="true"
+      android:allowBackup="false"
       android:label="@string/app_name"
       android:supportsRtl="true"
       tools:ignore="MissingApplicationIcon" />

--- a/feature-profile/src/main/AndroidManifest.xml
+++ b/feature-profile/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
   <uses-permission android:name="android.permission.CAMERA" />
 
   <application
-      android:allowBackup="true"
+      android:allowBackup="false"
       android:label="@string/app_name"
       android:supportsRtl="true"
       tools:ignore="MissingApplicationIcon">

--- a/feature-settings/src/main/AndroidManifest.xml
+++ b/feature-settings/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
   <application
-      android:allowBackup="true"
+      android:allowBackup="false"
       android:label="@string/app_name"
       android:supportsRtl="true"
       tools:ignore="MissingApplicationIcon">

--- a/feature_apps/src/main/AndroidManifest.xml
+++ b/feature_apps/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
   <application
-      android:allowBackup="true"
+      android:allowBackup="false"
       android:label="@string/app_name"
       android:supportsRtl="true"
       tools:ignore="MissingApplicationIcon" />

--- a/feature_editorial/src/main/AndroidManifest.xml
+++ b/feature_editorial/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
   <application
-      android:allowBackup="true"
+      android:allowBackup="false"
       android:label="@string/app_name"
       android:supportsRtl="true"
       tools:ignore="MissingApplicationIcon" />

--- a/feature_search/src/main/AndroidManifest.xml
+++ b/feature_search/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
   <application
-      android:allowBackup="true"
-      android:fullBackupContent="true"
+      android:allowBackup="false"
+      android:fullBackupContent="false"
       android:label="@string/app_name"
       android:supportsRtl="true"
       tools:ignore="MissingApplicationIcon" />

--- a/feature_updates/src/main/AndroidManifest.xml
+++ b/feature_updates/src/main/AndroidManifest.xml
@@ -3,8 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
   <application
-      android:allowBackup="true"
-      android:fullBackupContent="true"
+      android:allowBackup="false"
+      android:fullBackupContent="false"
       android:label="@string/app_name"
       android:supportsRtl="true"
       tools:ignore="MissingApplicationIcon"/>

--- a/install-manager/src/main/AndroidManifest.xml
+++ b/install-manager/src/main/AndroidManifest.xml
@@ -6,5 +6,5 @@
       android:name="android.permission.QUERY_ALL_PACKAGES"
       tools:ignore="QueryAllPackagesPermission" />
 
-  <application android:allowBackup="true" />
+  <application android:allowBackup="false" />
 </manifest>


### PR DESCRIPTION
**What does this PR do?**

It sets all the manifests' backup flags to false.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] See in the commit all the Manifests

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-3057](https://aptoide.atlassian.net/browse/APP-3057)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-3057](https://aptoide.atlassian.net/browse/APP-3057)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-3057]: https://aptoide.atlassian.net/browse/APP-3057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-3057]: https://aptoide.atlassian.net/browse/APP-3057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ