### PR TITLE
[AND-278] Add `action` parameter to the `download` and `install` events

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
@@ -13,6 +13,7 @@ import cm.aptoide.pt.feature_categories.analytics.AptoideAnalyticsInfoProvider
 import cm.aptoide.pt.feature_flags.domain.FeatureFlags
 import cm.aptoide.pt.install_manager.InstallManager
 import com.aptoide.android.aptoidegames.BuildConfig
+import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_ACTION
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_APKFY_APP_INSTALL
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_APP_AAB
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_APP_AAB_INSTALL_TIME
@@ -135,6 +136,7 @@ class BIAnalytics(private val analyticsSender: AnalyticsSender) {
   ) = analyticsSender.logEvent(name, params)
 
   companion object {
+    internal const val P_ACTION = "action"
     internal const val P_APP_AAB = "app_aab"
     internal const val P_APP_AAB_INSTALL_TIME = "app_aab_install_time"
     internal const val P_APP_APPC = "app_appc"
@@ -157,6 +159,7 @@ fun AnalyticsUIContext?.toBiParameters(vararg pairs: Pair<String, Any?>): Map<St
   this?.run {
     mapOfNonNull(
       *pairs,
+      P_ACTION to installAction?.name?.lowercase(),
       P_APKFY_APP_INSTALL to isApkfy,
       P_CONTEXT to currentScreen,
       P_PREVIOUS_CONTEXT to previousScreen,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/dto/AnalyticsData.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/dto/AnalyticsData.kt
@@ -5,6 +5,18 @@ import androidx.annotation.Keep
 import java.nio.charset.StandardCharsets
 
 @Keep
+@Suppress("unused")
+enum class InstallAction {
+  INSTALL,
+  UPDATE,
+  MIGRATE,
+  DOWNGRADE,
+  UPDATE_ALL,
+  RETRY,
+  UNINSTALL
+}
+
+@Keep
 data class AnalyticsUIContext(
   var currentScreen: String,
   val previousScreen: String?,
@@ -12,6 +24,7 @@ data class AnalyticsUIContext(
   val searchMeta: SearchMeta?,
   val itemPosition: Int?,
   val isApkfy: Boolean,
+  val installAction: InstallAction? = null
 ) {
   companion object {
     val Empty = AnalyticsUIContext(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/AnalyticsData.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/AnalyticsData.kt
@@ -3,10 +3,12 @@ package com.aptoide.android.aptoidegames.installer.analytics
 import androidx.annotation.Keep
 import com.aptoide.android.aptoidegames.analytics.dto.AnalyticsUIContext
 import com.aptoide.android.aptoidegames.analytics.dto.BundleMeta
+import com.aptoide.android.aptoidegames.analytics.dto.InstallAction
 import com.aptoide.android.aptoidegames.analytics.dto.SearchMeta
 
 @Keep
 data class AnalyticsPayload(
+  val action: InstallAction?,
   val isApkfy: Boolean,
   val isAab: Boolean,
   val aabTypes: String,
@@ -31,4 +33,5 @@ fun AnalyticsPayload.toAnalyticsUiContext(): AnalyticsUIContext = AnalyticsUICon
   bundleMeta = bundleMeta,
   searchMeta = searchMeta,
   itemPosition = itemPosition,
+  installAction = action
 )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/AnalyticsInstallPackageInfoMapper.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/AnalyticsInstallPackageInfoMapper.kt
@@ -27,6 +27,7 @@ class AnalyticsInstallPackageInfoMapper(
       val temporaryPayload: TemporaryPayload? = payload?.fromString()
       copy(
         payload = AnalyticsPayload(
+          action = context.installAction,
           isApkfy = context.isApkfy,
           isAab = temporaryPayload?.isAab ?: app.isAab(),
           aabTypes = getSplitTypesAnalyticsString(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -418,7 +418,6 @@ class InstallAnalytics(
     name = "click_on_install_button",
     app.toBIParameters(aabTypes = null) +
       analyticsContext.toBiParameters(
-        P_ACTION to analyticsContext.installAction?.name?.lowercase(),
         P_STORE to storeName,
         P_TRUSTED_BADGE to app.malware.asNullableParameter(),
         P_UPDATE_TYPE to getUserClicks(app.packageName)
@@ -477,7 +476,6 @@ class InstallAnalytics(
     .toTapsValue()
 
   companion object {
-    private const val P_ACTION = "action"
     private const val P_STORE = "store"
     private const val P_STATUS = "status"
     private const val P_TRUSTED_BADGE = "trusted_badge"


### PR DESCRIPTION
**What does this PR do?**

   Adds `action` parameter to the `download` and `install` Indicative events. 

   Had to refactor a bit to save the action value in the install package info payload.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] By commit

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-278](https://aptoide.atlassian.net/browse/AND-278)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-278](https://aptoide.atlassian.net/browse/AND-278)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-278]: https://aptoide.atlassian.net/browse/AND-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-278]: https://aptoide.atlassian.net/browse/AND-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ