### PR TITLE
[AND-81] - Add indicative not allowed permissions download error

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
@@ -1,7 +1,10 @@
 package com.aptoide.android.aptoidegames.installer.analytics
 
+import cm.aptoide.pt.install_manager.AbortException
 import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import cm.aptoide.pt.install_manager.workers.PackageDownloader
+import cm.aptoide.pt.installer.platform.REQUEST_INSTALL_PACKAGES_NOT_ALLOWED
+import cm.aptoide.pt.installer.platform.WRITE_EXTERNAL_STORAGE_NOT_ALLOWED
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
@@ -31,6 +34,25 @@ class DownloadProbe(
             packageName = packageName,
             analyticsPayload = analyticsPayload
           )
+
+          is AbortException -> {
+            when (it.message) {
+              REQUEST_INSTALL_PACKAGES_NOT_ALLOWED,
+              WRITE_EXTERNAL_STORAGE_NOT_ALLOWED -> analytics.sendDownloadAbortEvent(
+                packageName = packageName,
+                analyticsPayload = analyticsPayload,
+                errorMessage = it.message
+              )
+
+              else -> analytics.sendDownloadErrorEvent(
+                packageName = packageName,
+                analyticsPayload = analyticsPayload,
+                errorMessage = it.message,
+                errorType = it::class.simpleName,
+                errorCode = null
+              )
+            }
+          }
 
           null -> analytics.sendDownloadCompletedEvent(
             packageName = packageName,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -131,6 +131,26 @@ class InstallAnalytics(
     )
   }
 
+  fun sendDownloadAbortEvent(
+    packageName: String,
+    analyticsPayload: AnalyticsPayload?,
+    errorMessage: String?,
+  ) {
+    genericAnalytics.sendDownloadErrorEvent(
+      packageName = packageName,
+      analyticsPayload = analyticsPayload,
+      errorMessage = errorMessage
+    )
+
+    logBIDownloadEvent(
+      packageName = packageName,
+      status = "abort",
+      analyticsPayload = analyticsPayload,
+      P_ERROR_MESSAGE to errorMessage,
+      P_ERROR_TYPE to "permission",
+    )
+  }
+
   fun sendDownloadCancelEvent(
     packageName: String,
     analyticsPayload: AnalyticsPayload?,

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/InstallPermissions.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/InstallPermissions.kt
@@ -13,6 +13,9 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
+const val REQUEST_INSTALL_PACKAGES_NOT_ALLOWED = "REQUEST_INSTALL_PACKAGES permission not allowed"
+const val WRITE_EXTERNAL_STORAGE_NOT_ALLOWED = "WRITE_EXTERNAL_STORAGE permission not allowed"
+
 interface InstallPermissions {
   /**
    * Asks for installation permissions. Throws [AbortException] if user denies.
@@ -42,9 +45,11 @@ class InstallPermissionsImpl @Inject constructor(
           )
         )
       } else {
-        throw AbortException("Not allowed")
+        throw AbortException(REQUEST_INSTALL_PACKAGES_NOT_ALLOWED)
       }
-      if (!context.hasPackageInstallsPermission()) throw AbortException("Not allowed")
+      if (!context.hasPackageInstallsPermission()) throw AbortException(
+        REQUEST_INSTALL_PACKAGES_NOT_ALLOWED
+      )
     }
   }
 
@@ -58,7 +63,7 @@ class InstallPermissionsImpl @Inject constructor(
               Manifest.permission.WRITE_EXTERNAL_STORAGE
             )
           ) {
-            throw AbortException("Not allowed")
+            throw AbortException(WRITE_EXTERNAL_STORAGE_NOT_ALLOWED)
           }
 
           //Need to show rationale
@@ -67,10 +72,10 @@ class InstallPermissionsImpl @Inject constructor(
                 Manifest.permission.WRITE_EXTERNAL_STORAGE
               )
             ) {
-              throw AbortException("Not allowed")
+              throw AbortException(WRITE_EXTERNAL_STORAGE_NOT_ALLOWED)
             }
           } else {
-            throw AbortException("Not allowed")
+            throw AbortException(WRITE_EXTERNAL_STORAGE_NOT_ALLOWED)
           }
 
           //Need to open settings
@@ -82,10 +87,10 @@ class InstallPermissionsImpl @Inject constructor(
               )
             )
             if (!context.hasWriteExternalStoragePermission()) throw AbortException(
-              "Not allowed"
+              WRITE_EXTERNAL_STORAGE_NOT_ALLOWED
             )
           } else {
-            throw AbortException("Not allowed")
+            throw AbortException(WRITE_EXTERNAL_STORAGE_NOT_ALLOWED)
           }
         }
       }


### PR DESCRIPTION
**What does this PR do?**

It changes the name of the "Not Allowed" message when we get it from an AbortException by not accepting a permission to [name of the permission] permission not allowed. It also creates a new function to send a downloadAbortEvent to indicative, as stated in the ticket.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] DownloadProbe.kt
- [ ] InstallAnalytics.kt
- [ ] InstallPermissions.kt

**How should this be manually tested?**
  Try different ways of cancelling/not accepting the install permissions and see if the events are sent correctly.

  Flow on how to test this or QA Tickets related to this use-case: [AND-81](https://aptoide.atlassian.net/browse/AND-81)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-81](https://aptoide.atlassian.net/browse/AND-81)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[AND-81]: https://aptoide.atlassian.net/browse/AND-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-81]: https://aptoide.atlassian.net/browse/AND-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ