### PR TITLE
[AND-217] Add Analytics class and Indicative events for Payments

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/GenericAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/GenericAnalytics.kt
@@ -5,19 +5,11 @@ import android.content.res.Configuration
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.walletApp
 import cm.aptoide.pt.install_manager.InstallManager
-import com.appcoins.payments.arch.PaymentMethod
-import com.appcoins.payments.arch.ProductInfoData
-import com.appcoins.payments.arch.Transaction
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics.Companion.P_APPC_BILLING
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics.Companion.P_APP_SIZE
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics.Companion.P_CONTEXT
-import com.aptoide.android.aptoidegames.analytics.GenericAnalytics.Companion.P_CURRENCY
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics.Companion.P_ITEM_POSITION
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics.Companion.P_PACKAGE_NAME
-import com.aptoide.android.aptoidegames.analytics.GenericAnalytics.Companion.P_PAYMENT_METHOD
-import com.aptoide.android.aptoidegames.analytics.GenericAnalytics.Companion.P_PRICE
-import com.aptoide.android.aptoidegames.analytics.GenericAnalytics.Companion.P_SKU_ID
-import com.aptoide.android.aptoidegames.analytics.GenericAnalytics.Companion.P_SKU_NAME
 import com.aptoide.android.aptoidegames.analytics.dto.AnalyticsUIContext
 import com.aptoide.android.aptoidegames.analytics.dto.BundleMeta
 import com.aptoide.android.aptoidegames.analytics.dto.SearchMeta
@@ -191,111 +183,6 @@ class GenericAnalytics(private val analyticsSender: AnalyticsSender) {
     params = emptyMap()
   )
 
-  fun sendPaymentStartEvent(
-    packageName: String,
-    productInfoData: ProductInfoData?,
-  ) = analyticsSender.logEvent(
-    name = "iap_payment_start",
-    params = productInfoData.toGenericParameters(P_PACKAGE_NAME to packageName)
-  )
-
-  fun sendPaymentMethodsDismissedEvent(
-    packageName: String,
-    productInfoData: ProductInfoData?,
-  ) = analyticsSender.logEvent(
-    name = "iap_payment_dismissed",
-    params = productInfoData.toGenericParameters(
-      P_PACKAGE_NAME to packageName,
-      P_PAYMENT_METHOD to "list",
-      P_CONTEXT to "start"
-    )
-  )
-
-  fun sendPaymentDismissedEvent(
-    paymentMethod: PaymentMethod<*>,
-    context: String?,
-  ) = analyticsSender.logEvent(
-    name = "iap_payment_dismissed",
-    params = paymentMethod.toGenericParameters(P_CONTEXT to context)
-  )
-
-  fun sendPaymentDismissedEvent(
-    transaction: Transaction?,
-    context: String?,
-  ) = analyticsSender.logEvent(
-    name = "iap_payment_dismissed",
-    params = transaction
-      ?.toGenericParameters(P_CONTEXT to context)
-      ?: mapOf(
-        P_PAYMENT_METHOD to "unknown",
-        P_CONTEXT to context
-      )
-  )
-
-  fun sendPaymentBackEvent(paymentMethod: PaymentMethod<*>) = analyticsSender.logEvent(
-    name = "iap_payment_back",
-    params = paymentMethod.toGenericParameters()
-  )
-
-  fun sendPaymentBuyEvent(paymentMethod: PaymentMethod<*>) = analyticsSender.logEvent(
-    name = "iap_payment_buy",
-    params = paymentMethod.toGenericParameters()
-  )
-
-  fun sendPaymentTryAgainEvent(paymentMethod: PaymentMethod<*>) = analyticsSender.logEvent(
-    name = "iap_payment_try_again",
-    params = paymentMethod.toGenericParameters()
-  )
-
-  fun sendPaymentSuccessEvent(paymentMethod: PaymentMethod<*>) = analyticsSender.logEvent(
-    name = "iap_payment_conclusion",
-    params = paymentMethod.toGenericParameters(P_STATUS to "success")
-  )
-
-  fun sendPaymentErrorEvent(
-    paymentMethod: PaymentMethod<*>,
-    errorCode: String? = null,
-  ) = analyticsSender.logEvent(
-    name = "iap_payment_conclusion",
-    params = paymentMethod.toGenericParameters(
-      P_STATUS to "error",
-      P_ERROR_CODE to errorCode
-    )
-  )
-
-  fun sendPaymentSuccessEvent(transaction: Transaction?) = analyticsSender.logEvent(
-    name = "iap_payment_conclusion",
-    params = transaction
-      ?.toGenericParameters(P_STATUS to "success")
-      ?: mapOf(
-        P_PAYMENT_METHOD to "unknown",
-        P_STATUS to "success"
-      )
-  )
-
-  fun sendPaymentErrorEvent(
-    transaction: Transaction?,
-    errorCode: String? = null,
-  ) = analyticsSender.logEvent(
-    name = "iap_payment_conclusion",
-    params = transaction?.toGenericParameters(
-      P_STATUS to "error",
-      P_ERROR_CODE to errorCode
-    ) ?: mapOf(
-      P_PAYMENT_METHOD to "unknown",
-      P_STATUS to "error",
-      P_ERROR_CODE to errorCode
-    )
-  )
-
-  fun sendPaymentMethodsEvent(paymentMethod: PaymentMethod<*>) = analyticsSender.logEvent(
-    name = "iap_payment_methods",
-    params = paymentMethod.productInfo.toGenericParameters(
-      P_PACKAGE_NAME to paymentMethod.purchaseRequest.domain,
-      P_PAYMENT_METHOD to paymentMethod.id
-    )
-  )
-
   fun sendPaymentSupportClicked() = analyticsSender.logEvent(
     name = "payment_support_clicked",
     params = emptyMap()
@@ -325,19 +212,12 @@ class GenericAnalytics(private val analyticsSender: AnalyticsSender) {
     internal const val P_FIRST_LAUNCH = "first_launch"
     internal const val P_PACKAGE_NAME = "package_name"
     internal const val P_APP_SIZE = "app_size"
-    internal const val P_SKU_ID = "sku_id"
-    internal const val P_SKU_NAME = "sku_name"
-    internal const val P_PRICE = "price"
-    internal const val P_CURRENCY = "currency"
     internal const val P_CONTEXT = "context"
     internal const val P_ITEM_POSITION = "item_position"
     internal const val P_SCROLL_COUNT = "scroll_count"
     internal const val P_CATEGORY = "category"
     internal const val P_APPC_BILLING = "appc_billing"
     internal const val P_SERVICE = "service"
-    internal const val P_STATUS = "status"
-    internal const val P_PAYMENT_METHOD = "payment_method"
-    internal const val P_ERROR_CODE = "error_code"
   }
 }
 
@@ -376,33 +256,6 @@ fun App.toGenericParameters(): Array<Pair<String, Any>> = arrayOf(
   P_PACKAGE_NAME to packageName,
   P_APPC_BILLING to isAppCoins,
   P_APP_SIZE to appSize
-)
-
-fun PaymentMethod<*>.toGenericParameters(vararg pairs: Pair<String, Any?>) =
-  productInfo.toGenericParameters(
-    *pairs,
-    P_PACKAGE_NAME to purchaseRequest.domain,
-    P_PAYMENT_METHOD to id
-  )
-
-fun ProductInfoData?.toGenericParameters(vararg pairs: Pair<String, Any?>) = this?.run {
-  mapOfNonNull(
-    *pairs,
-    P_SKU_ID to sku,
-    P_SKU_NAME to title,
-    P_PRICE to priceValue,
-    P_CURRENCY to priceCurrency
-  )
-} ?: mapOfNonNull(*pairs)
-
-fun Transaction.toGenericParameters(vararg pairs: Pair<String, Any?>) = mapOfNonNull(
-  *pairs,
-  P_PACKAGE_NAME to domain,
-  P_PAYMENT_METHOD to method,
-  P_SKU_ID to product,
-  P_SKU_NAME to product,
-  P_PRICE to price.value,
-  P_CURRENCY to price.currency
 )
 
 fun <K, V : Any> mapOfNonNull(vararg pairs: Pair<K, V?>) = mapOf(*pairs)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/analytics/AnalyticsProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/analytics/AnalyticsProvider.kt
@@ -1,0 +1,30 @@
+package com.aptoide.android.aptoidegames.feature_payments.analytics
+
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import cm.aptoide.pt.extensions.runPreviewable
+import com.aptoide.android.aptoidegames.analytics.AnalyticsSender
+import com.aptoide.android.aptoidegames.analytics.BIAnalytics
+import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class AnalyticsInjectionsProvider @Inject constructor(
+  val paymentAnalytics: PaymentAnalytics,
+) : ViewModel()
+
+@Composable
+fun rememberPaymentAnalytics(): PaymentAnalytics = runPreviewable(
+  preview = {
+    PaymentAnalytics(
+      GenericAnalytics(object : AnalyticsSender {}),
+      BIAnalytics(object : AnalyticsSender {}),
+    )
+  },
+  real = {
+    val vm = hiltViewModel<AnalyticsInjectionsProvider>()
+    vm.paymentAnalytics
+  }
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/analytics/PaymentAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/analytics/PaymentAnalytics.kt
@@ -1,0 +1,218 @@
+package com.aptoide.android.aptoidegames.feature_payments.analytics
+
+import com.appcoins.payments.arch.PaymentMethod
+import com.appcoins.payments.arch.ProductInfoData
+import com.appcoins.payments.arch.Transaction
+import com.aptoide.android.aptoidegames.analytics.BIAnalytics
+import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
+import com.aptoide.android.aptoidegames.analytics.mapOfNonNull
+import com.aptoide.android.aptoidegames.feature_payments.analytics.PaymentAnalytics.Companion.P_CURRENCY
+import com.aptoide.android.aptoidegames.feature_payments.analytics.PaymentAnalytics.Companion.P_PAYMENT_METHOD
+import com.aptoide.android.aptoidegames.feature_payments.analytics.PaymentAnalytics.Companion.P_PRICE
+import com.aptoide.android.aptoidegames.feature_payments.analytics.PaymentAnalytics.Companion.P_SKU_ID
+import com.aptoide.android.aptoidegames.feature_payments.analytics.PaymentAnalytics.Companion.P_SKU_NAME
+
+class PaymentAnalytics(
+  private val genericAnalytics: GenericAnalytics,
+  private val biAnalytics: BIAnalytics,
+) {
+
+  fun sendPaymentStartEvent(
+    packageName: String,
+    productInfoData: ProductInfoData?,
+  ) {
+    val params = productInfoData.toGenericParameters(GenericAnalytics.P_PACKAGE_NAME to packageName)
+    genericAnalytics.logEvent(
+      name = "iap_payment_start",
+      params = params
+    )
+    biAnalytics.logEvent(
+      name = "iap_payment_start",
+      params = params
+    )
+  }
+
+  fun sendPaymentMethodsDismissedEvent(
+    packageName: String,
+    productInfoData: ProductInfoData?,
+  ) {
+    val params = productInfoData.toGenericParameters(
+      GenericAnalytics.P_PACKAGE_NAME to packageName,
+      P_PAYMENT_METHOD to "list",
+      GenericAnalytics.P_CONTEXT to "start"
+    )
+    logPaymentDismissed(params)
+  }
+
+  fun sendPaymentDismissedEvent(
+    paymentMethod: PaymentMethod<*>,
+    context: String?,
+  ) {
+    val params = paymentMethod.toGenericParameters(GenericAnalytics.P_CONTEXT to context)
+    logPaymentDismissed(params)
+  }
+
+  fun sendPaymentDismissedEvent(
+    transaction: Transaction?,
+    context: String?,
+  ) {
+    val params = transaction
+      ?.toGenericParameters(GenericAnalytics.P_CONTEXT to context)
+      ?: mapOfNonNull(
+        P_PAYMENT_METHOD to "unknown",
+        GenericAnalytics.P_CONTEXT to context
+      )
+    logPaymentDismissed(params)
+  }
+
+  fun sendPaymentBackEvent(paymentMethod: PaymentMethod<*>) {
+    val params = paymentMethod.toGenericParameters()
+    genericAnalytics.logEvent(
+      name = "iap_payment_back",
+      params = params
+    )
+    biAnalytics.logEvent(
+      name = "iap_payment_other_payment",
+      params = params
+    )
+  }
+
+  fun sendPaymentBuyEvent(paymentMethod: PaymentMethod<*>) {
+    val params = paymentMethod.toGenericParameters()
+    genericAnalytics.logEvent(
+      name = "iap_payment_buy",
+      params = params
+    )
+    biAnalytics.logEvent(
+      name = "iap_payment_buy",
+      params = params
+    )
+  }
+
+  fun sendPaymentTryAgainEvent(paymentMethod: PaymentMethod<*>) {
+    val params = paymentMethod.toGenericParameters()
+    genericAnalytics.logEvent(
+      name = "iap_payment_try_again",
+      params = params
+    )
+    biAnalytics.logEvent(
+      name = "iap_payment_try_again",
+      params = params
+    )
+  }
+
+  fun sendPaymentSuccessEvent(paymentMethod: PaymentMethod<*>) {
+    val params = paymentMethod.toGenericParameters(P_STATUS to "success")
+    logPaymentConclusion(params)
+  }
+
+  fun sendPaymentErrorEvent(
+    paymentMethod: PaymentMethod<*>,
+    errorCode: String? = null,
+  ) {
+    val params = paymentMethod.toGenericParameters(
+      P_STATUS to "error",
+      P_ERROR_CODE to errorCode
+    )
+    logPaymentConclusion(params)
+  }
+
+  fun sendPaymentSuccessEvent(transaction: Transaction?) {
+    val params = transaction
+      ?.toGenericParameters(P_STATUS to "success")
+      ?: mapOf(
+        P_PAYMENT_METHOD to "unknown",
+        P_STATUS to "success"
+      )
+    logPaymentConclusion(params)
+  }
+
+  fun sendPaymentErrorEvent(
+    transaction: Transaction?,
+    errorCode: String? = null,
+  ) {
+    val params = transaction?.toGenericParameters(
+      P_STATUS to "error",
+      P_ERROR_CODE to errorCode
+    ) ?: mapOfNonNull(
+      P_PAYMENT_METHOD to "unknown",
+      P_STATUS to "error",
+      P_ERROR_CODE to errorCode
+    )
+    logPaymentConclusion(params)
+  }
+
+  fun sendPaymentMethodsEvent(paymentMethod: PaymentMethod<*>) {
+    val params = paymentMethod.productInfo.toGenericParameters(
+      GenericAnalytics.P_PACKAGE_NAME to paymentMethod.purchaseRequest.domain,
+      P_PAYMENT_METHOD to paymentMethod.id
+    )
+    genericAnalytics.logEvent(
+      name = "iap_payment_methods",
+      params = params
+    )
+    biAnalytics.logEvent(
+      name = "iap_payment_methods",
+      params = params
+    )
+  }
+
+  private fun logPaymentDismissed(params: Map<String, Any>) {
+    genericAnalytics.logEvent(
+      name = "iap_payment_dismissed",
+      params = params
+    )
+    biAnalytics.logEvent(
+      name = "iap_payment_exit",
+      params = params
+    )
+  }
+
+  private fun logPaymentConclusion(params: Map<String, Any>) {
+    genericAnalytics.logEvent(
+      name = "iap_payment_conclusion",
+      params = params
+    )
+    biAnalytics.logEvent(
+      name = "iap_payment_conclusion",
+      params = params
+    )
+  }
+
+  companion object {
+    private const val P_ERROR_CODE = "error_code"
+    private const val P_STATUS = "status"
+    internal const val P_CURRENCY = "currency"
+    internal const val P_SKU_ID = "sku_id"
+    internal const val P_SKU_NAME = "sku_name"
+    internal const val P_PAYMENT_METHOD = "payment_method"
+    internal const val P_PRICE = "price"
+  }
+}
+
+fun PaymentMethod<*>.toGenericParameters(vararg pairs: Pair<String, Any?>) =
+  productInfo.toGenericParameters(
+    *pairs,
+    GenericAnalytics.P_PACKAGE_NAME to purchaseRequest.domain,
+    P_PAYMENT_METHOD to id
+  )
+
+fun ProductInfoData?.toGenericParameters(vararg pairs: Pair<String, Any?>) = this?.run {
+  mapOfNonNull(
+    *pairs,
+    P_SKU_ID to sku,
+    P_SKU_NAME to title,
+    P_PRICE to priceValue,
+    P_CURRENCY to priceCurrency
+  )
+} ?: mapOfNonNull(*pairs)
+
+fun Transaction.toGenericParameters(vararg pairs: Pair<String, Any?>) = mapOfNonNull(
+  *pairs,
+  GenericAnalytics.P_PACKAGE_NAME to domain,
+  P_PAYMENT_METHOD to method,
+  P_SKU_ID to product,
+  P_SKU_NAME to product,
+  P_PRICE to price.value,
+  P_CURRENCY to price.currency
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/di/PaymentsModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/di/PaymentsModule.kt
@@ -2,7 +2,10 @@ package com.aptoide.android.aptoidegames.feature_payments.di
 
 import android.content.Context
 import com.appcoins.payments.uri_handler.PaymentScreenContentProvider
+import com.aptoide.android.aptoidegames.analytics.BIAnalytics
+import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
 import com.aptoide.android.aptoidegames.feature_payments.AGPaymentScreenContentProvider
+import com.aptoide.android.aptoidegames.feature_payments.analytics.PaymentAnalytics
 import com.aptoide.android.aptoidegames.feature_payments.repository.PaymentsPreferencesRepository
 import com.aptoide.android.aptoidegames.feature_payments.repository.PreSelectedPaymentMethodRepository
 import com.aptoide.android.aptoidegames.paymentsPreferencesDataStore
@@ -34,6 +37,16 @@ interface PaymentsModule {
     @PaymentsPreferencesDataStore
     fun providePaymentsPreferencesDataStore(@ApplicationContext appContext: Context) =
       appContext.paymentsPreferencesDataStore
+
+    @Singleton
+    @Provides
+    fun providesPaymentAnalytics(
+      genericAnalytics: GenericAnalytics,
+      biAnalytics: BIAnalytics,
+    ): PaymentAnalytics = PaymentAnalytics(
+      genericAnalytics = genericAnalytics,
+      biAnalytics = biAnalytics
+    )
   }
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/payment_methods/MainPaymentsView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/payment_methods/MainPaymentsView.kt
@@ -51,13 +51,13 @@ import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.AptoideOutlinedText
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.SupportActivity
-import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
 import com.aptoide.android.aptoidegames.design_system.IndeterminateCircularLoading
 import com.aptoide.android.aptoidegames.drawables.icons.getAppcoinsClearLogo
 import com.aptoide.android.aptoidegames.drawables.icons.getLeftArrow
 import com.aptoide.android.aptoidegames.drawables.icons.getTintedWalletGift
 import com.aptoide.android.aptoidegames.feature_payments.AppGamesPaymentBottomSheet
+import com.aptoide.android.aptoidegames.feature_payments.analytics.rememberPaymentAnalytics
 import com.aptoide.android.aptoidegames.feature_payments.currentProductInfo
 import com.aptoide.android.aptoidegames.feature_payments.getRoute
 import com.aptoide.android.aptoidegames.feature_payments.presentation.PreselectedPaymentMethodEffect
@@ -97,14 +97,14 @@ private fun MainPaymentsView(
   PreselectedPaymentMethodEffect(paymentState, navigate)
 
   val productInfo = currentProductInfo()
-  val genericAnalytics = rememberGenericAnalytics()
+  val paymentAnalytics = rememberPaymentAnalytics()
 
   var hasPaymentStartBeenSent by rememberSaveable { mutableStateOf(false) }
 
   LaunchedEffect(key1 = productInfo, key2 = paymentState, key3 = hasPaymentStartBeenSent) {
     productInfo?.let {
       if (paymentState is PaymentMethodsUiState.Idle && !hasPaymentStartBeenSent) {
-        genericAnalytics.sendPaymentStartEvent(
+        paymentAnalytics.sendPaymentStartEvent(
           packageName = purchaseRequest.domain,
           productInfoData = it,
         )
@@ -123,7 +123,7 @@ private fun MainPaymentsView(
       if (paymentState is PaymentMethodsUiState.Error && paymentState.result is PaymentsItemOwnedResult) {
         onFinish(paymentState.result)
       } else {
-        genericAnalytics.sendPaymentMethodsDismissedEvent(
+        paymentAnalytics.sendPaymentMethodsDismissedEvent(
           packageName = purchaseRequest.domain,
           productInfoData = productInfo,
         )
@@ -131,7 +131,7 @@ private fun MainPaymentsView(
       }
     },
     onPaymentMethodClick = { paymentMethod ->
-      genericAnalytics.sendPaymentMethodsEvent(paymentMethod = paymentMethod)
+      paymentAnalytics.sendPaymentMethodsEvent(paymentMethod = paymentMethod)
       navigate(paymentMethod.getRoute())
     },
     onContactUsClick = onContactUsClick

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/paypal/PaypalScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/paypal/PaypalScreen.kt
@@ -49,7 +49,6 @@ import com.appcoins.payments.uri_handler.PaymentsCancelledResult
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.SupportActivity
-import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
 import com.aptoide.android.aptoidegames.design_system.PrimaryButton
 import com.aptoide.android.aptoidegames.drawables.icons.getCheck
@@ -65,6 +64,7 @@ import com.aptoide.android.aptoidegames.feature_payments.PortraitPaymentsNoConne
 import com.aptoide.android.aptoidegames.feature_payments.PurchaseInfoRow
 import com.aptoide.android.aptoidegames.feature_payments.SuccessView
 import com.aptoide.android.aptoidegames.feature_payments.analytics.paymentContext
+import com.aptoide.android.aptoidegames.feature_payments.analytics.rememberPaymentAnalytics
 import com.aptoide.android.aptoidegames.feature_payments.presentation.PaypalPaymentStateEffect
 import com.aptoide.android.aptoidegames.feature_payments.presentation.PreSelectedPaymentMethodViewModel
 import com.aptoide.android.aptoidegames.theme.AGTypography
@@ -116,18 +116,18 @@ private fun BuildPaypalScreen(
   val (paymentMethod, uiState) = rememberPaypalUIState()
   var finished by remember { mutableStateOf(false) }
 
-  val genericAnalytics = rememberGenericAnalytics()
+  val paymentAnalytics = rememberPaymentAnalytics()
 
   PaypalPaymentStateEffect(paymentMethod.id, uiState)
 
   LaunchedEffect(key1 = uiState, key2 = activityResultRegistry) {
     when (uiState) {
       is PaypalUIState.Error -> {
-        genericAnalytics.sendPaymentErrorEvent(paymentMethod = paymentMethod)
+        paymentAnalytics.sendPaymentErrorEvent(paymentMethod = paymentMethod)
       }
 
       is PaypalUIState.Success -> {
-        genericAnalytics.sendPaymentSuccessEvent(paymentMethod = paymentMethod)
+        paymentAnalytics.sendPaymentSuccessEvent(paymentMethod = paymentMethod)
         delay(3000)
         if (!finished) onFinish(uiState.result)
         finished = true
@@ -136,12 +136,12 @@ private fun BuildPaypalScreen(
       PaypalUIState.Canceled -> popBackStack()
       is PaypalUIState.GetBillingAgreement -> uiState.resolveWith(activityResultRegistry)
       is PaypalUIState.BillingAgreementUnavailable -> {
-        genericAnalytics.sendPaymentBuyEvent(paymentMethod)
+        paymentAnalytics.sendPaymentBuyEvent(paymentMethod)
         uiState.onBuyClick()
       }
 
       PaypalUIState.PaypalAgreementRemoved -> {
-        genericAnalytics.sendPaymentBackEvent(paymentMethod = paymentMethod)
+        paymentAnalytics.sendPaymentBackEvent(paymentMethod = paymentMethod)
         popBackStack()
       }
 
@@ -152,10 +152,10 @@ private fun BuildPaypalScreen(
   PaypalScreen(
     viewModelState = uiState,
     onBuyClicked = {
-      genericAnalytics.sendPaymentBuyEvent(paymentMethod)
+      paymentAnalytics.sendPaymentBuyEvent(paymentMethod)
     },
     onOtherPaymentMethodsClick = {
-      genericAnalytics.sendPaymentBackEvent(paymentMethod = paymentMethod)
+      paymentAnalytics.sendPaymentBackEvent(paymentMethod = paymentMethod)
       popBackStack()
     },
     onClick = {
@@ -165,7 +165,7 @@ private fun BuildPaypalScreen(
       }
     },
     onOutsideClick = {
-      genericAnalytics.sendPaymentDismissedEvent(
+      paymentAnalytics.sendPaymentDismissedEvent(
         paymentMethod = paymentMethod,
         context = uiState.paymentContext,
       )
@@ -173,7 +173,7 @@ private fun BuildPaypalScreen(
       finished = true
     },
     onRetryClick = {
-      genericAnalytics.sendPaymentTryAgainEvent(paymentMethod = paymentMethod)
+      paymentAnalytics.sendPaymentTryAgainEvent(paymentMethod = paymentMethod)
       popBackStack()
     },
     onContactUs = {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/transaction/TransactionScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/transaction/TransactionScreen.kt
@@ -28,7 +28,6 @@ import com.appcoins.payments.manager.presentation.rememberOngoingTransactionUISt
 import com.appcoins.payments.uri_handler.PaymentsCancelledResult
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.SupportActivity
-import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
 import com.aptoide.android.aptoidegames.feature_payments.AppGamesPaymentBottomSheet
 import com.aptoide.android.aptoidegames.feature_payments.LandscapePaymentErrorView
@@ -38,6 +37,7 @@ import com.aptoide.android.aptoidegames.feature_payments.PortraitPaymentErrorVie
 import com.aptoide.android.aptoidegames.feature_payments.PortraitPaymentsNoConnectionView
 import com.aptoide.android.aptoidegames.feature_payments.SuccessView
 import com.aptoide.android.aptoidegames.feature_payments.analytics.paymentContext
+import com.aptoide.android.aptoidegames.feature_payments.analytics.rememberPaymentAnalytics
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import kotlinx.coroutines.delay
 
@@ -89,19 +89,19 @@ private fun BuildOngoingTransactionScreen(
   )
   var finished by remember { mutableStateOf(false) }
 
-  val genericAnalytics = rememberGenericAnalytics()
+  val paymentAnalytics = rememberPaymentAnalytics()
 
   LaunchedEffect(key1 = uiState) {
     when (uiState) {
       is TransactionUIState.Error -> {
-        genericAnalytics.sendPaymentErrorEvent(
+        paymentAnalytics.sendPaymentErrorEvent(
           transaction = transaction,
           errorCode = uiState.result.message
         )
       }
 
       is TransactionUIState.Success -> {
-        genericAnalytics.sendPaymentSuccessEvent(transaction = transaction)
+        paymentAnalytics.sendPaymentSuccessEvent(transaction = transaction)
         delay(3000)
         if (!finished) onFinish(uiState.result)
         finished = true
@@ -120,7 +120,7 @@ private fun BuildOngoingTransactionScreen(
       }
     },
     onOutsideClick = {
-      genericAnalytics.sendPaymentDismissedEvent(
+      paymentAnalytics.sendPaymentDismissedEvent(
         transaction = transaction,
         context = uiState.paymentContext,
       )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/wallet/WalletInstallationScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/wallet/WalletInstallationScreen.kt
@@ -56,6 +56,7 @@ import com.aptoide.android.aptoidegames.feature_payments.PortraitPaymentErrorVie
 import com.aptoide.android.aptoidegames.feature_payments.PortraitPaymentsNoConnectionView
 import com.aptoide.android.aptoidegames.feature_payments.PurchaseInfoRow
 import com.aptoide.android.aptoidegames.feature_payments.analytics.PaymentContext
+import com.aptoide.android.aptoidegames.feature_payments.analytics.rememberPaymentAnalytics
 import com.aptoide.android.aptoidegames.installer.UserActionDialog
 import com.aptoide.android.aptoidegames.installer.analytics.AnalyticsInstallPackageInfoMapper
 import com.aptoide.android.aptoidegames.installer.forceInstallConstraints
@@ -127,7 +128,7 @@ private fun PaymentsWalletInstallationBottomSheetView(
   navigateBack: () -> Unit,
   navigate: (String) -> Unit,
 ) {
-  val genericAnalytics = rememberGenericAnalytics()
+  val paymentAnalytics = rememberPaymentAnalytics()
   val walletPaymentMethod = rememberWalletPaymentMethod(purchaseRequest)
   val (uiState, _) = rememberWalletApp()
 
@@ -138,7 +139,7 @@ private fun PaymentsWalletInstallationBottomSheetView(
     navigate = navigate,
     onOutsideClick = {
       walletPaymentMethod?.let {
-        genericAnalytics.sendPaymentDismissedEvent(
+        paymentAnalytics.sendPaymentDismissedEvent(
           paymentMethod = it,
           context = PaymentContext.SECOND_STEP,
         )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/wallet/WalletInstalledScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_payments/wallet/WalletInstalledScreen.kt
@@ -34,11 +34,11 @@ import com.appcoins.payments.arch.PurchaseRequest
 import com.appcoins.payments.uri_handler.PaymentsActivityResult
 import com.appcoins.payments.uri_handler.PaymentsCancelledResult
 import com.aptoide.android.aptoidegames.R
-import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
 import com.aptoide.android.aptoidegames.drawables.icons.getWalletInstalled
 import com.aptoide.android.aptoidegames.feature_payments.AppGamesPaymentBottomSheet
 import com.aptoide.android.aptoidegames.feature_payments.analytics.PaymentContext
+import com.aptoide.android.aptoidegames.feature_payments.analytics.rememberPaymentAnalytics
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.Palette
 import kotlinx.coroutines.delay
@@ -81,7 +81,7 @@ fun PaymentsWalletInstalledView(
   purchaseRequest: PurchaseRequest,
   onFinish: (PaymentsResult) -> Unit,
 ) {
-  val genericAnalytics = rememberGenericAnalytics()
+  val paymentAnalytics = rememberPaymentAnalytics()
   val walletPaymentMethod = rememberWalletPaymentMethod(purchaseRequest)
   val launcher = rememberLauncherForActivityResult(
     contract = StartActivityForResult()
@@ -113,7 +113,7 @@ fun PaymentsWalletInstalledView(
   WalletInstalledView(
     onOutsideClick = {
       walletPaymentMethod?.let {
-        genericAnalytics.sendPaymentDismissedEvent(
+        paymentAnalytics.sendPaymentDismissedEvent(
           paymentMethod = it,
           context = PaymentContext.CONCLUSION,
         )


### PR DESCRIPTION
**What does this PR do?**

It moves all `iap` analytics events to their own PaymentAnalytics class and adds all the Indicative events correspondent to the Firebase ones with the naming changes noted in the ticket

**Database changed?**

No

**Where should the reviewer start?**

- [ ] GenericAnalytics.kt
- [ ] AnalyticsProvider.kt
- [ ] PaymentAnalytics.kt
- [ ] AdyenCreditCardScreen.kt
- [ ] PaymentsModule.kt
- [ ] MainPaymentsView.kt
- [ ] PaypalScreen.kt
- [ ] TransactionScreen.kt
- [ ] WalletInstallationScreen.kt
- [ ] WalletInstalledScreen.kt

**How should this be manually tested?**

 Test payment methods' and their success/failure to see if events are being sent and sent correctly.

  Flow on how to test this or QA Tickets related to this use-case: [AND-217](https://aptoide.atlassian.net/browse/AND-217)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-217](https://aptoide.atlassian.net/browse/AND-217)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-217]: https://aptoide.atlassian.net/browse/AND-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-217]: https://aptoide.atlassian.net/browse/AND-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ