### PR TITLE
[APP-3083] Add new BI events related to installs

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -52,6 +52,36 @@ class InstallAnalytics(
     )
   }
 
+  fun sendRetryClick(
+    app: App,
+    networkType: String,
+    analyticsContext: AnalyticsUIContext,
+  ) {
+    genericAnalytics.sendRetryClick(
+      app = app,
+      networkType = networkType,
+      analyticsContext = analyticsContext
+    )
+
+    sendBIClickEvent(
+      app = app,
+      analyticsContext = analyticsContext,
+      action = "retry"
+    )
+  }
+
+  fun sendOpenClick(
+    packageName: String,
+    hasAPPCBilling: Boolean? = null,
+    analyticsContext: AnalyticsUIContext,
+  ) {
+    genericAnalytics.sendOpenClick(
+      packageName = packageName,
+      hasAPPCBilling = hasAPPCBilling,
+      analyticsContext = analyticsContext
+    )
+  }
+
   fun sendDownloadStartedEvent(
     packageName: String,
     analyticsPayload: AnalyticsPayload?,
@@ -222,30 +252,6 @@ class InstallAnalytics(
   ) {
     genericAnalytics.sendDownloadCancel(
       packageName = packageName,
-      analyticsContext = analyticsContext
-    )
-  }
-
-  fun sendOpenClick(
-    packageName: String,
-    hasAPPCBilling: Boolean? = null,
-    analyticsContext: AnalyticsUIContext,
-  ) {
-    genericAnalytics.sendOpenClick(
-      packageName = packageName,
-      hasAPPCBilling = hasAPPCBilling,
-      analyticsContext = analyticsContext
-    )
-  }
-
-  fun sendRetryClick(
-    app: App,
-    networkType: String,
-    analyticsContext: AnalyticsUIContext,
-  ) {
-    genericAnalytics.sendRetryClick(
-      app = app,
-      networkType = networkType,
       analyticsContext = analyticsContext
     )
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -109,6 +109,12 @@ class InstallAnalytics(
       packageName = packageName,
       analyticsPayload = analyticsPayload
     )
+
+    logBIDownloadEvent(
+      packageName = packageName,
+      status = "cancel",
+      analyticsPayload = analyticsPayload
+    )
   }
 
   fun sendInstallDialogImpressionEvent(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -27,7 +27,7 @@ class InstallAnalytics(
       analyticsContext = analyticsContext,
     )
 
-    sendClickEvent(
+    sendBIClickEvent(
       app = app,
       analyticsContext = analyticsContext,
       action = "install"
@@ -45,30 +45,10 @@ class InstallAnalytics(
       analyticsContext = analyticsContext,
     )
 
-    sendClickEvent(
+    sendBIClickEvent(
       app = app,
       analyticsContext = analyticsContext,
       action = "update"
-    )
-  }
-
-  private fun sendClickEvent(
-    app: App,
-    analyticsContext: AnalyticsUIContext,
-    action: String,
-  ) {
-    biAnalytics.logEvent(
-      name = "click_on_install_button",
-      app.toBIParameters(aabTypes = null) +
-        mapOfNonNull(
-          P_ACTION to action,
-          P_APKFY_APP_INSTALL to analyticsContext.isApkfy,
-          P_CONTEXT to analyticsContext.currentScreen,
-          P_PREVIOUS_CONTEXT to analyticsContext.previousScreen,
-          P_STORE to storeName,
-          P_TAG to analyticsContext.bundleMeta?.tag,
-          P_TRUSTED_BADGE to app.malware.asNullableParameter()
-        )
     )
   }
 
@@ -91,20 +71,10 @@ class InstallAnalytics(
       analyticsPayload = analyticsPayload
     )
 
-    biAnalytics.logEvent(
-      name = "download",
-      analyticsPayload.let {
-        it.toAppBIParameters(packageName) +
-          mapOfNonNull(
-            P_STATUS to "success",
-            P_APKFY_APP_INSTALL to it?.isApkfy,
-            P_CONTEXT to it?.context,
-            P_PREVIOUS_CONTEXT to it?.previousContext,
-            P_STORE to it?.store,
-            P_TAG to it?.bundleMeta?.tag,
-            P_TRUSTED_BADGE to it?.trustedBadge
-          )
-      }
+    logBIDownloadEvent(
+      packageName = packageName,
+      status = "success",
+      analyticsPayload = analyticsPayload
     )
   }
 
@@ -121,23 +91,13 @@ class InstallAnalytics(
       errorMessage = errorMessage
     )
 
-    biAnalytics.logEvent(
-      name = "download",
-      analyticsPayload.let {
-        it.toAppBIParameters(packageName) +
-          mapOfNonNull(
-            P_STATUS to "fail",
-            P_APKFY_APP_INSTALL to it?.isApkfy,
-            P_CONTEXT to it?.context,
-            P_ERROR_MESSAGE to errorMessage,
-            P_ERROR_TYPE to errorType,
-            P_ERROR_HTTP_CODE to errorCode,
-            P_PREVIOUS_CONTEXT to it?.previousContext,
-            P_STORE to it?.store,
-            P_TAG to it?.bundleMeta?.tag,
-            P_TRUSTED_BADGE to it?.trustedBadge
-          )
-      }
+    logBIDownloadEvent(
+      packageName = packageName,
+      status = "fail",
+      analyticsPayload = analyticsPayload,
+      P_ERROR_MESSAGE to errorMessage,
+      P_ERROR_TYPE to errorType,
+      P_ERROR_HTTP_CODE to errorCode,
     )
   }
 
@@ -200,20 +160,10 @@ class InstallAnalytics(
       analyticsPayload = analyticsPayload
     )
 
-    biAnalytics.logEvent(
-      name = "install",
-      analyticsPayload.let {
-        it.toAppBIParameters(packageName) +
-          mapOfNonNull(
-            P_STATUS to "success",
-            P_APKFY_APP_INSTALL to it?.isApkfy,
-            P_CONTEXT to it?.context,
-            P_PREVIOUS_CONTEXT to it?.previousContext,
-            P_STORE to it?.store,
-            P_TAG to it?.bundleMeta?.tag,
-            P_TRUSTED_BADGE to it?.trustedBadge
-          )
-      }
+    logBIInstallEvent(
+      packageName = packageName,
+      status = "success",
+      analyticsPayload = analyticsPayload
     )
   }
 
@@ -229,22 +179,12 @@ class InstallAnalytics(
       errorMessage = errorMessage
     )
 
-    biAnalytics.logEvent(
-      name = "install",
-      analyticsPayload.let {
-        it.toAppBIParameters(packageName) +
-          mapOfNonNull(
-            P_STATUS to "fail",
-            P_APKFY_APP_INSTALL to it?.isApkfy,
-            P_CONTEXT to it?.context,
-            P_ERROR_MESSAGE to errorMessage,
-            P_ERROR_TYPE to errorType,
-            P_PREVIOUS_CONTEXT to it?.previousContext,
-            P_STORE to it?.store,
-            P_TAG to it?.bundleMeta?.tag,
-            P_TRUSTED_BADGE to it?.trustedBadge
-          )
-      }
+    logBIInstallEvent(
+      packageName = packageName,
+      status = "fail",
+      analyticsPayload = analyticsPayload,
+      P_ERROR_MESSAGE to errorMessage,
+      P_ERROR_TYPE to errorType,
     )
   }
 
@@ -303,6 +243,70 @@ class InstallAnalytics(
       analyticsContext = analyticsContext
     )
   }
+
+  /**Reused functions**/
+
+  private fun sendBIClickEvent(
+    app: App,
+    analyticsContext: AnalyticsUIContext,
+    action: String,
+  ) = biAnalytics.logEvent(
+    name = "click_on_install_button",
+    app.toBIParameters(aabTypes = null) +
+      mapOfNonNull(
+        P_ACTION to action,
+        P_APKFY_APP_INSTALL to analyticsContext.isApkfy,
+        P_CONTEXT to analyticsContext.currentScreen,
+        P_PREVIOUS_CONTEXT to analyticsContext.previousScreen,
+        P_STORE to storeName,
+        P_TAG to analyticsContext.bundleMeta?.tag,
+        P_TRUSTED_BADGE to app.malware.asNullableParameter()
+      )
+  )
+
+  private fun logBIDownloadEvent(
+    packageName: String,
+    status: String,
+    analyticsPayload: AnalyticsPayload?,
+    vararg pairs: Pair<String, Any?>
+  ) = biAnalytics.logEvent(
+    name = "download",
+    analyticsPayload.let {
+      it.toAppBIParameters(packageName) +
+        mapOfNonNull(
+          P_STATUS to status,
+          P_APKFY_APP_INSTALL to it?.isApkfy,
+          P_CONTEXT to it?.context,
+          P_PREVIOUS_CONTEXT to it?.previousContext,
+          P_STORE to it?.store,
+          P_TAG to it?.bundleMeta?.tag,
+          P_TRUSTED_BADGE to it?.trustedBadge,
+          *pairs
+        )
+    }
+  )
+
+  private fun logBIInstallEvent(
+    packageName: String,
+    status: String,
+    analyticsPayload: AnalyticsPayload?,
+    vararg pairs: Pair<String, Any?>
+  ) = biAnalytics.logEvent(
+    name = "install",
+    analyticsPayload.let {
+      it.toAppBIParameters(packageName) +
+        mapOfNonNull(
+          P_STATUS to status,
+          P_APKFY_APP_INSTALL to it?.isApkfy,
+          P_CONTEXT to it?.context,
+          P_PREVIOUS_CONTEXT to it?.previousContext,
+          P_STORE to it?.store,
+          P_TAG to it?.bundleMeta?.tag,
+          P_TRUSTED_BADGE to it?.trustedBadge,
+          *pairs
+        )
+    }
+  )
 
   companion object {
     private const val P_ACTION = "action"


### PR DESCRIPTION
**What does this PR do?**

   - Extracts  common code in BI install analytics
   - Adds new BI download event with cancel status
   - Adds new BI click_on_install event with retry action, for when the user click on a retry button of an app

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] InstallAnalytics.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [APP-3083](https://aptoide.atlassian.net/browse/APP-3083)

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-3083](https://aptoide.atlassian.net/browse/APP-3083)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass