### PR TITLE
[AND-86] updates notification

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/UpdatesNotificationBuilder.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/UpdatesNotificationBuilder.kt
@@ -1,0 +1,133 @@
+package com.aptoide.android.aptoidegames.updates
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.res.Configuration
+import androidx.compose.ui.graphics.toArgb
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.graphics.drawable.toBitmap
+import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
+import cm.aptoide.pt.extensions.isAllowed
+import cm.aptoide.pt.feature_updates.presentation.UpdatesNotificationProvider
+import com.aptoide.android.aptoidegames.BuildConfig
+import com.aptoide.android.aptoidegames.MainActivity
+import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.notifications.getNotificationIcon
+import com.aptoide.android.aptoidegames.putDeeplink
+import com.aptoide.android.aptoidegames.putNotificationSource
+import com.aptoide.android.aptoidegames.theme.Palette
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UpdatesNotificationBuilder @Inject constructor(
+  @ApplicationContext private val context: Context,
+) : UpdatesNotificationProvider {
+
+  companion object {
+    const val UPDATES_NOTIFICATION_CHANNEL_ID = "updates_notification_channel"
+    const val UPDATES_NOTIFICATION_CHANNEL_NAME = "Updates Notification Channel"
+  }
+
+  init {
+    setupNotificationChannel(context)
+  }
+
+  private fun setupNotificationChannel(context: Context) {
+    val notificationManager =
+      context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+    if (notificationManager.getNotificationChannel(UPDATES_NOTIFICATION_CHANNEL_ID) == null) {
+      val name = UPDATES_NOTIFICATION_CHANNEL_NAME
+      val descriptionText = "Updates notification channel"
+      val importance = NotificationManager.IMPORTANCE_DEFAULT
+      val channel = NotificationChannel(
+        UPDATES_NOTIFICATION_CHANNEL_ID,
+        name,
+        importance
+      ).apply {
+        description = descriptionText
+        setSound(null, null)
+      }
+
+      notificationManager.createNotificationChannel(channel)
+    }
+  }
+
+  override suspend fun showUpdatesNotification(
+    numberOfUpdates: Int
+  ) {
+    val notificationId = "Updates".hashCode()
+    val notification = buildNotification(
+      requestCode = notificationId,
+      contentText = context.getString(R.string.update_notification_body),
+      contentTitle = context.resources.getQuantityString(
+        R.plurals.update_notification_title,
+        numberOfUpdates, numberOfUpdates
+      )
+    )
+
+    notification?.let { showNotification(notificationId, notification) }
+  }
+
+  @SuppressLint("MissingPermission")
+  private fun showNotification(
+    notificationId: Int,
+    notification: Notification,
+  ) {
+    if (context.isAllowed(Manifest.permission.POST_NOTIFICATIONS)) {
+      NotificationManagerCompat.from(context).notify(notificationId, notification)
+    }
+  }
+
+  private fun buildNotification(
+    requestCode: Int,
+    contentTitle: String? = null,
+    contentText: String,
+    channel: String = UPDATES_NOTIFICATION_CHANNEL_ID
+  ): Notification? = if (context.isAllowed(Manifest.permission.POST_NOTIFICATIONS)) {
+
+    val deepLink = buildUpdatesDeepLinkUri()
+
+    val clickIntent = PendingIntent.getActivity(
+      context,
+      requestCode,
+      Intent(context, MainActivity::class.java)
+        .putDeeplink(deepLink)
+        .putNotificationSource(),
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    )
+
+    val notificationIcon = BuildConfig.FLAVOR.getNotificationIcon()
+
+    val resources = context.resources
+    val uiMode = resources.configuration.uiMode
+    val isNightMode =
+      (uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+    val colorToUse = if (isNightMode) Palette.Primary.toArgb() else Palette.Black.toArgb()
+
+    NotificationCompat.Builder(context, channel)
+      .setShowWhen(true)
+      .setColor(colorToUse)
+      .setSmallIcon(notificationIcon)
+      .setLargeIcon(
+        VectorDrawableCompat.create(context.resources, R.drawable.app_icon, null)?.toBitmap()
+      )
+      .setContentTitle(contentTitle)
+      .setContentText(contentText)
+      .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+      .setAutoCancel(true)
+      .setContentIntent(clickIntent)
+      .build()
+  } else {
+    null
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/UpdatesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/UpdatesScreen.kt
@@ -59,6 +59,9 @@ fun updatesScreen() = ScreenData.withAnalytics(
   )
 }
 
+fun buildUpdatesDeepLinkUri() =
+  BuildConfig.DEEP_LINK_SCHEMA + updatesRoute
+
 @Composable
 fun UpdatesScreen(
   updatesUiState: UpdatesUiState,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/di/RepositoryModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/di/RepositoryModule.kt
@@ -1,0 +1,24 @@
+package com.aptoide.android.aptoidegames.updates.di
+
+import android.content.Context
+import cm.aptoide.pt.feature_updates.presentation.UpdatesNotificationProvider
+import com.aptoide.android.aptoidegames.updates.UpdatesNotificationBuilder
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object RepositoryModule {
+
+  @Provides
+  @Singleton
+  fun providesUpdatesNotificationProvider(
+    @ApplicationContext context: Context,
+  ): UpdatesNotificationProvider {
+    return UpdatesNotificationBuilder(context)
+  }
+}

--- a/app-games/src/main/res/drawable/app_icon.xml
+++ b/app-games/src/main/res/drawable/app_icon.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="120dp"
+    android:height="120dp"
+    android:viewportWidth="120"
+    android:viewportHeight="120">
+  <path
+      android:pathData="M17,17h86v86h-86z"
+      android:fillColor="#1E1E26"/>
+  <path
+      android:pathData="M17.14,0H102.86V17.14H120V111.43H102.86V120H17.14V102.86H0V12H17.14V0ZM85.71,25.71H77.14V34.29H68.57V44.57H60V51.43H51.43V42.86H42.86V34.29H34.29V25.71H25.71V68.57H34.29V77.14H42.86V85.71H51.43V94.29H68.57V85.71H77.14V77.14H85.71V68.57H94.29V34.29H85.71V25.71ZM42.86,60V68.57H34.29V60H42.86ZM42.86,60H51.43V51.43H42.86V60Z"
+      android:fillColor="#C8ED4F"
+      android:fillType="evenOdd"/>
+</vector>

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/Updates.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/Updates.kt
@@ -11,6 +11,7 @@ import cm.aptoide.pt.feature_apps.data.AppsListMapper
 import cm.aptoide.pt.feature_apps.data.model.AppJSON
 import cm.aptoide.pt.feature_updates.data.UpdatesRepository
 import cm.aptoide.pt.feature_updates.di.PrioritizedPackagesFilter
+import cm.aptoide.pt.feature_updates.presentation.UpdatesNotificationProvider
 import cm.aptoide.pt.install_manager.InstallManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -31,6 +32,7 @@ class Updates @Inject constructor(
   private val appsListMapper: AppsListMapper,
   @PrioritizedPackagesFilter private val prioritizedPackages: List<String>,
   private val installManager: InstallManager,
+  private val updatesNotificationBuilder: UpdatesNotificationProvider
 ) {
 
   val mutex: Mutex = Mutex()
@@ -69,6 +71,9 @@ class Updates @Inject constructor(
       }
     val updates = updatesRepository.loadUpdates(apksData)
     updatesRepository.replaceWith(*updates.toTypedArray())
+    if (updates.isNotEmpty()) {
+      updatesNotificationBuilder.showUpdatesNotification(updates.size)
+    }
   }
 
   suspend fun getAppsUpdates(): Flow<List<App>> {

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/presentation/UpdatesNotificationProvider.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/presentation/UpdatesNotificationProvider.kt
@@ -1,0 +1,5 @@
+package cm.aptoide.pt.feature_updates.presentation
+
+interface UpdatesNotificationProvider {
+  suspend fun showUpdatesNotification(numberOfUpdates: Int)
+}


### PR DESCRIPTION
**What does this PR do?**

This PR aims at implementing the updates notification.
Note 1. this was based on the PR https://github.com/Aptoide/aptoide-client-v8/pull/2052 so it shouldnt be merged before it.
This also means it has the commits from that branch. To review this pr, check by commit, my only single commit.

Note 2. This has strings hardcoded as they are not available yet.
Note 3. That this is hardcoded to send the notification up on app startup. This should obviosuly be removed and integrated on the https://aptoide.atlassian.net/browse/AND-85 ticket.


**Database changed?**

 No

**Where should the reviewer start?**

- [ ] UpdatesNotificationBuilder.kt

**How should this be manually tested?**

Open app, it will show a notification.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-86](https://aptoide.atlassian.net/browse/AND-86)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[AND-86]: https://aptoide.atlassian.net/browse/AND-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ