### PR TITLE
[AND-113] Fix my games drawable crashes

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/InstalledApps.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/InstalledApps.kt
@@ -1,0 +1,31 @@
+package com.aptoide.android.aptoidegames.feature_apps.presentation
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import cm.aptoide.pt.extensions.getAppIconDrawable
+import cm.aptoide.pt.extensions.runPreviewable
+import com.aptoide.android.aptoidegames.R
+
+@Composable
+fun rememberAppIconDrawable(
+  packageName: String,
+  context: Context,
+): Drawable? =
+  runPreviewable(preview = {
+    remember(
+      key1 = packageName,
+      key2 = context
+    ) {
+      AppCompatResources.getDrawable(context, R.mipmap.ic_launcher)
+    }
+  }, real = {
+    remember(
+      key1 = packageName,
+      key2 = context
+    ) {
+      context.getAppIconDrawable(packageName)
+    }
+  })

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MyGamesBundleView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MyGamesBundleView.kt
@@ -144,20 +144,20 @@ fun MyGamesBundleViewContent(
 fun rememberAppIconDrawable(
   packageName: String,
   context: Context,
-): Drawable =
+): Drawable? =
   runPreviewable(preview = {
     remember(
       key1 = packageName,
       key2 = context
     ) {
-      getDrawable(context, R.mipmap.ic_launcher)!!
+      getDrawable(context, R.mipmap.ic_launcher)
     }
   }, real = {
     remember(
       key1 = packageName,
       key2 = context
     ) {
-      context.getAppIconDrawable(packageName)!!
+      context.getAppIconDrawable(packageName)
     }
   })
 
@@ -202,7 +202,7 @@ fun MyGamesEmptyView(content: @Composable ColumnScope.() -> Unit) {
 
 @Composable
 fun MyGameView(
-  icon: Drawable,
+  icon: Drawable?,
   name: String,
   onClick: () -> Unit = {},
 ) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MyGamesBundleView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MyGamesBundleView.kt
@@ -1,8 +1,6 @@
 package com.aptoide.android.aptoidegames.feature_apps.presentation
 
-import android.content.Context
 import android.graphics.drawable.Drawable
-import androidx.appcompat.content.res.AppCompatResources.getDrawable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -29,7 +27,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -44,8 +41,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.extensions.PreviewDark
-import cm.aptoide.pt.extensions.getAppIconDrawable
-import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.feature_apps.data.MyGamesApp
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.R
@@ -139,27 +134,6 @@ fun MyGamesBundleViewContent(
     }
   }
 }
-
-@Composable
-fun rememberAppIconDrawable(
-  packageName: String,
-  context: Context,
-): Drawable? =
-  runPreviewable(preview = {
-    remember(
-      key1 = packageName,
-      key2 = context
-    ) {
-      getDrawable(context, R.mipmap.ic_launcher)
-    }
-  }, real = {
-    remember(
-      key1 = packageName,
-      key2 = context
-    ) {
-      context.getAppIconDrawable(packageName)
-    }
-  })
 
 @Composable
 fun MyGamesAppsListView(content: @Composable ColumnScope.() -> Unit) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/SeeAllMyGamesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/SeeAllMyGamesScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -33,7 +32,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.ScreenData
-import cm.aptoide.pt.extensions.getAppIconDrawable
 import cm.aptoide.pt.feature_apps.data.randomMyGamesApp
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.R
@@ -104,12 +102,8 @@ fun SeeAllMyGamesViewContent(
           items = uiState.installedAppsList,
           key = { it.packageName }
         ) {
-          val icon = remember(
-            key1 = it.packageName,
-            key2 = localContext
-          ) {
-            localContext.getAppIconDrawable(it.packageName)
-          }
+          val icon = rememberAppIconDrawable(it.packageName, localContext)
+
           AppItem(
             name = it.name,
             icon = icon,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_oos/OutOfSpaceAppItem.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_oos/OutOfSpaceAppItem.kt
@@ -22,13 +22,13 @@ import cm.aptoide.pt.download_view.presentation.DownloadUiState.Installed
 import cm.aptoide.pt.download_view.presentation.DownloadUiState.Outdated
 import cm.aptoide.pt.download_view.presentation.DownloadUiState.Uninstalling
 import cm.aptoide.pt.download_view.presentation.DownloadUiState.Waiting
-import cm.aptoide.pt.extensions.getAppIconDrawable
 import cm.aptoide.pt.extensions.getAppName
 import cm.aptoide.pt.extensions.getAppSize
 import cm.aptoide.pt.feature_apps.data.emptyApp
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.design_system.SecondarySmallOutlinedButton
+import com.aptoide.android.aptoidegames.feature_apps.presentation.rememberAppIconDrawable
 import com.aptoide.android.aptoidegames.installer.presentation.installViewStates
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.Palette
@@ -41,7 +41,7 @@ fun OutOfSpaceAppItem(packageName: String) {
     appSize = context.getAppSize(packageName),
     name = context.getAppName(packageName),
   )
-  val appIcon = context.getAppIconDrawable(packageName)
+  val appIcon = rememberAppIconDrawable(packageName, context)
   val (state) = installViewStates(
     app = app,
   )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/AppGamesPurchaseInfo.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/AppGamesPurchaseInfo.kt
@@ -22,13 +22,13 @@ import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.PreviewLandscapeDark
 import cm.aptoide.pt.extensions.format
-import cm.aptoide.pt.extensions.getAppIconDrawable
 import cm.aptoide.pt.extensions.getAppName
 import cm.aptoide.pt.extensions.runPreviewable
 import com.appcoins.payments.arch.ProductInfoData
 import com.appcoins.payments.arch.emptyProductInfoData
 import com.appcoins.payments.manager.presentation.rememberProductInfo
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
+import com.aptoide.android.aptoidegames.feature_apps.presentation.rememberAppIconDrawable
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.theme.Palette
@@ -95,7 +95,7 @@ private fun PurchaseInfoRowPortrait(
   modifier: Modifier = Modifier,
 ) {
   val localContext = LocalContext.current
-  val appIcon = localContext.getAppIconDrawable(buyingPackage)
+  val appIcon = rememberAppIconDrawable(buyingPackage, localContext)
   val appName = localContext.getAppName(buyingPackage).takeIf(String::isNotBlank)
 
   Row(
@@ -142,7 +142,7 @@ private fun PurchaseInfoRowLandscape(
   modifier: Modifier = Modifier,
 ) {
   val localContext = LocalContext.current
-  val appIcon = localContext.getAppIconDrawable(buyingPackage)
+  val appIcon = rememberAppIconDrawable(buyingPackage, localContext)
   val appName = localContext.getAppName(buyingPackage).takeIf(String::isNotBlank)
 
   Row(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/PromoCodeBottomSheetContent.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/PromoCodeBottomSheetContent.kt
@@ -91,7 +91,7 @@ class PromoCodeBottomSheet(
 @Composable
 fun PromoCodeBottomSheetContent(
   appName: String,
-  appIcon: Drawable,
+  appIcon: Drawable?,
   walletAppUiState: AppUiState,
   dismiss: () -> Unit,
   navigate: (String) -> Unit,

--- a/extensions/src/main/java/cm/aptoide/pt/extensions/PackageManagerExtensions.kt
+++ b/extensions/src/main/java/cm/aptoide/pt/extensions/PackageManagerExtensions.kt
@@ -60,7 +60,7 @@ fun ApplicationInfo.getSplitsSize(): Long = splitPublicSourceDirs
   ?.reduce { acc, it -> acc + it }
   ?: 0
 
-fun ApplicationInfo.loadIconDrawable(packageManager: PackageManager): Drawable =
+fun ApplicationInfo.loadIconDrawable(packageManager: PackageManager): Drawable? = runCatching {
   loadUnbadgedIcon(packageManager)
     .let { drawable ->
       if (drawable is AdaptiveIconDrawable) {
@@ -72,3 +72,4 @@ fun ApplicationInfo.loadIconDrawable(packageManager: PackageManager): Drawable =
         drawable
       }
     }
+}.getOrNull()


### PR DESCRIPTION
**What does this PR do?**

   - Adds error catching when loading installed app icon drawables.
   - Handles nullability in sections and screens that fetch installed app icon drawables.
   - Moves and reuses function that fetches installed app icon drawables.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-113](https://aptoide.atlassian.net/browse/AND-113)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-113](https://aptoide.atlassian.net/browse/AND-113)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-113]: https://aptoide.atlassian.net/browse/AND-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-113]: https://aptoide.atlassian.net/browse/AND-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ