### PR TITLE
[AND-289] Firebase download queue entry analytics on auto-update

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -95,11 +95,12 @@ class InstallAnalytics(
 
   fun sendOnInstallationQueued(
     packageName: String,
-    analyticsContext: AnalyticsUIContext
+    installPackageInfo: InstallPackageInfo
   ) {
     genericAnalytics.logEvent(
       name = "download_queue_entry",
-      params = analyticsContext.toGenericParameters(
+      params = installPackageInfo.toAppGenericParameters(
+        packageName = packageName,
         GenericAnalytics.P_PACKAGE_NAME to packageName,
       )
     )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/di/InstallerModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/di/InstallerModule.kt
@@ -30,6 +30,7 @@ import com.aptoide.android.aptoidegames.installer.database.InstallerDatabase
 import com.aptoide.android.aptoidegames.installer.database.InstallerDatabase.FirstMigration
 import com.aptoide.android.aptoidegames.installer.notifications.InstallerNotificationsManager
 import com.aptoide.android.aptoidegames.installer.notifications.RealInstallerNotificationsManager
+import com.aptoide.android.aptoidegames.installer.task_info.AptoideTaskInfoProbe
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -60,7 +61,10 @@ class InstallerModule {
     context = appContext,
     installManager = InstallManager.with(
       context = appContext,
-      taskInfoRepository = taskInfoRepository,
+      taskInfoRepository = AptoideTaskInfoProbe(
+        taskInfoRepository = taskInfoRepository,
+        installAnalytics = installAnalytics
+      ),
       packageDownloader = DownloadProbe(
         packageDownloader = downloadPermissionStateProbe,
         analytics = installAnalytics,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
@@ -124,10 +124,6 @@ fun installViewStates(
             app.campaigns?.toMMPLinkerCampaign()?.sendDownloadEvent(BuildConfig.OEMID)
             onInstallStarted()
             scheduledInstallListener.listenToWifiStart(app.packageName)
-            installAnalytics.sendOnInstallationQueued(
-              packageName = app.packageName,
-              analyticsContext = analyticsContext
-            )
             saveAppDetails(app) {
               installerNotifications.onInstallationQueued(app.packageName)
             }
@@ -183,10 +179,6 @@ fun installViewStates(
             app.campaigns?.toMMPLinkerCampaign()?.sendDownloadEvent(BuildConfig.OEMID)
             onInstallStarted()
             scheduledInstallListener.listenToWifiStart(app.packageName)
-            installAnalytics.sendOnInstallationQueued(
-              packageName = app.packageName,
-              analyticsContext = analyticsContext
-            )
             saveAppDetails(app) {
               installerNotifications.onInstallationQueued(app.packageName)
             }
@@ -252,10 +244,6 @@ fun installViewStates(
             app.campaigns?.toMMPLinkerCampaign()?.sendDownloadEvent(BuildConfig.OEMID)
             onInstallStarted()
             scheduledInstallListener.listenToWifiStart(app.packageName)
-            installAnalytics.sendOnInstallationQueued(
-              packageName = app.packageName,
-              analyticsContext = analyticsContext
-            )
             saveAppDetails(app) {
               installerNotifications.onInstallationQueued(app.packageName)
             }
@@ -362,10 +350,6 @@ fun installViewStates(
             )
             onInstallStarted()
             scheduledInstallListener.listenToWifiStart(app.packageName)
-            installAnalytics.sendOnInstallationQueued(
-              packageName = app.packageName,
-              analyticsContext = analyticsContext
-            )
             saveAppDetails(app) {
               installerNotifications.onInstallationQueued(app.packageName)
             }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/task_info/AptoideTaskInfoProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/task_info/AptoideTaskInfoProbe.kt
@@ -1,0 +1,19 @@
+package com.aptoide.android.aptoidegames.installer.task_info
+
+import cm.aptoide.pt.install_manager.dto.TaskInfo
+import cm.aptoide.pt.install_manager.repository.TaskInfoRepository
+import com.aptoide.android.aptoidegames.installer.analytics.InstallAnalytics
+
+class AptoideTaskInfoProbe(
+  private val taskInfoRepository: TaskInfoRepository,
+  private val installAnalytics: InstallAnalytics
+) : TaskInfoRepository {
+  override suspend fun getAll(): Set<TaskInfo> = taskInfoRepository.getAll()
+
+  override suspend fun saveJob(taskInfo: TaskInfo) {
+    taskInfoRepository.saveJob(taskInfo)
+    installAnalytics.sendOnInstallationQueued(taskInfo.packageName, taskInfo.installPackageInfo)
+  }
+
+  override suspend fun remove(vararg taskInfo: TaskInfo) = taskInfoRepository.remove(*taskInfo)
+}


### PR DESCRIPTION
**What does this PR do?**

   - Creates an analytics wrapper for the TaskInfoRepository.
   - Changes the download queue entry analytics event to be sent whenever a task is added to the TaskInfoRepository, instead of sending it inside the install view states. This guarantees that the event is sent even if there is no user interaction, which is the case of auto updates.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See commit.

**How should this be manually tested?**

- Test the auto update flow to guarantee that 

  Flow on how to test this or QA Tickets related to this use-case: [AND-289](https://aptoide.atlassian.net/browse/AND-289)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-289](https://aptoide.atlassian.net/browse/AND-289)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-289]: https://aptoide.atlassian.net/browse/AND-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-289]: https://aptoide.atlassian.net/browse/AND-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ