### PR TITLE
[AND-158] - Fix Cropped Screenshots

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideAsyncImage.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideAsyncImage.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -81,6 +80,7 @@ fun AptoideAsyncImage(
   contentDescription: String?,
   transformations: Transformation? = null,
   colorFilter: ColorFilter? = null,
+  contentScale: ContentScale = ContentScale.Crop,
 ) {
 
   val placeholderColor = Palette.Grey
@@ -90,7 +90,7 @@ fun AptoideAsyncImage(
     placeholder = if (placeholder) remember { ColorPainter(placeholderColor) } else null,
     error = remember { ColorPainter(placeholderColor) },
     contentDescription = contentDescription,
-    contentScale = ContentScale.Crop,
+    contentScale = contentScale,
     colorFilter = colorFilter,
     modifier = modifier,
   )
@@ -106,15 +106,17 @@ fun AptoideAsyncImageWithFullscreen(
   colorFilter: ColorFilter? = null,
   images: List<Any?> = listOf(data),
   selectedIndex: Int = 1,
+  contentScale: ContentScale = ContentScale.Crop,
 ) {
   var expanded by remember { mutableStateOf(false) }
   AptoideAsyncImage(
-    modifier = modifier.clickable{expanded = true},
+    modifier = modifier.clickable { expanded = true },
     data = data,
     placeholder = placeholder,
     transformations = transformations,
     colorFilter = colorFilter,
     contentDescription = contentDescription,
+    contentScale = contentScale
   )
 
   if (expanded) {
@@ -162,14 +164,14 @@ fun FullscreenImageViewer(
         state = pagerState,
         modifier = Modifier.fillMaxSize()
       ) { page ->
-          AptoideAsyncImage(
-            modifier = Modifier
-              .fillMaxSize()
-              .aspectRatio(16 / 9f)
-              .zoomable(zoomState),
-            data = images[page],
-            contentDescription = contentDescription
-          )
+        AptoideAsyncImage(
+          modifier = Modifier
+            .fillMaxSize()
+            .zoomable(zoomState),
+          data = images[page],
+          contentDescription = contentDescription,
+          contentScale = ContentScale.Fit
+        )
       }
 
       Image(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.navigation.navDeepLink
+import cm.aptoide.pt.aptoide_network.data.network.model.Screenshot
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.ScreenData
@@ -465,7 +466,7 @@ fun WhatsNew(app: App) {
           Text(
             modifier = Modifier
               .align(Alignment.CenterVertically),
-            text = it.parseDate()?.toFormattedString(pattern = "dd.MM.yyyy")?:"",
+            text = it.parseDate()?.toFormattedString(pattern = "dd.MM.yyyy") ?: "",
             color = Palette.GreyLight,
             style = AGTypography.SmallGames,
           )
@@ -497,7 +498,7 @@ fun WhatsNew(app: App) {
 }
 
 @Composable
-fun ScreenshotsList(screenshots: List<String>) {
+fun ScreenshotsList(screenshots: List<Screenshot>) {
   LazyRow(
     modifier = Modifier
       .fillMaxWidth()
@@ -515,10 +516,10 @@ fun ScreenshotsList(screenshots: List<String>) {
             contentDescription = stringResource
           }
           .size(268.dp, 152.dp),
-        data = screenshot,
+        data = screenshot.url,
         contentDescription = null,
         selectedIndex = index,
-        images = screenshots
+        images = screenshots.map { it.url },
       )
     }
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -36,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -499,6 +501,9 @@ fun WhatsNew(app: App) {
 
 @Composable
 fun ScreenshotsList(screenshots: List<Screenshot>) {
+  val density = LocalDensity.current.density
+  val densityDpi = LocalConfiguration.current.densityDpi
+
   LazyRow(
     modifier = Modifier
       .fillMaxWidth()
@@ -515,13 +520,67 @@ fun ScreenshotsList(screenshots: List<Screenshot>) {
           .clearAndSetSemantics {
             contentDescription = stringResource
           }
-          .size(268.dp, 152.dp),
-        data = screenshot.url,
+          .height(152.dp)
+          .aspectRatio(screenshot.width.toFloat() / screenshot.height.toFloat()),
+        data = screenshot.url.toImageUrlByDensity(
+          density = density,
+          densityDpi = densityDpi,
+          isPortrait = screenshot.height > screenshot.width
+        ),
         contentDescription = null,
         selectedIndex = index,
         images = screenshots.map { it.url },
+        contentScale = ContentScale.Fit,
       )
     }
+  }
+}
+
+fun String.toImageUrlByDensity(density: Float, densityDpi: Int, isPortrait: Boolean): String {
+  if (this.contains("_screen")) {
+    val densityMultiplier = getDensityMultiplier(density)
+    val dpi = getDensityDpi(densityDpi)
+    val defaultSize = if (isPortrait) 96 else 256
+    val splitUrl = this.split("_screen")
+    return splitUrl[0] + "_screen_" + (defaultSize * densityMultiplier.toInt()).toString() + "x" + dpi + splitUrl[1]
+  } else {
+    return this
+  }
+}
+
+private fun getDensityMultiplier(density: Float): Float {
+  return if (density <= 0.75f) {
+    0.75f
+  } else if (density <= 1f) {
+    1f
+  } else if (density <= 1.333f) {
+    1.3312500f
+  } else if (density <= 1.5f) {
+    1.5f
+  } else if (density <= 2f) {
+    2f
+  } else if (density <= 3f) {
+    3f
+  } else {
+    4f
+  }
+}
+
+private fun getDensityDpi(densityDpi: Int): Int {
+  return if (densityDpi <= 120) {
+    120
+  } else if (densityDpi <= 160) {
+    160
+  } else if (densityDpi <= 213) {
+    213
+  } else if (densityDpi <= 240) {
+    240
+  } else if (densityDpi <= 320) {
+    320
+  } else if (densityDpi <= 480) {
+    480
+  } else {
+    640
   }
 }
 

--- a/app/src/main/java/cm/aptoide/pt/appview/AppViewScreen.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/AppViewScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.navigation.NavGraphBuilder
 import cm.aptoide.pt.apps.AppsRowView
+import cm.aptoide.pt.aptoide_network.data.network.model.Screenshot
 import cm.aptoide.pt.aptoide_ui.AptoideAsyncImage
 import cm.aptoide.pt.aptoide_ui.R
 import cm.aptoide.pt.aptoide_ui.animations.animatedComposable
@@ -597,14 +598,14 @@ fun ReportAppCard(
 }
 
 @Composable
-fun ScreenshotsList(screenshots: List<String>) {
+fun ScreenshotsList(screenshots: List<Screenshot>) {
   LazyRow(
     modifier = Modifier.fillMaxWidth(),
     horizontalArrangement = Arrangement.spacedBy(8.dp)
   ) {
     items(screenshots) { screenshot ->
       AptoideAsyncImage(
-        data = screenshot,
+        data = screenshot.url,
         contentDescription = "Screenshot",
         placeholder = ColorPainter(AppTheme.colors.placeholderColor),
         modifier = Modifier

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/App.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/App.kt
@@ -1,5 +1,6 @@
 package cm.aptoide.pt.feature_apps.data
 
+import cm.aptoide.pt.aptoide_network.data.network.model.Screenshot
 import cm.aptoide.pt.extensions.getRandomString
 import cm.aptoide.pt.feature_apps.domain.AppSource
 import cm.aptoide.pt.feature_apps.domain.Rating
@@ -28,7 +29,7 @@ data class App(
   val versionCode: Int,
   val featureGraphic: String,
   val isAppCoins: Boolean,
-  val screenshots: List<String>?,
+  val screenshots: List<Screenshot>?,
   val description: String?,
   val news: String?,
   val videos: List<String> = emptyList(),
@@ -176,7 +177,7 @@ val randomApp
       versionName = "${Random.nextInt(3)}.${Random.nextInt(20)}.${Random.nextInt(100)}",
       versionCode = Random.nextInt(),
       isAppCoins = Random.nextBoolean(),
-      screenshots = List(Random.nextInt(10)) { "random" },
+      screenshots = List(Random.nextInt(10)) { Screenshot("random", 700, 700) },
       description = getRandomString(),
       news = getRandomString(),
       videos = List(Random.nextInt(2)) { "https://youtu.be/dQw4w9WgXcQ" },

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/Mappers.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/Mappers.kt
@@ -75,7 +75,7 @@ private fun AppJSON.toDomainModel(
   pDownloads = this.stats.pdownloads,
   versionName = this.file.vername,
   versionCode = this.file.vercode,
-  screenshots = this.media?.screenshots?.map { it.url },
+  screenshots = this.media?.screenshots,
   description = this.media?.description,
   news = if (this.media?.news.isNullOrEmpty()) null else this.media.news,
   videos = this.media?.videos?.filter { it.type == VideoTypeJSON.YOUTUBE }?.map { it.url }


### PR DESCRIPTION
**What does this PR do?**

It fixes the screenshots being cropped on the appview by changing the contentScale to Fit, applying the same density mapping to the screenshots urls that vanilla has, and changing the screenshots list to also contain their width and height, in order to scale the content having only a fixed height.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] See by commit

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-158](https://aptoide.atlassian.net/browse/AND-158)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-158](https://aptoide.atlassian.net/browse/AND-158)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-158]: https://aptoide.atlassian.net/browse/AND-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-158]: https://aptoide.atlassian.net/browse/AND-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ