### PR TITLE
[AND-97] AAB splits partial download issue

### DIFF
--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/network/DownloaderRepository.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/network/DownloaderRepository.kt
@@ -40,7 +40,16 @@ class DownloaderRepository @Inject constructor(
     versionCode: Long,
     installationFile: InstallationFile
   ): Flow<Double> {
-    val destinationFile = File(downloadsPath, installationFile.name)
+    val destinationDir = File(downloadsPath, packageName).apply {
+      if (!exists()) {
+        mkdirs().let {
+          if (!it) throw IllegalStateException("Can't create download folder: $downloadsPath/$packageName")
+        }
+      }
+    }
+
+    val destinationFile = File(destinationDir, installationFile.name)
+
     return flow {
       emit(0.0)
 

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AptoideAppsRepository.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/AptoideAppsRepository.kt
@@ -377,7 +377,6 @@ private fun mapAab(app: AppJSON) = app.aab?.let {
       Split(
         type = split.type,
         file = File(
-          _fileName = split.name,
           vername = app.file.vername,
           vercode = app.file.vercode,
           md5 = split.md5sum,
@@ -393,7 +392,6 @@ private fun mapAab(app: AppJSON) = app.aab?.let {
 fun DynamicSplitJSON.toDomainModel() = DynamicSplit(
   type = type,
   File(
-    _fileName = this.name,
     vername = "",
     vercode = 0,
     md5 = this.md5sum,
@@ -404,7 +402,6 @@ fun DynamicSplitJSON.toDomainModel() = DynamicSplit(
   deliveryTypes = this.deliveryTypes,
   splits = this.splits.map { split ->
     File(
-      _fileName = split.name,
       vername = "",
       vercode = 0,
       md5 = split.md5sum,


### PR DESCRIPTION
**What does this PR do?**

   - Refactors the downloads logic to separate downloads of different apps by directories. Each app has its downloaded files inside a specific directory which name is the app's package name.
   - Removes explicit file names from aab splits, making the splits file names fallback to the md5.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] DownloaderRepository.kt
- [ ] AptoideInstaller.kt
- [ ] AptoideAppsRepository.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-97](https://aptoide.atlassian.net/browse/AND-97)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-97](https://aptoide.atlassian.net/browse/AND-97)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[AND-97]: https://aptoide.atlassian.net/browse/AND-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-97]: https://aptoide.atlassian.net/browse/AND-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ