### PR TITLE
[AND-304] add support for survey via firebase notification

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/LaunchIntentExtensions.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/LaunchIntentExtensions.kt
@@ -22,6 +22,10 @@ val Intent?.isAhab: Boolean get() = this?.getBooleanExtra(AHAB_NOTIFICATION, fal
 
 fun Intent.markAsAhab(): Intent = putExtra(AHAB_NOTIFICATION, hasDeepLink)
 
+//External url
+const val EXTERNAL_KEY = "external_url"
+const val WEBVIEW_KEY = "webview"
+
 // Launch source
 private const val LAUNCH_SOURCE = "launchSource"
 
@@ -35,3 +39,12 @@ val Intent?.agDeepLink
     ?.getString(DEEPLINK_KEY)
     ?.withPrevScreen("notification")
     ?.let(Uri::parse)
+
+val Intent?.externalUrl
+  get() = this?.extras
+    ?.getString(EXTERNAL_KEY)
+    ?.let(Uri::parse)
+
+val Intent?.shouldOpenWebView
+  get() = this?.extras
+    ?.getString(WEBVIEW_KEY)?.toBooleanStrictOrNull() ?: false

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
@@ -111,6 +111,19 @@ class MainActivity : AppCompatActivity() {
     intent.takeIf { it.isAhab }?.agDeepLink.takeIf { it?.scheme == "promocode" }?.run {
       promoCodeRepository.setPromoCodeApp(PromoCodeApp(host!!, path!!))
     }
+
+    intent.externalUrl?.takeIf { it.scheme in listOf("http", "https") }
+      ?.let { uri ->
+        if (uri.toString().isNotEmpty()) {
+          if (intent.shouldOpenWebView) {
+            UrlActivity.open(this, uri.toString())
+          } else {
+            val intent = Intent(Intent.ACTION_VIEW, uri)
+            startActivity(intent)
+          }
+        }
+      }
+
     CoroutineScope(Dispatchers.IO).launch {
       intent?.getStringExtra(InstallerNotificationsBuilder.ALLOW_METERED_DOWNLOAD_FOR_PACKAGE)
         ?.let(installManager::getApp)


### PR DESCRIPTION
**What does this PR do?**

   This Pr aims to add support for notifications for external pages

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] MainActivity.kt
- [ ] LaunchIntentExtensions.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-304](https://aptoide.atlassian.net/browse/AND-304)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-304](https://aptoide.atlassian.net/browse/AND-304)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-304]: https://aptoide.atlassian.net/browse/AND-304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-304]: https://aptoide.atlassian.net/browse/AND-304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ