### PR TITLE
[APP-2911] Improve end of app view video

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/videos/presentation/YoutubePlayer.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/videos/presentation/YoutubePlayer.kt
@@ -178,6 +178,10 @@ fun AppViewYoutubePlayer(
             showVideo = true
           }
 
+          PlayerConstants.PlayerState.ENDED -> {
+            youtubePlayer?.cueVideo(videoId, 0f)
+          }
+
           else -> {}
         }
       }


### PR DESCRIPTION
**What does this PR do?**

   - Improves the end of an app view video, by moving the video back to the beginning when the video ends, instead of showing the related content section.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] YoutubePlayer.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-2911](https://aptoide.atlassian.net/browse/APP-2911)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-2911](https://aptoide.atlassian.net/browse/APP-2911)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[APP-2911]: https://aptoide.atlassian.net/browse/APP-2911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-2911]: https://aptoide.atlassian.net/browse/APP-2911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ