### PR TITLE
[AND-186] Implement GameGenie chat history saving

### DIFF
--- a/app-games/schemas/com.aptoide.android.aptoidegames.gamegenie.data.database.GameGenieDatabase/1.json
+++ b/app-games/schemas/com.aptoide.android.aptoidegames.gamegenie.data.database.GameGenieDatabase/1.json
@@ -1,0 +1,40 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "12e555120380577c031311a7e6b95524",
+    "entities": [
+      {
+        "tableName": "GameGenieHistory",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversation` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversation",
+            "columnName": "conversation",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '12e555120380577c031311a7e6b95524')"
+    ]
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/GameGenieApiService.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/GameGenieApiService.kt
@@ -9,7 +9,7 @@ import retrofit2.http.POST
 
 interface GameGenieApiService {
   @POST("chat")
-  suspend fun postMessages(
+  suspend fun postMessage(
     @Header("Authorization") bearerToken: String,
     @Body request: GameGenieRequest,
   ): GameGenieResponse

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/GameGenieRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/GameGenieRepository.kt
@@ -9,11 +9,11 @@ import javax.inject.Inject
 class GameGenieRepository @Inject constructor(
   private val apiService: GameGenieApiService,
 ) {
-  suspend fun getMessages(
+  suspend fun postMessage(
     token: Token,
     request: GameGenieRequest,
   ): GameGenieResponse {
-    return apiService.postMessages("Bearer ${token.token}", request)
+    return apiService.postMessage("Bearer ${token.token}", request)
   }
 
   suspend fun getToken(): TokenResponse {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/GameGenieDatabase.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/GameGenieDatabase.kt
@@ -1,0 +1,14 @@
+package com.aptoide.android.aptoidegames.gamegenie.data.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.aptoide.android.aptoidegames.gamegenie.data.database.model.Converters
+import com.aptoide.android.aptoidegames.gamegenie.data.database.model.GameGenieHistoryEntity
+
+@Database(entities = [GameGenieHistoryEntity::class], version = 1)
+@TypeConverters(Converters::class)
+abstract class GameGenieDatabase : RoomDatabase() {
+
+  abstract fun getGameGenieHistoryDao(): GameGenieHistoryDao
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/GameGenieHistoryDao.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/GameGenieHistoryDao.kt
@@ -1,0 +1,12 @@
+package com.aptoide.android.aptoidegames.gamegenie.data.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import com.aptoide.android.aptoidegames.gamegenie.data.database.model.GameGenieHistoryEntity
+
+@Dao
+interface GameGenieHistoryDao {
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun saveChatById(gameGenieHistoryEntity: GameGenieHistoryEntity)
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/model/ChatInteractionEntity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/model/ChatInteractionEntity.kt
@@ -1,0 +1,7 @@
+package com.aptoide.android.aptoidegames.gamegenie.data.database.model
+
+data class ChatInteractionEntity(
+  val gpt: String,
+  val user: String?,
+  val apps: String,
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/model/Converters.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/model/Converters.kt
@@ -1,0 +1,19 @@
+package com.aptoide.android.aptoidegames.gamegenie.data.database.model
+
+import androidx.room.TypeConverter
+import com.google.common.reflect.TypeToken
+import com.google.gson.Gson
+
+class Converters {
+
+  @TypeConverter
+  fun fromChatInteractionList(value: List<ChatInteractionEntity>): String {
+    return Gson().toJson(value)
+  }
+
+  @TypeConverter
+  fun toChatInteractionList(value: String): List<ChatInteractionEntity> {
+    val type = object : TypeToken<List<ChatInteractionEntity>>() {}.type
+    return Gson().fromJson(value, type)
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/model/GameGenieHistoryEntity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/model/GameGenieHistoryEntity.kt
@@ -1,0 +1,10 @@
+package com.aptoide.android.aptoidegames.gamegenie.data.database.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "GameGenieHistory")
+data class GameGenieHistoryEntity(
+  @PrimaryKey val id: String,
+  val conversation: List<ChatInteractionEntity>,
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/di/GameGenieModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/di/GameGenieModule.kt
@@ -1,16 +1,21 @@
 package com.aptoide.android.aptoidegames.gamegenie.di
 
+import android.content.Context
+import androidx.room.Room
 import cm.aptoide.pt.aptoide_network.di.BaseOkHttp
 import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieApiService
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieRepository
+import com.aptoide.android.aptoidegames.gamegenie.data.database.GameGenieDatabase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -29,4 +34,14 @@ internal object GameGenieModule {
   fun provideChatbotRepository(apiService: GameGenieApiService): GameGenieRepository {
     return GameGenieRepository(apiService)
   }
+
+  @Singleton
+  @Provides
+  fun provideGameGenieDatabase(
+    @ApplicationContext appContext: Context,
+  ): GameGenieDatabase = Room.databaseBuilder(
+    appContext,
+    GameGenieDatabase::class.java,
+    "ag_game_genie.db"
+  ).build()
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/domain/GameGenieChat.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/domain/GameGenieChat.kt
@@ -1,0 +1,6 @@
+package com.aptoide.android.aptoidegames.gamegenie.domain
+
+data class GameGenieChat(
+  val id: String,
+  val conversation: List<ChatInteraction>,
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieUIState.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieUIState.kt
@@ -1,12 +1,11 @@
 package com.aptoide.android.aptoidegames.gamegenie.presentation
 
-import com.aptoide.android.aptoidegames.gamegenie.domain.ChatInteraction
+import com.aptoide.android.aptoidegames.gamegenie.domain.GameGenieChat
 import com.aptoide.android.aptoidegames.gamegenie.domain.Token
 
 data class GameGenieUIState(
   val type: GameGenieUIStateType,
-  val conversation: List<ChatInteraction>,
-  val id: String,
+  val chat: GameGenieChat,
   val apps: List<String> = emptyList(),
   val token: Token?,
 )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieView.kt
@@ -96,7 +96,7 @@ fun ChatScreen(
       .fillMaxSize()
   ) {
     MessageList(
-      messages = uiState.conversation.asReversed(),
+      messages = uiState.chat.conversation.asReversed(),
       navigateTo = navigateTo,
       modifier = Modifier
         .weight(1f),


### PR DESCRIPTION
**What does this PR do?**

Implement chat history saving in Room. The idea of this is to present the past conversations with GameGenie, but for now we are only aiming to save the conversations, not to present them to the user.

**Database changed?**

   Yes

**Where should the reviewer start?**

- [ ] GameGenieHistoryDao.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-186](https://aptoide.atlassian.net/browse/AND-186)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-186](https://aptoide.atlassian.net/browse/AND-186)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-186]: https://aptoide.atlassian.net/browse/AND-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-186]: https://aptoide.atlassian.net/browse/AND-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ