### PR TITLE
[APP-2997] - Change native Loading Animation to custom one

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/UrlView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/UrlView.kt
@@ -4,15 +4,19 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
-import android.webkit.*
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.CircularProgressIndicator
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
+import android.webkit.WebView
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.aptoide.android.aptoidegames.design_system.IndeterminateCircularLoading
+import com.aptoide.android.aptoidegames.theme.Palette
 import com.google.accompanist.web.AccompanistWebViewClient
 import com.google.accompanist.web.WebView
 import com.google.accompanist.web.rememberWebViewState
@@ -45,7 +49,7 @@ fun UrlView(url: String) {
       client = AppWebViewClients(onLoaded)
     )
     if (loading.value) {
-      CircularProgressIndicator()
+      IndeterminateCircularLoading(color = Palette.Primary)
     }
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -82,6 +81,7 @@ import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
 import com.aptoide.android.aptoidegames.appview.AppViewHeaderConstants.FEATURE_GRAPHIC_HEIGHT
 import com.aptoide.android.aptoidegames.appview.AppViewHeaderConstants.VIDEO_HEIGHT
 import com.aptoide.android.aptoidegames.appview.permissions.buildAppPermissionsRoute
+import com.aptoide.android.aptoidegames.design_system.IndeterminateCircularLoading
 import com.aptoide.android.aptoidegames.drawables.icons.getBonusIconLeft
 import com.aptoide.android.aptoidegames.drawables.icons.getBookmarkStar
 import com.aptoide.android.aptoidegames.drawables.icons.getForward
@@ -200,7 +200,7 @@ fun LoadingView() {
     horizontalAlignment = Alignment.CenterHorizontally,
     verticalArrangement = Arrangement.Center
   ) {
-    CircularProgressIndicator()
+    IndeterminateCircularLoading(color = Palette.Primary)
   }
 }
 
@@ -303,11 +303,11 @@ fun AppViewContent(
           .padding(top = 160.dp)
           .align(Alignment.TopStart)
           .clickable {
-              val bonusTitle = bonusBundle.first
-              val bonusTag = bonusBundle.second
-              val route = buildSeeMoreBonusRoute (encode(bonusTitle), "${bonusTag}-more")
+            val bonusTitle = bonusBundle.first
+            val bonusTag = bonusBundle.second
+            val route = buildSeeMoreBonusRoute(encode(bonusTitle), "${bonusTag}-more")
 
-              navigate(route)
+            navigate(route)
           }
       ) {
         Image(
@@ -669,7 +669,7 @@ private fun ShowRelatedContentView(
         .padding(vertical = 44.dp),
       horizontalAlignment = Alignment.CenterHorizontally
     ) {
-      CircularProgressIndicator()
+      IndeterminateCircularLoading(color = Palette.Primary)
     }
   } else if (state.isEmpty()) {
     SmallEmptyView(
@@ -780,7 +780,7 @@ fun AppRatingAndDownloads(
     )
     downloads?.let {
       Text(
-        text = stringResource(R.string.downloads_number_title,it.formatDownloads()),
+        text = stringResource(R.string.downloads_number_title, it.formatDownloads()),
         maxLines = 1,
         style = AGTypography.InputsXS,
         overflow = TextOverflow.Ellipsis,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialViewScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
@@ -52,6 +51,7 @@ import com.aptoide.android.aptoidegames.UrlActivity
 import com.aptoide.android.aptoidegames.analytics.presentation.AnalyticsContext
 import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
+import com.aptoide.android.aptoidegames.design_system.IndeterminateCircularLoading
 import com.aptoide.android.aptoidegames.design_system.SecondaryButton
 import com.aptoide.android.aptoidegames.drawables.icons.getLeftArrow
 import com.aptoide.android.aptoidegames.error_views.GenericErrorView
@@ -118,7 +118,7 @@ private fun LoadingView() {
     horizontalAlignment = Alignment.CenterHorizontally,
     verticalArrangement = Arrangement.Center
   ) {
-    CircularProgressIndicator()
+    IndeterminateCircularLoading(color = Palette.Primary)
   }
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MyGamesBundleView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MyGamesBundleView.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -53,6 +52,7 @@ import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.presentation.AnalyticsContext
 import com.aptoide.android.aptoidegames.analytics.presentation.SwipeListener
 import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
+import com.aptoide.android.aptoidegames.design_system.IndeterminateCircularLoading
 import com.aptoide.android.aptoidegames.design_system.PrimarySmallButton
 import com.aptoide.android.aptoidegames.drawables.icons.getSingleGamepad
 import com.aptoide.android.aptoidegames.home.BundleHeader
@@ -261,8 +261,9 @@ fun MyGamesLoadingListView() {
       .wrapContentHeight(),
     horizontalAlignment = Alignment.CenterHorizontally
   ) {
-    CircularProgressIndicator(modifier = Modifier.padding(bottom = 12.dp))
+    IndeterminateCircularLoading(color = Palette.Primary)
     Text(
+      modifier = Modifier.padding(top = 12.dp),
       text = stringResource(R.string.my_games_progress_message),
       style = AGTypography.SubHeadingM,
       color = Palette.White,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/PaymentsErrorView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/PaymentsErrorView.kt
@@ -6,12 +6,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -19,6 +16,7 @@ import cm.aptoide.pt.extensions.PreviewLandscapeDark
 import com.appcoins.payments.arch.BadInputException
 import com.appcoins.payments.arch.PaymentsResult
 import com.aptoide.android.aptoidegames.SupportActivity
+import com.aptoide.android.aptoidegames.design_system.IndeterminateCircularLoading
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.theme.Palette
 
@@ -58,15 +56,9 @@ fun LoadingView() {
     modifier = Modifier
       .fillMaxWidth()
       .defaultMinSize(minHeight = 360.dp)
+      .padding(bottom = 16.dp)
   ) {
-    CircularProgressIndicator(
-      modifier = Modifier
-        .padding(bottom = 16.dp)
-        .size(64.dp, 64.dp),
-      backgroundColor = Color.Transparent,
-      color = Palette.Primary,
-      strokeWidth = 8.dp
-    )
+    IndeterminateCircularLoading(color = Palette.Primary, size = 64.dp)
   }
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/payment_methods/MainPaymentsView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/payment_methods/MainPaymentsView.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -26,7 +25,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -55,6 +53,7 @@ import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.SupportActivity
 import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
+import com.aptoide.android.aptoidegames.design_system.IndeterminateCircularLoading
 import com.aptoide.android.aptoidegames.drawables.icons.getAppcoinsClearLogo
 import com.aptoide.android.aptoidegames.drawables.icons.getLeftArrow
 import com.aptoide.android.aptoidegames.drawables.icons.getTintedWalletGift
@@ -313,7 +312,10 @@ private fun WalletPaymentMethod(
         contentDescription = null,
       )
       AptoideOutlinedText(
-        text = stringResource(id = R.string.bonus_banner_title, "20"), //TODO Hardcoded value (should come from backend in the future)
+        text = stringResource(
+          id = R.string.bonus_banner_title,
+          "20" //TODO Hardcoded value (should come from backend in the future)
+        ),
         style = AGTypography.InputsS,
         outlineWidth = 10f,
         outlineColor = Palette.Black,
@@ -368,15 +370,9 @@ fun LoadingView() {
     modifier = Modifier
       .fillMaxWidth()
       .defaultMinSize(minHeight = 360.dp)
+      .padding(bottom = 16.dp)
   ) {
-    CircularProgressIndicator(
-      modifier = Modifier
-        .padding(bottom = 16.dp)
-        .size(64.dp, 64.dp),
-      backgroundColor = Color.Transparent,
-      color = Palette.Primary,
-      strokeWidth = 8.dp
-    )
+    IndeterminateCircularLoading(color = Palette.Primary, size = 64.dp)
   }
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
@@ -67,6 +66,7 @@ import com.aptoide.android.aptoidegames.analytics.presentation.SwipeListener
 import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
 import com.aptoide.android.aptoidegames.analytics.presentation.withBundleMeta
 import com.aptoide.android.aptoidegames.categories.presentation.CategoriesBundle
+import com.aptoide.android.aptoidegames.design_system.IndeterminateCircularLoading
 import com.aptoide.android.aptoidegames.drawables.icons.getForward
 import com.aptoide.android.aptoidegames.editorial.EditorialBundle
 import com.aptoide.android.aptoidegames.error_views.GenericErrorView
@@ -253,7 +253,7 @@ fun LoadingBundleView(height: Dp) {
       .height(height),
     contentAlignment = Alignment.Center,
   ) {
-    CircularProgressIndicator()
+    IndeterminateCircularLoading(color = Palette.Primary)
   }
 }
 
@@ -433,7 +433,7 @@ fun LoadingView() {
     horizontalAlignment = Alignment.CenterHorizontally,
     verticalArrangement = Arrangement.Center
   ) {
-    CircularProgressIndicator()
+    IndeterminateCircularLoading(color = Palette.Primary)
   }
 }
 


### PR DESCRIPTION
**What does this PR do?**

   It replaces the occurrences CircularProgressIndicator with IndeterminateCircularLoading, our custom loading icon

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AppViewScreen.kt
- [ ] EditorialViewScreen.kt
- [ ] MyGamesBundleView.kt
- [ ] MainPaymentsView.kt
- [ ] PaymentsErrorView.kt
- [ ] BundlesView.kt
- [ ] UrlView.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2997](https://aptoide.atlassian.net/browse/APP-2997)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2997](https://aptoide.atlassian.net/browse/APP-2997)




**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2997]: https://aptoide.atlassian.net/browse/APP-2997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2997]: https://aptoide.atlassian.net/browse/APP-2997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ