### PR TITLE
[AND-261] Map Promotionals

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -233,6 +233,12 @@ fun BundlesView(
               navigate = navigateTo,
             )
 
+            Type.NEW_APP_VERSION,
+            Type.IN_GAME_EVENT,
+            Type.NEW_APP,
+            Type.NEWS_ITEM,
+            Type.APP_COMING_SOON -> Unit
+
             else -> Unit
           }
         }

--- a/feature-home/src/main/java/cm/aptoide/pt/feature_home/domain/Bundle.kt
+++ b/feature-home/src/main/java/cm/aptoide/pt/feature_home/domain/Bundle.kt
@@ -46,7 +46,12 @@ enum class Type {
   LIST,
   PUBLISHER_TAKEOVER,
   CATEGORIES,
-  HTML_GAMES
+  HTML_GAMES,
+  APP_COMING_SOON,
+  NEWS_ITEM,
+  NEW_APP,
+  NEW_APP_VERSION,
+  IN_GAME_EVENT,
 }
 
 val randomBundle

--- a/feature-home/src/main/java/cm/aptoide/pt/feature_home/domain/BundlesUseCase.kt
+++ b/feature-home/src/main/java/cm/aptoide/pt/feature_home/domain/BundlesUseCase.kt
@@ -46,14 +46,19 @@ class BundlesUseCase @Inject constructor(
     WidgetType.MY_GAMES,
     WidgetType.GAMES_MATCH,
     WidgetType.ACTION_ITEM,
-    -> BundleSource.MANUAL
+    WidgetType.NEW_APP,
+    WidgetType.NEWS_ITEM,
+    WidgetType.APP_COMING_SOON,
+    WidgetType.IN_GAME_EVENT,
+    WidgetType.NEW_APP_VERSION
+      -> BundleSource.MANUAL
 
     WidgetType.HTML_GAMES -> BundleSource.AUTOMATIC
 
     WidgetType.APPS_GROUP,
     WidgetType.ESKILLS,
     WidgetType.STORE_GROUPS,
-    -> if (view?.contains("group_id") == false) {
+      -> if (view?.contains("group_id") == false) {
       BundleSource.AUTOMATIC
     } else {
       BundleSource.MANUAL
@@ -77,7 +82,7 @@ class BundlesUseCase @Inject constructor(
         WidgetLayout.LIST -> Type.APP_GRID
         WidgetLayout.CURATION_1,
         WidgetLayout.UNDEFINED,
-        -> Type.FEATURE_GRAPHIC
+          -> Type.FEATURE_GRAPHIC
       }
     }
 
@@ -90,6 +95,13 @@ class BundlesUseCase @Inject constructor(
 
     WidgetType.STORE_GROUPS -> Type.CATEGORIES
     WidgetType.HTML_GAMES -> Type.HTML_GAMES
+
+    WidgetType.NEW_APP -> Type.NEW_APP
+    WidgetType.NEWS_ITEM -> Type.NEWS_ITEM
+    WidgetType.APP_COMING_SOON -> Type.APP_COMING_SOON
+    WidgetType.IN_GAME_EVENT -> Type.IN_GAME_EVENT
+    WidgetType.NEW_APP_VERSION -> Type.NEW_APP_VERSION
+
     else -> Type.UNKNOWN_BUNDLE
   }
 

--- a/feature-home/src/main/java/cm/aptoide/pt/feature_home/domain/Widget.kt
+++ b/feature-home/src/main/java/cm/aptoide/pt/feature_home/domain/Widget.kt
@@ -27,7 +27,12 @@ enum class WidgetType {
   MY_GAMES,
   GAMES_MATCH,
   STORE_GROUPS,
-  HTML_GAMES
+  HTML_GAMES,
+  NEWS_ITEM,
+  NEW_APP,
+  NEW_APP_VERSION,
+  IN_GAME_EVENT,
+  APP_COMING_SOON
 }
 
 enum class WidgetLayout {


### PR DESCRIPTION
**What does this PR do?**

This PR aims at implementing the initial mapping for promotional cards.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] WidgetType.kt

**How should this be manually tested?**

Use the rewrite and check it. Currently it is mapping to Unit on the UI, but soon those will be implemented with the respective viewmodels.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-261](https://aptoide.atlassian.net/browse/AND-261)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-261]: https://aptoide.atlassian.net/browse/AND-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ