### PR TITLE
[AND-168] Game Genie only in PT and JP

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
@@ -29,8 +29,8 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.runPreviewable
-import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
+import com.aptoide.android.aptoidegames.gamegenie.presentation.rememberGameGenieVisibility
 import com.aptoide.android.aptoidegames.home.BottomBarMenus
 import com.aptoide.android.aptoidegames.home.Icon
 import com.aptoide.android.aptoidegames.theme.AGTypography
@@ -56,11 +56,13 @@ fun AppGamesBottomBarPreview() {
 @Composable
 fun AppGamesBottomBar(navController: NavController) {
   val genericAnalytics = rememberGenericAnalytics()
-  val selection = selectionIndex(items = bottomNavigationItems, navController = navController)
+  val shouldShowGameGenie = rememberGameGenieVisibility()
+  val filteredBottomNavigationItems = bottomNavigationItems.filter(shouldShowGameGenie)
+  val selection =
+    selectionIndex(items = filteredBottomNavigationItems, navController = navController)
   if (selection >= 0) {
     AppGamesBottomNavigation(backgroundColor = Color.Transparent) {
-      bottomNavigationItems.forEachIndexed { index, item ->
-        if (item == BottomBarMenus.GameGenie && !BuildConfig.SHOW_GAME_GENIE) return@AppGamesBottomNavigation
+      filteredBottomNavigationItems.forEachIndexed { index, item ->
         val isSelected = selection == index
         AddBottomNavigationItem(
           item = item,
@@ -87,6 +89,15 @@ fun AppGamesBottomBar(navController: NavController) {
     }
   }
 }
+
+fun List<BottomBarMenus>.filter(shouldShowGameGenie: Boolean) =
+  filter {
+    if (shouldShowGameGenie) {
+      it != BottomBarMenus.Categories
+    } else {
+      it != BottomBarMenus.GameGenie
+    }
+  }
 
 @Composable
 fun RowScope.AddBottomNavigationItem(
@@ -143,8 +154,8 @@ val bottomNavigationItems = listOf(
   BottomBarMenus.Games,
   BottomBarMenus.Search,
   BottomBarMenus.Categories,
+  BottomBarMenus.GameGenie,
   BottomBarMenus.Updates,
-  BottomBarMenus.GameGenie
 )
 
 /**

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieFeatureProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieFeatureProvider.kt
@@ -1,0 +1,38 @@
+package com.aptoide.android.aptoidegames.gamegenie.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import cm.aptoide.pt.extensions.runPreviewable
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.random.Random
+
+@HiltViewModel
+class InjectionsProvider @Inject constructor(
+  val featureFlags: FeatureFlags,
+) : ViewModel()
+
+@Composable
+fun rememberGameGenieVisibility(): Boolean = runPreviewable(
+  preview = { Random.nextBoolean() },
+  real = {
+    val coroutineScope = rememberCoroutineScope()
+    var state by remember { mutableStateOf(false) }
+    val vm = hiltViewModel<InjectionsProvider>()
+    LaunchedEffect(key1 = Unit) {
+      coroutineScope.launch {
+        state = vm.featureFlags.getFlag("show_game_genie", false)
+      }
+    }
+    state
+  }
+)


### PR DESCRIPTION
**What does this PR do?**

This PR aims at implementing game genie feature flag. Should show only in Japan and Portugal.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AppGamesBottomBar.kt

**How should this be manually tested?**

Open the app and check if you have the game genie.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-168](https://aptoide.atlassian.net/browse/AND-168)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-168]: https://aptoide.atlassian.net/browse/AND-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ