### PR TITLE
[AND-98] Fix infinite installation loop for ag itself

### DIFF
--- a/aptoide-task-info/schemas/cm.aptoide.pt.task_info.database.TaskInfoDatabase/4.json
+++ b/aptoide-task-info/schemas/cm.aptoide.pt.task_info.database.TaskInfoDatabase/4.json
@@ -1,0 +1,138 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "dad4f2b18d77de108ee93fb4d091c1b1",
+    "entities": [
+      {
+        "tableName": "TaskInfo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`timestamp` INTEGER NOT NULL, `packageName` TEXT NOT NULL, `versionCode` INTEGER NOT NULL, `versionName` TEXT NOT NULL, `constraints` TEXT NOT NULL, `type` TEXT NOT NULL, `payload` TEXT, PRIMARY KEY(`timestamp`))",
+        "fields": [
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionCode",
+            "columnName": "versionCode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionName",
+            "columnName": "versionName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "constraints",
+            "columnName": "constraints",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "timestamp"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "InstallationFile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `taskTimestamp` INTEGER NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `md5` TEXT NOT NULL, `fileSize` INTEGER NOT NULL, `url` TEXT NOT NULL, `altUrl` TEXT NOT NULL, `localPath` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "taskTimestamp",
+            "columnName": "taskTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "md5",
+            "columnName": "md5",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "altUrl",
+            "columnName": "altUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'dad4f2b18d77de108ee93fb4d091c1b1')"
+    ]
+  }
+}

--- a/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/AptoideTaskInfoRepository.kt
+++ b/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/AptoideTaskInfoRepository.kt
@@ -57,7 +57,7 @@ class AptoideTaskInfoRepository @Inject constructor(
     installationFileDao.save(
       taskInfo.installPackageInfo.installationFiles.map {
         InstallationFileData(
-          packageName = taskInfo.packageName,
+          taskTimestamp = taskInfo.timestamp,
           name = it.name,
           type = it.type,
           md5 = it.md5,
@@ -70,9 +70,10 @@ class AptoideTaskInfoRepository @Inject constructor(
     )
   }
 
-  override suspend fun removeAll(packageName: String) {
-    taskInfoDao.remove(packageName)
-    installationFileDao.remove(packageName)
+  override suspend fun remove(vararg taskInfo: TaskInfo) {
+    val timestamps = taskInfo.map { it.timestamp }.toLongArray()
+    taskInfoDao.remove(*timestamps)
+    installationFileDao.remove(*timestamps)
   }
 }
 

--- a/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/database/InstallationFileDao.kt
+++ b/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/database/InstallationFileDao.kt
@@ -9,6 +9,6 @@ interface InstallationFileDao {
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun save(appInfoEntity: List<InstallationFileData>)
 
-  @Query("DELETE FROM InstallationFile WHERE packageName = :packageName")
-  suspend fun remove(packageName: String)
+  @Query("DELETE FROM InstallationFile WHERE taskTimestamp IN (:timestamp)")
+  suspend fun remove(vararg timestamp: Long)
 }

--- a/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/database/TaskInfoDao.kt
+++ b/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/database/TaskInfoDao.kt
@@ -14,6 +14,6 @@ interface TaskInfoDao {
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun save(appInfoEntity: TaskInfoData)
 
-  @Query("DELETE FROM TaskInfo WHERE packageName = :packageName")
-  suspend fun remove(packageName: String)
+  @Query("DELETE FROM TaskInfo WHERE timestamp IN (:timestamp)")
+  suspend fun remove(vararg timestamp: Long)
 }

--- a/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/database/TaskInfoDatabase.kt
+++ b/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/database/TaskInfoDatabase.kt
@@ -11,7 +11,7 @@ import cm.aptoide.pt.task_info.database.model.InstallationFileData
 import cm.aptoide.pt.task_info.database.model.TaskInfoData
 
 @Database(
-  version = 3,
+  version = 4,
   exportSchema = true,
   entities = [TaskInfoData::class, InstallationFileData::class],
   autoMigrations = [

--- a/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/database/model/InstallationFileData.kt
+++ b/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/database/model/InstallationFileData.kt
@@ -7,7 +7,7 @@ import cm.aptoide.pt.install_manager.dto.InstallationFile
 @Entity(tableName = "InstallationFile")
 data class InstallationFileData(
   @PrimaryKey(autoGenerate = true) val id: Int? = null,
-  val packageName: String,
+  val taskTimestamp: Long,
   val name: String,
   val type: InstallationFile.Type,
   val md5: String,

--- a/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/database/model/TaskInfoData.kt
+++ b/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/database/model/TaskInfoData.kt
@@ -6,11 +6,11 @@ import cm.aptoide.pt.install_manager.Task
 
 @Entity(tableName = "TaskInfo")
 data class TaskInfoData(
-  @PrimaryKey val packageName: String,
+  @PrimaryKey val timestamp: Long,
+  val packageName: String,
   val versionCode: Long,
   val versionName: String,
   val constraints: String,
   val type: Task.Type,
-  val timestamp: Long,
   val payload: String?,
 )

--- a/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/database/model/TaskInfoWithFiles.kt
+++ b/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/database/model/TaskInfoWithFiles.kt
@@ -5,6 +5,6 @@ import androidx.room.Relation
 
 data class TaskInfoWithFiles(
   @Embedded val taskInfo: TaskInfoData,
-  @Relation(parentColumn = "packageName", entityColumn = "packageName")
+  @Relation(parentColumn = "timestamp", entityColumn = "taskTimestamp")
   val installationFiles: List<InstallationFileData>
 )

--- a/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/di/TaskInfoModule.kt
+++ b/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/di/TaskInfoModule.kt
@@ -30,6 +30,8 @@ object TaskInfoModule {
   @Provides
   fun provideTaskInfoDatabase(@ApplicationContext appContext: Context): TaskInfoDatabase =
     Room.databaseBuilder(appContext, TaskInfoDatabase::class.java, "aptoide_task_info.db")
+      .fallbackToDestructiveMigration()
+      .fallbackToDestructiveMigrationOnDowngrade()
       .addMigrations(FirstMigration())
       .build()
 }

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/App.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/App.kt
@@ -24,6 +24,21 @@ interface App {
   val taskFlow: Flow<Task?>
 
   /**
+   * Checks if can install.
+   *
+   * @param installPackageInfo - a package info to use for the installation
+   * @param constraints - constraints to respect
+   * @return null if can
+   * @return [IllegalStateException] if another task is already running
+   * @return [IllegalArgumentException] if same or newer version is already known to be installed
+   * @return [OutOfSpaceException] if there is not enough space to download and install
+   */
+  fun canInstall(
+    installPackageInfo: InstallPackageInfo,
+    constraints: Constraints
+  ): Throwable?
+
+  /**
    * Creates an installation task.
    *
    * @param installPackageInfo - a package info to use for the installation

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/repository/TaskInfoRepository.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/repository/TaskInfoRepository.kt
@@ -26,10 +26,10 @@ interface TaskInfoRepository {
   suspend fun saveJob(taskInfo: TaskInfo)
 
   /**
-   * Removes all enqueued task jobs by package name.
+   * Removes enqueued task job.
    *
-   * @param packageName - a package name
+   * @param taskInfo - the task to remove
    */
-  suspend fun removeAll(packageName: String)
+  suspend fun remove(vararg taskInfo: TaskInfo)
 }
 

--- a/install-manager/src/test/java/cm/aptoide/pt/install_manager/InstallManagerTest.kt
+++ b/install-manager/src/test/java/cm/aptoide/pt/install_manager/InstallManagerTest.kt
@@ -243,7 +243,6 @@ internal class InstallManagerTest {
     m When "not installed app install started"
     val notInstalledTask = installManager.getApp(notInstalledPackage).install(installInfo)
     m And "outdated version app update stated with unmetered network constraint"
-    scope.advanceTimeBy(1.milliseconds)
     val outdatedTask = installManager.getApp(outdatedPackage).install(
       installPackageInfo = installInfo,
       constraints = Constraints(
@@ -252,7 +251,6 @@ internal class InstallManagerTest {
       )
     )
     m And "current version app uninstall started"
-    scope.advanceTimeBy(1.milliseconds)
     val currentTask = installManager.getApp(currentPackage).uninstall()
     m And "get currently scheduled apps"
     val scheduledInitially = installManager.scheduledApps
@@ -408,7 +406,6 @@ internal class InstallManagerTest {
     m And "not installed app install started"
     val notInstalledTask = installManager.getApp(notInstalledPackage).install(installInfo)
     m And "outdated version app update stated with unmetered network constraint"
-    scope.advanceTimeBy(1.milliseconds)
     val outdatedTask = installManager.getApp(outdatedPackage).install(
       installPackageInfo = installInfo,
       constraints = Constraints(
@@ -417,7 +414,6 @@ internal class InstallManagerTest {
       )
     )
     m And "current version app uninstall started"
-    scope.advanceTimeBy(1.milliseconds)
     val currentTask = installManager.getApp(currentPackage).uninstall()
     m And "get currently scheduled apps after first scheduled runnable task started"
     scope.advanceTimeBy(10.seconds)
@@ -506,7 +502,6 @@ internal class InstallManagerTest {
     m And "not installed app install started"
     val notInstalledTask = installManager.getApp(notInstalledPackage).install(installInfo)
     m And "outdated version app update stated with unmetered network constraint"
-    scope.advanceTimeBy(1.milliseconds)
     val outdatedTask = installManager.getApp(outdatedPackage).install(
       installPackageInfo = installInfo,
       constraints = Constraints(
@@ -515,7 +510,6 @@ internal class InstallManagerTest {
       )
     )
     m And "current version app uninstall started"
-    scope.advanceTimeBy(1.milliseconds)
     val currentTask = installManager.getApp(currentPackage).uninstall()
     m And "get currently scheduled apps after first scheduled runnable task started"
     scope.advanceTimeBy(10.seconds)

--- a/install-manager/src/test/java/cm/aptoide/pt/install_manager/TestData.kt
+++ b/install-manager/src/test/java/cm/aptoide/pt/install_manager/TestData.kt
@@ -451,6 +451,10 @@ internal class TaskInfoRepositoryMock : TaskInfoRepository {
   }
 
   fun get(pn: String): TaskInfo? = info.find { it.packageName == pn }
+
+  fun add(taskInfo: TaskInfo) = apply {
+    info.add(taskInfo)
+  }
 }
 
 // Crashes on duplicated calls for optimization reasons


### PR DESCRIPTION
**What does this PR do?**

   - Adds logic to the install manager that, when trying to restore installation tasks for apps, checks if the apps meanwhile have already been installed or updated. For each app that is already installed/updated, its installation task is removed and not restored.
   - Extracts a package info extension function that checks if an app Is outdated, by comparing it with a provided version code.

**Database changed?**

   Yes

**Where should the reviewer start?**

- [ ] RealInstallManager.kt
- [ ] PackageManagerExtensions.kt
- [ ] DownloadViewModel.kt

**How should this be manually tested?**

**INSTRUCTIONS FOR HOW TO TEST THIS ARE PROVIDED IN THE TICKET'S COMMENTS.**

  Flow on how to test this or QA Tickets related to this use-case: [AND-98](https://aptoide.atlassian.net/browse/AND-98)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-98](https://aptoide.atlassian.net/browse/AND-98)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[AND-98]: https://aptoide.atlassian.net/browse/AND-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-98]: https://aptoide.atlassian.net/browse/AND-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ