### PR TITLE
[AND-128] - Support Editorial to App view Navigation

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialViewScreen.kt
@@ -53,6 +53,7 @@ import com.aptoide.android.aptoidegames.UrlActivity
 import com.aptoide.android.aptoidegames.analytics.presentation.AnalyticsContext
 import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
+import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
 import com.aptoide.android.aptoidegames.design_system.IndeterminateCircularLoading
 import com.aptoide.android.aptoidegames.design_system.SecondaryButton
 import com.aptoide.android.aptoidegames.drawables.icons.getLeftArrow
@@ -229,7 +230,7 @@ private fun ArticleViewContent(
             item {
               AppItem(
                 app = it,
-                onClick = { },
+                onClick = { navigate(buildAppViewRoute(it)) },
                 modifier = Modifier.padding(horizontal = 16.dp)
               ) {
                 InstallViewShort(app = it)


### PR DESCRIPTION
**What does this PR do?**

It adds navigation to the app item present in EditorialViewScreen

**Database changed?**

No

**Where should the reviewer start?**

- [ ] EditorialViewScreen.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-128](https://aptoide.atlassian.net/browse/AND-128)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-128](https://aptoide.atlassian.net/browse/AND-128)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-128]: https://aptoide.atlassian.net/browse/AND-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-128]: https://aptoide.atlassian.net/browse/AND-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ