### PR TITLE
[AND-280] Add download_queue_entry and download_queue_exit event

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
@@ -33,6 +33,10 @@ class DownloadProbe(
           packageName = packageName,
           installPackageInfo = installPackageInfo
         )
+        analytics.sendOnInstallationRemovedFromQueue(
+          packageName = packageName,
+          installPackageInfo = installPackageInfo
+        )
       }
       .onEach {
         if (initialTimestamp == 0L && it.progress >= 0) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -127,6 +127,28 @@ class InstallAnalytics(
     )
   }
 
+  fun sendOnInstallationQueued(
+    packageName: String,
+    analyticsContext: AnalyticsUIContext
+    )=
+    genericAnalytics.logEvent(
+      name = "queue_entry",
+      params = analyticsContext.toGenericParameters(
+        GenericAnalytics.P_PACKAGE_NAME to packageName,
+      )
+    )
+
+  fun sendOnInstallationRemovedFromQueue(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo
+  )=
+    genericAnalytics.logEvent(
+      name = "queue_exit",
+      params = installPackageInfo.toAppGenericParameters(
+        packageName = packageName,
+      )
+    )
+
   fun sendDownloadStartedEvent(
     packageName: String,
     installPackageInfo: InstallPackageInfo

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
@@ -123,6 +123,10 @@ fun installViewStates(
             app.campaigns?.toMMPLinkerCampaign()?.sendDownloadEvent(BuildConfig.OEMID)
             onInstallStarted()
             scheduledInstallListener.listenToWifiStart(app.packageName)
+            installAnalytics.sendOnInstallationQueued(
+              packageName = app.packageName,
+              analyticsContext = analyticsContext
+            )
             saveAppDetails(app) {
               installerNotifications.onInstallationQueued(app.packageName)
             }
@@ -177,6 +181,10 @@ fun installViewStates(
             app.campaigns?.toMMPLinkerCampaign()?.sendDownloadEvent(BuildConfig.OEMID)
             onInstallStarted()
             scheduledInstallListener.listenToWifiStart(app.packageName)
+            installAnalytics.sendOnInstallationQueued(
+              packageName = app.packageName,
+              analyticsContext = analyticsContext
+            )
             saveAppDetails(app) {
               installerNotifications.onInstallationQueued(app.packageName)
             }
@@ -207,6 +215,10 @@ fun installViewStates(
 
               else -> { ->
                 canceled = true
+                installAnalytics.sendOnInstallationRemovedFromQueue(
+                  packageName = app.packageName,
+                  installPackageInfo= downloadUiState.installPackageInfo
+                  )
                 installAnalytics.sendDownloadCancel(app, analyticsContext)
                 // While task is the queue the Package Downloader will not be called and cancellation
                 // will not be caught by the  Package Downloader probe.
@@ -267,6 +279,10 @@ fun installViewStates(
             )
             onInstallStarted()
             scheduledInstallListener.listenToWifiStart(app.packageName)
+            installAnalytics.sendOnInstallationQueued(
+              packageName = app.packageName,
+              analyticsContext = analyticsContext
+            )
             saveAppDetails(app) {
               installerNotifications.onInstallationQueued(app.packageName)
             }


### PR DESCRIPTION
**What does this PR do?**

   This PR aims to adds download_queue_entry and download_queue_exit events

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] DownloadProbe.kt
- [ ] InstallAnalytics.kt
- [ ] InstallViewStates.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-280](https://aptoide.atlassian.net/browse/AND-280)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-280](https://aptoide.atlassian.net/browse/AND-280)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-280]: https://aptoide.atlassian.net/browse/AND-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-280]: https://aptoide.atlassian.net/browse/AND-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ