### PR TITLE
[AND-228] Reverse suggestion ids for GameGenie

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/MessageList.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/MessageList.kt
@@ -44,8 +44,9 @@ fun MessageList(
       }
 
       if (idx == messages.lastIndex) {
-        suggestions.forEachIndexed { index, suggestion ->
-          SuggestionBox(suggestion, onSuggestionClick, index)
+        suggestions.forEachIndexed { reversedIndex, suggestion ->
+          val actualIndex = suggestions.size - reversedIndex
+          SuggestionBox(suggestion, onSuggestionClick, actualIndex)
         }
 
         MessageBubble(


### PR DESCRIPTION
**What does this PR do?**

Fix the order of GameGenie suggestion ids. Since the layout is reversed, the suggestion ids became inverted.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] MessageList.kt

**How should this be manually tested?**

Open the app and check the logs game genie_suggests_click position

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-228](https://aptoide.atlassian.net/browse/AND-228)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-228]: https://aptoide.atlassian.net/browse/AND-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ