### PR TITLE
[AND-150] - Change updates' strings when the only app is AG

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesNotificationBuilder.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesNotificationBuilder.kt
@@ -15,6 +15,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import cm.aptoide.pt.extensions.isAllowed
+import cm.aptoide.pt.feature_apps.data.model.AppJSON
 import cm.aptoide.pt.feature_updates.presentation.UpdatesNotificationProvider
 import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.MainActivity
@@ -63,16 +64,22 @@ class UpdatesNotificationBuilder @Inject constructor(
   }
 
   override suspend fun showUpdatesNotification(
-    numberOfUpdates: Int
+    updates: List<AppJSON>
   ) {
+    val title =
+      if (updates.size == 1 && updates.first().packageName == BuildConfig.APPLICATION_ID) {
+        context.resources.getString(R.string.update_aptoide_games_update_notification)
+      } else {
+        context.resources.getQuantityString(
+          R.plurals.update_notification_title,
+          updates.size, updates.size
+        )
+      }
     val notificationId = "Updates".hashCode()
     val notification = buildNotification(
       requestCode = notificationId,
       contentText = context.getString(R.string.update_notification_body),
-      contentTitle = context.resources.getQuantityString(
-        R.plurals.update_notification_title,
-        numberOfUpdates, numberOfUpdates
-      )
+      contentTitle = title
     )
 
     notification?.let { showNotification(notificationId, notification) }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesScreen.kt
@@ -118,7 +118,7 @@ private fun AppsList(
     modifier = Modifier.fillMaxWidth(),
     horizontalAlignment = Alignment.CenterHorizontally
   ) {
-    UpdateBox(updates = appList.size)
+    UpdateBox(updates = appList)
     LazyColumn(
       modifier = Modifier
         .semantics { collectionInfo = CollectionInfo(appList.size, 1) }
@@ -142,7 +142,17 @@ private fun AppsList(
 }
 
 @Composable
-fun UpdateBox(updates:Int) {
+fun UpdateBox(updates: List<App>) {
+  val text =
+    if (updates.size == 1 && updates.first().packageName == BuildConfig.APPLICATION_ID) {
+      stringResource(R.string.update_aptoide_games_update_notification)
+    } else {
+      pluralStringResource(
+        R.plurals.update_games_can_be_updated_body,
+        updates.size,
+        updates.size
+      )
+    }
   Box(
     modifier = Modifier
       .fillMaxWidth()
@@ -163,11 +173,8 @@ fun UpdateBox(updates:Int) {
         modifier = Modifier
           .fillMaxWidth()
           .padding(start = 8.dp),
-        text = pluralStringResource(
-          R.plurals.update_games_can_be_updated_body,
-          updates,
-          updates
-        ), color = Palette.White,
+        text = text,
+        color = Palette.White,
         style = AGTypography.BodyBold,
       )
     }
@@ -177,7 +184,7 @@ fun UpdateBox(updates:Int) {
 @Preview(showBackground = true)
 @Composable
 fun PreviewUpdateBox() {
-  UpdateBox(5)
+  UpdateBox(List((0..5).random()) { randomApp })
 }
 
 @Preview(showBackground = false)

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/Updates.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/Updates.kt
@@ -73,7 +73,7 @@ class Updates @Inject constructor(
     val updates = updatesRepository.loadUpdates(apksData)
     updatesRepository.replaceWith(*updates.toTypedArray())
     if (updates.isNotEmpty()) {
-      updatesNotificationBuilder.showUpdatesNotification(updates.size)
+      updatesNotificationBuilder.showUpdatesNotification(updates)
     }
   }
 

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/presentation/UpdatesNotificationProvider.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/presentation/UpdatesNotificationProvider.kt
@@ -1,5 +1,7 @@
 package cm.aptoide.pt.feature_updates.presentation
 
+import cm.aptoide.pt.feature_apps.data.model.AppJSON
+
 interface UpdatesNotificationProvider {
-  suspend fun showUpdatesNotification(numberOfUpdates: Int)
+  suspend fun showUpdatesNotification(updates: List<AppJSON>)
 }


### PR DESCRIPTION
**What does this PR do?**

It shows a custom string both on notifications and updates view when the only outdated app is AG

**Database changed?**

No

**Where should the reviewer start?**

- [ ] UpdatesNotificationBuilder.kt
- [ ] UpdatesScreen.kt
- [ ] Updates.kt
- [ ] UpdatesNotificationProvider.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-150](https://aptoide.atlassian.net/browse/AND-150)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-150](https://aptoide.atlassian.net/browse/AND-150)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-150]: https://aptoide.atlassian.net/browse/AND-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-150]: https://aptoide.atlassian.net/browse/AND-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ