### PR TITLE
[AND-148] auto update in empty state

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -56,7 +56,7 @@ import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.theme.Palette
 import com.aptoide.android.aptoidegames.toolbar.AppGamesTopBar
-import com.aptoide.android.aptoidegames.updates.presentation.UpdatesPreferencesViewModel
+import com.aptoide.android.aptoidegames.updates.di.rememberAutoUpdate
 
 const val settingsRoute = "settings"
 
@@ -67,8 +67,7 @@ fun settingsScreen(showSnack: (String) -> Unit) = ScreenData(
   val genericAnalytics = rememberGenericAnalytics()
   val networkPreferencesViewModel = hiltViewModel<NetworkPreferencesViewModel>()
   val downloadOnlyOverWifi by networkPreferencesViewModel.downloadOnlyOverWifi.collectAsState()
-  val updatesPreferencesViewModel = hiltViewModel<UpdatesPreferencesViewModel>()
-  val autoUpdateGames by updatesPreferencesViewModel.shouldAutoUpdateGames.collectAsState()
+  val (autoUpdateGames, toggleAutoUpdateGames) = rememberAutoUpdate()
   val deviceInfo = rememberDeviceInfo()
   val clipboardManager: ClipboardManager = LocalClipboardManager.current
   val copiedMessage = stringResource(R.string.settings_copied_to_clipboard_message)
@@ -88,7 +87,7 @@ fun settingsScreen(showSnack: (String) -> Unit) = ScreenData(
       }
     },
     toggleAutoUpdateGames = { isChecked ->
-      updatesPreferencesViewModel.setAutoUpdateGames(isChecked)
+      toggleAutoUpdateGames(isChecked)
     },
     onPrivacyPolicyClick = { UrlActivity.open(context, ppUrl) },
     onTermsConditionsClick = { UrlActivity.open(context, tcUrl) },

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -56,7 +56,7 @@ import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.theme.Palette
 import com.aptoide.android.aptoidegames.toolbar.AppGamesTopBar
-import com.aptoide.android.aptoidegames.updates.UpdatesPreferencesViewModel
+import com.aptoide.android.aptoidegames.updates.presentation.UpdatesPreferencesViewModel
 
 const val settingsRoute = "settings"
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/di/ViewModelProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/di/ViewModelProvider.kt
@@ -1,0 +1,40 @@
+package com.aptoide.android.aptoidegames.updates.di
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import cm.aptoide.pt.extensions.runPreviewable
+import com.aptoide.android.aptoidegames.updates.presentation.UpdatesPreferencesViewModel
+import com.aptoide.android.aptoidegames.updates.repository.UpdatesPreferencesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class InjectionsProvider @Inject constructor(
+  val updatesPreferencesRepository: UpdatesPreferencesRepository
+) : ViewModel()
+
+@Composable
+fun rememberAutoUpdate(): Pair<Boolean, (Boolean) -> Unit> = runPreviewable(
+  preview = { false to {} },
+  real = {
+    val injectionsProvider = hiltViewModel<InjectionsProvider>()
+    val vm: UpdatesPreferencesViewModel = viewModel(
+      key = "updatepreferences",
+      factory = object : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+          @Suppress("UNCHECKED_CAST")
+          return UpdatesPreferencesViewModel(
+            updatesPreferencesRepository = injectionsProvider.updatesPreferencesRepository,
+          ) as T
+        }
+      }
+    )
+    val uiState by vm.shouldAutoUpdateGames.collectAsState()
+    uiState to vm::setAutoUpdateGames
+  }
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesPreferencesViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesPreferencesViewModel.kt
@@ -1,4 +1,4 @@
-package com.aptoide.android.aptoidegames.updates
+package com.aptoide.android.aptoidegames.updates.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesScreen.kt
@@ -12,13 +12,20 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.Divider
 import androidx.compose.material.Text
+import androidx.compose.material.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.CollectionInfo
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.collectionInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -36,6 +43,7 @@ import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
 import com.aptoide.android.aptoidegames.analytics.presentation.withItemPosition
 import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
+import com.aptoide.android.aptoidegames.design_system.AptoideGamesSwitch
 import com.aptoide.android.aptoidegames.drawables.icons.getBolt
 import com.aptoide.android.aptoidegames.drawables.icons.getNoUpdates
 import com.aptoide.android.aptoidegames.feature_apps.presentation.AppItem
@@ -43,6 +51,7 @@ import com.aptoide.android.aptoidegames.home.LoadingView
 import com.aptoide.android.aptoidegames.installer.presentation.InstallViewShort
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.Palette
+import com.aptoide.android.aptoidegames.updates.di.rememberAutoUpdate
 
 const val updatesRoute = "updates"
 
@@ -76,35 +85,93 @@ fun UpdatesScreen(
 
 @Composable
 fun NoUpdatesScreen() {
+  val (autoUpdateGames, toggleAutoUpdate) = rememberAutoUpdate()
+  val showAutoUpdateToggle = remember { mutableStateOf(false) }
+  LaunchedEffect(key1 = autoUpdateGames) {
+    if (!autoUpdateGames) showAutoUpdateToggle.value = true
+  }
+
   Column(
     modifier = Modifier.fillMaxSize(),
     verticalArrangement = Arrangement.Center,
     horizontalAlignment = Alignment.CenterHorizontally
   ) {
-    Image(
-      modifier = Modifier
-        .padding(bottom = 88.dp, start = 16.dp, end = 16.dp)
-        .fillMaxWidth(),
-      imageVector = getNoUpdates(Palette.Primary, Palette.White, Palette.GreyLight),
-      contentDescription = null,
+    if (showAutoUpdateToggle.value) {
+      NoUpdatesTopSection(40)
+      NoUpdatesViewWithAutoUpdateOff(autoUpdateGames, toggleAutoUpdate)
+    } else {
+      NoUpdatesTopSection(88)
+    }
+  }
+}
+
+@Composable
+private fun NoUpdatesTopSection(imageBottomPadding: Int) {
+  Image(
+    modifier = Modifier
+      .padding(bottom = imageBottomPadding.dp, start = 16.dp, end = 16.dp)
+      .fillMaxWidth(),
+    imageVector = getNoUpdates(Palette.Primary, Palette.White, Palette.GreyLight),
+    contentDescription = null,
+  )
+  Text(
+    modifier = Modifier.padding(horizontal = 40.dp),
+    text = stringResource(R.string.update_up_to_date_title),
+    style = AGTypography.Title,
+    color = Palette.White,
+    maxLines = 2,
+    overflow = TextOverflow.Ellipsis,
+    textAlign = TextAlign.Center,
+  )
+  Text(
+    modifier = Modifier.padding(horizontal = 40.dp),
+    text = stringResource(R.string.update_up_to_date_body),
+    style = AGTypography.Title,
+    color = Palette.White,
+    maxLines = 2,
+    overflow = TextOverflow.Ellipsis,
+    textAlign = TextAlign.Center,
+  )
+}
+
+@Composable
+private fun NoUpdatesViewWithAutoUpdateOff(
+  autoUpdateGames: Boolean,
+  toggleAutoUpdate: (Boolean) -> Unit
+) {
+  Divider(
+    modifier = Modifier.padding(top = 48.dp, start = 16.dp, end = 16.dp, bottom = 24.dp),
+    color = Palette.GreyDark
+  )
+  Text(
+    modifier = Modifier.padding(horizontal = 24.dp),
+    text = stringResource(R.string.update_auto_update_title),
+    style = AGTypography.InputsM,
+    color = Palette.White,
+    maxLines = 2,
+    overflow = TextOverflow.Ellipsis
+  )
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = Modifier
+      .toggleable(
+        value = autoUpdateGames,
+        role = Role.Switch,
+        onValueChange = toggleAutoUpdate
+      )
+      .fillMaxWidth()
+      .padding(start = 24.dp, end = 24.dp, top = 8.dp)
+      .minimumInteractiveComponentSize()
+  ) {
+    AptoideGamesSwitch(
+      checked = autoUpdateGames,
+      onCheckedChanged = toggleAutoUpdate
     )
     Text(
-      modifier = Modifier.padding(horizontal = 40.dp),
-      text = stringResource(R.string.update_up_to_date_title),
-      style = AGTypography.Title,
-      color = Palette.White,
-      maxLines = 2,
-      overflow = TextOverflow.Ellipsis,
-      textAlign = TextAlign.Center,
-    )
-    Text(
-      modifier = Modifier.padding(horizontal = 40.dp),
-      text = stringResource(R.string.update_up_to_date_body),
-      style = AGTypography.Title,
-      color = Palette.White,
-      maxLines = 2,
-      overflow = TextOverflow.Ellipsis,
-      textAlign = TextAlign.Center,
+      text = stringResource(R.string.update_auto_update_slider),
+      modifier = Modifier.padding(start = 8.dp),
+      style = AGTypography.BodyBold,
+      color = Palette.GreyLight
     )
   }
 }


### PR DESCRIPTION
**What does this PR do?**

   This PR aims at implementing the auto update switch on the empty state of the updates.
Also took the oportunity to refactor the update flag view model.

**Database changed?**

 No

**Where should the reviewer start?**

- [ ] UpdatesScreen.kt

**How should this be manually tested?**

Open the section (with no updates -> or simply change the idle state to show the no updates screen as well) with auto update off, check if you see the toggle. Then turn on, reopen the view and check if you have the simple version of the empty screen

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-148](https://aptoide.atlassian.net/browse/AND-148)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-148]: https://aptoide.atlassian.net/browse/AND-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ