### PR TITLE
[AND-196] Add download speed to download analytics events

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/DownloaderSelector.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/DownloaderSelector.kt
@@ -1,16 +1,14 @@
 package com.aptoide.android.aptoidegames.installer
 
 import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+import cm.aptoide.pt.install_manager.DownloadInfo
 import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import cm.aptoide.pt.install_manager.workers.PackageDownloader
 import com.aptoide.android.aptoidegames.installer.ff.isFetchDownloaderEnabled
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class DownloaderSelector @Inject constructor(
@@ -23,7 +21,7 @@ class DownloaderSelector @Inject constructor(
   override fun download(
     packageName: String,
     installPackageInfo: InstallPackageInfo,
-  ): Flow<Int> = flow { emit(getPackageDownloader()) }
+  ): Flow<DownloadInfo> = flow { emit(getPackageDownloader()) }
     .flatMapLatest { it.download(packageName, installPackageInfo) }
 
   private suspend fun getPackageDownloader(): PackageDownloader =

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
@@ -1,6 +1,7 @@
 package com.aptoide.android.aptoidegames.installer.analytics
 
 import cm.aptoide.pt.install_manager.AbortException
+import cm.aptoide.pt.install_manager.DownloadInfo
 import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import cm.aptoide.pt.install_manager.workers.PackageDownloader
 import cm.aptoide.pt.installer.platform.REQUEST_INSTALL_PACKAGES_NOT_ALLOWED
@@ -21,7 +22,7 @@ class DownloadProbe(
   override fun download(
     packageName: String,
     installPackageInfo: InstallPackageInfo,
-  ): Flow<Int> {
+  ): Flow<DownloadInfo> {
     return packageDownloader.download(packageName, installPackageInfo)
       .onStart {
         analytics.sendDownloadStartedEvent(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/ScheduledDownloadsListener.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/ScheduledDownloadsListener.kt
@@ -7,7 +7,7 @@ import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.install_manager.App
 import cm.aptoide.pt.install_manager.InstallManager
 import cm.aptoide.pt.install_manager.Task.State
-import cm.aptoide.pt.install_manager.Task.State.PENDING
+import cm.aptoide.pt.install_manager.Task.State.Pending
 import cm.aptoide.pt.install_manager.dto.Constraints.NetworkType
 import cm.aptoide.pt.install_manager.environment.NetworkConnection
 import cm.aptoide.pt.network_listener.NetworkConnectionImpl
@@ -70,7 +70,7 @@ class ScheduledDownloadsListenerImpl @Inject constructor(
   override fun listenToWifiStart(app: App) {
     this.launch {
       app.taskFlow.filterNotNull().first()
-        .takeIf { it.state == PENDING }
+        .takeIf { it.state is Pending }
         ?.takeIf { it.constraints.networkType == NetworkType.UNMETERED }
         ?.let { task ->
           networkConnection.states
@@ -78,9 +78,9 @@ class ScheduledDownloadsListenerImpl @Inject constructor(
             .distinctUntilChanged()
             .filter { it }
             .flatMapLatest { _ ->
-              task.takeIf { it.state == PENDING }
+              task.takeIf { it.state is Pending }
                 ?.stateAndProgress
-                ?.map { (state) -> state != State.DOWNLOADING }
+                ?.map { state -> state !is State.Downloading }
                 ?.takeWhile { it }
                 ?.onCompletion {
                   if (it == null && task.constraints.networkType == NetworkType.UNMETERED) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/InstallerNotificationsBuilder.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/InstallerNotificationsBuilder.kt
@@ -95,12 +95,11 @@ class InstallerNotificationsBuilder @Inject constructor(
     packageName: String,
     appDetails: AppDetails?,
     state: State,
-    progress: Int,
     size: Long,
   ) {
     val notificationId = stringToIntConverter.getStringId(packageName)
 
-    if (state == State.CANCELED || state == State.ABORTED || state == State.OUT_OF_SPACE || state == State.FAILED) {
+    if (state == State.Canceled || state == State.Aborted || state == State.OutOfSpace || state == State.Failed) {
       cancelNotification(notificationId)
     } else {
       val notification = buildNotification(
@@ -108,23 +107,23 @@ class InstallerNotificationsBuilder @Inject constructor(
         packageName = packageName,
         appDetails = appDetails,
         progress = when (state) {
-          State.DOWNLOADING -> max(progress, 0)
-          State.INSTALLING,
-          State.READY_TO_INSTALL,
-          State.PENDING,
+          is State.Downloading -> max(state.progress, 0)
+          is State.Installing,
+          State.ReadyToInstall,
+          is State.Pending,
           -> -1
 
           else -> null
         },
         contentText = when (state) {
-          State.COMPLETED -> context.getString(R.string.notification_1_installed_title)
-          State.DOWNLOADING ->
+          State.Completed -> context.getString(R.string.notification_1_installed_title)
+          is State.Downloading ->
             context.getString(
-              R.string.notification_downloading_body, max(progress, 0).toString(),
+              R.string.notification_downloading_body, max(state.progress, 0).toString(),
               TextFormatter.formatBytes(size)
             )
 
-          State.INSTALLING -> context.getString(R.string.notification_preparing_title)
+          is State.Installing -> context.getString(R.string.notification_preparing_title)
           else -> ""
         }
       )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/RealInstallerNotificationsManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/RealInstallerNotificationsManager.kt
@@ -98,10 +98,10 @@ class RealInstallerNotificationsManager @Inject constructor(
   @OptIn(ExperimentalCoroutinesApi::class)
   private suspend fun onInstallationQueued(app: App) {
     app.task?.let {
-      it.stateAndProgress.flatMapLatest { (state, progress) ->
+      it.stateAndProgress.flatMapLatest { state ->
         val appDetails = appDetailsUseCase.getAppDetails(app)
 
-        if (state == State.PENDING) {
+        if (state is State.Pending) {
           networkConnection.states.map { networkState ->
             val networkConstraint = it.constraints.networkType
             if (networkState == GONE || (networkState == METERED && networkConstraint == UNMETERED)) {
@@ -121,7 +121,6 @@ class RealInstallerNotificationsManager @Inject constructor(
             packageName = app.packageName,
             appDetails = appDetails,
             state = state,
-            progress = progress,
             size = it.installPackageInfo.filesSize,
           )
           flowOf(Unit)

--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadViewModel.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadViewModel.kt
@@ -69,46 +69,46 @@ class DownloadViewModel(
 
     val taskStates = appInstaller.taskFlow.flatMapConcat { task ->
       task?.stateAndProgress
-        ?.map { (state, progress) ->
+        ?.map { state ->
           task to when (state) {
-            Task.State.ABORTED,
-            Task.State.CANCELED,
+            Task.State.Aborted,
+            Task.State.Canceled,
               -> null
 
-            Task.State.PENDING -> DownloadUiState.Waiting(
+            is Task.State.Pending -> DownloadUiState.Waiting(
               installPackageInfo = task.installPackageInfo,
               action = task::cancel
             )
 
-            Task.State.DOWNLOADING -> DownloadUiState.Downloading(
+            is Task.State.Downloading -> DownloadUiState.Downloading(
               installPackageInfo = task.installPackageInfo,
               cancel = task::cancel,
-              downloadProgress = progress
+              downloadProgress = state.progress
             )
 
-            Task.State.INSTALLING -> DownloadUiState.Installing(
+            is Task.State.Installing -> DownloadUiState.Installing(
               installPackageInfo = task.installPackageInfo,
-              installProgress = progress
+              installProgress = state.progress
             )
 
-            Task.State.UNINSTALLING -> DownloadUiState.Uninstalling(
+            is Task.State.Uninstalling -> DownloadUiState.Uninstalling(
               installPackageInfo = task.installPackageInfo
             )
 
-            Task.State.COMPLETED -> DownloadUiState.Installed(
+            Task.State.Completed -> DownloadUiState.Installed(
               open = ::open,
               uninstall = ::uninstall
             )
 
-            Task.State.OUT_OF_SPACE,
-            Task.State.FAILED -> DownloadUiState.Error(
+            Task.State.OutOfSpace,
+            Task.State.Failed -> DownloadUiState.Error(
               retryWith = when (task.type) {
                 INSTALL -> ::install
                 UNINSTALL -> ::uninstall
               },
             )
 
-            Task.State.READY_TO_INSTALL -> DownloadUiState.ReadyToInstall(
+            Task.State.ReadyToInstall -> DownloadUiState.ReadyToInstall(
               installPackageInfo = task.installPackageInfo,
               cancel = task::cancel
             )

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/DownloadInfo.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/DownloadInfo.kt
@@ -1,0 +1,6 @@
+package cm.aptoide.pt.install_manager
+
+data class DownloadInfo(
+  val progress: Int,
+  val downloadedBytes: Long,
+)

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/RealInstallManager.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/RealInstallManager.kt
@@ -68,7 +68,7 @@ internal class RealInstallManager(
     get() = appsCache.busyApps.values
       .filterNotNull()
       .sortedBy { (it.task as RealTask?)?.taskInfo?.timestamp }
-      .filter { it.task?.state == Task.State.PENDING }
+      .filter { it.task?.state is Task.State.Pending }
 
   override val appsChanges: Flow<App> = systemUpdates.map(::getOrCreateApp)
 

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/RealTask.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/RealTask.kt
@@ -37,10 +37,10 @@ internal class RealTask internal constructor(
 
   override val isFinished
     get() = state in listOf(
-      Task.State.ABORTED,
-      Task.State.CANCELED,
-      Task.State.COMPLETED,
-      Task.State.FAILED
+      Task.State.Aborted,
+      Task.State.Canceled,
+      Task.State.Completed,
+      Task.State.Failed
     )
 
   override val packageName: String = this.taskInfo.packageName
@@ -51,19 +51,19 @@ internal class RealTask internal constructor(
 
   override val constraints: Constraints get() = taskInfo.constraints
 
-  private val _stateAndProgress = MutableStateFlow(Task.State.PENDING to -1)
+  private val _stateAndProgress = MutableStateFlow<Task.State>(Task.State.Pending)
 
   override val state: Task.State
-    get() = _stateAndProgress.value.first
+    get() = _stateAndProgress.value
 
-  override val stateAndProgress: Flow<Pair<Task.State, Int>> = _stateAndProgress.transformWhile {
+  override val stateAndProgress: Flow<Task.State> = _stateAndProgress.transformWhile {
     emit(it)
-    it.first !in listOf(
-      Task.State.ABORTED,
-      Task.State.CANCELED,
-      Task.State.COMPLETED,
-      Task.State.OUT_OF_SPACE,
-      Task.State.FAILED
+    it !in listOf(
+      Task.State.Aborted,
+      Task.State.Canceled,
+      Task.State.Completed,
+      Task.State.OutOfSpace,
+      Task.State.Failed
     )
   }
 
@@ -82,23 +82,23 @@ internal class RealTask internal constructor(
     if (isFinished) return // Already finished.
     job = when (type) {
       Task.Type.UNINSTALL -> packageInstaller.uninstall(packageName)
-        .onStart { _stateAndProgress.emit(Task.State.UNINSTALLING to -1) }
-        .onEach { _stateAndProgress.emit(state to it) }
+        .onStart { _stateAndProgress.emit(Task.State.Uninstalling(-1)) }
+        .onEach { _stateAndProgress.emit(Task.State.Uninstalling(it)) }
 
       Task.Type.INSTALL -> {
         listOf(
           packageDownloader.download(packageName, installPackageInfo)
             .onStart {
-              _stateAndProgress.emit(Task.State.DOWNLOADING to -1)
+              _stateAndProgress.emit(Task.State.Downloading(-1))
               checkSizeToState(sizeEstimator.getDownloadSize(installPackageInfo))
             }
-            .onEach { _stateAndProgress.emit(Task.State.DOWNLOADING to it) },
+            .onEach { _stateAndProgress.emit(Task.State.Downloading(it)) },
           packageInstaller.install(packageName, installPackageInfo)
             .onStart {
-              _stateAndProgress.emit(Task.State.READY_TO_INSTALL to -1)
+              _stateAndProgress.emit(Task.State.ReadyToInstall)
               checkSizeToState(sizeEstimator.getInstallSize(installPackageInfo))
             }
-            .onEach { _stateAndProgress.emit(Task.State.INSTALLING to it) }
+            .onEach { _stateAndProgress.emit(Task.State.Installing(it)) }
         )
           .asFlow()
           .flattenConcat()
@@ -106,13 +106,13 @@ internal class RealTask internal constructor(
     }
       .onCompletion {
         val result = when (it) {
-          null -> Task.State.COMPLETED
-          is AbortException -> Task.State.ABORTED
-          is CancellationException -> Task.State.CANCELED
-          is OutOfSpaceException -> Task.State.OUT_OF_SPACE
-          else -> Task.State.FAILED
+          null -> Task.State.Completed
+          is AbortException -> Task.State.Aborted
+          is CancellationException -> Task.State.Canceled
+          is OutOfSpaceException -> Task.State.OutOfSpace
+          else -> Task.State.Failed
         }
-        _stateAndProgress.emit(result to -1)
+        _stateAndProgress.emit(result)
       }
       .catch { /* Suppress failures */ }
       .launchIn(scope)
@@ -123,7 +123,7 @@ internal class RealTask internal constructor(
   }
 
   override fun allowDownloadOnMetered() {
-    if (taskInfo.type == Task.Type.INSTALL && state == Task.State.PENDING) {
+    if (taskInfo.type == Task.Type.INSTALL && state is Task.State.Pending) {
       scope.launch {
         //Remove old task
         taskInfoRepository.remove(taskInfo)
@@ -137,7 +137,7 @@ internal class RealTask internal constructor(
         taskInfoRepository.saveJob(taskInfo)
         jobDispatcher.enqueue(this@RealTask)
       }
-      _stateAndProgress.tryEmit(Task.State.PENDING to -2)
+      _stateAndProgress.tryEmit(Task.State.Pending)
     }
   }
 
@@ -145,7 +145,7 @@ internal class RealTask internal constructor(
     scope.launch {
       if (isFinished) return@launch
       job?.cancel() ?: run {
-        _stateAndProgress.tryEmit(Task.State.CANCELED to -1)
+        _stateAndProgress.tryEmit(Task.State.Canceled)
         taskInfoRepository.remove(taskInfo)
         appsCache.setBusy(packageName, false)
       }

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/RealTask.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/RealTask.kt
@@ -92,7 +92,7 @@ internal class RealTask internal constructor(
               _stateAndProgress.emit(Task.State.Downloading(-1))
               checkSizeToState(sizeEstimator.getDownloadSize(installPackageInfo))
             }
-            .onEach { _stateAndProgress.emit(Task.State.Downloading(it)) },
+            .onEach { _stateAndProgress.emit(Task.State.Downloading(it.progress)) },
           packageInstaller.install(packageName, installPackageInfo)
             .onStart {
               _stateAndProgress.emit(Task.State.ReadyToInstall)

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/Task.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/Task.kt
@@ -48,10 +48,10 @@ interface Task {
   val state: State
 
   /**
-   * The [Flow] of the task state and progress as it changes. Immediately emits the
+   * The [Flow] of the task state as it changes. Immediately emits the
    * current ones for any new subscriber. Completes as soon as task is finished.
    */
-  val stateAndProgress: Flow<Pair<State, Int>>
+  val stateAndProgress: Flow<State>
 
   /**
    * Allows the task to perform downloads on metered networks. And schedules it's execution
@@ -82,35 +82,35 @@ interface Task {
     UNINSTALL
   }
 
-  enum class State {
+  sealed class State {
     /* Waiting to be started */
-    PENDING,
+    object Pending: State()
 
     /* Downloading the files */
-    DOWNLOADING,
+    data class Downloading(val progress: Int): State()
 
     /* Files are ready for installation */
-    READY_TO_INSTALL,
+    object ReadyToInstall: State()
 
     /* Installing the downloaded files */
-    INSTALLING,
+    data class Installing(val progress: Int): State()
 
     /* Uninstalling the app files */
-    UNINSTALLING,
+    data class Uninstalling(val progress: Int): State()
 
     /* Work is finished */
-    COMPLETED,
+    object Completed: State()
 
     /* Work is aborted */
-    ABORTED,
+    object Aborted: State()
 
     /* Work is canceled */
-    CANCELED,
+    object Canceled: State()
 
     /* Work is failed */
-    FAILED,
+    object Failed: State()
 
     /* Work is failed due to lack of space */
-    OUT_OF_SPACE,
+    object OutOfSpace: State()
   }
 }

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/workers/PackageDownloader.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/workers/PackageDownloader.kt
@@ -1,6 +1,7 @@
 package cm.aptoide.pt.install_manager.workers
 
 import cm.aptoide.pt.install_manager.AbortException
+import cm.aptoide.pt.install_manager.DownloadInfo
 import cm.aptoide.pt.install_manager.OutOfSpaceException
 import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import kotlinx.coroutines.CancellationException
@@ -28,5 +29,5 @@ interface PackageDownloader {
   fun download(
     packageName: String,
     installPackageInfo: InstallPackageInfo,
-  ): Flow<Int>
+  ): Flow<DownloadInfo>
 }

--- a/install-manager/src/test/java/cm/aptoide/pt/install_manager/AppTest.kt
+++ b/install-manager/src/test/java/cm/aptoide/pt/install_manager/AppTest.kt
@@ -48,7 +48,7 @@ internal class AppTest {
     m And "get running install task from the app immediately"
     val currentITaskNow = app.task
     m And "get running install task from the app after some progress happened"
-    currentITaskNow?.stateAndProgress?.first { it.first != Task.State.PENDING }
+    currentITaskNow?.stateAndProgress?.first { it !is Task.State.Pending }
     val currentITaskLater = app.task
     m And "wait until install task is finished"
     scope.advanceUntilIdle()
@@ -59,7 +59,7 @@ internal class AppTest {
     m And "get running uninstall task from the app immediately"
     val currentUTaskNow = app.task
     m And "get running uninstall task from the app after some progress happened"
-    currentITaskNow?.stateAndProgress?.first { it.first != Task.State.PENDING }
+    currentITaskNow?.stateAndProgress?.first { it !is Task.State.Pending }
     val currentUTaskLater = app.task
     m And "wait until uninstall task is finished"
     scope.advanceUntilIdle()
@@ -105,14 +105,14 @@ internal class AppTest {
     val packageInfo = app.packageInfo
     m And "get package info for the app during installation with given constraints"
     app.install(installInfo, constraints)
-      .stateAndProgress.first { it.first != Task.State.PENDING }
+      .stateAndProgress.first { it !is Task.State.Pending }
     val installingPackageInfo = app.packageInfo
     m And "get the info for the app after installation"
     scope.advanceUntilIdle()
     val installedPackageInfo = app.packageInfo
     m And "get package info for the app during uninstallation with given constraints"
     app.uninstall(constraints)
-      .stateAndProgress.first { it.first != Task.State.PENDING }
+      .stateAndProgress.first { it !is Task.State.Pending }
     val uninstallingPackageInfo = app.packageInfo
     m And "get the info for the app after uninstallation"
     scope.advanceUntilIdle()
@@ -531,7 +531,7 @@ internal class AppTest {
     m And "get app install call result with given constraints"
     val task = app.install(installInfo, constraints)
     m And "wait until task will be ready to cancel"
-    task.stateAndProgress.first { it.first == Task.State.DOWNLOADING }
+    task.stateAndProgress.first { it is Task.State.Downloading }
     m And "call the task cancel"
     task.cancel()
     m And "wait until the task finishes"
@@ -564,7 +564,7 @@ internal class AppTest {
     m And "get app install call result with given constraints"
     val task = app.install(installInfo, constraints)
     m And "wait until task will be ready to cancel"
-    task.stateAndProgress.first { it.first == Task.State.INSTALLING }
+    task.stateAndProgress.first { it is Task.State.Installing }
     m And "call the task cancel"
     task.cancel()
     m And "wait until the task finishes"
@@ -719,7 +719,7 @@ internal class AppTest {
     m And "get app uninstall call result with given constraints"
     val task = app.uninstall(constraints)
     m And "wait until task will be ready to cancel"
-    task.stateAndProgress.first { it.first == Task.State.UNINSTALLING }
+    task.stateAndProgress.first { it is Task.State.Uninstalling }
     m And "call the task cancel"
     task.cancel()
     m And "wait until the task finishes"

--- a/install-manager/src/test/java/cm/aptoide/pt/install_manager/TasksTest.kt
+++ b/install-manager/src/test/java/cm/aptoide/pt/install_manager/TasksTest.kt
@@ -38,7 +38,7 @@ internal class TasksTest {
     val task = installManager.getApp(outdatedPackage).install(installInfo, constraints)
 
     m When "wait for some progress to happen"
-    task.stateAndProgress.first { it.first == Task.State.DOWNLOADING }
+    task.stateAndProgress.first { it is Task.State.Downloading }
 
     m Then "a new install task info saved to the repo"
     mocks.taskInfoRepository.get(outdatedPackage)!!.run {
@@ -61,7 +61,7 @@ internal class TasksTest {
     val task = installManager.getApp(outdatedPackage).uninstall(constraints)
 
     m When "wait for some progress to happen"
-    task.stateAndProgress.first { it.first != Task.State.PENDING }
+    task.stateAndProgress.first { it !is Task.State.Pending }
 
     m Then "a new uninstall task info saved to the repo"
     mocks.taskInfoRepository.get(outdatedPackage)!!.run {
@@ -97,12 +97,12 @@ internal class TasksTest {
     m Then "first collected data has all the states till success"
     assertEquals(successfulInstallSequence, result)
     m And "second collected data contains only terminal state"
-    assertEquals(listOf(Task.State.COMPLETED to -1), result2)
+    assertEquals(listOf(Task.State.Completed), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.COMPLETED, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.Completed, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -131,12 +131,12 @@ internal class TasksTest {
     m Then "first collected data has all the states till success"
     assertEquals(successfulInstallSequence, result)
     m And "second collected data contains only terminal state"
-    assertEquals(listOf(Task.State.COMPLETED to -1), result2)
+    assertEquals(listOf(Task.State.Completed), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.COMPLETED, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.Completed, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -165,12 +165,12 @@ internal class TasksTest {
     m Then "first collected data has all the states till success"
     assertEquals(successfulUninstallSequence, result)
     m And "second collected data contains only terminal state"
-    assertEquals(listOf(Task.State.COMPLETED to -1), result2)
+    assertEquals(listOf(Task.State.Completed), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.COMPLETED, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.Completed, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -201,18 +201,18 @@ internal class TasksTest {
     m Then "first collected data ends with failed state before download starts"
     assertEquals(
       listOf(
-        Task.State.PENDING to -1,
-        Task.State.OUT_OF_SPACE to -1
+        Task.State.Pending,
+        Task.State.OutOfSpace
       ),
       result
     )
     m And "second collected data contains only failed state"
-    assertEquals(listOf(Task.State.OUT_OF_SPACE to -1), result2)
+    assertEquals(listOf(Task.State.OutOfSpace), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.OUT_OF_SPACE, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.OutOfSpace, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -243,18 +243,18 @@ internal class TasksTest {
     m Then "first collected data ends with failed state before download starts"
     assertEquals(
       listOf(
-        Task.State.PENDING to -1,
-        Task.State.OUT_OF_SPACE to -1
+        Task.State.Pending,
+        Task.State.OutOfSpace
       ),
       result
     )
     m And "second collected data contains only failed state"
-    assertEquals(listOf(Task.State.OUT_OF_SPACE to -1), result2)
+    assertEquals(listOf(Task.State.OutOfSpace), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.OUT_OF_SPACE, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.OutOfSpace, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -285,12 +285,12 @@ internal class TasksTest {
     m Then "first collected data ends with failed state after some progress of download"
     assertEquals(failedDownloadSequence, result)
     m And "second collected data contains only failed state"
-    assertEquals(listOf(Task.State.FAILED to -1), result2)
+    assertEquals(listOf(Task.State.Failed), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.FAILED, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.Failed, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -321,12 +321,12 @@ internal class TasksTest {
     m Then "first collected data ends with out of space state after some progress of download"
     assertEquals(outOfSpaceDownloadSequence, result)
     m And "second collected data contains only failed state"
-    assertEquals(listOf(Task.State.OUT_OF_SPACE to -1), result2)
+    assertEquals(listOf(Task.State.OutOfSpace), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.OUT_OF_SPACE, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.OutOfSpace, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -357,12 +357,12 @@ internal class TasksTest {
     m Then "first collected data ends with failed state on install"
     assertEquals(failedInstallSequence, result)
     m And "second collected data contains only failed state"
-    assertEquals(listOf(Task.State.FAILED to -1), result2)
+    assertEquals(listOf(Task.State.Failed), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.FAILED, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.Failed, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -393,12 +393,12 @@ internal class TasksTest {
     m Then "first collected data ends with out of space state on install"
     assertEquals(outOfSpaceInstallSequence, result)
     m And "second collected data contains only failed state"
-    assertEquals(listOf(Task.State.OUT_OF_SPACE to -1), result2)
+    assertEquals(listOf(Task.State.OutOfSpace), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.OUT_OF_SPACE, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.OutOfSpace, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -429,12 +429,12 @@ internal class TasksTest {
     m Then "first collected data ends with failed state on uninstall"
     assertEquals(failedUninstall, result)
     m And "second collected data contains only failed state"
-    assertEquals(listOf(Task.State.FAILED to -1), result2)
+    assertEquals(listOf(Task.State.Failed), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.FAILED, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.Failed, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -465,12 +465,12 @@ internal class TasksTest {
     m Then "first collected data ends with aborted state on download"
     assertEquals(abortedDownload, result)
     m And "second collected data contains only aborted state"
-    assertEquals(listOf(Task.State.ABORTED to -1), result2)
+    assertEquals(listOf(Task.State.Aborted), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.ABORTED, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.Aborted, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -501,12 +501,12 @@ internal class TasksTest {
     m Then "first collected data ends with aborted state on install"
     assertEquals(abortedInstall, result)
     m And "second collected data contains only aborted state"
-    assertEquals(listOf(Task.State.ABORTED to -1), result2)
+    assertEquals(listOf(Task.State.Aborted), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.ABORTED, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.Aborted, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -537,12 +537,12 @@ internal class TasksTest {
     m Then "first collected data ends with aborted state on uninstall"
     assertEquals(abortedUninstall, result)
     m And "second collected data contains only aborted state"
-    assertEquals(listOf(Task.State.ABORTED to -1), result2)
+    assertEquals(listOf(Task.State.Aborted), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.ABORTED, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.Aborted, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -560,7 +560,7 @@ internal class TasksTest {
     m When "remember current task state"
     val initialState = task.state
     m And "collect the task state and progress"
-    var result = emptyList<Pair<Task.State, Int>>()
+    var result = emptyList<Task.State>()
     scope.launch {
       result = task.stateAndProgress.toList()
     }
@@ -576,18 +576,18 @@ internal class TasksTest {
     m Then "first collected data ends with cancelled state before download"
     assertEquals(
       listOf(
-        Task.State.PENDING to -1,
-        Task.State.CANCELED to -1
+        Task.State.Pending,
+        Task.State.Canceled
       ),
       result
     )
     m And "second collected data contains only cancelled state"
-    assertEquals(listOf(Task.State.CANCELED to -1), result2)
+    assertEquals(listOf(Task.State.Canceled), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.CANCELED, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.Canceled, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -605,12 +605,12 @@ internal class TasksTest {
     m When "remember current task state"
     val initialState = task.state
     m And "collect the task state and progress"
-    var result = emptyList<Pair<Task.State, Int>>()
+    var result = emptyList<Task.State>()
     scope.launch {
       result = task.stateAndProgress.toList()
     }
     m And "wait until download passes 50%"
-    task.stateAndProgress.first { it.first == Task.State.DOWNLOADING && it.second >= 50 }
+    task.stateAndProgress.first { it is Task.State.Downloading && it.progress >= 50 }
     m And "call the task cancel"
     task.cancel()
     m And "wait until the task finishes"
@@ -623,12 +623,12 @@ internal class TasksTest {
     m Then "first collected data ends with cancelled state after on download"
     assertEquals(canceledDownload, result)
     m And "second collected data contains only cancelled state"
-    assertEquals(listOf(Task.State.CANCELED to -1), result2)
+    assertEquals(listOf(Task.State.Canceled), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.CANCELED, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.Canceled, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -646,12 +646,12 @@ internal class TasksTest {
     m When "remember current task state"
     val initialState = task.state
     m And "collect the task state and progress"
-    var result = emptyList<Pair<Task.State, Int>>()
+    var result = emptyList<Task.State>()
     scope.launch {
       result = task.stateAndProgress.toList()
     }
     m And "wait until installation passes 50%"
-    task.stateAndProgress.first { it.first == Task.State.INSTALLING && it.second >= 50 }
+    task.stateAndProgress.first { it is Task.State.Installing && it.progress >= 50 }
     m And "call the task cancel"
     task.cancel()
     m And "wait until the task finishes"
@@ -664,12 +664,12 @@ internal class TasksTest {
     m Then "first collected data ends with cancelled state on install"
     assertEquals(canceledInstall, result)
     m And "second collected data contains only cancelled state"
-    assertEquals(listOf(Task.State.CANCELED to -1), result2)
+    assertEquals(listOf(Task.State.Canceled), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.CANCELED, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.Canceled, finalState)
   }
 
   @ParameterizedTest(name = "{0}")
@@ -687,12 +687,12 @@ internal class TasksTest {
     m When "remember current task state"
     val initialState = task.state
     m And "collect the task state and progress"
-    var result = emptyList<Pair<Task.State, Int>>()
+    var result = emptyList<Task.State>()
     scope.launch {
       result = task.stateAndProgress.toList()
     }
     m And "wait until uninstallation passes 50%"
-    task.stateAndProgress.first { it.first == Task.State.UNINSTALLING && it.second >= 50 }
+    task.stateAndProgress.first { it is Task.State.Uninstalling && it.progress >= 50 }
     m And "call the task cancel"
     task.cancel()
     m And "wait until the task finishes"
@@ -705,12 +705,12 @@ internal class TasksTest {
     m Then "first collected data ends with cancelled state on uninstall"
     assertEquals(canceledUninstall, result)
     m And "second collected data contains only cancelled state"
-    assertEquals(listOf(Task.State.CANCELED to -1), result2)
+    assertEquals(listOf(Task.State.Canceled), result2)
     m And "there is no task info in the repo for the outdated app package name"
     assertNull(mocks.taskInfoRepository.get(outdatedPackage))
     m And "remembered task states are as expected"
-    assertEquals(Task.State.PENDING, initialState)
-    assertEquals(Task.State.CANCELED, finalState)
+    assertEquals(Task.State.Pending, initialState)
+    assertEquals(Task.State.Canceled, finalState)
   }
 
   @ParameterizedTest(name = "{0}")


### PR DESCRIPTION
**What does this PR do?**

   - Refactor Task State to include task progress
   - Changes the PackageDownloader interface and implementations so that it can emit more complex download info. It now returns not only the progress, but also the total number of downloaded bytes.
   - Adds the new download speed parameter to download analytics events.

**Database changed?**

   No

**Where should the reviewer start?**

See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-196](https://aptoide.atlassian.net/browse/AND-196)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-196](https://aptoide.atlassian.net/browse/AND-196)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-196]: https://aptoide.atlassian.net/browse/AND-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-196]: https://aptoide.atlassian.net/browse/AND-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ