### PR TITLE
[APP-3073] - Add android_language Indicative User Property

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
@@ -44,6 +44,7 @@ class BIAnalytics(private val analyticsSender: AnalyticsSender) {
   ) {
     CoroutineScope(Dispatchers.Main).launch {
       val isFirstLaunch = appLaunchPreferencesManager.isFirstLaunch()
+      val locale = context.resources.configuration.locales[0]
 
       Indicative.launch(context, BuildConfig.INDICATIVE_KEY)
       Indicative.setUniqueID(analyticsInfoProvider.getAnalyticsId())
@@ -54,6 +55,7 @@ class BIAnalytics(private val analyticsSender: AnalyticsSender) {
         "android_brand" to Build.MANUFACTURER,
         "android_model" to Build.MODEL,
         "aptoide_package" to BuildConfig.APPLICATION_ID,
+        "android_language" to "${locale.language}-${locale.country}",
         "theme" to "dark",
         "logged_in" to "NA",
         "gms" to context.getGMSValue()


### PR DESCRIPTION
**What does this PR do?**

It adds a new user property to indicative called android_language, that's the device language ISO code (ex.: pt-BR)

**Database changed?**

No

**Where should the reviewer start?**

- [ ] BIAnalytics.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-3073](https://aptoide.atlassian.net/browse/APP-3073)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-3073](https://aptoide.atlassian.net/browse/APP-3073)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-3073]: https://aptoide.atlassian.net/browse/APP-3073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-3073]: https://aptoide.atlassian.net/browse/APP-3073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ