### PR TITLE
[AND-96] Remove the + when we don't round it down

### DIFF
--- a/extensions/src/main/java/cm/aptoide/pt/extensions/IntExtensions.kt
+++ b/extensions/src/main/java/cm/aptoide/pt/extensions/IntExtensions.kt
@@ -10,7 +10,7 @@ import java.util.Locale
 fun Int.spAsDp(): Dp = with(LocalDensity.current) { sp.toDp() }
 
 fun Int.formatDownloads(): String {
-  val suffixes = listOf("", "K", "M", "B", "T")
+  val suffixes = listOf("", "K+", "M+", "B+", "T+")
   var value = this.toDouble()
   var index = 0
 
@@ -19,5 +19,5 @@ fun Int.formatDownloads(): String {
     index++
   }
 
-  return String.format(Locale.ENGLISH, "%d%s+", value.toInt(), suffixes[index])
+  return String.format(Locale.ENGLISH, "%d%s", value.toInt(), suffixes[index])
 }


### PR DESCRIPTION
**What does this PR do?**

   Only adds + sign when we round it down

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] IntExtensions.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-96](https://aptoide.atlassian.net/browse/AND-96)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-96](https://aptoide.atlassian.net/browse/AND-96)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-96]: https://aptoide.atlassian.net/browse/AND-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-96]: https://aptoide.atlassian.net/browse/AND-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ