### PR TITLE
[AND-213] Add package downloader implementation change with the feature flag

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
@@ -71,25 +71,28 @@ class BIAnalytics(private val analyticsSender: AnalyticsSender) {
         .getApp("com.dti.folderlauncher")
         .packageInfoFlow
         .map { it != null }
-        .onEach { analyticsSender.setUserProperties("is_gh_installed" to it) }
+        .onEach { setUserProperties("is_gh_installed" to it) }
         .launchIn(this)
       installManager
         .getApp("cm.aptoide.pt")
         .packageInfoFlow
         .map { it != null }
-        .onEach { analyticsSender.setUserProperties("is_vanilla_installed" to it) }
+        .onEach { setUserProperties("is_vanilla_installed" to it) }
         .launchIn(this)
       installManager
         .getApp(walletApp.packageName)
         .packageInfoFlow
         .map { it != null }
-        .onEach { analyticsSender.setUserProperties("is_wallet_app_installed" to it) }
+        .onEach { setUserProperties("is_wallet_app_installed" to it) }
         .launchIn(this)
 
-      analyticsSender.setUserProperties("first_session" to isFirstLaunch)
+      setUserProperties("first_session" to isFirstLaunch)
       setFeatureFlagsProperties(featureFlags)
     }
   }
+
+  fun setUserProperties(vararg props: Pair<String, Any?>) =
+    analyticsSender.setUserProperties(*props)
 
   private suspend fun setFeatureFlagsProperties(featureFlags: FeatureFlags) {
     val apkfyVariant = featureFlags.getFlagAsString("apkfy_variant")

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/FirebaseAnalyticsSender.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/FirebaseAnalyticsSender.kt
@@ -2,7 +2,9 @@ package com.aptoide.android.aptoidegames.analytics
 
 import androidx.annotation.Size
 import androidx.core.os.bundleOf
+import com.aptoide.android.aptoidegames.BuildConfig
 import com.google.firebase.analytics.FirebaseAnalytics
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -11,11 +13,22 @@ class FirebaseAnalyticsSender @Inject constructor(
   private val firebaseAnalytics: FirebaseAnalytics,
 ) : AnalyticsSender {
   override fun setUserProperties(vararg props: Pair<String, Any?>) = props.forEach {
+    if (BuildConfig.DEBUG) {
+      Timber.tag("GA").i("set UP  ${it.first} = ${it.second}")
+    }
     firebaseAnalytics.setUserProperty(it.first, it.second?.toString())
   }
 
   override fun logEvent(
     @Size(min = 1L, max = 40L) name: String,
     params: Map<String, Any?>?,
-  ) = firebaseAnalytics.logEvent(name, params?.let { bundleOf(*it.toList().toTypedArray()) })
+  ) {
+    if (BuildConfig.DEBUG) {
+      Timber.tag("GA").i(name)
+      params?.entries?.forEach {
+        Timber.tag("GA").i("  ${it.key}: ${it.value.toString()}")
+      }
+    }
+    firebaseAnalytics.logEvent(name, params?.let { bundleOf(*it.toList().toTypedArray()) })
+  }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/IndicativeAnalyticsSender.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/IndicativeAnalyticsSender.kt
@@ -1,17 +1,33 @@
 package com.aptoide.android.aptoidegames.analytics
 
 import androidx.annotation.Size
+import com.aptoide.android.aptoidegames.BuildConfig
 import com.indicative.client.android.Indicative
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class IndicativeAnalyticsSender @Inject constructor() : AnalyticsSender {
-  override fun setUserProperties(vararg props: Pair<String, Any?>) =
+  override fun setUserProperties(vararg props: Pair<String, Any?>) {
+    if (BuildConfig.DEBUG) {
+      props.forEach {
+        Timber.tag("BA").i("set UP  ${it.first} = ${it.second}")
+      }
+    }
     Indicative.addProperties(props.toMap())
+  }
 
   override fun logEvent(
     @Size(min = 1L, max = 40L) name: String,
     params: Map<String, Any?>?,
-  ) = Indicative.recordEvent(name, params)
+  ) {
+    if (BuildConfig.DEBUG) {
+      Timber.tag("BA").i(name)
+      params?.entries?.forEach {
+        Timber.tag("BA").i("  ${it.key}: ${it.value.toString()}")
+      }
+    }
+    Indicative.recordEvent(name, params)
+  }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/DownloaderSelector.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/DownloaderSelector.kt
@@ -1,0 +1,35 @@
+package com.aptoide.android.aptoidegames.installer
+
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
+import cm.aptoide.pt.install_manager.workers.PackageDownloader
+import com.aptoide.android.aptoidegames.installer.ff.isFetchDownloaderEnabled
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class DownloaderSelector @Inject constructor(
+  private val featureFlags: FeatureFlags,
+  private val aptoidePackageDownloader: PackageDownloader,
+  private val fetchPackageDownloader: PackageDownloader,
+) : PackageDownloader {
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  override fun download(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo,
+  ): Flow<Int> = flow { emit(getPackageDownloader()) }
+    .flatMapLatest { it.download(packageName, installPackageInfo) }
+
+  private suspend fun getPackageDownloader(): PackageDownloader =
+    if (featureFlags.isFetchDownloaderEnabled() == true) {
+      fetchPackageDownloader
+    } else {
+      aptoidePackageDownloader
+    }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/AnalyticsProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/AnalyticsProvider.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import cm.aptoide.pt.extensions.runPreviewable
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
 import com.aptoide.android.aptoidegames.analytics.AnalyticsSender
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
@@ -19,6 +20,7 @@ class AnalyticsInjectionsProvider @Inject constructor(
 fun rememberInstallAnalytics(): InstallAnalytics = runPreviewable(
   preview = {
     InstallAnalytics(
+      object : FeatureFlags {},
       GenericAnalytics(object : AnalyticsSender {}),
       BIAnalytics(object : AnalyticsSender {}),
       "",

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
@@ -32,7 +32,7 @@ class DownloadProbe(
       }
       .onCompletion {
         when (it) {
-          is CancellationException -> analytics.sendDownloadCancelEvent(
+          is CancellationException -> analytics.sendDownloadCanceledEvent(
             packageName = packageName,
             installPackageInfo = installPackageInfo
           )
@@ -78,7 +78,7 @@ class DownloadProbe(
     //if it was not cancelled by the Package Downloader, it means that it is on queue,
     // so the analytics won't be called after completion on the download method.
     // We need to call it here
-    if (!cancelled) analytics.sendDownloadCancelEvent(
+    if (!cancelled) analytics.sendDownloadCanceledInQueueEvent(
       packageName = packageName,
       installPackageInfo = InstallPackageInfo(
         versionCode = 0,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
@@ -5,11 +5,11 @@ import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import cm.aptoide.pt.install_manager.workers.PackageDownloader
 import cm.aptoide.pt.installer.platform.REQUEST_INSTALL_PACKAGES_NOT_ALLOWED
 import cm.aptoide.pt.installer.platform.WRITE_EXTERNAL_STORAGE_NOT_ALLOWED
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import retrofit2.HttpException
-import java.util.concurrent.CancellationException
 
 class DownloadProbe(
   private val packageDownloader: PackageDownloader,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
@@ -2,7 +2,6 @@ package com.aptoide.android.aptoidegames.installer.analytics
 
 import cm.aptoide.pt.install_manager.AbortException
 import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
-import cm.aptoide.pt.install_manager.dto.InstallationFile
 import cm.aptoide.pt.install_manager.workers.PackageDownloader
 import cm.aptoide.pt.installer.platform.REQUEST_INSTALL_PACKAGES_NOT_ALLOWED
 import cm.aptoide.pt.installer.platform.WRITE_EXTERNAL_STORAGE_NOT_ALLOWED
@@ -16,13 +15,11 @@ class DownloadProbe(
   private val packageDownloader: PackageDownloader,
   private val analytics: InstallAnalytics,
 ) : PackageDownloader {
-  private var cachedSizes = mutableMapOf<String, Long>()
 
   override fun download(
     packageName: String,
     installPackageInfo: InstallPackageInfo,
   ): Flow<Int> {
-    cachedSizes[packageName] = installPackageInfo.filesSize
     return packageDownloader.download(packageName, installPackageInfo)
       .onStart {
         analytics.sendDownloadStartedEvent(
@@ -70,32 +67,5 @@ class DownloadProbe(
           )
         }
       }
-  }
-
-  override fun cancel(packageName: String): Boolean {
-    val cancelled = packageDownloader.cancel(packageName)
-
-    //if it was not cancelled by the Package Downloader, it means that it is on queue,
-    // so the analytics won't be called after completion on the download method.
-    // We need to call it here
-    if (!cancelled) analytics.sendDownloadCanceledInQueueEvent(
-      packageName = packageName,
-      installPackageInfo = InstallPackageInfo(
-        versionCode = 0,
-        installationFiles = setOf(
-          InstallationFile(
-            name = "",
-            type = InstallationFile.Type.BASE,
-            md5 = "",
-            fileSize = cachedSizes[packageName] ?: 0,
-            url = "",
-            altUrl = "",
-            localPath = ""
-          )
-        )
-      ),
-    )
-
-    return cancelled
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -190,7 +190,7 @@ class InstallAnalytics(
     )
   }
 
-  fun sendDownloadCancelEvent(
+  fun sendDownloadCanceledEvent(
     packageName: String,
     installPackageInfo: InstallPackageInfo
   ) {
@@ -205,7 +205,20 @@ class InstallAnalytics(
     logBIDownloadEvent(
       packageName = packageName,
       status = "cancel",
-      installPackageInfo = installPackageInfo
+      installPackageInfo = installPackageInfo,
+      P_ERROR_TYPE to "downloading"
+    )
+  }
+
+  fun sendDownloadCanceledInQueueEvent(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo
+  ) {
+    logBIDownloadEvent(
+      packageName = packageName,
+      status = "cancel",
+      installPackageInfo = installPackageInfo,
+      P_ERROR_TYPE to "queue"
     )
   }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -2,6 +2,7 @@ package com.aptoide.android.aptoidegames.installer.analytics
 
 import cm.aptoide.pt.extensions.toInt
 import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
 import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
@@ -13,13 +14,30 @@ import com.aptoide.android.aptoidegames.analytics.toBiParameters
 import com.aptoide.android.aptoidegames.analytics.toGenericParameters
 import com.aptoide.android.aptoidegames.installer.analytics.InstallAnalytics.Companion.P_APP_SIZE_MB
 import com.aptoide.android.aptoidegames.installer.analytics.InstallAnalytics.Companion.P_UPDATE_TYPE
+import com.aptoide.android.aptoidegames.installer.ff.isFetchDownloaderEnabled
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class InstallAnalytics(
+  private val featureFlags: FeatureFlags,
   private val genericAnalytics: GenericAnalytics,
   private val biAnalytics: BIAnalytics,
   private val storeName: String,
   private val silentInstallChecker: SilentInstallChecker,
 ) {
+
+  init {
+    CoroutineScope(Dispatchers.Main).launch {
+      featureFlags.isFetchDownloaderEnabled()?.let {
+        if (it) {
+          "ab_test_download_lib_dec_19" to "group_b"
+        } else {
+          "ab_test_download_lib_dec_19" to "group_a"
+        }
+      }
+    }
+  }
 
   fun sendInstallClickEvent(
     app: App,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -2,6 +2,7 @@ package com.aptoide.android.aptoidegames.installer.analytics
 
 import cm.aptoide.pt.extensions.toInt
 import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
 import com.aptoide.android.aptoidegames.analytics.asNullableParameter
@@ -10,6 +11,7 @@ import com.aptoide.android.aptoidegames.analytics.mapOfNonNull
 import com.aptoide.android.aptoidegames.analytics.toBIParameters
 import com.aptoide.android.aptoidegames.analytics.toBiParameters
 import com.aptoide.android.aptoidegames.analytics.toGenericParameters
+import com.aptoide.android.aptoidegames.installer.analytics.InstallAnalytics.Companion.P_APP_SIZE_MB
 import com.aptoide.android.aptoidegames.installer.analytics.InstallAnalytics.Companion.P_UPDATE_TYPE
 
 class InstallAnalytics(
@@ -109,11 +111,11 @@ class InstallAnalytics(
 
   fun sendDownloadStartedEvent(
     packageName: String,
-    analyticsPayload: AnalyticsPayload?,
+    installPackageInfo: InstallPackageInfo
   ) {
     genericAnalytics.logEvent(
       name = "app_download",
-      params = analyticsPayload.toAppGenericParameters(
+      params = installPackageInfo.toAppGenericParameters(
         packageName = packageName,
         P_STATUS to "started"
       )
@@ -122,12 +124,11 @@ class InstallAnalytics(
 
   fun sendDownloadCompletedEvent(
     packageName: String,
-    analyticsPayload: AnalyticsPayload?,
-    appSizeSegment: Int,
+    installPackageInfo: InstallPackageInfo
   ) {
     genericAnalytics.logEvent(
       name = "app_download",
-      params = analyticsPayload.toAppGenericParameters(
+      params = installPackageInfo.toAppGenericParameters(
         packageName = packageName,
         P_STATUS to "success"
       )
@@ -136,22 +137,20 @@ class InstallAnalytics(
     logBIDownloadEvent(
       packageName = packageName,
       status = "success",
-      analyticsPayload = analyticsPayload,
-      appSizeSegment = appSizeSegment,
+      installPackageInfo = installPackageInfo
     )
   }
 
   fun sendDownloadErrorEvent(
     packageName: String,
-    analyticsPayload: AnalyticsPayload?,
-    appSizeSegment: Int,
+    installPackageInfo: InstallPackageInfo,
     errorMessage: String?,
     errorType: String?,
     errorCode: Int?,
   ) {
     genericAnalytics.logEvent(
       name = "app_download",
-      params = analyticsPayload.toAppGenericParameters(
+      params = installPackageInfo.toAppGenericParameters(
         packageName = packageName,
         P_STATUS to "fail",
         P_ERROR_MESSAGE to (errorMessage ?: "failure")
@@ -161,8 +160,7 @@ class InstallAnalytics(
     logBIDownloadEvent(
       packageName = packageName,
       status = "fail",
-      analyticsPayload = analyticsPayload,
-      appSizeSegment = appSizeSegment,
+      installPackageInfo = installPackageInfo,
       P_ERROR_MESSAGE to errorMessage,
       P_ERROR_TYPE to errorType,
       P_ERROR_HTTP_CODE to errorCode,
@@ -171,13 +169,12 @@ class InstallAnalytics(
 
   fun sendDownloadAbortEvent(
     packageName: String,
-    analyticsPayload: AnalyticsPayload?,
-    appSizeSegment: Int,
+    installPackageInfo: InstallPackageInfo,
     errorMessage: String?,
   ) {
     genericAnalytics.logEvent(
       name = "app_download",
-      params = analyticsPayload.toAppGenericParameters(
+      params = installPackageInfo.toAppGenericParameters(
         packageName = packageName,
         P_STATUS to "fail",
         P_ERROR_MESSAGE to (errorMessage ?: "failure")
@@ -187,8 +184,7 @@ class InstallAnalytics(
     logBIDownloadEvent(
       packageName = packageName,
       status = "abort",
-      analyticsPayload = analyticsPayload,
-      appSizeSegment = appSizeSegment,
+      installPackageInfo = installPackageInfo,
       P_ERROR_MESSAGE to errorMessage,
       P_ERROR_TYPE to "permission",
     )
@@ -196,12 +192,11 @@ class InstallAnalytics(
 
   fun sendDownloadCancelEvent(
     packageName: String,
-    analyticsPayload: AnalyticsPayload?,
-    appSizeSegment: Int,
+    installPackageInfo: InstallPackageInfo
   ) {
     genericAnalytics.logEvent(
       name = "app_download",
-      params = analyticsPayload.toAppGenericParameters(
+      params = installPackageInfo.toAppGenericParameters(
         packageName = packageName,
         P_STATUS to "cancel"
       )
@@ -210,8 +205,7 @@ class InstallAnalytics(
     logBIDownloadEvent(
       packageName = packageName,
       status = "cancel",
-      analyticsPayload = analyticsPayload,
-      appSizeSegment = appSizeSegment,
+      installPackageInfo = installPackageInfo
     )
   }
 
@@ -233,11 +227,11 @@ class InstallAnalytics(
 
   fun sendInstallStartedEvent(
     packageName: String,
-    analyticsPayload: AnalyticsPayload?,
+    installPackageInfo: InstallPackageInfo
   ) {
     genericAnalytics.logEvent(
       name = "app_installed",
-      params = analyticsPayload.toAppGenericParameters(
+      params = installPackageInfo.toAppGenericParameters(
         packageName = packageName,
         P_STATUS to "started"
       )
@@ -246,11 +240,11 @@ class InstallAnalytics(
 
   fun sendInstallCancelEvent(
     packageName: String,
-    analyticsPayload: AnalyticsPayload?,
+    installPackageInfo: InstallPackageInfo
   ) {
     genericAnalytics.logEvent(
       name = "app_installed",
-      params = analyticsPayload.toAppGenericParameters(
+      params = installPackageInfo.toAppGenericParameters(
         packageName = packageName,
         P_STATUS to "cancel"
       )
@@ -259,11 +253,11 @@ class InstallAnalytics(
 
   fun sendInstallCompletedEvent(
     packageName: String,
-    analyticsPayload: AnalyticsPayload?,
+    installPackageInfo: InstallPackageInfo
   ) {
     genericAnalytics.logEvent(
       name = "app_installed",
-      params = analyticsPayload.toAppGenericParameters(
+      params = installPackageInfo.toAppGenericParameters(
         packageName = packageName,
         P_STATUS to "success"
       )
@@ -272,19 +266,19 @@ class InstallAnalytics(
     logBIInstallEvent(
       packageName = packageName,
       status = "success",
-      analyticsPayload = analyticsPayload
+      installPackageInfo = installPackageInfo
     )
   }
 
   fun sendInstallErrorEvent(
     packageName: String,
-    analyticsPayload: AnalyticsPayload?,
+    installPackageInfo: InstallPackageInfo,
     errorMessage: String?,
     errorType: String?,
   ) {
     genericAnalytics.logEvent(
       name = "app_installed",
-      params = analyticsPayload.toAppGenericParameters(
+      params = installPackageInfo.toAppGenericParameters(
         packageName = packageName,
         P_STATUS to "fail",
         P_ERROR_MESSAGE to (errorMessage ?: "failure")
@@ -294,7 +288,7 @@ class InstallAnalytics(
     logBIInstallEvent(
       packageName = packageName,
       status = "fail",
-      analyticsPayload = analyticsPayload,
+      installPackageInfo = installPackageInfo,
       P_ERROR_MESSAGE to errorMessage,
       P_ERROR_TYPE to errorType,
     )
@@ -326,10 +320,10 @@ class InstallAnalytics(
 
   fun sendDownloadRestartedEvent(
     packageName: String,
-    analyticsPayload: AnalyticsPayload?,
+    installPackageInfo: InstallPackageInfo,
   ) = genericAnalytics.logEvent(
     name = "app_download",
-    params = analyticsPayload.toAppGenericParameters(
+    params = installPackageInfo.toAppGenericParameters(
       packageName = packageName,
       P_STATUS to "restart"
     )
@@ -408,39 +402,42 @@ class InstallAnalytics(
   private fun logBIDownloadEvent(
     packageName: String,
     status: String,
-    analyticsPayload: AnalyticsPayload?,
-    appSizeSegment: Int,
+    installPackageInfo: InstallPackageInfo,
     vararg pairs: Pair<String, Any?>
   ) = biAnalytics.logEvent(
     name = "download",
-    analyticsPayload.let {
-      it.toAppBIParameters(packageName) +
-        it?.toAnalyticsUiContext().toBiParameters(
-          P_STATUS to status,
-          P_APP_SIZE_MB to appSizeSegment,
-          P_STORE to it?.store,
-          P_TRUSTED_BADGE to it?.trustedBadge,
-          *pairs
-        )
-    }
+    installPackageInfo.payload
+      .toAnalyticsPayload()
+      .let {
+        it.toAppBIParameters(packageName) +
+          it?.toAnalyticsUiContext().toBiParameters(
+            P_STATUS to status,
+            installPackageInfo.getAppSizeSegment(),
+            P_STORE to it?.store,
+            P_TRUSTED_BADGE to it?.trustedBadge,
+            *pairs
+          )
+      }
   )
 
   private fun logBIInstallEvent(
     packageName: String,
     status: String,
-    analyticsPayload: AnalyticsPayload?,
+    installPackageInfo: InstallPackageInfo,
     vararg pairs: Pair<String, Any?>
   ) = biAnalytics.logEvent(
     name = "install",
-    analyticsPayload.let {
-      it.toAppBIParameters(packageName) +
-        it?.toAnalyticsUiContext().toBiParameters(
-          P_STATUS to status,
-          P_STORE to it?.store,
-          P_TRUSTED_BADGE to it?.trustedBadge,
-          *pairs
-        )
-    }
+    installPackageInfo.payload
+      .toAnalyticsPayload()
+      .let {
+        it.toAppBIParameters(packageName) +
+          it?.toAnalyticsUiContext().toBiParameters(
+            P_STATUS to status,
+            P_STORE to it?.store,
+            P_TRUSTED_BADGE to it?.trustedBadge,
+            *pairs
+          )
+      }
   )
 
   private fun getUserClicks(packageName: String): String = silentInstallChecker
@@ -454,7 +451,6 @@ class InstallAnalytics(
     private const val P_ACTION = "action"
     private const val P_STORE = "store"
     private const val P_STATUS = "status"
-    private const val P_APP_SIZE_MB = "app_size_mb"
     private const val P_TRUSTED_BADGE = "trusted_badge"
     private const val P_ERROR_MESSAGE = "error_message"
     private const val P_ERROR_TYPE = "error_type"
@@ -463,20 +459,37 @@ class InstallAnalytics(
     internal const val P_PROMPT_TYPE = "prompt_type"
     internal const val P_SERVICE = "service"
     internal const val P_UPDATE_TYPE = "update_type"
+    internal const val P_APP_SIZE_MB = "app_size_mb"
   }
 }
+
+private fun InstallPackageInfo.toAppGenericParameters(
+  packageName: String,
+  vararg pairs: Pair<String, Any?>
+): Map<String, Any> = payload
+  .toAnalyticsPayload()
+  .toAppGenericParameters(packageName, getAppSizeSegment(), *pairs)
+
+private fun InstallPackageInfo.getAppSizeSegment(): Pair<String, Int> = P_APP_SIZE_MB.to(
+  filesSize.toInt()
+    .takeIf { it > 0 }
+    ?.div(100_000_000)
+    ?.times(100)
+    ?: 0
+)
 
 private fun AnalyticsPayload?.toAppGenericParameters(
   packageName: String,
   vararg pairs: Pair<String, Any?>
 ): Map<String, Any> =
   this?.run {
-    toAnalyticsUiContext().toGenericParameters(
-      *pairs,
-      GenericAnalytics.P_PACKAGE_NAME to packageName,
-      GenericAnalytics.P_APPC_BILLING to isAppCoins,
-      P_UPDATE_TYPE to userClicks.toTapsValue()
-    )
+    toAnalyticsUiContext()
+      .toGenericParameters(
+        *pairs,
+        GenericAnalytics.P_PACKAGE_NAME to packageName,
+        GenericAnalytics.P_APPC_BILLING to isAppCoins,
+        P_UPDATE_TYPE to userClicks.toTapsValue()
+      )
   } ?: mapOfNonNull(*pairs)
 
 private fun AnalyticsPayload?.toAppBIParameters(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallProbe.kt
@@ -48,6 +48,4 @@ class InstallProbe(
   }
 
   override fun uninstall(packageName: String): Flow<Int> = packageInstaller.uninstall(packageName)
-
-  override fun cancel(packageName: String): Boolean = packageInstaller.cancel(packageName)
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallProbe.kt
@@ -16,31 +16,30 @@ class InstallProbe(
     packageName: String,
     installPackageInfo: InstallPackageInfo,
   ): Flow<Int> {
-    val analyticsPayload = installPackageInfo.payload.toAnalyticsPayload()
     return packageInstaller.install(packageName, installPackageInfo)
       .onStart {
         analytics.sendInstallStartedEvent(
           packageName = packageName,
-          analyticsPayload = analyticsPayload
+          installPackageInfo = installPackageInfo
         )
       }
       .onCompletion {
         when (it) {
           is CancellationException -> analytics.sendInstallCancelEvent(
             packageName = packageName,
-            analyticsPayload = analyticsPayload
+            installPackageInfo = installPackageInfo
           )
 
           null -> {
             analytics.sendInstallCompletedEvent(
               packageName = packageName,
-              analyticsPayload = analyticsPayload
+              installPackageInfo = installPackageInfo
             )
           }
 
           else -> analytics.sendInstallErrorEvent(
             packageName = packageName,
-            analyticsPayload = analyticsPayload,
+            installPackageInfo = installPackageInfo,
             errorMessage = it.message,
             errorType = it::class.simpleName
           )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallProbe.kt
@@ -2,10 +2,10 @@ package com.aptoide.android.aptoidegames.installer.analytics
 
 import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import cm.aptoide.pt.install_manager.workers.PackageInstaller
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
-import kotlin.coroutines.cancellation.CancellationException
 
 class InstallProbe(
   private val packageInstaller: PackageInstaller,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/ScheduledDownloadsListener.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/ScheduledDownloadsListener.kt
@@ -73,7 +73,6 @@ class ScheduledDownloadsListenerImpl @Inject constructor(
         .takeIf { it.state == PENDING }
         ?.takeIf { it.constraints.networkType == NetworkType.UNMETERED }
         ?.let { task ->
-          val analyticsPayload = task.installPackageInfo.payload.toAnalyticsPayload()!!
           networkConnection.states
             .map { it != NetworkConnection.State.UNMETERED }
             .distinctUntilChanged()
@@ -85,7 +84,7 @@ class ScheduledDownloadsListenerImpl @Inject constructor(
                 ?.takeWhile { it }
                 ?.onCompletion {
                   if (it == null && task.constraints.networkType == NetworkType.UNMETERED) {
-                    analytics.sendDownloadRestartedEvent(app.packageName, analyticsPayload)
+                    analytics.sendDownloadRestartedEvent(app.packageName, task.installPackageInfo)
                   }
                 } ?: flow { emit(false) }
             }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/di/InstallerModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/di/InstallerModule.kt
@@ -17,6 +17,7 @@ import cm.aptoide.pt.installer.obb.OBBInstallManager
 import cm.aptoide.pt.task_info.AptoideTaskInfoRepository
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
+import com.aptoide.android.aptoidegames.installer.DownloaderSelector
 import com.aptoide.android.aptoidegames.installer.analytics.AnalyticsInstallPackageInfoMapper
 import com.aptoide.android.aptoidegames.installer.analytics.DownloadProbe
 import com.aptoide.android.aptoidegames.installer.analytics.InstallAnalytics
@@ -48,8 +49,9 @@ class InstallerModule {
   @Provides
   fun provideInstallManager(
     @ApplicationContext appContext: Context,
+    featureFlags: FeatureFlags,
     taskInfoRepository: AptoideTaskInfoRepository,
-    downloader: AptoideDownloader,
+    aptoideDownloader: AptoideDownloader,
     installer: AptoideInstaller,
     installAnalytics: InstallAnalytics,
     networkConnection: NetworkConnection,
@@ -60,7 +62,11 @@ class InstallerModule {
       context = appContext,
       taskInfoRepository = taskInfoRepository,
       packageDownloader = DownloadProbe(
-        packageDownloader = downloader,
+        packageDownloader = DownloaderSelector(
+          featureFlags = featureFlags,
+          aptoidePackageDownloader = aptoideDownloader,
+          fetchPackageDownloader = aptoideDownloader
+        ),
         analytics = installAnalytics,
       ),
       packageInstaller = InstallProbe(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/di/InstallerModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/di/InstallerModule.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import androidx.room.Room
 import cm.aptoide.pt.aptoide_network.di.StoreName
 import cm.aptoide.pt.download_view.di.UIInstallPackageInfoMapper
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
 import cm.aptoide.pt.install_info_mapper.domain.CachingInstallPackageInfoMapper
 import cm.aptoide.pt.install_info_mapper.domain.InstallPackageInfoMapper
 import cm.aptoide.pt.install_manager.InstallManager
@@ -123,11 +124,13 @@ class InstallerModule {
   @Singleton
   @Provides
   fun providesInstallAnalytics(
+    featureFlags: FeatureFlags,
     genericAnalytics: GenericAnalytics,
     biAnalytics: BIAnalytics,
     @StoreName storeName: String,
     silentInstallChecker: SilentInstallChecker,
   ): InstallAnalytics = InstallAnalytics(
+    featureFlags = featureFlags,
     genericAnalytics = genericAnalytics,
     biAnalytics = biAnalytics,
     storeName = storeName,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/ff/Extensions.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/ff/Extensions.kt
@@ -1,0 +1,5 @@
+package com.aptoide.android.aptoidegames.installer.ff
+
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+
+suspend fun FeatureFlags.isFetchDownloaderEnabled(): Boolean? = getFlag("use_fetch_downloader")

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallView.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.Divider
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -34,9 +35,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.download_view.presentation.DownloadUiState
-import cm.aptoide.pt.download_view.presentation.ExecutionBlocker.CONNECTION
-import cm.aptoide.pt.download_view.presentation.ExecutionBlocker.QUEUE
 import cm.aptoide.pt.download_view.presentation.ExecutionBlocker.UNMETERED
+import cm.aptoide.pt.download_view.presentation.downloadUiStates
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
@@ -60,83 +60,16 @@ private fun InstallViewProcessingPreview() {
       thickness = 8.dp
     )
   }
+  val states = remember { downloadUiStates }
   AptoideTheme(darkTheme = isSystemInDarkTheme()) {
     Column(
       modifier = Modifier.verticalScroll(rememberScrollState()),
       verticalArrangement = Arrangement.Center,
     ) {
-      divider()
-      InstallViewContent(installViewState = null.toInstallViewState(randomApp))
-      divider()
-      InstallViewContent(
-        installViewState = DownloadUiState.Install(installWith = {}).toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewContent(
-        installViewState = DownloadUiState.Outdated({}, updateWith = {}, uninstall = {})
-          .toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewContent(
-        installViewState = DownloadUiState.Waiting(action = {}, blocker = QUEUE)
-          .toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewContent(
-        installViewState = DownloadUiState.Waiting(action = {}, blocker = CONNECTION)
-          .toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewContent(
-        installViewState = DownloadUiState.Waiting(action = {}, blocker = UNMETERED)
-          .toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewContent(
-        installViewState = DownloadUiState.Downloading(
-          size = 830282380,
-          downloadProgress = -1,
-          cancel = {}
-        ).toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewContent(
-        installViewState = DownloadUiState.Downloading(
-          size = 830282380,
-          downloadProgress = 33,
-          cancel = {}
-        ).toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewContent(
-        installViewState = DownloadUiState.ReadyToInstall(cancel = {}).toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewContent(
-        installViewState = DownloadUiState.Installing(
-          size = 830282302,
-          installProgress = -1
-        ).toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewContent(
-        installViewState = DownloadUiState.Installing(
-          size = 830282302,
-          installProgress = 66
-        ).toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewContent(
-        installViewState = DownloadUiState.Uninstalling.toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewContent(
-        installViewState = DownloadUiState.Installed({}, {}).toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewContent(
-        installViewState = DownloadUiState.Error(retryWith = {}).toInstallViewState(randomApp)
-      )
+      states.forEach {
+        divider()
+        InstallViewContent(installViewState = it.toInstallViewState(randomApp))
+      }
       divider()
     }
   }
@@ -253,7 +186,7 @@ private fun InstallViewContent(
       horizontalSpacing = horizontalSpacing,
     )
 
-    DownloadUiState.Uninstalling -> ProgressView(
+    is DownloadUiState.Uninstalling -> ProgressView(
       title = installViewState.stateDescription,
       verticalSpacing = verticalSpacing,
       horizontalSpacing = horizontalSpacing,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewShort.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewShort.kt
@@ -5,12 +5,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.download_view.presentation.DownloadUiState
-import cm.aptoide.pt.download_view.presentation.ExecutionBlocker.CONNECTION
-import cm.aptoide.pt.download_view.presentation.ExecutionBlocker.QUEUE
 import cm.aptoide.pt.download_view.presentation.ExecutionBlocker.UNMETERED
+import cm.aptoide.pt.download_view.presentation.downloadUiStates
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
@@ -29,101 +29,13 @@ fun InstallViewShortPreview() {
       thickness = 8.dp
     )
   }
+  val states = remember { downloadUiStates }
   AptoideTheme(darkTheme = isSystemInDarkTheme()) {
     Column(verticalArrangement = Arrangement.Center) {
-      divider()
-      InstallViewShortContent(installViewState = null.toInstallViewState(randomApp))
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.Install(installWith = {}).toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.Outdated({}, updateWith = {}, uninstall = {})
-          .toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.Waiting(action = {}, blocker = QUEUE)
-          .toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.Waiting(action = {}, blocker = QUEUE)
-          .toInstallViewState(randomApp),
-        cancelable = false
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.Waiting(action = {}, blocker = CONNECTION)
-          .toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.Waiting(action = {}, blocker = UNMETERED)
-          .toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.Downloading(
-          size = 830282380,
-          downloadProgress = -1,
-          cancel = {}
-        ).toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.Downloading(
-          size = 830282380,
-          downloadProgress = 33,
-          cancel = {}
-        ).toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.Downloading(
-          size = 830282380,
-          downloadProgress = -1,
-          cancel = {}
-        ).toInstallViewState(randomApp),
-        cancelable = false
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.ReadyToInstall(cancel = {}).toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.ReadyToInstall(cancel = {})
-          .toInstallViewState(randomApp),
-        cancelable = false
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.Installing(
-          size = 830282302,
-          installProgress = -1
-        ).toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.Installing(
-          size = 830282302,
-          installProgress = 66
-        ).toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.Uninstalling.toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.Installed({}, {}).toInstallViewState(randomApp)
-      )
-      divider()
-      InstallViewShortContent(
-        installViewState = DownloadUiState.Error(retryWith = {}).toInstallViewState(randomApp)
-      )
+      states.forEach {
+        divider()
+        InstallViewShortContent(installViewState = it.toInstallViewState(randomApp))
+      }
       divider()
     }
   }
@@ -201,7 +113,7 @@ private fun InstallViewShortContent(
 
     null,
     is DownloadUiState.Installing,
-    DownloadUiState.Uninstalling,
-    -> Unit
+    is DownloadUiState.Uninstalling,
+      -> Unit
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
@@ -208,6 +208,13 @@ fun installViewStates(
               else -> { ->
                 canceled = true
                 installAnalytics.sendDownloadCancel(app, analyticsContext)
+                // While task is the queue the Package Downloader will not be called and cancellation
+                // will not be caught by the  Package Downloader probe.
+                // So we need to call this event here
+                installAnalytics.sendDownloadCanceledInQueueEvent(
+                  packageName = app.packageName,
+                  installPackageInfo = downloadUiState.installPackageInfo
+                )
                 cancel()
               }
             }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
@@ -193,28 +193,29 @@ fun installViewStates(
         )
 
         is DownloadUiState.Waiting -> DownloadUiState.Waiting(
+          installPackageInfo = downloadUiState.installPackageInfo,
           blocker = downloadUiState.blocker,
-          action = downloadUiState.action?.let {
+          action = downloadUiState.action?.let { cancel ->
             when (downloadUiState.blocker) {
               UNMETERED -> { ->
                 installAnalytics.sendResumeDownloadClick(
                   app = app,
                   downloadOnlyOverWifiSetting = downloadOnlyOverWifi
                 )
-                it()
+                cancel()
               }
 
               else -> { ->
                 canceled = true
                 installAnalytics.sendDownloadCancel(app, analyticsContext)
-                it()
+                cancel()
               }
             }
           }
         )
 
         is DownloadUiState.Downloading -> DownloadUiState.Downloading(
-          size = downloadUiState.size,
+          installPackageInfo = downloadUiState.installPackageInfo,
           downloadProgress = downloadUiState.downloadProgress,
           cancel = {
             canceled = true
@@ -232,7 +233,7 @@ fun installViewStates(
         )
 
         is DownloadUiState.Installing,
-        DownloadUiState.Uninstalling,
+        is DownloadUiState.Uninstalling,
           -> downloadUiState
 
         is DownloadUiState.Installed -> DownloadUiState.Installed(
@@ -288,7 +289,7 @@ fun DownloadUiState?.toInstallViewState(app: App): InstallViewState {
     )
 
     is DownloadUiState.Installing -> stringResource(R.string.install_installing_message)
-    DownloadUiState.Uninstalling -> stringResource(R.string.uninstalling)
+    is DownloadUiState.Uninstalling -> stringResource(R.string.uninstalling)
     is DownloadUiState.Installed -> stringResource(R.string.appview_status_installed_talkback)
     is DownloadUiState.Error,
       -> stringResource(R.string.appview_status_failed_talkback)
@@ -305,7 +306,7 @@ fun DownloadUiState?.toInstallViewState(app: App): InstallViewState {
       -> stringResource(R.string.appview_action_cancel_talkback)
 
     is DownloadUiState.Installing,
-    DownloadUiState.Uninstalling,
+    is DownloadUiState.Uninstalling,
       -> null
 
     is DownloadUiState.Installed -> stringResource(R.string.button_open_app_title)
@@ -433,7 +434,7 @@ fun DownloadUiState.Downloading.getProgressString(
   stringResource(
     resourceId,
     downloadProgress.toString(),
-    TextFormatter.formatBytes(size)
+    TextFormatter.formatBytes(installPackageInfo.filesSize)
   )
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/ProgressText.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/ProgressText.kt
@@ -15,6 +15,7 @@ import cm.aptoide.pt.download_view.presentation.DownloadUiState.Outdated
 import cm.aptoide.pt.download_view.presentation.DownloadUiState.ReadyToInstall
 import cm.aptoide.pt.download_view.presentation.DownloadUiState.Uninstalling
 import cm.aptoide.pt.download_view.presentation.DownloadUiState.Waiting
+import cm.aptoide.pt.download_view.presentation.randomInstallPackageInfo
 import cm.aptoide.pt.download_view.presentation.rememberDownloadState
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
@@ -59,7 +60,7 @@ private fun ProgressTextContent(
     is Downloading -> state.getProgressString()
     is ReadyToInstall -> stringResource(string.install_waiting_installation_message)
     is Installing -> stringResource(string.install_installing_message)
-    Uninstalling -> stringResource(string.uninstalling)
+    is Uninstalling -> stringResource(string.uninstalling)
 
     else -> ""
   }
@@ -86,7 +87,7 @@ private fun ProgressTextContent(
     is Downloading,
     is ReadyToInstall,
     is Installing,
-    Uninstalling,
+    is Uninstalling,
     -> Text(
       modifier = modifier,
       text = text,
@@ -129,7 +130,7 @@ fun ProgressTextContentInstallingPreview() {
   AptoideTheme {
     ProgressTextContent(
       app = randomApp,
-      state = Downloading(Random.nextLong(500000, 1000000), Random.nextInt(0, 100), {}),
+      state = Downloading(randomInstallPackageInfo, Random.nextInt(0, 100), {}),
       showVersionName = Random.nextBoolean()
     )
   }

--- a/app/src/main/java/cm/aptoide/pt/appview/DownloadView.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/DownloadView.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -33,6 +34,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.aptoide_ui.textformatter.TextFormatter.Companion.formatBytes
 import cm.aptoide.pt.download_view.presentation.DownloadUiState
+import cm.aptoide.pt.download_view.presentation.downloadUiStates
 import cm.aptoide.pt.download_view.presentation.rememberDownloadState
 import cm.aptoide.pt.extensions.PreviewAll
 import cm.aptoide.pt.feature_apps.data.App
@@ -52,17 +54,7 @@ fun DownloadPreview() {
   }
   AptoideTheme(darkTheme = isSystemInDarkTheme()) {
     val app = randomApp.copy(isAppCoins = false)
-    val states = listOf(
-      DownloadUiState.Install(installWith = {}),
-      DownloadUiState.Outdated({}, updateWith = {}, uninstall = {}),
-      DownloadUiState.Waiting(action = null),
-      DownloadUiState.Downloading(33, cancel = {}),
-      DownloadUiState.ReadyToInstall(cancel = {}),
-      DownloadUiState.Installing(66),
-      DownloadUiState.Uninstalling,
-      DownloadUiState.Installed({}, {}),
-      DownloadUiState.Error(retryWith = {})
-    )
+    val states = remember { downloadUiStates }
     LazyColumn {
       states.forEach { uiState ->
         item {
@@ -97,18 +89,7 @@ fun DownloadAppcPreview() {
   }
   AptoideTheme(darkTheme = isSystemInDarkTheme()) {
     val app = randomApp.copy(isAppCoins = true)
-    val states = listOf(
-      null,
-      DownloadUiState.Install(installWith = {}),
-      DownloadUiState.Outdated(open = {}, updateWith = {}, uninstall = {}),
-      DownloadUiState.Waiting(action = null),
-      DownloadUiState.Downloading(size = 33, cancel = {}),
-      DownloadUiState.ReadyToInstall(cancel = {}),
-      DownloadUiState.Installing(size = 66),
-      DownloadUiState.Uninstalling,
-      DownloadUiState.Installed({}, {}),
-      DownloadUiState.Error(retryWith = {}),
-    )
+    val states = remember { downloadUiStates }
     LazyColumn {
       states.forEach { uiState ->
         item {

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideDownloader.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideDownloader.kt
@@ -7,22 +7,21 @@ import cm.aptoide.pt.install_manager.workers.PackageDownloader
 import cm.aptoide.pt.installer.network.DownloaderRepository
 import cm.aptoide.pt.installer.platform.InstallPermissions
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import javax.inject.Inject
+import kotlin.coroutines.coroutineContext
 
 class AptoideDownloader @Inject constructor(
   @ApplicationContext private val context: Context,
   private val downloaderRepository: DownloaderRepository,
   private val installPermissions: InstallPermissions,
 ) : PackageDownloader {
-  private val downloadsInProgress = mutableSetOf<String>()
 
   @Suppress("OPT_IN_USAGE")
   override fun download(
@@ -46,16 +45,10 @@ class AptoideDownloader @Inject constructor(
             diff * item.fileSize / filesSize
           }
       }.map {
-        if (!downloadsInProgress.contains(packageName)) throw CancellationException()
+        coroutineContext.ensureActive()
         totalProgress += it
         (totalProgress * 100).toInt()
       }
   }.distinctUntilChanged()
-    .onCompletion { downloadsInProgress.remove(packageName) }
-    .also {
-      downloadsInProgress += packageName
-      InstallerWorker.enqueue(context)
-    }
-
-  override fun cancel(packageName: String) = downloadsInProgress.remove(packageName)
+    .also { InstallerWorker.enqueue(context) }
 }

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstaller.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstaller.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.onCompletion
 import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
@@ -44,7 +43,6 @@ class AptoideInstaller @Inject constructor(
   private val installEvents: InstallEvents,
   private val installPermissions: InstallPermissions,
 ) : PackageInstaller {
-  private val installInProgress = mutableSetOf<String>()
   private val initialPermissionsAllowed = getPermissionsState()
 
   init {
@@ -162,8 +160,6 @@ class AptoideInstaller @Inject constructor(
     }
   }
     .distinctUntilChanged()
-    .onCompletion { installInProgress.remove(packageName) }
-    .also { installInProgress += packageName }
 
   override fun uninstall(packageName: String): Flow<Int> = flow {
     emit(0)
@@ -173,8 +169,6 @@ class AptoideInstaller @Inject constructor(
     context.startActivity(intent)
     emit(99)
   }
-
-  override fun cancel(packageName: String) = installInProgress.contains(packageName)
 
   private suspend fun InstallPackageInfo.getCheckedFiles(
     downloadsDir: File,

--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadUiState.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadUiState.kt
@@ -1,8 +1,9 @@
 package cm.aptoide.pt.download_view.presentation
 
-import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import cm.aptoide.pt.install_manager.dto.Constraints
 import cm.aptoide.pt.install_manager.dto.Constraints.NetworkType.ANY
+import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
+import cm.aptoide.pt.install_manager.dto.InstallationFile
 import kotlin.random.Random
 import kotlin.random.nextInt
 import kotlin.random.nextLong
@@ -26,22 +27,25 @@ sealed class DownloadUiState {
   }
 
   data class Waiting(
+    val installPackageInfo: InstallPackageInfo,
     val blocker: ExecutionBlocker = ExecutionBlocker.QUEUE,
     val action: (() -> Unit)?,
   ) : DownloadUiState()
 
   data class Downloading(
-    val size: Long = 0,
+    val installPackageInfo: InstallPackageInfo,
     val downloadProgress: Int = 0,
     val cancel: () -> Unit,
   ) : DownloadUiState()
 
   data class Installing(
-    val size: Long = 0,
+    val installPackageInfo: InstallPackageInfo,
     val installProgress: Int = 0,
   ) : DownloadUiState()
 
-  object Uninstalling : DownloadUiState()
+  data class Uninstalling(
+    val installPackageInfo: InstallPackageInfo,
+  ) : DownloadUiState()
 
   data class Installed(
     val open: () -> Unit,
@@ -67,6 +71,7 @@ sealed class DownloadUiState {
   }
 
   data class ReadyToInstall(
+    val installPackageInfo: InstallPackageInfo = InstallPackageInfo(0),
     val cancel: () -> Unit,
   ) : DownloadUiState()
 }
@@ -77,26 +82,77 @@ enum class ExecutionBlocker {
   UNMETERED,
 }
 
-class DownloadUiStateProvider : PreviewParameterProvider<DownloadUiState> {
-  override val values: Sequence<DownloadUiState> = sequenceOf(
-    DownloadUiState.Install(installWith = {}),
-    DownloadUiState.Waiting(action = null),
+val downloadUiStates: List<DownloadUiState>
+  get() = listOf(
+    DownloadUiState.Install(
+      installWith = {}
+    ),
+    DownloadUiState.Outdated(
+      open = {},
+      updateWith = {},
+      uninstall = {}
+    ),
+    DownloadUiState.Waiting(
+      installPackageInfo = randomInstallPackageInfo,
+      blocker = ExecutionBlocker.QUEUE,
+      action = null
+    ),
+    DownloadUiState.Waiting(
+      installPackageInfo = randomInstallPackageInfo,
+      blocker = ExecutionBlocker.CONNECTION,
+      action = null
+    ),
+    DownloadUiState.Waiting(
+      installPackageInfo = randomInstallPackageInfo,
+      blocker = ExecutionBlocker.UNMETERED,
+      action = null
+    ),
     DownloadUiState.Downloading(
-      size = Random.nextLong(5000000L..300000000L),
+      installPackageInfo = randomInstallPackageInfo,
+      downloadProgress = -1,
+      cancel = {}
+    ),
+    DownloadUiState.Downloading(
+      installPackageInfo = randomInstallPackageInfo,
       downloadProgress = Random.nextInt(0..100),
       cancel = {}
     ),
+    DownloadUiState.ReadyToInstall(
+      installPackageInfo = randomInstallPackageInfo,
+      cancel = {}
+    ),
     DownloadUiState.Installing(
-      size = Random.nextLong(5000000L..300000000L),
+      installPackageInfo = randomInstallPackageInfo,
+      installProgress = -1,
+    ),
+    DownloadUiState.Installing(
+      installPackageInfo = randomInstallPackageInfo,
       installProgress = Random.nextInt(0..100),
     ),
-    DownloadUiState.Uninstalling,
+    DownloadUiState.Uninstalling(
+      installPackageInfo = randomInstallPackageInfo
+    ),
     DownloadUiState.Installed(
       open = {},
       uninstall = {}
     ),
-    DownloadUiState.Outdated(open = {}, updateWith = {}, uninstall = {}),
-    DownloadUiState.Error(retryWith = {}),
-    DownloadUiState.ReadyToInstall(cancel = {})
+    DownloadUiState.Error(
+      retryWith = {}
+    )
   )
-}
+
+val randomInstallPackageInfo
+  get() = InstallPackageInfo(
+    versionCode = 0,
+    installationFiles = setOf(
+      InstallationFile(
+        name = "",
+        type = InstallationFile.Type.BASE,
+        md5 = "",
+        fileSize = Random.nextLong(5000000L..300000000L),
+        url = "",
+        altUrl = "",
+        localPath = ""
+      )
+    )
+  )

--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadViewModel.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadViewModel.kt
@@ -76,21 +76,25 @@ class DownloadViewModel(
               -> null
 
             Task.State.PENDING -> DownloadUiState.Waiting(
+              installPackageInfo = task.installPackageInfo,
               action = task::cancel
             )
 
             Task.State.DOWNLOADING -> DownloadUiState.Downloading(
-              size = task.installPackageInfo.filesSize,
+              installPackageInfo = task.installPackageInfo,
               cancel = task::cancel,
               downloadProgress = progress
             )
 
             Task.State.INSTALLING -> DownloadUiState.Installing(
-              size = task.installPackageInfo.filesSize,
+              installPackageInfo = task.installPackageInfo,
               installProgress = progress
             )
 
-            Task.State.UNINSTALLING -> DownloadUiState.Uninstalling
+            Task.State.UNINSTALLING -> DownloadUiState.Uninstalling(
+              installPackageInfo = task.installPackageInfo
+            )
+
             Task.State.COMPLETED -> DownloadUiState.Installed(
               open = ::open,
               uninstall = ::uninstall
@@ -105,6 +109,7 @@ class DownloadViewModel(
             )
 
             Task.State.READY_TO_INSTALL -> DownloadUiState.ReadyToInstall(
+              installPackageInfo = task.installPackageInfo,
               cancel = task::cancel
             )
           }
@@ -136,6 +141,7 @@ class DownloadViewModel(
             }
 
             DownloadUiState.Waiting(
+              installPackageInfo = task.installPackageInfo,
               blocker = blocker,
               action = action
             )
@@ -193,7 +199,6 @@ class DownloadViewModel(
   private fun uninstall(resolver: ConstraintsResolver) = uninstall()
 
   private fun uninstall() {
-    viewModelState.update { DownloadUiState.Waiting(action = null) }
     try {
       appInstaller.uninstall()
     } catch (_: Exception) {

--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/ViewModelProvider.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/ViewModelProvider.kt
@@ -30,9 +30,7 @@ class InjectionsProvider @Inject constructor(
 
 @Composable
 fun rememberDownloadState(app: App): DownloadUiState? = runPreviewable(
-  preview = {
-    DownloadUiStateProvider().values.toList().random()
-  },
+  preview = { downloadUiStates.random() },
   real = {
     val injectionsProvider = hiltViewModel<InjectionsProvider>()
     val downloadViewViewModel: DownloadViewModel = viewModel(

--- a/feature-flags/src/main/java/cm/aptoide/pt/feature_flags/di/RepositoryModule.kt
+++ b/feature-flags/src/main/java/cm/aptoide/pt/feature_flags/di/RepositoryModule.kt
@@ -2,8 +2,11 @@ package cm.aptoide.pt.feature_flags.di
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import cm.aptoide.pt.feature_flags.data.SettingsLocalRepositoryImpl
 import cm.aptoide.pt.feature_flags.data.FeatureFlagsLocalRepository
+import cm.aptoide.pt.feature_flags.data.SettingsLocalRepositoryImpl
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+import cm.aptoide.pt.feature_flags.domain.FeatureFlagsImpl
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -13,16 +16,23 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-internal object RepositoryModule {
+internal interface RepositoryModule {
 
-  @Provides
   @Singleton
-  fun provideSettingsLocalRepository(
-    @FeatureFlagsDataStore featureFlags: DataStore<Preferences>
-  ) : FeatureFlagsLocalRepository =
-    SettingsLocalRepositoryImpl(
-      featureFlagsDataStore = featureFlags
-    )
+  @Binds
+  fun bindsFeatureFlags(featureFlagsImpl: FeatureFlagsImpl): FeatureFlags
+
+  companion object {
+
+    @Provides
+    @Singleton
+    fun provideSettingsLocalRepository(
+      @FeatureFlagsDataStore featureFlags: DataStore<Preferences>
+    ): FeatureFlagsLocalRepository =
+      SettingsLocalRepositoryImpl(
+        featureFlagsDataStore = featureFlags
+      )
+  }
 }
 
 @Qualifier

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/workers/PackageDownloader.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/workers/PackageDownloader.kt
@@ -20,22 +20,13 @@ interface PackageDownloader {
    * @param packageName - a package name
    * @param installPackageInfo - a package info
    * @returns Flow of progress values between 0 and 100.
-   * Flow throws anything except [CancellationException], signalling about download failure
+   * Flow throws [CancellationException] if download was canceled by user
    * Or [AbortException] if download was aborted with the reason in message
    * Or [OutOfSpaceException] if there is not enough space to download
+   * Or anything else, signalling about download failure
    */
   fun download(
     packageName: String,
     installPackageInfo: InstallPackageInfo,
   ): Flow<Int>
-
-  /**
-   * Cancel package files download if active.
-   * Downloaded files caching is responsibility of this downloader.
-   * The [download] Flow for the [packageName] must throw [CancellationException] on this call.
-   *
-   * @param packageName - a package name
-   * @returns true there was something to cancel and it was cancelled.
-   */
-  fun cancel(packageName: String): Boolean
 }

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/workers/PackageInstaller.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/workers/PackageInstaller.kt
@@ -18,9 +18,10 @@ interface PackageInstaller {
    * @param packageName - a package name
    * @param installPackageInfo - a package info
    * @returns Flow of progress values between 0 and 100.
-   * Flow throws anything except [CancellationException], signalling about installation failure
+   * Flow throws [CancellationException] if installation was canceled by user
    * Or [AbortException] if installation was aborted with the reason in message
    * Or [OutOfSpaceException] if there is not enough space to install
+   * Or anything else, signalling about download failure
    */
   fun install(
     packageName: String,
@@ -37,13 +38,4 @@ interface PackageInstaller {
    * Or [AbortException] if uninstallation was aborted with the reason in message
    */
   fun uninstall(packageName: String): Flow<Int>
-
-  /**
-   * Cancel package files installation/uninstallation if active.
-   * The [install]/[uninstall] Flow for the [packageName] must throw [CancellationException] on this call.
-   *
-   * @param packageName - a package name
-   * @returns true there was something to cancel and it was cancelled.
-   */
-  fun cancel(packageName: String): Boolean
 }

--- a/install-manager/src/test/java/cm/aptoide/pt/install_manager/TasksTest.kt
+++ b/install-manager/src/test/java/cm/aptoide/pt/install_manager/TasksTest.kt
@@ -609,8 +609,8 @@ internal class TasksTest {
     scope.launch {
       result = task.stateAndProgress.toList()
     }
-    m And "wait until download starts"
-    task.stateAndProgress.first { it.first == Task.State.DOWNLOADING }
+    m And "wait until download passes 50%"
+    task.stateAndProgress.first { it.first == Task.State.DOWNLOADING && it.second >= 50 }
     m And "call the task cancel"
     task.cancel()
     m And "wait until the task finishes"
@@ -650,8 +650,8 @@ internal class TasksTest {
     scope.launch {
       result = task.stateAndProgress.toList()
     }
-    m And "wait until installation starts"
-    task.stateAndProgress.first { it.first == Task.State.INSTALLING }
+    m And "wait until installation passes 50%"
+    task.stateAndProgress.first { it.first == Task.State.INSTALLING && it.second >= 50 }
     m And "call the task cancel"
     task.cancel()
     m And "wait until the task finishes"
@@ -691,8 +691,8 @@ internal class TasksTest {
     scope.launch {
       result = task.stateAndProgress.toList()
     }
-    m And "wait until uninstallation starts"
-    task.stateAndProgress.first { it.first == Task.State.UNINSTALLING }
+    m And "wait until uninstallation passes 50%"
+    task.stateAndProgress.first { it.first == Task.State.UNINSTALLING && it.second >= 50 }
     m And "call the task cancel"
     task.cancel()
     m And "wait until the task finishes"
@@ -773,7 +773,7 @@ internal class TasksTest {
       .stream()
 
     @JvmStatic
-    fun networkStateAndConstraintsProvider(): Stream<Arguments> = NetworkConnection.State.values()
+    fun networkStateAndConstraintsProvider(): Stream<Arguments> = NetworkConnection.State.entries
       .map { state ->
         constraints.filter { it.networkType == NetworkType.UNMETERED }
           .map { constraints ->


### PR DESCRIPTION
**What does this PR do?**

   Adds package downloader selector by feature flag and user property for the current AB test variant. 

   Had to refactor workers cancellation in order to support runtime suspended switch of the downloader implementation.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] By commit

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-213](https://aptoide.atlassian.net/browse/AND-213)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-213](https://aptoide.atlassian.net/browse/AND-213)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-213]: https://aptoide.atlassian.net/browse/AND-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-213]: https://aptoide.atlassian.net/browse/AND-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ