### PR TITLE
[AND-242] Filter bundle for hmd devices that are not fusion

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -2,6 +2,7 @@ package com.aptoide.android.aptoidegames.home
 
 import android.content.Context
 import android.net.Uri.encode
+import android.os.Build
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -59,6 +60,7 @@ import cm.aptoide.pt.feature_home.presentation.BundlesViewUiState
 import cm.aptoide.pt.feature_home.presentation.BundlesViewUiStateType
 import cm.aptoide.pt.feature_home.presentation.bundlesList
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
+import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.presentation.AnalyticsContext
 import com.aptoide.android.aptoidegames.analytics.presentation.InitialAnalyticsMeta
@@ -148,10 +150,12 @@ fun BundlesScreen(
           onRetryClick = loadFreshHomeBundles
         )
 
-        BundlesViewUiStateType.IDLE -> BundlesView(
-          viewState,
-          navigate
-        )
+        BundlesViewUiStateType.IDLE -> {
+          BundlesView(
+            viewState.filterHMD(),
+            navigate
+          )
+        }
       }
     }
 
@@ -468,4 +472,16 @@ private fun calculateLoopedBundleInitialItem(appsListSize: Int): Int {
 private fun Int.floorMod(other: Int): Int = when (other) {
   0 -> this
   else -> this - floorDiv(other) * other
+}
+
+private fun BundlesViewUiState.filterHMD(): BundlesViewUiState {
+  return if (BuildConfig.MARKET_NAME == "aptoide-games-hmd"
+    && Build.MANUFACTURER.lowercase().contains("hmd")
+    && (Build.MODEL.lowercase().contains("fusion") || Build.MODEL.lowercase()
+      .contains("nighthawk"))
+  ) {
+    this
+  } else {
+    this.copy(bundles = bundles.filter { it.tag != "apps-group-hmd-controller" })
+  }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR aims at implementing a filter where the "apps-group-hmd-controller" bundle is only shown for users that have an hmd phone and the fusion model.
PS: The values for the manufacturer and model are still pending confirmation with hmd.

**Database changed?**

 No

**Where should the reviewer start?**

- [ ] BundlesView.kt

**How should this be manually tested?**

Open the app in your phone and check that the bundles doesnt show. To check showing, either you fake the function on the code or we wait for an hmd device.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-242](https://aptoide.atlassian.net/browse/AND-242)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-242]: https://aptoide.atlassian.net/browse/AND-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ