### PR TITLE
[AND-301] Add apkfy guest uid as indicative user property

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
@@ -49,11 +49,12 @@ class BIAnalytics(private val analyticsSender: AnalyticsSender) {
     appLaunchPreferencesManager: AppLaunchPreferencesManager,
     featureFlags: FeatureFlags,
   ) {
+    Indicative.launch(context, BuildConfig.INDICATIVE_KEY)
+
     CoroutineScope(Dispatchers.Main).launch {
       val isFirstLaunch = appLaunchPreferencesManager.isFirstLaunch()
       val locale = context.resources.configuration.locales[0]
 
-      Indicative.launch(context, BuildConfig.INDICATIVE_KEY)
       Indicative.setUniqueID(analyticsInfoProvider.getAnalyticsId())
 
       analyticsSender.setUserProperties(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
@@ -9,6 +9,10 @@ class ApkfyAnalytics @Inject constructor(
   private val biAnalytics: BIAnalytics,
 ) {
 
+  fun setGuestUIDUserProperty(guestUid: String) = biAnalytics.setUserProperties(
+    "aptoide_mmp_guest_id" to guestUid
+  )
+
   fun sendApkfySuccessEvent(
     data: String,
     isRetry: Boolean,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyManagerProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyManagerProbe.kt
@@ -30,6 +30,7 @@ class ApkfyManagerProbe(
           apkfyModel = apkfyManager.getApkfy()
             ?.also(apkfyAnalytics::setApkfyUTMProperties)
             ?.also { idsRepository.saveId(GUEST_UID_KEY, it.guestUid) }
+            ?.also { apkfyAnalytics.setGuestUIDUserProperty(it.guestUid) }
             .also {
               // TODO: improve this logic
               AptoideMMPCampaign.guestUID = it?.guestUid ?: idsRepository.getId(GUEST_UID_KEY)
@@ -64,7 +65,10 @@ class ApkfyManagerProbe(
 
       return apkfyModel
     } else {
-      AptoideMMPCampaign.guestUID = idsRepository.getId(GUEST_UID_KEY)
+      idsRepository.getId(GUEST_UID_KEY).let {
+        apkfyAnalytics.setGuestUIDUserProperty(it)
+        AptoideMMPCampaign.guestUID = it
+      }
       return null
     }
   }


### PR DESCRIPTION
**What does this PR do?**

   - Adds the apkfy guest uid as indicative user property, regardless if the guest uid is fetched from the apkfy or from the shared preferences.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-301](https://aptoide.atlassian.net/browse/AND-301)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-301](https://aptoide.atlassian.net/browse/AND-301)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-301]: https://aptoide.atlassian.net/browse/AND-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-301]: https://aptoide.atlassian.net/browse/AND-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ