### PR TITLE
[AND-126] - Fix Updates Batch and empty signatures' errors

### DIFF
--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/Updates.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/Updates.kt
@@ -67,6 +67,7 @@ class Updates @Inject constructor(
           versionCode = PackageInfoCompat.getLongVersionCode(it)
         )
       }
+      .filter { it.signature.isNotEmpty() }
     val updates = updatesRepository.loadUpdates(apksData)
     updatesRepository.replaceWith(*updates.toTypedArray())
   }


### PR DESCRIPTION
**What does this PR do?**

It filters the installed apps without signatures and makes every updates' batch request not depend on others so if one fails the others still load on the updatesList.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] See by commit

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-126](https://aptoide.atlassian.net/browse/AND-126)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-126](https://aptoide.atlassian.net/browse/AND-126)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
