### PR TITLE
[AND-37] Change permission flow

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
@@ -3,7 +3,6 @@ package com.aptoide.android.aptoidegames.installer.analytics
 import cm.aptoide.pt.install_manager.AbortException
 import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import cm.aptoide.pt.install_manager.workers.PackageDownloader
-import cm.aptoide.pt.installer.platform.REQUEST_INSTALL_PACKAGES_NOT_ALLOWED
 import cm.aptoide.pt.installer.platform.WRITE_EXTERNAL_STORAGE_NOT_ALLOWED
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onCompletion
@@ -37,7 +36,6 @@ class DownloadProbe(
 
           is AbortException -> {
             when (it.message) {
-              REQUEST_INSTALL_PACKAGES_NOT_ALLOWED,
               WRITE_EXTERNAL_STORAGE_NOT_ALLOWED -> analytics.sendDownloadAbortEvent(
                 packageName = packageName,
                 analyticsPayload = analyticsPayload,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -197,6 +197,26 @@ class InstallAnalytics(
     )
   }
 
+  fun sendInstallAbortEvent(
+    packageName: String,
+    analyticsPayload: AnalyticsPayload?,
+    errorMessage: String?,
+  ) {
+    genericAnalytics.sendInstallErrorEvent(
+      packageName = packageName,
+      analyticsPayload = analyticsPayload,
+      errorMessage = errorMessage
+    )
+
+    logBIInstallEvent(
+      packageName = packageName,
+      status = "abort",
+      analyticsPayload = analyticsPayload,
+      P_ERROR_MESSAGE to errorMessage,
+      P_ERROR_TYPE to "permission",
+    )
+  }
+
   fun sendInstallCancelEvent(
     packageName: String,
     analyticsPayload: AnalyticsPayload?,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallProbe.kt
@@ -1,7 +1,10 @@
 package com.aptoide.android.aptoidegames.installer.analytics
 
+import cm.aptoide.pt.install_manager.AbortException
 import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import cm.aptoide.pt.install_manager.workers.PackageInstaller
+import cm.aptoide.pt.installer.platform.REQUEST_INSTALL_PACKAGES_NOT_ALLOWED
+import cm.aptoide.pt.installer.platform.WRITE_EXTERNAL_STORAGE_NOT_ALLOWED
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
@@ -30,6 +33,24 @@ class InstallProbe(
             packageName = packageName,
             analyticsPayload = analyticsPayload
           )
+
+          is AbortException -> {
+            when (it.message) {
+              REQUEST_INSTALL_PACKAGES_NOT_ALLOWED,
+              WRITE_EXTERNAL_STORAGE_NOT_ALLOWED -> analytics.sendInstallAbortEvent(
+                packageName = packageName,
+                analyticsPayload = analyticsPayload,
+                errorMessage = it.message
+              )
+
+              else -> analytics.sendInstallErrorEvent(
+                packageName = packageName,
+                analyticsPayload = analyticsPayload,
+                errorMessage = it.message,
+                errorType = it::class.simpleName,
+              )
+            }
+          }
 
           null -> {
             analytics.sendInstallCompletedEvent(

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideDownloader.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideDownloader.kt
@@ -32,7 +32,6 @@ class AptoideDownloader @Inject constructor(
         if(installPackageInfo.hasObb()) {
           installPermissions.checkIfCanWriteExternal()
         }
-        installPermissions.checkIfCanInstall()
       }
       .flatMapMerge(concurrency = 3) { item ->
         var progress = 0.0


### PR DESCRIPTION
**What does this PR do?**

  This PR aims to only ask  for unknown sources permission only after the download

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AptoideDownloader.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-37](https://aptoide.atlassian.net/browse/AND-37)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-37](https://aptoide.atlassian.net/browse/AND-37)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-37]: https://aptoide.atlassian.net/browse/AND-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-37]: https://aptoide.atlassian.net/browse/AND-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ