### PR TITLE
[AND-25] Fix OOS dialog

### DIFF
--- a/feature-oos/src/main/java/cm/aptoide/pt/feature_oos/presentation/AvailableSpaceViewModel.kt
+++ b/feature-oos/src/main/java/cm/aptoide/pt/feature_oos/presentation/AvailableSpaceViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.install_info_mapper.domain.InstallPackageInfoMapper
 import cm.aptoide.pt.install_manager.InstallManager
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.launchIn
@@ -33,7 +34,10 @@ class AvailableSpaceViewModel(
     installManager.appsChanges
       .map {}
       .onStart { emit(Unit) }
-      .map { installManager.getMissingFreeSpaceFor(installPackageInfoMapper.map(app)) }
+      .map {
+        delay(1500)
+        installManager.getMissingFreeSpaceFor(installPackageInfoMapper.map(app))
+      }
       .onEach { requiredSpace -> viewModelState.update { requiredSpace } }
       .launchIn(viewModelScope)
   }


### PR DESCRIPTION
**What does this PR do?**

This PR addresses an issue with the OOS required space calculation. The miscalculation occurs because there is a slight delay in the system's update process; as a result, when checking the device storage after an uninstall, the system has not yet reflected the freed space.

Please fell free to discuss alternative solutions in this case I used the same solution as vanilla

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AvailableSpaceViewModel.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-25](https://aptoide.atlassian.net/browse/AND-25)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-25](https://aptoide.atlassian.net/browse/AND-25)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[AND-25]: https://aptoide.atlassian.net/browse/AND-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-25]: https://aptoide.atlassian.net/browse/AND-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ