### PR TITLE
[AND-100] - Add indicative empty search_result_click

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/search/analytics/SearchAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/search/analytics/SearchAnalytics.kt
@@ -42,6 +42,15 @@ class SearchAnalytics(
     )
   }
 
+  fun sendEmptySearchResultClickEvent(
+    searchMeta: SearchMeta,
+  ) {
+    biAnalytics.logEvent(
+      name = "Search_Result_Click",
+      params = mapOf(P_POSITION to "empty") + searchMeta.toBIParameters(null)
+    )
+  }
+
   companion object {
     private const val P_POSITION = "position"
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/search/presentation/SearchView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/search/presentation/SearchView.kt
@@ -156,7 +156,10 @@ fun searchScreen() = ScreenData.withAnalytics(
           buildAppViewRoute(app).withItemPosition(index)
         )
       },
-      onItemInstallStarted = {}
+      onItemInstallStarted = {},
+      onEmptyView = {
+        searchMeta?.let { searchAnalytics.sendEmptySearchResultClickEvent(it) }
+      }
     )
   }
 }
@@ -171,6 +174,7 @@ fun SearchView(
   onSearchQueryClick: () -> Unit,
   onItemClick: (Int, App) -> Unit,
   onItemInstallStarted: (App) -> Unit,
+  onEmptyView: () -> Unit,
 ) {
   Column {
     SearchAppBar(
@@ -203,6 +207,7 @@ fun SearchView(
 
       is SearchUiState.Results -> {
         if (uiState.searchResults.isEmpty()) {
+          onEmptyView()
           EmptyView(text = stringResource(R.string.search_empty_body, searchValue))
         } else {
           SearchResultsView(


### PR DESCRIPTION
**What does this PR do?**

(On draft until some questions are answered when Ana comes back) - It adds a search_result_click event sent when the search results come out empty.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] SearchAnalytics.kt
- [ ] SearchView.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-100](https://aptoide.atlassian.net/browse/AND-100)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-100](https://aptoide.atlassian.net/browse/AND-100)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

[AND-100]: https://aptoide.atlassian.net/browse/AND-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-100]: https://aptoide.atlassian.net/browse/AND-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ