### PR TITLE
[AND-152] - Change DEEPLINK_KEY from ag.link to dti.link

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/LaunchIntentExtensions.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/LaunchIntentExtensions.kt
@@ -5,7 +5,7 @@ import android.net.Uri
 import com.aptoide.android.aptoidegames.analytics.presentation.withPrevScreen
 
 // Deep link
-private const val DEEPLINK_KEY = "ag.link"
+private const val DEEPLINK_KEY = "dti.link"
 
 val Intent?.hasDeepLink get() = this?.extras?.containsKey(DEEPLINK_KEY) ?: false
 


### PR DESCRIPTION
**What does this PR do?**

Changes the DEEPLINK_KEY to the same as DT, so navigation through AHAB campaigns' deeplinks work correctly

**Database changed?**

No

**Where should the reviewer start?**

- [ ] LaunchIntentExtensions.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-152](https://aptoide.atlassian.net/browse/AND-152)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-152](https://aptoide.atlassian.net/browse/AND-152)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
