### PR TITLE
[AND-182] Add error url for download fail analytics event

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -168,6 +168,7 @@ class InstallAnalytics(
     errorMessage: String?,
     errorType: String?,
     errorCode: Int?,
+    errorUrl: String?,
   ) {
     genericAnalytics.logEvent(
       name = "app_download",
@@ -186,6 +187,7 @@ class InstallAnalytics(
       P_ERROR_MESSAGE to errorMessage,
       P_ERROR_TYPE to errorType,
       P_ERROR_HTTP_CODE to errorCode,
+      P_ERROR_URL to errorUrl
     )
   }
 
@@ -497,6 +499,7 @@ class InstallAnalytics(
     private const val P_ERROR_MESSAGE = "error_message"
     private const val P_ERROR_TYPE = "error_type"
     private const val P_ERROR_HTTP_CODE = "error_http_code"
+    private const val P_ERROR_URL = "error_url"
     internal const val P_WIFI_SETTING = "wifi_setting"
     internal const val P_PROMPT_TYPE = "prompt_type"
     internal const val P_SERVICE = "service"

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/DownloadException.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/DownloadException.kt
@@ -1,0 +1,15 @@
+package cm.aptoide.pt.installer
+
+import androidx.annotation.Keep
+
+/**
+ * An exception that wraps exceptions caused by a file download failure.
+ *
+ * @property url - the file download url that caused the exception.
+ * @property cause - the exception thrown by the file download failure.
+ */
+@Keep
+class DownloadException(
+  val url: String,
+  override val cause: Throwable
+) : Exception()

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/fetch/FetchDownloader.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/fetch/FetchDownloader.kt
@@ -10,6 +10,7 @@ import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import cm.aptoide.pt.install_manager.dto.InstallationFile
 import cm.aptoide.pt.install_manager.dto.hasObb
 import cm.aptoide.pt.install_manager.workers.PackageDownloader
+import cm.aptoide.pt.installer.DownloadException
 import cm.aptoide.pt.installer.InstallerWorker
 import cm.aptoide.pt.installer.di.DownloadsPath
 import cm.aptoide.pt.installer.platform.InstallPermissions
@@ -186,7 +187,12 @@ class FetchDownloader @Inject constructor(
 
         override fun onQueued(download: Download, waitingOnNetwork: Boolean) {
           if (waitingOnNetwork) {
-            close(download.error.throwable ?: IOException("Network disconnected"))
+            close(
+              DownloadException(
+                url = download.url,
+                cause = download.error.throwable ?: IOException("Network disconnected")
+              )
+            )
           }
           super.onQueued(download, waitingOnNetwork)
         }
@@ -196,7 +202,12 @@ class FetchDownloader @Inject constructor(
           error: Error,
           throwable: Throwable?
         ) {
-          close(throwable ?: IllegalStateException("Error downloading files"))
+          close(
+            DownloadException(
+              url = download.url,
+              cause = throwable ?: IllegalStateException("Error downloading files")
+            )
+          )
         }
 
         override fun onProgress(

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/network/DownloaderRepository.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/network/DownloaderRepository.kt
@@ -3,9 +3,11 @@ package cm.aptoide.pt.installer.network
 import cm.aptoide.pt.aptoide_network.di.DownloadsOKHttp
 import cm.aptoide.pt.extensions.checkMd5
 import cm.aptoide.pt.install_manager.dto.InstallationFile
+import cm.aptoide.pt.installer.DownloadException
 import cm.aptoide.pt.installer.di.DownloadsPath
 import cm.aptoide.pt.installer.platform.copyWithProgressTo
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
@@ -99,6 +101,9 @@ class DownloaderRepository @Inject constructor(
       .distinctUntilChanged()
       .retry(retries = RETRY_TIMES)
       .onCompletion { it?.printStackTrace() }
+      .catch {
+        throw DownloadException(url = installationFile.url, cause = it)
+      }
   }
 }
 


### PR DESCRIPTION
**What does this PR do?**

   - Adds the error url parameter for download fail analytics event.
   - Adds a new DownloadException that is used to wrap exceptions coming from PackageDownloader implementations.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-182](https://aptoide.atlassian.net/browse/AND-182)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-182](https://aptoide.atlassian.net/browse/AND-182)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-182]: https://aptoide.atlassian.net/browse/AND-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-182]: https://aptoide.atlassian.net/browse/AND-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ