### PR TITLE
[AND-230] Fix scroll speed and replay in editor choice carousel videos

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AutoScrollViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AutoScrollViewModel.kt
@@ -1,6 +1,7 @@
 package com.aptoide.android.aptoidegames.feature_apps.presentation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider.Factory
 import androidx.lifecycle.viewModelScope
@@ -68,6 +69,11 @@ class AutoScrollViewModel(scrollSpeedInSeconds: Long) : ViewModel() {
     currentItem = item
   }
 
+  fun updateSpeed(scrollSpeedInSeconds: Long) {
+    delayTime = TimeUnit.SECONDS.toMillis(scrollSpeedInSeconds)
+    start()
+  }
+
   override fun onCleared() {
     super.onCleared()
     cancel()
@@ -79,7 +85,7 @@ fun perCarouselViewModel(
   carouselTag: String,
   scrollSpeedInSeconds: Long = DEFAULT_AUTO_SCROLL_SPEED
 ): AutoScrollViewModel {
-  return viewModel(
+  val vm: AutoScrollViewModel = viewModel(
     key = carouselTag,
     factory = object : Factory {
       override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -88,4 +94,10 @@ fun perCarouselViewModel(
       }
     }
   )
+
+  LaunchedEffect(scrollSpeedInSeconds) {
+    vm.updateSpeed(scrollSpeedInSeconds)
+  }
+
+  return vm
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/videos/presentation/YoutubePlayer.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/videos/presentation/YoutubePlayer.kt
@@ -105,7 +105,7 @@ fun CarouselAppYoutubePlayer(
         PlayerConstants.PlayerState.PAUSED,
         PlayerConstants.PlayerState.PLAYING -> showVideo = true
 
-        PlayerConstants.PlayerState.ENDED -> youtubePlayer?.cueVideo(videoId, 0f)
+        PlayerConstants.PlayerState.ENDED -> youtubePlayer?.seekTo(0f)
 
         else -> Unit
       }


### PR DESCRIPTION
**What does this PR do?**

   - Adds a method to change the speed of a carousel in the AutoScrollViewModel and makes the AutoScrollViewModel provider automatically react to changes in the speed received.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-230](https://aptoide.atlassian.net/browse/AND-230)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-230](https://aptoide.atlassian.net/browse/AND-230)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-230]: https://aptoide.atlassian.net/browse/AND-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-230]: https://aptoide.atlassian.net/browse/AND-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ