### PR TITLE
[AND-201] Handle Bottom Navigation clicks on the same menu

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
@@ -31,6 +31,7 @@ import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.runPreviewable
 import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
 import com.aptoide.android.aptoidegames.gamegenie.presentation.rememberGameGenieVisibility
+import com.aptoide.android.aptoidegames.home.BottomBarMenuHandler
 import com.aptoide.android.aptoidegames.home.BottomBarMenus
 import com.aptoide.android.aptoidegames.home.Icon
 import com.aptoide.android.aptoidegames.theme.AGTypography
@@ -64,6 +65,8 @@ fun AppGamesBottomBar(navController: NavController) {
     AppGamesBottomNavigation(backgroundColor = Color.Transparent) {
       filteredBottomNavigationItems.forEachIndexed { index, item ->
         val isSelected = selection == index
+        if (isSelected)
+          BottomBarMenuHandler.menuSelected(item)
         AddBottomNavigationItem(
           item = item,
           isSelected = isSelected,
@@ -75,14 +78,17 @@ fun AppGamesBottomBar(navController: NavController) {
               BottomBarMenus.Updates -> genericAnalytics.sendBottomBarUpdatesClick()
               BottomBarMenus.GameGenie -> genericAnalytics.sendBottomBarGameGenieClick()
             }
-            navController.navigate(item.route) {
-              popUpTo(navController.graph.startDestinationId) {
-                inclusive =
-                  BottomBarMenus.Games.route == item.route
-                    && BottomBarMenus.Games.route == navController.currentDestination?.route
+            if (!isSelected) {
+              navController.navigate(item.route) {
+                popUpTo(navController.graph.startDestinationId) {
+                  inclusive =
+                    BottomBarMenus.Games.route == item.route
+                      && BottomBarMenus.Games.route == navController.currentDestination?.route
+                }
+                launchSingleTop = true
               }
-              launchSingleTop = true
             }
+            BottomBarMenuHandler.menuSelected(item)
           }
         )
       }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/AllCategoriesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/AllCategoriesView.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -50,6 +51,7 @@ import com.aptoide.android.aptoidegames.categories.presentation.CategoriesGridCo
 import com.aptoide.android.aptoidegames.error_views.GenericErrorView
 import com.aptoide.android.aptoidegames.error_views.NoConnectionView
 import com.aptoide.android.aptoidegames.home.LoadingView
+import com.aptoide.android.aptoidegames.home.rememberBottomBarMenuScrollState
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.theme.Palette
@@ -155,6 +157,10 @@ fun CategoryList(
   content: LazyGridScope.() -> Unit,
 ) {
   LazyVerticalGrid(
+    state = rememberBottomBarMenuScrollState(
+      state = rememberLazyGridState(),
+      route = allCategoriesRoute
+    ),
     modifier = Modifier
       .semantics { collectionInfo = CollectionInfo(size, GRID_COLUMNS) }
       .wrapContentSize(Alignment.TopCenter),

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BottomBarMenuHandler.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BottomBarMenuHandler.kt
@@ -1,0 +1,43 @@
+package com.aptoide.android.aptoidegames.home
+
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import cm.aptoide.pt.extensions.runPreviewable
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+object BottomBarMenuHandler {
+  private val _currentRoute = MutableSharedFlow<String>(replay = 1)
+  val currentRoute = _currentRoute.asSharedFlow()
+
+  fun menuSelected(menu: BottomBarMenus) {
+    _currentRoute.tryEmit(menu.route.split("?")[0])
+  }
+}
+
+@Composable
+fun <T : ScrollableState> rememberBottomBarMenuScrollState(
+  state: T,
+  route: String
+): T = runPreviewable(
+  preview = { state },
+  real = {
+    var previousRoute: String? = null
+    LaunchedEffect(Unit) {
+      BottomBarMenuHandler.currentRoute.collect {
+        if (it == previousRoute && it == route) {
+          when (state) {
+            is LazyListState -> state.animateScrollToItem(0)
+            is LazyGridState -> state.animateScrollToItem(0)
+          }
+        } else {
+          previousRoute = it
+        }
+      }
+    }
+    state
+  }
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.ExperimentalMaterialApi
@@ -135,7 +136,7 @@ fun BundlesScreen(
       when (viewState.type) {
         BundlesViewUiStateType.LOADING,
         BundlesViewUiStateType.RELOADING,
-        -> LoadingView()
+          -> LoadingView()
 
         BundlesViewUiStateType.NO_CONNECTION -> NoConnectionView(
           onRetryClick = {
@@ -158,7 +159,7 @@ fun BundlesScreen(
       BundlesViewUiStateType.IDLE,
       BundlesViewUiStateType.LOADING,
       BundlesViewUiStateType.RELOADING,
-      -> PullRefreshIndicator(
+        -> PullRefreshIndicator(
         refreshing = isRefreshing,
         state = pullRefreshState,
         modifier = Modifier.align(Alignment.TopCenter)
@@ -181,6 +182,7 @@ fun BundlesView(
       .padding(top = 16.dp)
   ) {
     LazyColumn(
+      state = rememberBottomBarMenuScrollState(state = rememberLazyListState(), route = gamesRoute),
       modifier = Modifier
         .fillMaxSize()
         .wrapContentSize(Alignment.TopCenter),

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/search/presentation/SearchView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/search/presentation/SearchView.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Icon
@@ -80,6 +81,7 @@ import com.aptoide.android.aptoidegames.feature_apps.presentation.AppItem
 import com.aptoide.android.aptoidegames.feature_apps.presentation.AppsGridBundle
 import com.aptoide.android.aptoidegames.feature_apps.presentation.LargeAppItem
 import com.aptoide.android.aptoidegames.feature_apps.presentation.rememberTrendingBundle
+import com.aptoide.android.aptoidegames.home.rememberBottomBarMenuScrollState
 import com.aptoide.android.aptoidegames.installer.presentation.InstallViewShort
 import com.aptoide.android.aptoidegames.search.SearchType
 import com.aptoide.android.aptoidegames.theme.AGTypography
@@ -609,9 +611,10 @@ fun EmptySearchView(
   onItemInstallStarted: (App) -> Unit,
 ) {
   LazyColumn(
+    state = rememberBottomBarMenuScrollState(state = rememberLazyListState(), route = searchRoute),
     modifier = Modifier.padding(start = 16.dp, end = 16.dp),
     contentPadding = PaddingValues(bottom = 72.dp),
-    ) {
+  ) {
     itemsIndexed(
       items = searchResults,
     ) { index, app ->

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
@@ -50,6 +51,7 @@ import com.aptoide.android.aptoidegames.drawables.icons.getBolt
 import com.aptoide.android.aptoidegames.drawables.icons.getNoUpdates
 import com.aptoide.android.aptoidegames.feature_apps.presentation.AppItemUpdates
 import com.aptoide.android.aptoidegames.home.LoadingView
+import com.aptoide.android.aptoidegames.home.rememberBottomBarMenuScrollState
 import com.aptoide.android.aptoidegames.installer.presentation.InstallViewShort
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.Palette
@@ -188,6 +190,10 @@ private fun AppsList(
   ) {
     UpdateBox(updates = appList)
     LazyColumn(
+      state = rememberBottomBarMenuScrollState(
+        state = rememberLazyListState(),
+        route = updatesRoute
+      ),
       modifier = Modifier
         .semantics { collectionInfo = CollectionInfo(appList.size, 1) }
         .padding(start = 16.dp, end = 16.dp)


### PR DESCRIPTION
**What does this PR do?**

It makes every bottom navigation menu not reload if it's clicked but we are already in that view. Then in Home, Search (on the results only), Updates and Categories it scrolls to the top of the list/page

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AppGamesBottomBar.kt
- [ ] AllCategoriesView.kt
- [ ] BottomBarMenuHandler.kt
- [ ] BundlesView.kt
- [ ] SearchView.kt
- [ ] UpdatesScreen.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-201](https://aptoide.atlassian.net/browse/AND-201)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-201](https://aptoide.atlassian.net/browse/AND-201)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-201]: https://aptoide.atlassian.net/browse/AND-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-201]: https://aptoide.atlassian.net/browse/AND-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ