### PR TITLE
[AND-215] Fix stuck download with Fetch on connection failed

### DIFF
--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/fetch/FetchDownloader.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/fetch/FetchDownloader.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import okhttp3.OkHttpClient
 import java.io.File
+import java.io.IOException
 import javax.inject.Inject
 import kotlin.coroutines.coroutineContext
 
@@ -181,6 +182,13 @@ class FetchDownloader @Inject constructor(
               close()
             }
           }
+        }
+
+        override fun onQueued(download: Download, waitingOnNetwork: Boolean) {
+          if (waitingOnNetwork) {
+            close(download.error.throwable ?: IOException("Network disconnected"))
+          }
+          super.onQueued(download, waitingOnNetwork)
         }
 
         override fun onError(

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/fetch/FetchDownloader.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/fetch/FetchDownloader.kt
@@ -5,7 +5,6 @@ import androidx.core.net.toFile
 import androidx.core.net.toUri
 import cm.aptoide.pt.aptoide_network.di.DownloadsOKHttp
 import cm.aptoide.pt.extensions.checkMd5
-import cm.aptoide.pt.install_manager.AbortException
 import cm.aptoide.pt.install_manager.DownloadInfo
 import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import cm.aptoide.pt.install_manager.dto.InstallationFile
@@ -189,7 +188,7 @@ class FetchDownloader @Inject constructor(
           error: Error,
           throwable: Throwable?
         ) {
-          close(throwable ?: AbortException("Error downloading files"))
+          close(throwable ?: IllegalStateException("Error downloading files"))
         }
 
         override fun onProgress(


### PR DESCRIPTION
**What does this PR do?**

   - Fixes a bug where the progress is stuck and there is no error when the network fails, while using the Fetch package downloader.
   - Fixes the returned exception types, so that the errors can be correctly propagated and shown at UI level.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] FetchDownloader.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-215](https://aptoide.atlassian.net/browse/AND-215)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-215](https://aptoide.atlassian.net/browse/AND-215)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-215]: https://aptoide.atlassian.net/browse/AND-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-215]: https://aptoide.atlassian.net/browse/AND-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ