### PR TITLE
[AND-132] Fix TaskInfo DB fallback to destructive migration

### DIFF
--- a/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/di/TaskInfoModule.kt
+++ b/aptoide-task-info/src/main/java/cm/aptoide/pt/task_info/di/TaskInfoModule.kt
@@ -31,7 +31,6 @@ object TaskInfoModule {
   fun provideTaskInfoDatabase(@ApplicationContext appContext: Context): TaskInfoDatabase =
     Room.databaseBuilder(appContext, TaskInfoDatabase::class.java, "aptoide_task_info.db")
       .fallbackToDestructiveMigration()
-      .fallbackToDestructiveMigrationOnDowngrade()
       .addMigrations(FirstMigration())
       .build()
 }


### PR DESCRIPTION
**What does this PR do?**

   - Fixes the TaskInfo DB fallback to destructive migration, by removing the unecessary call to fallbackToDestructiveMigrationOnDowngrade, since it was removing the fallback on upgrades.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] TaskInfoModule.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-132](https://aptoide.atlassian.net/browse/AND-132)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-132](https://aptoide.atlassian.net/browse/AND-132)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-132]: https://aptoide.atlassian.net/browse/AND-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-132]: https://aptoide.atlassian.net/browse/AND-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ