### PR TITLE
[AND-288] Change uninstalls to use android's PackageInstaller

### DIFF
--- a/aptoide-installer/src/main/AndroidManifest.xml
+++ b/aptoide-installer/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+  <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
   <uses-permission android:name="android.permission.ENFORCE_UPDATE_OWNERSHIP" />
   <uses-permission android:name="android.permission.UPDATE_PACKAGES_WITHOUT_USER_ACTION" />
   <!--Permissions for the Android below 11 (R)-->

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/di/AptoideInstallerModule.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/di/AptoideInstallerModule.kt
@@ -5,6 +5,8 @@ import cm.aptoide.pt.installer.platform.InstallEvents
 import cm.aptoide.pt.installer.platform.InstallEventsImpl
 import cm.aptoide.pt.installer.platform.InstallPermissions
 import cm.aptoide.pt.installer.platform.InstallPermissionsImpl
+import cm.aptoide.pt.installer.platform.UninstallEvents
+import cm.aptoide.pt.installer.platform.UninstallEventsImpl
 import cm.aptoide.pt.installer.platform.UserActionHandler
 import cm.aptoide.pt.installer.platform.UserActionHandlerImpl
 import cm.aptoide.pt.installer.platform.UserActionLauncher
@@ -30,6 +32,11 @@ object AptoideInstallerModule {
   @Singleton
   fun providesInstallEvents(installFinisherImpl: InstallEventsImpl): InstallEvents =
     installFinisherImpl
+
+  @Provides
+  @Singleton
+  fun providesUninstallEvents(uninstallFinisherImpl: UninstallEventsImpl): UninstallEvents =
+    uninstallFinisherImpl
 
   @Provides
   @Singleton

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/UninstallEvents.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/UninstallEvents.kt
@@ -1,0 +1,103 @@
+package cm.aptoide.pt.installer.platform
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageInstaller
+import android.os.Build
+import android.os.Bundle
+import androidx.core.content.ContextCompat
+import cm.aptoide.pt.extensions.goAsync
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.withTimeout
+import javax.inject.Inject
+import javax.inject.Singleton
+
+const val UNINSTALL_API_COMPLETE_ACTION = "uninstall_api_complete"
+internal const val UNINSTALL_TIMEOUT = 300_000L
+
+interface UninstallEvents {
+  val events: Flow<UninstallResult>
+}
+
+@Singleton
+class UninstallEventsImpl @Inject constructor(
+  @ApplicationContext context: Context,
+  private val userActionLauncher: UserActionLauncher,
+) : BroadcastReceiver(), UninstallEvents {
+
+  init {
+    // Register itself to listen for the events
+    ContextCompat.registerReceiver(
+      context,
+      this,
+      IntentFilter(UNINSTALL_API_COMPLETE_ACTION),
+      ContextCompat.RECEIVER_NOT_EXPORTED
+    )
+  }
+
+  private val _events = MutableSharedFlow<UninstallResult>(replay = 1, extraBufferCapacity = 10)
+
+  override val events: Flow<UninstallResult> = _events
+
+  override fun onReceive(
+    context: Context,
+    intent: Intent,
+  ): Unit = goAsync(Dispatchers.IO) {
+    intent.extras
+      ?.takeIf { UNINSTALL_API_COMPLETE_ACTION == intent.action }
+      ?.toEvent(context)
+      ?.also { _events.emit(it) }
+  }
+
+  private suspend fun Bundle.toEvent(context: Context): UninstallResult? {
+    val message = getString(PackageInstaller.EXTRA_STATUS_MESSAGE, "No message")
+    val id = getInt("${context.packageName}.uninstall_id")
+    return when (getInt(PackageInstaller.EXTRA_STATUS, -1)) {
+      PackageInstaller.STATUS_PENDING_USER_ACTION -> intent
+        .toUninstallResult(id, message)
+
+      PackageInstaller.STATUS_SUCCESS -> UninstallResult.Success(id)
+      PackageInstaller.STATUS_FAILURE_ABORTED -> UninstallResult.Abort(id, message)
+      PackageInstaller.STATUS_FAILURE,
+      PackageInstaller.STATUS_FAILURE_BLOCKED,
+      PackageInstaller.STATUS_FAILURE_CONFLICT,
+      PackageInstaller.STATUS_FAILURE_INCOMPATIBLE,
+      PackageInstaller.STATUS_FAILURE_INVALID,
+      PackageInstaller.STATUS_FAILURE_STORAGE,
+        -> UninstallResult.Fail(id, message)
+
+      else -> UninstallResult.Fail(id, message)
+    }
+  }
+
+  private val Bundle.intent
+    get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      getParcelable(Intent.EXTRA_INTENT, Intent::class.java)
+    } else {
+      @Suppress("DEPRECATION")
+      getParcelable(Intent.EXTRA_INTENT) as Intent?
+    }
+
+  private suspend fun Intent?.toUninstallResult(
+    id: Int,
+    message: String,
+  ): UninstallResult? = if (this == null) {
+    UninstallResult.Fail(id, message)
+  } else {
+    try {
+      // Schedule the timeout for the intent launch result
+      withTimeout(UNINSTALL_TIMEOUT) {
+        userActionLauncher.launchIntent(this@toUninstallResult)
+      }
+      null
+    } catch (t: TimeoutCancellationException) {
+      UninstallResult.Fail(id, t.message ?: "Unknown reason")
+    }
+  }
+}

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/UninstallResult.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/UninstallResult.kt
@@ -1,0 +1,10 @@
+package cm.aptoide.pt.installer.platform
+
+sealed class UninstallResult {
+
+  abstract val id: Int?
+
+  data class Success(override val id: Int) : UninstallResult()
+  data class Fail(override val id: Int, val message: String) : UninstallResult()
+  data class Abort(override val id: Int, val message: String) : UninstallResult()
+}


### PR DESCRIPTION
**What does this PR do?**

   - Changes uninstalls to use android's PackageInstaller, replacing the ACTION_DELETE system intent previously used for uninstalls.
   - Makes the migrate action rely on the uninstall task state, in order to start the installation only when the uninstall task is completed.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

- this can be tested through the migration test flow, as described in PR #2171 

  Flow on how to test this or QA Tickets related to this use-case: [AND-288](https://aptoide.atlassian.net/browse/AND-288)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-288](https://aptoide.atlassian.net/browse/AND-288)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-288]: https://aptoide.atlassian.net/browse/AND-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-288]: https://aptoide.atlassian.net/browse/AND-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ