### PR TITLE
[AND-51] - support different store names multiple apks

### DIFF
--- a/app-games/build.gradle.kts
+++ b/app-games/build.gradle.kts
@@ -176,7 +176,8 @@ android {
         } else {
           "_unsigned"
         }
-        val storeName = System.getenv("STORE_NAME")?.let { "_$it" } ?: ""
+        val storeName =
+          System.getenv("STORE_NAME")?.takeIf { it != "aptoide-games" }?.let { "_$it" } ?: ""
         val outputFileName =
           "AptoideGames_${variant.baseName}_${variant.versionName}_${variant.versionCode}$storeName$isSigned.apk"
         println("OutputFileName: $outputFileName")

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
@@ -55,6 +55,7 @@ class BIAnalytics(private val analyticsSender: AnalyticsSender) {
         "android_brand" to Build.MANUFACTURER,
         "android_model" to Build.MODEL,
         "aptoide_package" to BuildConfig.APPLICATION_ID,
+        "aptoide_store" to BuildConfig.MARKET_NAME,
         "android_language" to "${locale.language}-${locale.country}",
         "theme" to "dark",
         "logged_in" to "NA",

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/DeviceInfoViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/DeviceInfoViewModel.kt
@@ -51,9 +51,9 @@ class DeviceInfoViewModel(
       val pid = runCatching { walletProvider.getWallet() }.getOrNull()?.address ?: "-"
       viewModelState.update {
         "${deviceInfo.getDeviceInfoSummary()}\n" +
-          "AptoideGames: ${Integer.toHexString(storeName.hashCode())}\n" +
+          "AG: $storeName\n" +
           "PID: $pid\n" +
-          "AptoideGames version: ${BuildConfig.VERSION_NAME}(${BuildConfig.VERSION_CODE})\n"
+          "AG version: ${BuildConfig.VERSION_NAME}(${BuildConfig.VERSION_CODE})\n"
       }
     }
   }


### PR DESCRIPTION
**What does this PR do?**

- [ ] Adds aptoide_store indicative user property, corresponding to the store name of the build
- [ ] Changes the device info to show AG instead of AptoideGames, and changes the store hash to the store name
- [ ] Changes the logic for the outputFileName, since we will always have STORE_NAME on Jenkins builds now

**Database changed?**

No

**Where should the reviewer start?**

- [ ] See by commit

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-51](https://aptoide.atlassian.net/browse/AND-51)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-51](https://aptoide.atlassian.net/browse/AND-51)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[AND-51]: https://aptoide.atlassian.net/browse/AND-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-51]: https://aptoide.atlassian.net/browse/AND-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ