### PR TITLE
[AND-83] - implement empty and loading states for updates

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/NoUpdates.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/drawables/icons/NoUpdates.kt
@@ -1,0 +1,196 @@
+package com.aptoide.android.aptoidegames.drawables.icons
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.group
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.aptoide.android.aptoidegames.theme.Palette
+
+@Preview
+@Composable
+fun TestNoUpdates() {
+  Image(
+    imageVector = getNoUpdates(Palette.Primary, Palette.White, Palette.GreyLight),
+    contentDescription = null,
+    modifier = Modifier.size(240.dp)
+  )
+}
+
+fun getNoUpdates(
+  color1: Color,
+  color2: Color,
+  color3: Color
+): ImageVector = ImageVector.Builder(
+  name = "NoUpdates",
+  defaultWidth = 328.0.dp,
+  defaultHeight = 144.0.dp,
+  viewportWidth = 328.0f,
+  viewportHeight = 144.0f
+).apply {
+  path(
+    fill = SolidColor(color1),
+    stroke = null,
+    strokeLineWidth = 0.0f,
+    strokeLineCap = Butt,
+    strokeLineJoin = Miter,
+    strokeLineMiter = 4.0f,
+    pathFillType = NonZero
+  ) {
+    moveTo(288.0f, 16.0f)
+    horizontalLineToRelative(16.0f)
+    verticalLineToRelative(16.0f)
+    horizontalLineToRelative(-16.0f)
+    close()
+  }
+  path(
+    fill = SolidColor(color3),
+    stroke = null,
+    strokeLineWidth = 0.0f,
+    strokeLineCap = Butt,
+    strokeLineJoin = Miter,
+    strokeLineMiter = 4.0f,
+    pathFillType = NonZero
+  ) {
+    moveTo(252.0f, 83.0f)
+    horizontalLineToRelative(8.0f)
+    verticalLineToRelative(8.0f)
+    horizontalLineToRelative(-8.0f)
+    close()
+  }
+  path(
+    fill = SolidColor(color2),
+    stroke = null,
+    strokeLineWidth = 0.0f,
+    strokeLineCap = Butt,
+    strokeLineJoin = Miter,
+    strokeLineMiter = 4.0f,
+    pathFillType = NonZero
+  ) {
+    moveTo(76.0f, 8.0f)
+    horizontalLineToRelative(8.0f)
+    verticalLineToRelative(8.0f)
+    horizontalLineToRelative(-8.0f)
+    close()
+  }
+  group {
+    path(
+      fill = SolidColor(color1),
+      stroke = null,
+      strokeLineWidth = 0.0f,
+      strokeLineCap = Butt,
+      strokeLineJoin = Miter,
+      strokeLineMiter = 4.0f,
+      pathFillType = NonZero
+    ) {
+      moveTo(235.944f, 0.0f)
+      curveTo(235.809f, 4.119f, 236.124f, 8.287f, 235.944f, 12.399f)
+      curveTo(235.217f, 29.008f, 230.113f, 45.162f, 221.131f, 59.153f)
+      curveTo(211.615f, 73.977f, 198.331f, 86.453f, 183.073f, 95.209f)
+      lineTo(140.717f, 52.821f)
+      curveTo(146.942f, 41.382f, 156.197f, 30.889f, 166.231f, 22.549f)
+      curveTo(181.273f, 10.052f, 199.52f, 1.909f, 219.186f, 0.286f)
+      lineTo(235.944f, 0.0f)
+      close()
+      moveTo(190.082f, 30.741f)
+      curveTo(172.926f, 32.696f, 175.217f, 59.036f, 192.729f, 57.801f)
+      curveTo(210.712f, 56.531f, 208.4f, 28.655f, 190.082f, 30.741f)
+      close()
+    }
+    path(
+      fill = SolidColor(color1),
+      stroke = null,
+      strokeLineWidth = 0.0f,
+      strokeLineCap = Butt,
+      strokeLineJoin = Miter,
+      strokeLineMiter = 4.0f,
+      pathFillType = NonZero
+    ) {
+      moveTo(92.0f, 144.0f)
+      lineTo(108.108f, 115.454f)
+      curveTo(113.272f, 108.791f, 117.691f, 94.938f, 127.34f, 94.115f)
+      curveTo(138.006f, 93.205f, 145.153f, 104.569f, 139.269f, 113.658f)
+      curveTo(137.607f, 116.227f, 134.836f, 117.978f, 132.369f, 119.718f)
+      curveTo(123.638f, 125.88f, 114.196f, 131.058f, 105.147f, 136.726f)
+      lineTo(92.0f, 144.0f)
+      close()
+    }
+    path(
+      fill = SolidColor(color1),
+      stroke = null,
+      strokeLineWidth = 0.0f,
+      strokeLineCap = Butt,
+      strokeLineJoin = Miter,
+      strokeLineMiter = 4.0f,
+      pathFillType = NonZero
+    ) {
+      moveTo(174.814f, 99.473f)
+      curveTo(169.153f, 101.834f, 163.351f, 103.856f, 157.368f, 105.272f)
+      lineTo(130.721f, 78.9f)
+      curveTo(131.801f, 72.685f, 134.028f, 66.752f, 136.227f, 60.872f)
+      lineTo(174.814f, 99.473f)
+      close()
+    }
+    path(
+      fill = SolidColor(color1),
+      stroke = null,
+      strokeLineWidth = 0.0f,
+      strokeLineCap = Butt,
+      strokeLineJoin = Miter,
+      strokeLineMiter = 4.0f,
+      pathFillType = NonZero
+    ) {
+      moveTo(147.214f, 131.319f)
+      lineTo(152.004f, 112.158f)
+      lineTo(155.399f, 115.136f)
+      curveTo(164.879f, 111.858f, 174.708f, 109.415f, 183.549f, 104.548f)
+      lineTo(180.892f, 114.427f)
+      lineTo(147.218f, 131.319f)
+      horizontalLineTo(147.214f)
+      close()
+    }
+    path(
+      fill = SolidColor(color1),
+      stroke = null,
+      strokeLineWidth = 0.0f,
+      strokeLineCap = Butt,
+      strokeLineJoin = Miter,
+      strokeLineMiter = 4.0f,
+      pathFillType = NonZero
+    ) {
+      moveTo(130.869f, 52.698f)
+      curveTo(129.221f, 56.386f, 127.417f, 59.993f, 126.076f, 63.822f)
+      curveTo(124.149f, 69.328f, 123.041f, 75.113f, 120.782f, 80.509f)
+      lineTo(123.825f, 83.972f)
+      lineTo(104.67f, 88.765f)
+      lineTo(121.439f, 55.239f)
+      curveTo(121.622f, 54.879f, 121.943f, 54.808f, 122.286f, 54.674f)
+      curveTo(123.076f, 54.367f, 130.548f, 52.398f, 130.869f, 52.698f)
+      close()
+    }
+    path(
+      fill = SolidColor(color1),
+      stroke = null,
+      strokeLineWidth = 0.0f,
+      strokeLineCap = Butt,
+      strokeLineJoin = Miter,
+      strokeLineMiter = 4.0f,
+      pathFillType = NonZero
+    ) {
+      moveTo(49.0f, 67.0f)
+      horizontalLineToRelative(16.0f)
+      verticalLineToRelative(16.0f)
+      horizontalLineToRelative(-16.0f)
+      close()
+    }
+  }
+}.build()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BottomBarMenus.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BottomBarMenus.kt
@@ -7,14 +7,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import cm.aptoide.pt.feature_updates.presentation.UpdatesUiState
+import cm.aptoide.pt.feature_updates.presentation.rememberUpdates
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.dto.BundleMeta
 import com.aptoide.android.aptoidegames.analytics.presentation.withBundleMeta
@@ -60,12 +58,11 @@ fun BottomBarMenus.Icon() = when (this) {
   BottomBarMenus.Search -> getSearch(Palette.GreyLight).AsBottomBarIcon()
   BottomBarMenus.Categories -> getCategories(Palette.GreyLight).AsBottomBarIcon()
   BottomBarMenus.Updates -> {
-    //TODO: replace hardcoded value with actual state
-    var showUpdatesBubble by rememberSaveable { mutableStateOf(true) }
+    val updatesUiState = rememberUpdates()
 
     Box {
       getDownloadIcon(Palette.GreyLight).AsBottomBarIcon()
-      if (showUpdatesBubble) {
+      if (updatesUiState is UpdatesUiState.Idle) {
         Box(
           modifier = Modifier
             .padding(top = 3.dp)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/UpdatesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/UpdatesScreen.kt
@@ -1,10 +1,30 @@
 package com.aptoide.android.aptoidegames.updates
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.navigation.navDeepLink
 import cm.aptoide.pt.extensions.ScreenData
+import cm.aptoide.pt.feature_updates.presentation.UpdatesUiState
+import cm.aptoide.pt.feature_updates.presentation.rememberUpdates
 import com.aptoide.android.aptoidegames.BuildConfig
+import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
+import com.aptoide.android.aptoidegames.drawables.icons.getNoUpdates
+import com.aptoide.android.aptoidegames.home.LoadingView
+import com.aptoide.android.aptoidegames.theme.AGTypography
+import com.aptoide.android.aptoidegames.theme.Palette
 
 const val updatesRoute = "updates"
 
@@ -13,11 +33,57 @@ fun updatesScreen() = ScreenData.withAnalytics(
   screenAnalyticsName = "Updates",
   deepLinks = listOf(navDeepLink { uriPattern = BuildConfig.DEEP_LINK_SCHEMA + updatesRoute })
 ) { _, navigate, _ ->
-  UpdatesScreen(navigate = navigate)
+  val updatesUiState = rememberUpdates()
+
+  UpdatesScreen(
+    updatesUiState = updatesUiState,
+    navigate = navigate
+  )
 }
 
 @Composable
 fun UpdatesScreen(
+  updatesUiState: UpdatesUiState,
   navigate: (String) -> Unit,
 ) {
+  when (updatesUiState) {
+    is UpdatesUiState.Empty -> NoUpdatesScreen()
+    is UpdatesUiState.Loading -> LoadingView()
+    is UpdatesUiState.Idle -> {} //TODO Implement
+  }
+}
+
+@Composable
+fun NoUpdatesScreen() {
+  Column(
+    modifier = Modifier.fillMaxSize(),
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally
+  ) {
+    Image(
+      modifier = Modifier
+        .padding(bottom = 88.dp, start = 16.dp, end = 16.dp)
+        .fillMaxWidth(),
+      imageVector = getNoUpdates(Palette.Primary, Palette.White, Palette.GreyLight),
+      contentDescription = null,
+    )
+    Text(
+      modifier = Modifier.padding(horizontal = 40.dp),
+      text = stringResource(R.string.update_up_to_date_title),
+      style = AGTypography.Title,
+      color = Palette.White,
+      maxLines = 2,
+      overflow = TextOverflow.Ellipsis,
+      textAlign = TextAlign.Center,
+    )
+    Text(
+      modifier = Modifier.padding(horizontal = 40.dp),
+      text = stringResource(R.string.update_up_to_date_body),
+      style = AGTypography.Title,
+      color = Palette.White,
+      maxLines = 2,
+      overflow = TextOverflow.Ellipsis,
+      textAlign = TextAlign.Center,
+    )
+  }
 }

--- a/app/src/main/java/cm/aptoide/pt/updates/UpdatesView.kt
+++ b/app/src/main/java/cm/aptoide/pt/updates/UpdatesView.kt
@@ -47,8 +47,9 @@ fun NavGraphBuilder.updatesScreen(
   val uiState by updatesViewModel.uiState.collectAsState()
 
   UpdatesScreen(uiState = uiState,
-    onInstalledAppClick = { updatesViewModel.onOpenInstalledApp(it) },
-    onInstalledAppLongClick = { updatesViewModel.onUninstallApp(it) }
+    //TODO OnClicks
+    onInstalledAppClick = { },
+    onInstalledAppLongClick = { }
   )
 }
 
@@ -66,7 +67,7 @@ fun UpdatesScreen(
       }
     ) {
       InstalledAppsList(
-        uiState.installedAppsList,
+        emptyList(), //TODO For now this is just an EmptyList, was uiState.installedAppsList
         onInstalledAppClick = { onInstalledAppClick(it) },
         onInstalledAppLongClick = { onInstalledAppLongClick(it) }
       )

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/presentation/UpdatesUiState.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/presentation/UpdatesUiState.kt
@@ -1,5 +1,21 @@
 package cm.aptoide.pt.feature_updates.presentation
 
-import cm.aptoide.pt.feature_updates.domain.InstalledApp
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_apps.data.randomApp
+import kotlin.random.Random
+import kotlin.random.nextInt
 
-data class UpdatesUiState(val installedAppsList: List<InstalledApp>)
+sealed class UpdatesUiState {
+  data class Idle(val updatesList: List<App>) : UpdatesUiState()
+  object Empty : UpdatesUiState()
+  object Loading : UpdatesUiState()
+}
+
+class UpdatesUiStateProvider : PreviewParameterProvider<UpdatesUiState> {
+  override val values: Sequence<UpdatesUiState> = sequenceOf(
+    UpdatesUiState.Idle(List(Random.nextInt(1..12)) { randomApp }),
+    UpdatesUiState.Empty,
+    UpdatesUiState.Loading,
+  )
+}

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/presentation/ViewModelProvider.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/presentation/ViewModelProvider.kt
@@ -1,0 +1,38 @@
+package cm.aptoide.pt.feature_updates.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import cm.aptoide.pt.extensions.runPreviewable
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+//TODO add needed arguments
+@HiltViewModel
+class InjectionsProvider @Inject constructor() : ViewModel()
+
+//TODO add needed logic and arguments
+@Composable
+fun rememberUpdates():
+  UpdatesUiState = runPreviewable(
+  preview = {
+    UpdatesUiStateProvider().values.toSet().random()
+  },
+  real = {
+    val injectionsProvider = hiltViewModel<InjectionsProvider>()
+    val vm: UpdatesViewModel = viewModel(
+      key = "UpdatesVM", //TODO Temp
+      factory = object : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+          @Suppress("UNCHECKED_CAST")
+          return UpdatesViewModel() as T
+        }
+      }
+    )
+    val uiState by vm.uiState.collectAsState()
+    uiState
+  })


### PR DESCRIPTION
**What does this PR do?**

It implements a mock View Model and the UiState for updates, as well as the Empty and Loading views for the updates section for Aptoide Games

**Database changed?**

No

**Where should the reviewer start?**

- [ ] See by commit

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-83](https://aptoide.atlassian.net/browse/AND-83)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-83](https://aptoide.atlassian.net/browse/AND-83)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[AND-83]: https://aptoide.atlassian.net/browse/AND-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-83]: https://aptoide.atlassian.net/browse/AND-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ