### PR TITLE
[AND-303] Add exception handling when getting installed packages

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
@@ -6,6 +6,8 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.hilt.work.HiltWorkerFactory
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.work.Configuration
 import androidx.work.Configuration.Provider
 import cm.aptoide.pt.feature_campaigns.AptoideMMPCampaign
@@ -37,6 +39,8 @@ import com.aptoide.android.aptoidegames.installer.notifications.InstallerNotific
 import com.aptoide.android.aptoidegames.launch.AppLaunchPreferencesManager
 import com.aptoide.android.aptoidegames.network.AptoideGetHeaders
 import com.google.firebase.FirebaseApp
+import com.google.firebase.crashlytics.ktx.crashlytics
+import com.google.firebase.ktx.Firebase
 import dagger.hilt.EntryPoint
 import dagger.hilt.EntryPoints
 import dagger.hilt.InstallIn
@@ -123,7 +127,13 @@ class AptoideApplication : Application(), ImageLoaderFactory, Provider {
     initPayments()
     initIndicative()
     setUserProperties()
-    updates.initialize(this)
+    AndroidViewModel(this).viewModelScope.launch {
+      try {
+        updates.initialize(this@AptoideApplication)
+      } catch (e: Throwable) {
+        Firebase.crashlytics.recordException(e)
+      }
+    }
     AptoideMMPCampaign.init(BuildConfig.OEMID, BuildConfig.MARKET_NAME)
   }
 


### PR DESCRIPTION
**What does this PR do?**

   - Fixes a reported crash when getting the user installed packages, which throwed either a DeadObjectException or a BadParcelableException, by catching the exceptions and returning an empty list of installed packages instead.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-303](https://aptoide.atlassian.net/browse/AND-303)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-303](https://aptoide.atlassian.net/browse/AND-303)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-303]: https://aptoide.atlassian.net/browse/AND-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-303]: https://aptoide.atlassian.net/browse/AND-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ