### PR TITLE
[AND-183] - Add null check on openInstalledApp activity

### DIFF
--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/InstalledAppOpener.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/InstalledAppOpener.kt
@@ -6,6 +6,7 @@ class InstalledAppOpener(private val context: Context) {
 
   fun openInstalledApp(packageName: String) {
     val intentForPackage = context.packageManager.getLaunchIntentForPackage(packageName)
-    context.startActivity(intentForPackage)
+    if (intentForPackage != null)
+      context.startActivity(intentForPackage)
   }
 }


### PR DESCRIPTION
**What does this PR do?**

There were some times that the app was crashing when users tried to open a game, due to the intent being null. Added a null check so that doesn't happen.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] InstalledAppOpener.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-183](https://aptoide.atlassian.net/browse/AND-183)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-183](https://aptoide.atlassian.net/browse/AND-183)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-183]: https://aptoide.atlassian.net/browse/AND-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-183]: https://aptoide.atlassian.net/browse/AND-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ