### PR TITLE
[AND-180] - Add lang parameter to requests

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/di/RepositoryModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/di/RepositoryModule.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import cm.aptoide.pt.aptoide_network.data.network.GetAcceptLanguage
 import cm.aptoide.pt.aptoide_network.data.network.GetUserAgent
 import cm.aptoide.pt.aptoide_network.data.network.QLogicInterceptor
+import cm.aptoide.pt.aptoide_network.data.network.QueryLangInterceptor
 import cm.aptoide.pt.aptoide_network.di.BaseOkHttp
 import cm.aptoide.pt.aptoide_network.di.RetrofitBuzz
 import cm.aptoide.pt.aptoide_network.di.StoreDomain
@@ -35,6 +36,7 @@ import com.aptoide.android.aptoidegames.idsDataStore
 import com.aptoide.android.aptoidegames.launch.AppLaunchPreferencesManager
 import com.aptoide.android.aptoidegames.network.AptoideGetHeaders
 import com.aptoide.android.aptoidegames.network.AptoideQLogicInterceptor
+import com.aptoide.android.aptoidegames.network.AptoideQueryLangInterceptor
 import com.aptoide.android.aptoidegames.networkPreferencesDataStore
 import com.aptoide.android.aptoidegames.permissions.AppPermissionsManager
 import com.aptoide.android.aptoidegames.search.repository.AppGamesAutoCompleteSuggestionsRepository
@@ -200,6 +202,16 @@ class RepositoryModule {
   ): QLogicInterceptor {
     return AptoideQLogicInterceptor(
       deviceInfo = deviceInfo,
+    )
+  }
+
+  @Provides
+  @Singleton
+  fun providesQueryLangInterceptor(
+    @ApplicationContext appContext: Context
+  ): QueryLangInterceptor {
+    return AptoideQueryLangInterceptor(
+      context = appContext
     )
   }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/network/AptoideQueryLangInterceptor.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/network/AptoideQueryLangInterceptor.kt
@@ -1,0 +1,26 @@
+package com.aptoide.android.aptoidegames.network
+
+import android.content.Context
+import cm.aptoide.pt.aptoide_network.data.network.QueryLangInterceptor
+import dagger.hilt.android.qualifiers.ApplicationContext
+import okhttp3.Interceptor.Chain
+import okhttp3.Response
+import javax.inject.Inject
+
+class AptoideQueryLangInterceptor @Inject constructor(
+  @ApplicationContext private val context: Context
+) : QueryLangInterceptor {
+
+  override fun buildLang(): String {
+    val locale = context.resources.configuration.locales[0]
+    return "${locale.language}_${locale.country}"
+  }
+
+  override fun intercept(chain: Chain): Response {
+    val originalRequest = chain.request()
+    val newUrl = originalRequest.url.newBuilder()
+    newUrl.addQueryParameter("lang", buildLang())
+    val newRequest = originalRequest.newBuilder().url(newUrl.build()).build()
+    return chain.proceed(newRequest)
+  }
+}

--- a/app/src/main/java/cm/aptoide/pt/di/RepositoryModule.kt
+++ b/app/src/main/java/cm/aptoide/pt/di/RepositoryModule.kt
@@ -8,6 +8,7 @@ import cm.aptoide.pt.appcoins.di.APIChainBDSDomain
 import cm.aptoide.pt.aptoide_network.data.network.GetAcceptLanguage
 import cm.aptoide.pt.aptoide_network.data.network.GetUserAgent
 import cm.aptoide.pt.aptoide_network.data.network.QLogicInterceptor
+import cm.aptoide.pt.aptoide_network.data.network.QueryLangInterceptor
 import cm.aptoide.pt.aptoide_network.di.BaseOkHttp
 import cm.aptoide.pt.aptoide_network.di.RetrofitBuzz
 import cm.aptoide.pt.aptoide_network.di.StoreDomain
@@ -25,6 +26,7 @@ import cm.aptoide.pt.feature_search.domain.repository.SearchStoreManager
 import cm.aptoide.pt.feature_updates.di.PrioritizedPackagesFilter
 import cm.aptoide.pt.network.AptoideGetHeaders
 import cm.aptoide.pt.network.AptoideQLogicInterceptor
+import cm.aptoide.pt.network.AptoideQueryLangInterceptor
 import cm.aptoide.pt.network.repository.IdsRepository
 import cm.aptoide.pt.profile.data.UserProfileRepository
 import cm.aptoide.pt.profile.di.UserProfileDataStore
@@ -82,7 +84,6 @@ class RepositoryModule {
   @APIChainBDSDomain
   fun provideAPIChainBDSDomain(): String = BuildConfig.APTOIDE_WEB_SERVICES_APICHAIN_BDS_HOST
 
-
   @Singleton
   @Provides
   fun providesIdsRepository(
@@ -112,6 +113,16 @@ class RepositoryModule {
     return AptoideQLogicInterceptor(
       userPreferencesRepository = userPreferencesRepository,
       deviceInfo = deviceInfo,
+    )
+  }
+
+  @Provides
+  @Singleton
+  fun providesQueryLangInterceptor(
+    @ApplicationContext appContext: Context
+  ): QueryLangInterceptor {
+    return AptoideQueryLangInterceptor(
+      context = appContext
     )
   }
 

--- a/app/src/main/java/cm/aptoide/pt/network/AptoideQueryLangInterceptor.kt
+++ b/app/src/main/java/cm/aptoide/pt/network/AptoideQueryLangInterceptor.kt
@@ -1,0 +1,26 @@
+package cm.aptoide.pt.network
+
+import android.content.Context
+import cm.aptoide.pt.aptoide_network.data.network.QueryLangInterceptor
+import dagger.hilt.android.qualifiers.ApplicationContext
+import okhttp3.Interceptor.Chain
+import okhttp3.Response
+import javax.inject.Inject
+
+class AptoideQueryLangInterceptor @Inject constructor(
+  @ApplicationContext private val context: Context
+) : QueryLangInterceptor {
+
+  override fun buildLang(): String {
+    val locale = context.resources.configuration.locales[0]
+    return "${locale.language}_${locale.country}"
+  }
+
+  override fun intercept(chain: Chain): Response {
+    val originalRequest = chain.request()
+    val newUrl = originalRequest.url.newBuilder()
+    newUrl.addQueryParameter("lang", buildLang())
+    val newRequest = originalRequest.newBuilder().url(newUrl.build()).build()
+    return chain.proceed(newRequest)
+  }
+}

--- a/aptoide-network/src/main/java/cm/aptoide/pt/aptoide_network/data/network/QueryLangInterceptor.kt
+++ b/aptoide-network/src/main/java/cm/aptoide/pt/aptoide_network/data/network/QueryLangInterceptor.kt
@@ -1,0 +1,7 @@
+package cm.aptoide.pt.aptoide_network.data.network
+
+import okhttp3.Interceptor
+
+interface QueryLangInterceptor : Interceptor {
+  fun buildLang(): String
+}

--- a/aptoide-network/src/main/java/cm/aptoide/pt/aptoide_network/di/NetworkModule.kt
+++ b/aptoide-network/src/main/java/cm/aptoide/pt/aptoide_network/di/NetworkModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import cm.aptoide.pt.aptoide_network.data.network.AcceptLanguageInterceptor
 import cm.aptoide.pt.aptoide_network.data.network.PostCacheInterceptor
 import cm.aptoide.pt.aptoide_network.data.network.QLogicInterceptor
+import cm.aptoide.pt.aptoide_network.data.network.QueryLangInterceptor
 import cm.aptoide.pt.aptoide_network.data.network.UserAgentInterceptor
 import cm.aptoide.pt.aptoide_network.data.network.VersionCodeInterceptor
 import dagger.Module
@@ -32,6 +33,7 @@ object NetworkModule {
     @ApplicationContext context: Context,
     userAgentInterceptor: UserAgentInterceptor,
     qLogicInterceptor: QLogicInterceptor,
+    queryLangInterceptor: QueryLangInterceptor,
     versionCodeInterceptor: VersionCodeInterceptor,
     languageInterceptor: AcceptLanguageInterceptor,
     httpLoggingInterceptor: HttpLoggingInterceptor,
@@ -40,6 +42,7 @@ object NetworkModule {
     OkHttpClient.Builder()
       .cache(Cache(context.cacheDir, 10 * 1024 * 1024))
       .addInterceptor(userAgentInterceptor)
+      .addInterceptor(queryLangInterceptor)
       .addInterceptor(qLogicInterceptor)
       .addInterceptor(versionCodeInterceptor)
       .addInterceptor(languageInterceptor)


### PR DESCRIPTION
**What does this PR do?**

Adds the lang parameter to baseOkHttpRequests, following Vanilla's logic 

**Database changed?**

No

**Where should the reviewer start?**

- [ ] RepositoryModule.kt (app)
- [ ] AptoideLangInterceptor.kt (app)
- [ ] RepositoryModule.kt (app-games)
- [ ] AptoideLangInterceptor.kt (app-games)
- [ ] LangInterceptor.kt (aptoide-network)
- [ ] NetworkModule.kt (aptoide-network)

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-180](https://aptoide.atlassian.net/browse/AND-180)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-180](https://aptoide.atlassian.net/browse/AND-180)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-180]: https://aptoide.atlassian.net/browse/AND-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-180]: https://aptoide.atlassian.net/browse/AND-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ