### PR TITLE
[AND-305] Call mmp download events on auto updates

### DIFF
--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/Updates.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/Updates.kt
@@ -7,6 +7,7 @@ import cm.aptoide.pt.extensions.getSignature
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.AppsListMapper
 import cm.aptoide.pt.feature_apps.data.model.AppJSON
+import cm.aptoide.pt.feature_campaigns.toAptoideMMPCampaign
 import cm.aptoide.pt.feature_updates.data.AutoUpdateWorker
 import cm.aptoide.pt.feature_updates.data.UpdatesRepository
 import cm.aptoide.pt.feature_updates.data.UpdatesWorker
@@ -153,6 +154,14 @@ class Updates @Inject constructor(
               networkType = UNMETERED
             )
           )
+
+          it.campaigns?.toAptoideMMPCampaign()
+            ?.sendDownloadEvent(
+              bundleTag = null,
+              searchKeyword = null,
+              currentScreen = null,
+              isCta = false
+            )
         }
     }
   }


### PR DESCRIPTION
**What does this PR do?**

   - Makes auto updates call the respective map download events for each app being updated.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-305](https://aptoide.atlassian.net/browse/AND-305)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-305](https://aptoide.atlassian.net/browse/AND-305)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-305]: https://aptoide.atlassian.net/browse/AND-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-305]: https://aptoide.atlassian.net/browse/AND-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ