### PR TITLE
[AND-137] - Add Trending Bundle to Empty Search Screen

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/di/RepositoryModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/di/RepositoryModule.kt
@@ -69,6 +69,12 @@ class RepositoryModule {
 
   @Singleton
   @Provides
+  @DefaultTrendingUrl
+  fun provideDefaultTrendingUrl(): String =
+    "${BuildConfig.STORE_DOMAIN}listApps/sort=trending60d/limit=9"
+
+  @Singleton
+  @Provides
   @StoreName
   fun provideStoreName(): String = BuildConfig.MARKET_NAME.lowercase(Locale.ROOT)
 
@@ -243,3 +249,7 @@ annotation class AppLaunchDataStore
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class IdsDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultTrendingUrl

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/Bundles.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/Bundles.kt
@@ -1,0 +1,71 @@
+package com.aptoide.android.aptoidegames.feature_apps.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import cm.aptoide.pt.aptoide_network.domain.UrlsCache
+import cm.aptoide.pt.extensions.runPreviewable
+import cm.aptoide.pt.feature_home.domain.Bundle
+import cm.aptoide.pt.feature_home.domain.BundleSource.AUTOMATIC
+import cm.aptoide.pt.feature_home.domain.Type.APP_GRID
+import cm.aptoide.pt.feature_home.domain.WidgetAction
+import cm.aptoide.pt.feature_home.domain.WidgetActionType.BUTTON
+import cm.aptoide.pt.feature_home.domain.randomBundle
+import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.di.DefaultTrendingUrl
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+private const val TRENDING_TAG = "apps-group-trending"
+private const val TRENDING_MORE_TAG = "apps-group-trending-more"
+
+@HiltViewModel
+private class BundlesInjectionsProvider @Inject constructor(
+  val urlsCache: UrlsCache,
+  @DefaultTrendingUrl val defaultTrendingUrl: String,
+) : ViewModel()
+
+@Composable
+fun rememberTrendingBundle(): Bundle? = runPreviewable(
+  preview = { randomBundle },
+  real = {
+    val injectionsProvider = hiltViewModel<BundlesInjectionsProvider>()
+    var url by remember { mutableStateOf<String?>(null) }
+    var moreUrl by remember { mutableStateOf<String?>(null) }
+    var isLoading by remember { mutableStateOf(true) }
+
+    LaunchedEffect(injectionsProvider) {
+      url = injectionsProvider.urlsCache.get(id = TRENDING_TAG)
+      if (url.isNullOrEmpty()) {
+        url = injectionsProvider.defaultTrendingUrl
+        injectionsProvider.urlsCache.putAll(mapOf(TRENDING_TAG to url!!))
+      }
+      moreUrl = injectionsProvider.urlsCache.get(id = TRENDING_MORE_TAG)
+      isLoading = false
+    }
+    if (isLoading) {
+      return@runPreviewable null
+    }
+    Bundle(
+      title = stringResource(R.string.fixed_bundle_trending_title),
+      actions = if (moreUrl.isNullOrEmpty()) emptyList() else listOf(
+        WidgetAction(
+          type = BUTTON,
+          tag = TRENDING_MORE_TAG,
+          url = moreUrl!!
+        )
+      ),
+      type = APP_GRID,
+      tag = TRENDING_TAG,
+      view = "",
+      bundleSource = AUTOMATIC,
+      timestamp = "0"
+    )
+  }
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/search/presentation/SearchView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/search/presentation/SearchView.kt
@@ -3,6 +3,7 @@ package com.aptoide.android.aptoidegames.search.presentation
 import android.view.KeyEvent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
@@ -49,6 +50,7 @@ import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -69,12 +71,14 @@ import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
 import com.aptoide.android.aptoidegames.drawables.icons.getAsterisk
 import com.aptoide.android.aptoidegames.drawables.icons.getClose
 import com.aptoide.android.aptoidegames.drawables.icons.getGames
+import com.aptoide.android.aptoidegames.drawables.icons.getGenericError
 import com.aptoide.android.aptoidegames.drawables.icons.getSearch
-import com.aptoide.android.aptoidegames.error_views.EmptyView
 import com.aptoide.android.aptoidegames.error_views.GenericErrorView
 import com.aptoide.android.aptoidegames.error_views.NoConnectionView
 import com.aptoide.android.aptoidegames.feature_apps.presentation.AppItem
+import com.aptoide.android.aptoidegames.feature_apps.presentation.AppsGridBundle
 import com.aptoide.android.aptoidegames.feature_apps.presentation.LargeAppItem
+import com.aptoide.android.aptoidegames.feature_apps.presentation.rememberTrendingBundle
 import com.aptoide.android.aptoidegames.installer.presentation.InstallViewShort
 import com.aptoide.android.aptoidegames.search.SearchType
 import com.aptoide.android.aptoidegames.theme.AGTypography
@@ -159,7 +163,8 @@ fun searchScreen() = ScreenData.withAnalytics(
       onItemInstallStarted = {},
       onEmptyView = {
         searchMeta?.let { searchAnalytics.sendEmptySearchResultClickEvent(it) }
-      }
+      },
+      navigate = navigateTo,
     )
   }
 }
@@ -175,6 +180,7 @@ fun SearchView(
   onItemClick: (Int, App) -> Unit,
   onItemInstallStarted: (App) -> Unit,
   onEmptyView: () -> Unit,
+  navigate: (String) -> Unit,
 ) {
   Column {
     SearchAppBar(
@@ -208,7 +214,7 @@ fun SearchView(
       is SearchUiState.Results -> {
         if (uiState.searchResults.isEmpty()) {
           onEmptyView()
-          EmptyView(text = stringResource(R.string.search_empty_body, searchValue))
+          EmptySearchView(searchValue, navigate)
         } else {
           SearchResultsView(
             searchResults = uiState.searchResults,
@@ -555,6 +561,43 @@ fun AutoCompleteSearchSuggestionItem(
       style = AGTypography.DescriptionGames,
       color = Palette.GreyLight,
     )
+  }
+}
+
+@Composable
+fun EmptySearchView(
+  searchValue: String,
+  navigate: (String) -> Unit,
+) {
+  val trendingBundle = rememberTrendingBundle()
+  Column(
+    modifier = Modifier.fillMaxSize(),
+    verticalArrangement = Arrangement.SpaceBetween
+  ) {
+    Column(
+      modifier = Modifier
+        .fillMaxWidth()
+        .weight(1f),
+      verticalArrangement = Arrangement.Center
+    ) {
+      Image(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(all = 16.dp),
+        imageVector = getGenericError(Palette.Primary, Palette.GreyLight, Palette.White),
+        contentDescription = null,
+      )
+      Text(
+        modifier = Modifier.padding(start = 40.dp, end = 40.dp, bottom = 32.dp),
+        text = stringResource(R.string.search_empty_body, searchValue),
+        style = AGTypography.Title,
+        color = Palette.White,
+        maxLines = 4,
+        overflow = TextOverflow.Ellipsis,
+        textAlign = TextAlign.Center,
+      )
+    }
+    trendingBundle?.let { AppsGridBundle(trendingBundle, navigate) }
   }
 }
 


### PR DESCRIPTION
**What does this PR do?**

Refactors the empty search screen to also show the trending bundle, changing also the UI paddings for the error image and text.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] RepositoryModule.kt
- [ ] Bundles.kt
- [ ] SearchView.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-137](https://aptoide.atlassian.net/browse/AND-137)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-137](https://aptoide.atlassian.net/browse/AND-137)




**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-137]: https://aptoide.atlassian.net/browse/AND-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-137]: https://aptoide.atlassian.net/browse/AND-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ