### PR TITLE
[AND-295] Add APKFY analytics and retry logic

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
@@ -19,17 +19,7 @@ class ApkfyAnalytics @Inject constructor(
           utmContent = utmContent,
           utmPackageName = packageName
         )
-      } else if (packageName == null && oemId == null) {
-        //Safe to assume there are no utms, so no need to check
-        biAnalytics.setUTMProperties(
-          utmSource = UTM_PROPERTY_NO_APKFY,
-          utmMedium = UTM_PROPERTY_NO_APKFY,
-          utmCampaign = UTM_PROPERTY_NO_APKFY,
-          utmTerm = UTM_PROPERTY_NO_APKFY,
-          utmContent = UTM_PROPERTY_NO_APKFY,
-          utmPackageName = UTM_PROPERTY_NO_APKFY
-        )
-      } else {
+      } else if (hasApkfy()) {
         biAnalytics.setUTMProperties(
           utmSource = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
           utmMedium = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
@@ -37,6 +27,15 @@ class ApkfyAnalytics @Inject constructor(
           utmTerm = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
           utmContent = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
           utmPackageName = packageName
+        )
+      } else {
+        biAnalytics.setUTMProperties(
+          utmSource = UTM_PROPERTY_NO_APKFY,
+          utmMedium = UTM_PROPERTY_NO_APKFY,
+          utmCampaign = UTM_PROPERTY_NO_APKFY,
+          utmTerm = UTM_PROPERTY_NO_APKFY,
+          utmContent = UTM_PROPERTY_NO_APKFY,
+          utmPackageName = UTM_PROPERTY_NO_APKFY
         )
       }
     }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
@@ -1,0 +1,49 @@
+package com.aptoide.android.aptoidegames.apkfy.analytics
+
+import cm.aptoide.pt.feature_apkfy.domain.ApkfyModel
+import com.aptoide.android.aptoidegames.analytics.BIAnalytics
+import jakarta.inject.Inject
+
+class ApkfyAnalytics @Inject constructor(
+  private val biAnalytics: BIAnalytics,
+) {
+
+  fun setApkfyUTMProperties(apkfyModel: ApkfyModel) {
+    apkfyModel.run {
+      if (hasUTMs()) {
+        biAnalytics.setUTMProperties(
+          utmSource = utmSource,
+          utmMedium = utmMedium,
+          utmCampaign = utmCampaign,
+          utmTerm = utmTerm,
+          utmContent = utmContent,
+          utmPackageName = packageName
+        )
+      } else if (packageName == null && oemId == null) {
+        //Safe to assume there are no utms, so no need to check
+        biAnalytics.setUTMProperties(
+          utmSource = UTM_PROPERTY_NO_APKFY,
+          utmMedium = UTM_PROPERTY_NO_APKFY,
+          utmCampaign = UTM_PROPERTY_NO_APKFY,
+          utmTerm = UTM_PROPERTY_NO_APKFY,
+          utmContent = UTM_PROPERTY_NO_APKFY,
+          utmPackageName = UTM_PROPERTY_NO_APKFY
+        )
+      } else {
+        biAnalytics.setUTMProperties(
+          utmSource = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
+          utmMedium = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
+          utmCampaign = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
+          utmTerm = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
+          utmContent = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
+          utmPackageName = packageName
+        )
+      }
+    }
+  }
+
+  companion object {
+    private const val UTM_PROPERTY_NO_APKFY = "NO_APKFY"
+    private const val UTM_PROPERTY_APKFY_WITHOUT_UTMS = "APKFY_BUT_NO_UTM"
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
@@ -2,11 +2,38 @@ package com.aptoide.android.aptoidegames.apkfy.analytics
 
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyModel
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
+import com.aptoide.android.aptoidegames.analytics.mapOfNonNull
 import jakarta.inject.Inject
 
 class ApkfyAnalytics @Inject constructor(
   private val biAnalytics: BIAnalytics,
 ) {
+
+  fun sendApkfySuccessEvent(
+    data: String,
+  ) {
+    biAnalytics.logEvent(
+      name = "ag_aptoide_mmp",
+      mapOfNonNull(
+        P_STATUS to "success",
+        P_DATA to data
+      )
+    )
+  }
+
+  fun sendApkfyFailEvent(
+    errorMessage: String?,
+    errorType: String?,
+    errorCode: Int? = null,
+  ) = biAnalytics.logEvent(
+    name = "ag_aptoide_mmp",
+    mapOfNonNull(
+      P_STATUS to "fail",
+      P_ERROR_MESSAGE to errorMessage,
+      P_ERROR_TYPE to errorType,
+      P_ERROR_HTTP_CODE to errorCode
+    )
+  )
 
   fun setApkfyUTMProperties(apkfyModel: ApkfyModel) {
     apkfyModel.run {
@@ -44,5 +71,11 @@ class ApkfyAnalytics @Inject constructor(
   companion object {
     private const val UTM_PROPERTY_NO_APKFY = "NO_APKFY"
     private const val UTM_PROPERTY_APKFY_WITHOUT_UTMS = "APKFY_BUT_NO_UTM"
+
+    private const val P_STATUS = "status"
+    private const val P_DATA = "data"
+    private const val P_ERROR_MESSAGE = "error_message"
+    private const val P_ERROR_TYPE = "error_type"
+    private const val P_ERROR_HTTP_CODE = "error_http_code"
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
@@ -11,12 +11,16 @@ class ApkfyAnalytics @Inject constructor(
 
   fun sendApkfySuccessEvent(
     data: String,
+    isRetry: Boolean,
+    callNumber: Int,
   ) {
     biAnalytics.logEvent(
       name = "ag_aptoide_mmp",
       mapOfNonNull(
         P_STATUS to "success",
-        P_DATA to data
+        P_DATA to data,
+        P_RETRY to isRetry,
+        P_CALL_NUMBER to callNumber
       )
     )
   }
@@ -25,13 +29,17 @@ class ApkfyAnalytics @Inject constructor(
     errorMessage: String?,
     errorType: String?,
     errorCode: Int? = null,
+    isRetry: Boolean,
+    callNumber: Int,
   ) = biAnalytics.logEvent(
     name = "ag_aptoide_mmp",
     mapOfNonNull(
       P_STATUS to "fail",
       P_ERROR_MESSAGE to errorMessage,
       P_ERROR_TYPE to errorType,
-      P_ERROR_HTTP_CODE to errorCode
+      P_ERROR_HTTP_CODE to errorCode,
+      P_RETRY to isRetry,
+      P_CALL_NUMBER to callNumber
     )
   )
 
@@ -77,5 +85,7 @@ class ApkfyAnalytics @Inject constructor(
     private const val P_ERROR_MESSAGE = "error_message"
     private const val P_ERROR_TYPE = "error_type"
     private const val P_ERROR_HTTP_CODE = "error_http_code"
+    private const val P_RETRY = "retry"
+    private const val P_CALL_NUMBER = "call_number"
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyManagerProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyManagerProbe.kt
@@ -4,6 +4,8 @@ import cm.aptoide.pt.feature_apkfy.domain.ApkfyManager
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyModel
 import cm.aptoide.pt.feature_campaigns.AptoideMMPCampaign
 import com.aptoide.android.aptoidegames.IdsRepository
+import com.google.gson.Gson
+import retrofit2.HttpException
 
 class ApkfyManagerProbe(
   private val apkfyManager: ApkfyManager,
@@ -16,17 +18,30 @@ class ApkfyManagerProbe(
   }
 
   override suspend fun getApkfy(): ApkfyModel? {
-    if (idsRepository.getId(GUEST_UID_KEY).isEmpty()) {
-      return apkfyManager.getApkfy()
-        ?.also(apkfyAnalytics::setApkfyUTMProperties)
-        ?.also {
-          idsRepository.saveId(GUEST_UID_KEY, it.guestUid)
-        }.also {
-          // TODO: improve this logic
-          AptoideMMPCampaign.guestUID = it?.guestUid ?: idsRepository.getId(GUEST_UID_KEY)
-        }
-    } else {
-      AptoideMMPCampaign.guestUID = idsRepository.getId(GUEST_UID_KEY)
+    try {
+      if (idsRepository.getId(GUEST_UID_KEY).isEmpty()) {
+        return apkfyManager.getApkfy()
+          ?.also(apkfyAnalytics::setApkfyUTMProperties)
+          ?.also {
+            idsRepository.saveId(GUEST_UID_KEY, it.guestUid)
+          }
+          ?.also {
+            apkfyAnalytics.sendApkfySuccessEvent(data = Gson().toJson(it))
+          }
+          .also {
+            // TODO: improve this logic
+            AptoideMMPCampaign.guestUID = it?.guestUid ?: idsRepository.getId(GUEST_UID_KEY)
+          }
+      } else {
+        AptoideMMPCampaign.guestUID = idsRepository.getId(GUEST_UID_KEY)
+        return null
+      }
+    } catch (e: Throwable) {
+      apkfyAnalytics.sendApkfyFailEvent(
+        errorMessage = e.message,
+        errorType = e::class.simpleName,
+        errorCode = (e as? HttpException)?.code()
+      )
       return null
     }
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyManagerProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyManagerProbe.kt
@@ -4,24 +4,21 @@ import cm.aptoide.pt.feature_apkfy.domain.ApkfyManager
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyModel
 import cm.aptoide.pt.feature_campaigns.AptoideMMPCampaign
 import com.aptoide.android.aptoidegames.IdsRepository
-import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 
 class ApkfyManagerProbe(
   private val apkfyManager: ApkfyManager,
-  private val biAnalytics: BIAnalytics,
+  private val apkfyAnalytics: ApkfyAnalytics,
   private val idsRepository: IdsRepository,
 ) : ApkfyManager {
 
   companion object {
-    private const val UTM_PROPERTY_NO_APKFY = "NO_APKFY"
-    private const val UTM_PROPERTY_APKFY_WITHOUT_UTMS = "APKFY_BUT_NO_UTM"
     private const val GUEST_UID_KEY = "GUEST_UID"
   }
 
   override suspend fun getApkfy(): ApkfyModel? {
     if (idsRepository.getId(GUEST_UID_KEY).isEmpty()) {
       return apkfyManager.getApkfy()
-        ?.also(::setApkfyUTMProperties)
+        ?.also(apkfyAnalytics::setApkfyUTMProperties)
         ?.also {
           idsRepository.saveId(GUEST_UID_KEY, it.guestUid)
         }.also {
@@ -31,40 +28,6 @@ class ApkfyManagerProbe(
     } else {
       AptoideMMPCampaign.guestUID = idsRepository.getId(GUEST_UID_KEY)
       return null
-    }
-  }
-
-  private fun setApkfyUTMProperties(apkfyModel: ApkfyModel) {
-    apkfyModel.run {
-      if (hasUTMs()) {
-        biAnalytics.setUTMProperties(
-          utmSource = utmSource,
-          utmMedium = utmMedium,
-          utmCampaign = utmCampaign,
-          utmTerm = utmTerm,
-          utmContent = utmContent,
-          utmPackageName = packageName
-        )
-      } else if (packageName == null && oemId == null) {
-        //Safe to assume there are no utms, so no need to check
-        biAnalytics.setUTMProperties(
-          utmSource = UTM_PROPERTY_NO_APKFY,
-          utmMedium = UTM_PROPERTY_NO_APKFY,
-          utmCampaign = UTM_PROPERTY_NO_APKFY,
-          utmTerm = UTM_PROPERTY_NO_APKFY,
-          utmContent = UTM_PROPERTY_NO_APKFY,
-          utmPackageName = UTM_PROPERTY_NO_APKFY
-        )
-      } else {
-        biAnalytics.setUTMProperties(
-          utmSource = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-          utmMedium = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-          utmCampaign = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-          utmTerm = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-          utmContent = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-          utmPackageName = packageName
-        )
-      }
     }
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyManagerProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyManagerProbe.kt
@@ -5,6 +5,7 @@ import cm.aptoide.pt.feature_apkfy.domain.ApkfyModel
 import cm.aptoide.pt.feature_campaigns.AptoideMMPCampaign
 import com.aptoide.android.aptoidegames.IdsRepository
 import com.google.gson.Gson
+import kotlinx.coroutines.delay
 import retrofit2.HttpException
 
 class ApkfyManagerProbe(
@@ -18,30 +19,52 @@ class ApkfyManagerProbe(
   }
 
   override suspend fun getApkfy(): ApkfyModel? {
-    try {
-      if (idsRepository.getId(GUEST_UID_KEY).isEmpty()) {
-        return apkfyManager.getApkfy()
-          ?.also(apkfyAnalytics::setApkfyUTMProperties)
-          ?.also {
-            idsRepository.saveId(GUEST_UID_KEY, it.guestUid)
+    //TODO: improve this logic. Move the retries outside this probe.
+    if (idsRepository.getId(GUEST_UID_KEY).isEmpty()) {
+      var isRetry = false
+      var apkfyModel: ApkfyModel? = null
+      var attempts = 0
+
+      while (attempts < 3) { //Apkfy call repeated at most 3 times, to make sure there is no apkfy app associated
+        try {
+          apkfyModel = apkfyManager.getApkfy()
+            ?.also(apkfyAnalytics::setApkfyUTMProperties)
+            ?.also { idsRepository.saveId(GUEST_UID_KEY, it.guestUid) }
+            .also {
+              // TODO: improve this logic
+              AptoideMMPCampaign.guestUID = it?.guestUid ?: idsRepository.getId(GUEST_UID_KEY)
+            }
+            ?.also {
+              apkfyAnalytics.sendApkfySuccessEvent(
+                data = Gson().toJson(it),
+                isRetry = isRetry,
+                callNumber = attempts
+              )
+            }
+
+          if (apkfyModel != null && apkfyModel.hasApkfy()) {
+            break
           }
-          ?.also {
-            apkfyAnalytics.sendApkfySuccessEvent(data = Gson().toJson(it))
-          }
-          .also {
-            // TODO: improve this logic
-            AptoideMMPCampaign.guestUID = it?.guestUid ?: idsRepository.getId(GUEST_UID_KEY)
-          }
-      } else {
-        AptoideMMPCampaign.guestUID = idsRepository.getId(GUEST_UID_KEY)
-        return null
+
+          isRetry = false
+        } catch (e: Throwable) {
+          apkfyAnalytics.sendApkfyFailEvent(
+            errorMessage = e.message,
+            errorType = e::class.simpleName,
+            errorCode = (e as? HttpException)?.code(),
+            isRetry = isRetry,
+            callNumber = attempts
+          )
+          isRetry = true
+        }
+
+        attempts++
+        delay(5000L)
       }
-    } catch (e: Throwable) {
-      apkfyAnalytics.sendApkfyFailEvent(
-        errorMessage = e.message,
-        errorType = e::class.simpleName,
-        errorCode = (e as? HttpException)?.code()
-      )
+
+      return apkfyModel
+    } else {
+      AptoideMMPCampaign.guestUID = idsRepository.getId(GUEST_UID_KEY)
       return null
     }
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/di/RepositoryModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/di/RepositoryModule.kt
@@ -3,8 +3,8 @@ package com.aptoide.android.aptoidegames.apkfy.di
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyManager
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyManagerImpl
 import com.aptoide.android.aptoidegames.IdsRepository
-import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.apkfy.DownloadPermissionStateProbe
+import com.aptoide.android.aptoidegames.apkfy.analytics.ApkfyAnalytics
 import com.aptoide.android.aptoidegames.apkfy.analytics.ApkfyManagerProbe
 import com.aptoide.android.aptoidegames.installer.DownloaderSelector
 import dagger.Module
@@ -21,12 +21,12 @@ internal object RepositoryModule {
   @Singleton
   fun provideApkfyManager(
     apkfyManager: ApkfyManagerImpl,
-    biAnalytics: BIAnalytics,
+    apkfyAnalytics: ApkfyAnalytics,
     idsRepository: IdsRepository
   ): ApkfyManager =
     ApkfyManagerProbe(
       apkfyManager = apkfyManager,
-      biAnalytics = biAnalytics,
+      apkfyAnalytics = apkfyAnalytics,
       idsRepository = idsRepository
     )
 

--- a/feature-apkfy/src/main/java/cm/aptoide/pt/feature_apkfy/domain/ApkfyModel.kt
+++ b/feature-apkfy/src/main/java/cm/aptoide/pt/feature_apkfy/domain/ApkfyModel.kt
@@ -13,6 +13,8 @@ data class ApkfyModel(
   val utmTerm: String?,
   val utmContent: String?,
 ) : AppSource {
+  fun hasApkfy() = packageName != null || appId != null
+
   fun hasUTMs() = this.run {
     utmSource != null || utmMedium != null || utmCampaign != null || utmTerm != null || utmContent != null
   }


### PR DESCRIPTION
**What does this PR do?**

   - Extracts the method that sets the apkfy UTM properties to a class responsible for handling APKFY related analytics.
   - Adds a new event to collect info about the apkfy calls.
   - Adds retry logic to repeat the apkfy call in case it fails.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-295](https://aptoide.atlassian.net/browse/AND-295)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-295](https://aptoide.atlassian.net/browse/AND-295)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-295]: https://aptoide.atlassian.net/browse/AND-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-295]: https://aptoide.atlassian.net/browse/AND-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ