### PR TITLE
[AND-82] Implement bottom navigation entry for updates

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/GenericAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/GenericAnalytics.kt
@@ -309,6 +309,11 @@ class GenericAnalytics(private val analyticsSender: AnalyticsSender) {
     params = emptyMap()
   )
 
+  fun sendBottomBarUpdatesClick() = analyticsSender.logEvent(
+    name = "bn_updates_clicked",
+    params = emptyMap()
+  )
+
   fun sendNotificationOptIn() = analyticsSender.logEvent(
     name = "notification_opt_in",
     params = emptyMap()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
@@ -67,6 +67,7 @@ fun AppGamesBottomBar(navController: NavController) {
               BottomBarMenus.Games -> genericAnalytics.sendBottomBarHomeClick()
               BottomBarMenus.Search -> genericAnalytics.sendBottomBarSearchClick()
               BottomBarMenus.Categories -> genericAnalytics.sendBottomBarCategoriesClick()
+              BottomBarMenus.Updates -> genericAnalytics.sendBottomBarUpdatesClick()
             }
             navController.navigate(item.route) {
               popUpTo(navController.graph.startDestinationId) {
@@ -136,6 +137,7 @@ val bottomNavigationItems = listOf(
   BottomBarMenus.Games,
   BottomBarMenus.Search,
   BottomBarMenus.Categories,
+  BottomBarMenus.Updates,
 )
 
 /**

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material.BottomNavigationItem
-import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
@@ -31,6 +30,7 @@ import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.runPreviewable
 import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
 import com.aptoide.android.aptoidegames.home.BottomBarMenus
+import com.aptoide.android.aptoidegames.home.Icon
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.theme.Palette
@@ -94,12 +94,7 @@ fun RowScope.AddBottomNavigationItem(
     selected = isSelected,
     onClick = onItemClicked,
     alwaysShowLabel = true,
-    icon = {
-      Icon(
-        imageVector = item.icon,
-        contentDescription = null,
-      )
-    },
+    icon = { item.Icon() },
     label = {
       Text(
         text = stringResource(id = item.titleId),

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.selection.selectableGroup
@@ -89,6 +90,7 @@ fun RowScope.AddBottomNavigationItem(
   onItemClicked: () -> Unit,
 ) {
   BottomNavigationItem(
+    modifier = Modifier.fillMaxHeight(),
     selected = isSelected,
     onClick = onItemClicked,
     alwaysShowLabel = true,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/Download.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/Download.kt
@@ -1,0 +1,70 @@
+package com.aptoide.android.aptoidegames.drawables.icons
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.group
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.aptoide.android.aptoidegames.theme.Palette
+
+@Preview
+@Composable
+fun TestDownloadIcon() {
+  Image(
+    imageVector = getDownloadIcon(Palette.Primary),
+    contentDescription = null,
+    modifier = Modifier.size(240.dp)
+  )
+}
+
+fun getDownloadIcon(color: Color): ImageVector =
+  ImageVector.Builder(
+    name = "DownloadIcon",
+    defaultWidth = 24.0.dp,
+    defaultHeight = 24.0.dp,
+    viewportWidth = 24.0f,
+    viewportHeight = 24.0f
+  ).apply {
+    group {
+      path(
+        fill = SolidColor(color),
+        stroke = null,
+        strokeLineWidth = 0.0f,
+        strokeLineCap = Butt,
+        strokeLineJoin = Miter,
+        strokeLineMiter = 4.0f,
+        pathFillType = NonZero
+      ) {
+        moveTo(12.0f, 15.875f)
+        lineTo(7.2125f, 11.0875f)
+        lineTo(8.5125f, 9.7625f)
+        lineTo(11.0625f, 12.3125f)
+        verticalLineTo(4.25f)
+        horizontalLineTo(12.9375f)
+        verticalLineTo(12.3125f)
+        lineTo(15.4875f, 9.7625f)
+        lineTo(16.7875f, 11.0875f)
+        lineTo(12.0f, 15.875f)
+        close()
+        moveTo(4.25f, 19.75f)
+        verticalLineTo(14.9375f)
+        horizontalLineTo(6.125f)
+        verticalLineTo(17.875f)
+        horizontalLineTo(17.875f)
+        verticalLineTo(14.9375f)
+        horizontalLineTo(19.75f)
+        verticalLineTo(19.75f)
+        horizontalLineTo(4.25f)
+        close()
+      }
+    }
+  }.build()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BottomBarMenus.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BottomBarMenus.kt
@@ -1,5 +1,7 @@
 package com.aptoide.android.aptoidegames.home
 
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.dto.BundleMeta
@@ -14,25 +16,34 @@ import com.aptoide.android.aptoidegames.theme.Palette
 sealed class BottomBarMenus(
   val route: String,
   val titleId: Int,
-  val icon: ImageVector,
 ) {
   object Games : BottomBarMenus(
     route = gamesRoute,
-    titleId = R.string.bottom_navigation_discovery,
-    icon = getDiscovery(Palette.GreyLight)
+    titleId = R.string.bottom_navigation_discovery
   )
 
   object Search : BottomBarMenus(
     route = searchRoute
       .withBundleMeta(BundleMeta("search", "app")),
-    titleId = R.string.search,
-    icon = getSearch(Palette.GreyLight)
+    titleId = R.string.search
   )
 
   object Categories : BottomBarMenus(
     route = buildAllCategoriesRoute()
       .withBundleMeta(BundleMeta("categories-more", "app")),
-    titleId = R.string.categories,
-    icon = getCategories(Palette.GreyLight)
+    titleId = R.string.categories
   )
 }
+
+@Composable
+fun BottomBarMenus.Icon() = when (this) {
+  BottomBarMenus.Games -> getDiscovery(Palette.GreyLight).AsBottomBarIcon()
+  BottomBarMenus.Search -> getSearch(Palette.GreyLight).AsBottomBarIcon()
+  BottomBarMenus.Categories -> getCategories(Palette.GreyLight).AsBottomBarIcon()
+}
+
+@Composable
+private fun ImageVector.AsBottomBarIcon() = Icon(
+  imageVector = this,
+  contentDescription = null,
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BottomBarMenus.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BottomBarMenus.kt
@@ -1,17 +1,31 @@
 package com.aptoide.android.aptoidegames.home
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.dto.BundleMeta
 import com.aptoide.android.aptoidegames.analytics.presentation.withBundleMeta
 import com.aptoide.android.aptoidegames.categories.presentation.buildAllCategoriesRoute
 import com.aptoide.android.aptoidegames.drawables.icons.getCategories
 import com.aptoide.android.aptoidegames.drawables.icons.getDiscovery
+import com.aptoide.android.aptoidegames.drawables.icons.getDownloadIcon
 import com.aptoide.android.aptoidegames.drawables.icons.getSearch
 import com.aptoide.android.aptoidegames.search.presentation.searchRoute
 import com.aptoide.android.aptoidegames.theme.Palette
+import com.aptoide.android.aptoidegames.updates.updatesRoute
 
 sealed class BottomBarMenus(
   val route: String,
@@ -33,6 +47,11 @@ sealed class BottomBarMenus(
       .withBundleMeta(BundleMeta("categories-more", "app")),
     titleId = R.string.categories
   )
+
+  object Updates : BottomBarMenus(
+    route = updatesRoute.withBundleMeta(BundleMeta("updates", "app")),
+    titleId = R.string.bottom_navigation_updates
+  )
 }
 
 @Composable
@@ -40,6 +59,23 @@ fun BottomBarMenus.Icon() = when (this) {
   BottomBarMenus.Games -> getDiscovery(Palette.GreyLight).AsBottomBarIcon()
   BottomBarMenus.Search -> getSearch(Palette.GreyLight).AsBottomBarIcon()
   BottomBarMenus.Categories -> getCategories(Palette.GreyLight).AsBottomBarIcon()
+  BottomBarMenus.Updates -> {
+    //TODO: replace hardcoded value with actual state
+    var showUpdatesBubble by rememberSaveable { mutableStateOf(true) }
+
+    Box {
+      getDownloadIcon(Palette.GreyLight).AsBottomBarIcon()
+      if (showUpdatesBubble) {
+        Box(
+          modifier = Modifier
+            .padding(top = 3.dp)
+            .size(10.dp)
+            .background(Palette.Error, CircleShape)
+            .align(Alignment.TopEnd)
+        )
+      }
+    }
+  }
 }
 
 @Composable

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
@@ -48,6 +48,7 @@ import com.aptoide.android.aptoidegames.search.presentation.searchScreen
 import com.aptoide.android.aptoidegames.settings.settingsScreen
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.toolbar.AppGamesToolBar
+import com.aptoide.android.aptoidegames.updates.updatesScreen
 import kotlinx.coroutines.launch
 
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
@@ -231,6 +232,12 @@ private fun NavigationGraph(
       navigate = navController::navigateTo,
       goBack = navController::navigateUp,
       screenData = appPermissionsScreen()
+    )
+
+    staticComposable(
+      navigate = navController::navigateTo,
+      goBack = navController::navigateUp,
+      screenData = updatesScreen()
     )
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/UpdatesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/UpdatesScreen.kt
@@ -1,0 +1,23 @@
+package com.aptoide.android.aptoidegames.updates
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.navDeepLink
+import cm.aptoide.pt.extensions.ScreenData
+import com.aptoide.android.aptoidegames.BuildConfig
+import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
+
+const val updatesRoute = "updates"
+
+fun updatesScreen() = ScreenData.withAnalytics(
+  route = updatesRoute,
+  screenAnalyticsName = "Updates",
+  deepLinks = listOf(navDeepLink { uriPattern = BuildConfig.DEEP_LINK_SCHEMA + updatesRoute })
+) { _, navigate, _ ->
+  UpdatesScreen(navigate = navigate)
+}
+
+@Composable
+fun UpdatesScreen(
+  navigate: (String) -> Unit,
+) {
+}


### PR DESCRIPTION
**What does this PR do?**

~**IN DRAFT WHILE THE REQUIRED STRINGS ARE NOT ADDED**~

   - Adds a bottom navigation item for the updates
   - Creates the skeleton screen for the updates.
   - Fixes an issue in the bottom bar items alignment, that started after updating the compose version.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-82](https://aptoide.atlassian.net/browse/AND-82)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-82](https://aptoide.atlassian.net/browse/AND-82)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[AND-82]: https://aptoide.atlassian.net/browse/AND-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-82]: https://aptoide.atlassian.net/browse/AND-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ