### PR TITLE
[AND-245] Add promo code bottom sheet analytics

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/analytics/AnalyticsProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/analytics/AnalyticsProvider.kt
@@ -1,0 +1,28 @@
+package com.aptoide.android.aptoidegames.promo_codes.analytics
+
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import cm.aptoide.pt.extensions.runPreviewable
+import com.aptoide.android.aptoidegames.analytics.AnalyticsSender
+import com.aptoide.android.aptoidegames.analytics.BIAnalytics
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class AnalyticsInjectionsProvider @Inject constructor(
+  val promoCodeAnalytics: PromoCodeAnalytics,
+) : ViewModel()
+
+@Composable
+fun rememberPromoCodeAnalytics(): PromoCodeAnalytics = runPreviewable(
+  preview = {
+    PromoCodeAnalytics(
+      biAnalytics = BIAnalytics(object : AnalyticsSender {}),
+    )
+  },
+  real = {
+    val vm = hiltViewModel<AnalyticsInjectionsProvider>()
+    vm.promoCodeAnalytics
+  }
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/analytics/PromoCodeAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/analytics/PromoCodeAnalytics.kt
@@ -1,0 +1,56 @@
+package com.aptoide.android.aptoidegames.promo_codes.analytics
+
+import com.aptoide.android.aptoidegames.analytics.BIAnalytics
+import com.aptoide.android.aptoidegames.analytics.dto.AnalyticsUIContext
+import com.aptoide.android.aptoidegames.analytics.toBiParameters
+
+class PromoCodeAnalytics(
+  private val biAnalytics: BIAnalytics,
+) {
+
+  fun sendPromoCodeImpressionEvent(
+    analyticsContext: AnalyticsUIContext,
+    status: String,
+    withWallet: Boolean? = null
+  ) = sendPromoCodeEvent(
+    analyticsContext = analyticsContext,
+    action = "impression",
+    status = status,
+    withWallet = withWallet
+  )
+
+  fun sendPromoCodeClickEvent(
+    analyticsContext: AnalyticsUIContext,
+    withWallet: Boolean? = null
+  ) = sendPromoCodeEvent(
+    analyticsContext = analyticsContext,
+    action = "click",
+    withWallet = withWallet
+  )
+
+  private fun sendPromoCodeEvent(
+    analyticsContext: AnalyticsUIContext,
+    action: String,
+    status: String? = null,
+    withWallet: Boolean? = null
+  ) {
+    biAnalytics.logEvent(
+      name = "ag_promo_codes",
+      analyticsContext.toBiParameters(
+        P_ACTION to action,
+        P_TYPE to when (withWallet) {
+          true -> "with_wallet_app"
+          false -> "with_wallet_app"
+          null -> "n-a"
+        },
+        P_STATUS to status
+      )
+    )
+  }
+
+  companion object {
+    private const val P_ACTION = "action"
+    private const val P_TYPE = "type"
+    private const val P_STATUS = "status"
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/di/PromoCodesModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/di/PromoCodesModule.kt
@@ -1,0 +1,20 @@
+package com.aptoide.android.aptoidegames.promo_codes.di
+
+import com.aptoide.android.aptoidegames.analytics.BIAnalytics
+import com.aptoide.android.aptoidegames.promo_codes.analytics.PromoCodeAnalytics
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class PromoCodesModule {
+
+  @Singleton
+  @Provides
+  fun providesPromoCodeAnalytics(biAnalytics: BIAnalytics): PromoCodeAnalytics = PromoCodeAnalytics(
+    biAnalytics = biAnalytics,
+  )
+}


### PR DESCRIPTION
**What does this PR do?**

   - Adds new analytics to the promo code bottom sheet. Specifically, an analytics event to know when the bottom sheet is shown and to know when the user clicks on the button to use the promo code.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-245](https://aptoide.atlassian.net/browse/AND-245)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-245](https://aptoide.atlassian.net/browse/AND-245)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-245]: https://aptoide.atlassian.net/browse/AND-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-245]: https://aptoide.atlassian.net/browse/AND-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ