### PR TITLE
[AND-157] - Switch Payments and Support order on Settings

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -153,19 +153,6 @@ fun SettingsViewContent(
         }
       }
       SettingsSectionDivider()
-      SettingsSection(title = stringResource(id = R.string.settings_billing_terms_body)) {
-        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-          SettingsCaretItem(
-            title = stringResource(id = R.string.settings_payments_title),
-            onClick = onContactSupportClick
-          )
-          SettingsCaretItem(
-            title = stringResource(id = R.string.settings_contact_support_body),
-            onClick = onBillingTermsClick
-          )
-        }
-      }
-      SettingsSectionDivider()
       SettingsSection(
         title = stringResource(R.string.settings_support)
       ) {
@@ -212,6 +199,19 @@ fun SettingsViewContent(
               title = copyText
             )
           }
+        }
+      }
+      SettingsSectionDivider()
+      SettingsSection(title = stringResource(id = R.string.settings_billing_terms_body)) {
+        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+          SettingsCaretItem(
+            title = stringResource(id = R.string.settings_payments_title),
+            onClick = onContactSupportClick
+          )
+          SettingsCaretItem(
+            title = stringResource(id = R.string.settings_contact_support_body),
+            onClick = onBillingTermsClick
+          )
         }
       }
       SettingsSectionDivider()


### PR DESCRIPTION
**What does this PR do?**

It changes the order of settings to General, Support, Payments, Legal

**Database changed?**

No

**Where should the reviewer start?**

- [ ] SettingsScreen.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-157](https://aptoide.atlassian.net/browse/AND-157)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-157](https://aptoide.atlassian.net/browse/AND-157)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-157]: https://aptoide.atlassian.net/browse/AND-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-157]: https://aptoide.atlassian.net/browse/AND-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ