### PR TITLE
[AND-104] - Update PTO Header UI

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/PublisherTakeOverBundle.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/PublisherTakeOverBundle.kt
@@ -140,20 +140,23 @@ fun PublisherTakeOverContent(
           verticalAlignment = Alignment.CenterVertically,
           horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-          AptoideAsyncImage(
-            modifier = Modifier
-              .size(64.dp)
-              .background(color = Color.Transparent),
-            data = bundle.bundleIcon,
-            contentDescription = null,
-          )
+          val textStyle = bundle.bundleIcon?.let { AGTypography.InputsL } ?: AGTypography.Title
+          bundle.bundleIcon?.let {
+            AptoideAsyncImage(
+              modifier = Modifier
+                .size(40.dp)
+                .background(color = Color.Transparent),
+              data = it,
+              contentDescription = null,
+            )
+          }
           Text(
             text = bundle.title.translateOrKeep(LocalContext.current),
             modifier = Modifier.semantics { heading() },
             overflow = TextOverflow.Ellipsis,
             maxLines = 2,
             color = Palette.White,
-            style = AGTypography.Title
+            style = textStyle
           )
         }
 
@@ -167,7 +170,7 @@ fun PublisherTakeOverContent(
           AppsListUiState.Empty,
           AppsListUiState.Error,
           AppsListUiState.NoConnection,
-          -> { /*nothing to show*/
+            -> { /*nothing to show*/
           }
 
           AppsListUiState.Loading -> LoadingBundleView(height = 184.dp)
@@ -181,7 +184,7 @@ fun PublisherTakeOverContent(
           AppsListUiState.Empty,
           AppsListUiState.Error,
           AppsListUiState.NoConnection,
-          -> { /*nothing to show*/
+            -> { /*nothing to show*/
           }
 
           AppsListUiState.Loading -> LoadingBundleView(height = 184.dp)


### PR DESCRIPTION
**What does this PR do?**

- Reduces the bundleIcon size to 40x40px
- Makes the icon optional
- If have icon the title style is InputsL, otherwise it stays Title as it was before this change.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] PublisherTakeOverBundle.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-104](https://aptoide.atlassian.net/browse/AND-104)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-104](https://aptoide.atlassian.net/browse/AND-104)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-104]: https://aptoide.atlassian.net/browse/AND-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-104]: https://aptoide.atlassian.net/browse/AND-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ