### PR TITLE
[AND-230] Editor's Choice video A/B testing

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/GenericAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/GenericAnalytics.kt
@@ -207,6 +207,9 @@ class GenericAnalytics(private val analyticsSender: AnalyticsSender) {
 
   fun sendApkfyTimeout() = analyticsSender.logEvent("apkfy_timeout", params = emptyMap())
 
+  fun sendECVideosFlagReady() =
+    analyticsSender.logEvent("ec_videos_flag_ready", params = emptyMap())
+
   companion object {
     internal const val P_OPEN_TYPE = "open_type"
     internal const val P_FIRST_LAUNCH = "first_launch"

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AutoScrollViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AutoScrollViewModel.kt
@@ -11,11 +11,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import java.util.concurrent.TimeUnit
 
-class AutoScrollViewModel : ViewModel() {
+const val DEFAULT_AUTO_SCROLL_SPEED = 4L
+
+class AutoScrollViewModel(scrollSpeedInSeconds: Long) : ViewModel() {
 
   private var currentItem: Int = 0
-  private var delayTime: Long = DEFAULT_AUTO_SCROLL_SPEED
+  private var delayTime: Long = TimeUnit.SECONDS.toMillis(scrollSpeedInSeconds)
 
   private val viewModelState = MutableStateFlow<Int?>(null)
 
@@ -69,20 +72,19 @@ class AutoScrollViewModel : ViewModel() {
     super.onCleared()
     cancel()
   }
-
-  companion object {
-    const val DEFAULT_AUTO_SCROLL_SPEED = 4000L
-  }
 }
 
 @Composable
-fun perCarouselViewModel(carouselTag: String): AutoScrollViewModel {
+fun perCarouselViewModel(
+  carouselTag: String,
+  scrollSpeedInSeconds: Long = DEFAULT_AUTO_SCROLL_SPEED
+): AutoScrollViewModel {
   return viewModel(
     key = carouselTag,
     factory = object : Factory {
       override fun <T : ViewModel> create(modelClass: Class<T>): T {
         @Suppress("UNCHECKED_CAST")
-        return AutoScrollViewModel() as T
+        return AutoScrollViewModel(scrollSpeedInSeconds) as T
       }
     }
   )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/PublisherTakeOverBundle.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/PublisherTakeOverBundle.kt
@@ -204,7 +204,7 @@ fun PublisherTakeOverListView(
   HorizontalPagerView(
     appsList = appsList,
     modifier = Modifier.padding(bottom = 24.dp)
-  ) { modifier, page, app ->
+  ) { modifier, page, app, _ ->
 
     Box(
       modifier

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -361,7 +361,7 @@ fun HorizontalPagerView(
   appsList: List<App>,
   modifier: Modifier = Modifier,
   scrollSpeedInSeconds: Long = DEFAULT_AUTO_SCROLL_SPEED,
-  content: @Composable (modifier: Modifier, page: Int, app: App) -> Unit,
+  content: @Composable (modifier: Modifier, page: Int, app: App, isCurrentPage: Boolean) -> Unit,
 ) {
   val screenWidth = LocalConfiguration.current.screenWidthDp.dp
   val padding = (screenWidth - 280.dp - 16.dp) / 2 + 8.dp
@@ -434,7 +434,12 @@ fun HorizontalPagerView(
           translationX = ((size.width - (size.width * scale)) / 2) * pageOffset.sign
         }
       }
-    content(pageModifier, page, app)
+    content(
+      pageModifier,
+      page,
+      app,
+      page == pagerState.currentPage.minus(1).floorMod(appsList.size)
+    )
   }
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -87,6 +87,7 @@ import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.Palette
 import kotlinx.coroutines.launch
 import kotlin.math.absoluteValue
+import kotlin.math.sign
 
 val translatedTitles = mapOf(
   "Just Arrived" to R.string.fixed_bundle_just_arrived_title,
@@ -360,7 +361,6 @@ fun HorizontalPagerView(
   modifier: Modifier = Modifier,
   content: @Composable (modifier: Modifier, page: Int, app: App) -> Unit,
 ) {
-
   val screenWidth = LocalConfiguration.current.screenWidthDp.dp
   val padding = (screenWidth - 280.dp - 16.dp) / 2 + 8.dp
   val contentPadding = PaddingValues(
@@ -416,14 +416,17 @@ fun HorizontalPagerView(
         val pageOffset = (
           (pagerState.currentPage - index) + pagerState
             .currentPageOffsetFraction
-          ).absoluteValue
+          )
 
         lerp(
           start = 0.87f,
           stop = 1f,
-          fraction = 1f - pageOffset.coerceIn(0f, 1f)
+          fraction = 1f - pageOffset.absoluteValue.coerceIn(0f, 1f)
         ).also { scale ->
           scaleY = scale
+          scaleX = scale
+
+          translationX = ((size.width - (size.width * scale)) / 2) * pageOffset.sign
         }
       }
     content(pageModifier, page, app)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -78,6 +78,7 @@ import com.aptoide.android.aptoidegames.feature_apps.presentation.AppsGridBundle
 import com.aptoide.android.aptoidegames.feature_apps.presentation.BonusSectionView
 import com.aptoide.android.aptoidegames.feature_apps.presentation.CarouselBundle
 import com.aptoide.android.aptoidegames.feature_apps.presentation.CarouselLargeBundle
+import com.aptoide.android.aptoidegames.feature_apps.presentation.DEFAULT_AUTO_SCROLL_SPEED
 import com.aptoide.android.aptoidegames.feature_apps.presentation.MyGamesBundleView
 import com.aptoide.android.aptoidegames.feature_apps.presentation.PublisherTakeOverBundle
 import com.aptoide.android.aptoidegames.feature_apps.presentation.buildSeeMoreRoute
@@ -359,6 +360,7 @@ fun SeeMoreView(
 fun HorizontalPagerView(
   appsList: List<App>,
   modifier: Modifier = Modifier,
+  scrollSpeedInSeconds: Long = DEFAULT_AUTO_SCROLL_SPEED,
   content: @Composable (modifier: Modifier, page: Int, app: App) -> Unit,
 ) {
   val screenWidth = LocalConfiguration.current.screenWidthDp.dp
@@ -376,7 +378,10 @@ fun HorizontalPagerView(
   )
   val scope = rememberCoroutineScope()
 
-  val autoScrollViewModel = perCarouselViewModel(carouselTag = appsList.hashCode().toString())
+  val autoScrollViewModel = perCarouselViewModel(
+    carouselTag = appsList.hashCode().toString(),
+    scrollSpeedInSeconds = scrollSpeedInSeconds.takeIf { it > 0L } ?: DEFAULT_AUTO_SCROLL_SPEED
+  )
   val currentPage by autoScrollViewModel.uiState.collectAsState()
 
   /*Used when the current page state is changed in the AutoScrollViewModel*/

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeVideoStateProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeVideoStateProvider.kt
@@ -1,0 +1,74 @@
+package com.aptoide.android.aptoidegames.home
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import cm.aptoide.pt.extensions.runPreviewable
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+import cm.aptoide.pt.install_manager.environment.NetworkConnection
+import com.aptoide.android.aptoidegames.analytics.presentation.rememberBIAnalytics
+import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
+import com.aptoide.android.aptoidegames.apkfy.presentation.InjectionsProvider
+import com.aptoide.android.aptoidegames.network.presentation.rememberNetworkState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.random.Random
+
+@HiltViewModel
+class InjectionsProvider @Inject constructor(
+  val featureFlags: FeatureFlags,
+) : ViewModel()
+
+@Composable
+fun rememberShouldShowVideos(bundleTag: String): Boolean = runPreviewable(
+  preview = { Random.nextBoolean() },
+  real = {
+    val vm = hiltViewModel<InjectionsProvider>()
+
+    val analytics = rememberGenericAnalytics()
+    val biAnalytics = rememberBIAnalytics()
+    val networkState = rememberNetworkState()
+    val unmeteredConnection by remember(networkState) {
+      derivedStateOf { networkState == NetworkConnection.State.UNMETERED }
+    }
+
+    var ecVideoVariant: String? by remember { mutableStateOf(null) }
+    var shouldShowECVideo: Boolean? by remember { mutableStateOf(null) }
+
+    val showVideos by remember(shouldShowECVideo, unmeteredConnection) {
+      derivedStateOf {
+        bundleTag == "apps-group-editors-choice" && shouldShowECVideo == true && unmeteredConnection
+      }
+    }
+
+    LaunchedEffect(Unit) {
+      ecVideoVariant = vm.featureFlags.getFlagAsString("ab_test_ec_videos_jan_29")?.also {
+        //Flag fetched but user the A/B test has not activated yet
+        biAnalytics.setUserProperties("ab_test_ec_videos_jan_29" to "n-a")
+      }
+      shouldShowECVideo = when (vm.featureFlags.getFlagAsString("ab_test_ec_videos_jan_29")) {
+        "group_a" -> false
+        "group_b" -> true
+        else -> null
+      }
+    }
+
+    LaunchedEffect(shouldShowECVideo, unmeteredConnection) {
+      if (bundleTag == "apps-group-editors-choice" && shouldShowECVideo != null && unmeteredConnection) {
+        analytics.sendECVideosFlagReady()
+
+        ecVideoVariant?.let {
+          biAnalytics.setUserProperties("ab_test_ec_videos_jan_29" to it)
+        }
+      }
+    }
+
+    showVideos
+  }
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/network/presentation/NetworkStateProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/network/presentation/NetworkStateProvider.kt
@@ -1,0 +1,33 @@
+package com.aptoide.android.aptoidegames.network.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import cm.aptoide.pt.extensions.runPreviewable
+import cm.aptoide.pt.install_manager.environment.NetworkConnection
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class NetworkStateInjectionsProvider @Inject constructor(
+  val networkConnection: NetworkConnection
+) : ViewModel()
+
+@Composable
+fun rememberNetworkState(): NetworkConnection.State? = runPreviewable(
+  preview = { NetworkConnection.State.entries.toTypedArray().random() },
+  real = {
+    val vm = hiltViewModel<NetworkStateInjectionsProvider>()
+    var state by remember { mutableStateOf(vm.networkConnection.state) }
+
+    vm.networkConnection.setOnChangeListener {
+      state = it
+    }
+
+    state
+  }
+)

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/Mappers.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/Mappers.kt
@@ -82,6 +82,7 @@ private fun AppJSON.toDomainModel(
   description = this.media?.description,
   news = if (this.media?.news.isNullOrEmpty()) null else this.media.news,
   videos = this.media?.videos?.filter { it.type == VideoTypeJSON.YOUTUBE }?.map { it.url }
+    ?: this.media?.video?.takeIf { it.source == "youtube" }?.url?.let { listOf(it) }
     ?: emptyList(),
   store = Store(
     storeName = this.store.name,

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/model/AppJSON.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/model/AppJSON.kt
@@ -38,14 +38,23 @@ data class Media(
   var description: String,
   var news: String,
   var videos: List<VideoJSON>,
+  var video: SingleVideoJSON,
   var screenshots: List<Screenshot>,
 )
 
 @Keep
 data class VideoJSON(
   val type: VideoTypeJSON,
+  val source: String,
   val url: String,
   val thumbnail: String,
+)
+
+@Keep
+data class SingleVideoJSON(
+  val source: String,
+  val url: String,
+  val thumb: String,
 )
 
 @Keep


### PR DESCRIPTION
**What does this PR do?**

   - Adds video support for auto carousel app items.
   - Adds all the necessary logic to fetch the feature flag regarding the editor's choice video A/B testing.
   - Fixes an issue with offset item scaling in the auto carousel.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

- **To test, simply install AG and check if the videos appear and work correctly in case the A/B testing variant is the second one. The flag can be checked through a proxy service, for example.**
- **Check if the video only runs on unmetered connections (as it is intended) and that it stops correctly and shows only the feature graphics on metered connections.**

  Flow on how to test this or QA Tickets related to this use-case: [AND-230](https://aptoide.atlassian.net/browse/AND-230)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-230](https://aptoide.atlassian.net/browse/AND-230)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-230]: https://aptoide.atlassian.net/browse/AND-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-230]: https://aptoide.atlassian.net/browse/AND-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ