### PR TITLE
[AND-188] Add conversation history to GameGenie

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/GameGenieRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/GameGenieRepository.kt
@@ -1,13 +1,17 @@
 package com.aptoide.android.aptoidegames.gamegenie.data
 
+import com.aptoide.android.aptoidegames.gamegenie.data.database.GameGenieHistoryDao
+import com.aptoide.android.aptoidegames.gamegenie.data.database.model.GameGenieHistoryEntity
 import com.aptoide.android.aptoidegames.gamegenie.domain.Token
 import com.aptoide.android.aptoidegames.gamegenie.io_models.GameGenieRequest
 import com.aptoide.android.aptoidegames.gamegenie.io_models.GameGenieResponse
 import com.aptoide.android.aptoidegames.gamegenie.io_models.TokenResponse
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GameGenieRepository @Inject constructor(
   private val apiService: GameGenieApiService,
+  private val gameGenieDao: GameGenieHistoryDao,
 ) {
   suspend fun postMessage(
     token: Token,
@@ -18,5 +22,21 @@ class GameGenieRepository @Inject constructor(
 
   suspend fun getToken(): TokenResponse {
     return apiService.getToken()
+  }
+
+  suspend fun saveChatById(entity: GameGenieHistoryEntity) {
+    gameGenieDao.saveChatById(entity)
+  }
+
+  suspend fun getAllChats(): Flow<List<GameGenieHistoryEntity>> {
+    return gameGenieDao.getAllChats()
+  }
+
+  suspend fun getChatById(id: String): GameGenieHistoryEntity {
+    return gameGenieDao.getChatById(id)
+  }
+
+  suspend fun deleteChat(id: String) {
+    gameGenieDao.deleteChat(id)
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/GameGenieHistoryDao.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/GameGenieHistoryDao.kt
@@ -3,10 +3,21 @@ package com.aptoide.android.aptoidegames.gamegenie.data.database
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
+import androidx.room.Query
 import com.aptoide.android.aptoidegames.gamegenie.data.database.model.GameGenieHistoryEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface GameGenieHistoryDao {
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun saveChatById(gameGenieHistoryEntity: GameGenieHistoryEntity)
+
+  @Query("SELECT * FROM GameGenieHistory")
+  fun getAllChats(): Flow<List<GameGenieHistoryEntity>>
+
+  @Query("SELECT * FROM GameGenieHistory WHERE id=:chatId")
+  suspend fun getChatById(chatId: String): GameGenieHistoryEntity
+
+  @Query("DELETE FROM GameGenieHistory WHERE id=:chatId")
+  suspend fun deleteChat(chatId: String)
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/model/Converters.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/model/Converters.kt
@@ -5,15 +5,16 @@ import com.google.common.reflect.TypeToken
 import com.google.gson.Gson
 
 class Converters {
+  private val gson = Gson()
 
   @TypeConverter
   fun fromChatInteractionList(value: List<ChatInteractionEntity>): String {
-    return Gson().toJson(value)
+    return gson.toJson(value)
   }
 
   @TypeConverter
   fun toChatInteractionList(value: String): List<ChatInteractionEntity> {
     val type = object : TypeToken<List<ChatInteractionEntity>>() {}.type
-    return Gson().fromJson(value, type)
+    return gson.fromJson(value, type)
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/di/GameGenieModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/di/GameGenieModule.kt
@@ -7,6 +7,7 @@ import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieApiService
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieRepository
 import com.aptoide.android.aptoidegames.gamegenie.data.database.GameGenieDatabase
+import com.aptoide.android.aptoidegames.gamegenie.data.database.GameGenieHistoryDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -31,8 +32,11 @@ internal object GameGenieModule {
   }
 
   @Provides
-  fun provideChatbotRepository(apiService: GameGenieApiService): GameGenieRepository {
-    return GameGenieRepository(apiService)
+  fun provideChatbotRepository(
+    apiService: GameGenieApiService,
+    dao: GameGenieHistoryDao,
+  ): GameGenieRepository {
+    return GameGenieRepository(apiService, dao)
   }
 
   @Singleton
@@ -44,4 +48,9 @@ internal object GameGenieModule {
     GameGenieDatabase::class.java,
     "ag_game_genie.db"
   ).build()
+
+  @Singleton
+  @Provides
+  fun provideGameGenieDao(database: GameGenieDatabase): GameGenieHistoryDao =
+    database.getGameGenieHistoryDao()
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/domain/ConversationInfo.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/domain/ConversationInfo.kt
@@ -1,0 +1,7 @@
+package com.aptoide.android.aptoidegames.gamegenie.domain
+
+data class ConversationInfo(
+  val id: String,
+  val title: String?,
+  val firstMessage: String,
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/ConversationHistoryUIState.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/ConversationHistoryUIState.kt
@@ -1,0 +1,12 @@
+package com.aptoide.android.aptoidegames.gamegenie.presentation
+
+import com.aptoide.android.aptoidegames.gamegenie.domain.ConversationInfo
+
+sealed class ConversationHistoryUIState {
+  object Loading : ConversationHistoryUIState()
+
+  data class Idle(
+    val pastConversations: List<ConversationInfo>,
+    val onDeleteChat: (String) -> Unit,
+  ) : ConversationHistoryUIState()
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/ConversationHistoryViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/ConversationHistoryViewModel.kt
@@ -1,0 +1,50 @@
+package com.aptoide.android.aptoidegames.gamegenie.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ConversationHistoryViewModel @Inject constructor(
+  private val gameGenieRepository: GameGenieRepository,
+) : ViewModel() {
+
+  private val viewModelState =
+    MutableStateFlow<ConversationHistoryUIState>(ConversationHistoryUIState.Loading)
+
+  val uiState = viewModelState
+    .stateIn(
+      viewModelScope,
+      SharingStarted.Eagerly,
+      viewModelState.value
+    )
+
+  init {
+    viewModelScope.launch {
+      gameGenieRepository.getAllChats().map {
+        val pastConversations =
+          it.map { conversation -> conversation.toConversationInfo() }.reversed()
+        viewModelState.update {
+          ConversationHistoryUIState.Idle(pastConversations, onDeleteChat = { deleteChat(it) })
+        }
+      }.catch { cause: Throwable -> cause.printStackTrace() }
+        .collect()
+    }
+  }
+
+  private fun deleteChat(id: String) {
+    viewModelScope.launch {
+      gameGenieRepository.deleteChat(id)
+    }
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieView.kt
@@ -1,5 +1,6 @@
 package com.aptoide.android.aptoidegames.gamegenie.presentation
 
+import ConversationsDrawer
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -38,18 +39,25 @@ fun gameGenieScreen() = ScreenData.withAnalytics(
   val uiState by viewModel.uiState.collectAsState()
   val analytics = rememberGameGenieAnalytics()
 
-  ChatbotView(
-    uiState = uiState,
-    navigateTo = navigate,
-    onError = viewModel::reload,
-    onMessageSend = { message ->
-      viewModel.sendMessage(message)
+  ConversationsDrawer(
+    mainScreen = {
+      ChatbotView(
+        uiState = uiState,
+        navigateTo = navigate,
+        onError = viewModel::reload,
+        onMessageSend = { message ->
+          viewModel.sendMessage(message)
+        },
+        onSuggestionSend = { message, index ->
+          viewModel.sendMessage(message)
+          analytics.sendGameGenieSuggestionClick(index)
+        },
+        onAllAppsFail = viewModel::setGeneralError
+      )
     },
-    onSuggestionSend = { message, index ->
-      viewModel.sendMessage(message)
-      analytics.sendGameGenieSuggestionClick(index)
-    },
-    onAllAppsFail = viewModel::setGeneralError
+    loadConversationFn = viewModel::loadConversation,
+    currentChatId = uiState.chat.id,
+    newChatFn = viewModel::createNewChat,
   )
 }
 
@@ -138,6 +146,7 @@ fun ChatScreen(
       onMessageSent = onMessageSend,
       modifier = Modifier
         .fillMaxWidth()
+        .padding(bottom = 8.dp)
     )
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/ViewModelProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/ViewModelProvider.kt
@@ -1,0 +1,40 @@
+package com.aptoide.android.aptoidegames.gamegenie.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import cm.aptoide.pt.extensions.runPreviewable
+import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class GameGenieViewModelInjectionsProvider @Inject constructor(
+  val gameGenieRepository: GameGenieRepository,
+) : ViewModel()
+
+@Composable
+fun rememberGameGenieHistoryUiState(): ConversationHistoryUIState =
+  runPreviewable(
+    preview = {
+      ConversationHistoryUIState.Loading
+    }, real = {
+      val injectionsProvider = hiltViewModel<GameGenieViewModelInjectionsProvider>()
+      val vm: ConversationHistoryViewModel = viewModel(
+        key = "ConversationHistoryViewModel",
+        factory = object : ViewModelProvider.Factory {
+          override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            @Suppress("UNCHECKED_CAST")
+            return ConversationHistoryViewModel(
+              gameGenieRepository = injectionsProvider.gameGenieRepository,
+            ) as T
+          }
+        }
+      )
+      val uiState by vm.uiState.collectAsState()
+      uiState
+    })

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/ConversationHistoryBox.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/ConversationHistoryBox.kt
@@ -1,0 +1,81 @@
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.minimumInteractiveComponentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.aptoide.android.aptoidegames.drawables.icons.getClose
+import com.aptoide.android.aptoidegames.drawables.icons.getGames
+import com.aptoide.android.aptoidegames.gamegenie.domain.ConversationInfo
+import com.aptoide.android.aptoidegames.theme.AGTypography
+import com.aptoide.android.aptoidegames.theme.Palette
+
+@Composable
+fun ConversationHistoryBox(
+  conversationInfo: ConversationInfo,
+  onClick: (String) -> Unit,
+  isSelected: Boolean,
+  onDelete: (String) -> Unit,
+) {
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .then(
+        if (isSelected)
+          Modifier.background(Palette.GreyDark)
+        else
+          Modifier
+      )
+  ) {
+    Row(
+      modifier = Modifier
+        .height(56.dp)
+        .fillMaxWidth()
+        .clickable {
+          onClick(conversationInfo.id)
+        },
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      Image(
+        modifier = Modifier
+          .padding(16.dp)
+          .size(24.dp),
+        imageVector = getGames(Palette.Black, Palette.Grey),
+        contentDescription = null
+      )
+      Text(
+        text = conversationInfo.title ?: conversationInfo.firstMessage,
+        style = AGTypography.DescriptionGames,
+        color = Palette.GreyLight,
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 1,
+        modifier = Modifier
+          .weight(1f)
+          .padding(vertical = 16.dp)
+      )
+      Icon(
+        imageVector = getClose(Palette.White),
+        tint = Palette.GreyLight,
+        contentDescription = null,
+        modifier = Modifier
+          .padding(start = 8.dp, end = 8.dp)
+          .clickable {
+            onDelete(conversationInfo.id)
+          }
+          .minimumInteractiveComponentSize()
+          .size(16.dp)
+      )
+    }
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/ConversationsDrawer.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/ConversationsDrawer.kt
@@ -1,0 +1,148 @@
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.aptoide.android.aptoidegames.BuildConfig
+import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.gamegenie.presentation.composables.DrawerContent
+import com.aptoide.android.aptoidegames.theme.Palette
+import com.aptoide.android.aptoidegames.toolbar.getToolBarLogo
+import kotlinx.coroutines.launch
+
+private const val DRAWER_SIZE = 304f
+private const val ANIMATION_DURATION = 300
+
+@Composable
+fun ConversationsDrawer(
+  mainScreen: @Composable () -> Unit,
+  loadConversationFn: (String) -> Unit,
+  currentChatId: String,
+  newChatFn: () -> Unit,
+) {
+  val isOpen = remember { mutableStateOf(false) }
+  val screenOffsetX = remember { Animatable(0f) }
+  val scope = rememberCoroutineScope()
+
+  fun openDrawer() {
+    scope.launch {
+      screenOffsetX.animateTo(DRAWER_SIZE, tween(ANIMATION_DURATION))
+      isOpen.value = true
+    }
+  }
+
+  fun closeDrawer() {
+    scope.launch {
+      screenOffsetX.animateTo(0f, tween(ANIMATION_DURATION))
+      isOpen.value = false
+    }
+  }
+
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .pointerInput(Unit) {
+        detectHorizontalDragGestures(
+          onHorizontalDrag = { change, dragAmount ->
+            change.consume()
+            scope.launch {
+              val target = screenOffsetX.value + dragAmount / 2
+              screenOffsetX.snapTo(target.coerceIn(0f, DRAWER_SIZE))
+            }
+          },
+          onDragEnd = {
+            if (screenOffsetX.value > DRAWER_SIZE / 2) {
+              openDrawer()
+            } else {
+              closeDrawer()
+            }
+          }
+        )
+      }
+  ) {
+    Box(
+      modifier = Modifier
+        .fillMaxSize()
+        .offset(x = screenOffsetX.value.dp)
+        .background(Palette.GreyDark.copy(alpha = (screenOffsetX.value / DRAWER_SIZE * 0.5f)))
+        .pointerInput(Unit) {
+          detectTapGestures { closeDrawer() }
+        }
+    ) {
+      Column(horizontalAlignment = Alignment.CenterHorizontally) {
+
+        Box(modifier = Modifier.fillMaxWidth()) {
+          Row(
+            modifier = Modifier.align(Alignment.CenterStart)
+          ) {
+            IconButton(
+              onClick = {
+                if (isOpen.value) {
+                  closeDrawer()
+                } else {
+                  openDrawer()
+                }
+              }
+            ) {
+              Icon(
+                painter = painterResource(R.drawable.more),
+                contentDescription = "Toggle Drawer",
+                tint = Color.White
+              )
+            }
+          }
+          Image(
+            imageVector = BuildConfig.FLAVOR.getToolBarLogo(Palette.Primary),
+            contentDescription = null,
+            modifier = Modifier
+              .align(Alignment.Center)
+              .padding(top = 8.dp)
+          )
+        }
+        mainScreen()
+      }
+    }
+
+    Box(
+      modifier = Modifier
+        .fillMaxHeight()
+        .width(DRAWER_SIZE.dp)
+        .offset(x = screenOffsetX.value.dp - DRAWER_SIZE.dp - 1.dp)
+    ) {
+      DrawerContent(
+        { id ->
+          loadConversationFn(id)
+          closeDrawer()
+        },
+        currentChatId,
+        {
+          newChatFn()
+          closeDrawer()
+        }
+      )
+    }
+  }
+}
+

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/DrawerContent.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/DrawerContent.kt
@@ -1,0 +1,129 @@
+package com.aptoide.android.aptoidegames.gamegenie.presentation.composables
+
+import ConversationHistoryBox
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Button
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.aptoide.android.aptoidegames.BuildConfig
+import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.gamegenie.domain.ConversationInfo
+import com.aptoide.android.aptoidegames.gamegenie.presentation.ConversationHistoryUIState.Idle
+import com.aptoide.android.aptoidegames.gamegenie.presentation.ConversationHistoryUIState.Loading
+import com.aptoide.android.aptoidegames.gamegenie.presentation.rememberGameGenieHistoryUiState
+import com.aptoide.android.aptoidegames.theme.AGTypography
+import com.aptoide.android.aptoidegames.theme.Palette
+import com.aptoide.android.aptoidegames.toolbar.getToolBarLogo
+
+@Composable
+fun DrawerContent(
+  onConversationClick: (String) -> Unit,
+  currentChatId: String,
+  onNewChatClick: () -> Unit,
+) {
+
+  when (val uiState = rememberGameGenieHistoryUiState()) {
+    is Idle -> GameGenieDrawerContent(
+      onConversationClick = onConversationClick,
+      currentChatId = currentChatId,
+      onNewChatClick = onNewChatClick,
+      conversations = uiState.pastConversations,
+      onDeleteChat = uiState.onDeleteChat
+    )
+
+    Loading -> {}
+  }
+}
+
+@Composable
+private fun GameGenieDrawerContent(
+  onConversationClick: (String) -> Unit,
+  currentChatId: String,
+  onNewChatClick: () -> Unit,
+  conversations: List<ConversationInfo>,
+  onDeleteChat: (String) -> Unit,
+) {
+  Box(
+    modifier = Modifier.fillMaxSize()
+  ) {
+    Column(
+      modifier = Modifier
+        .fillMaxSize()
+        .padding(bottom = 8.dp)
+    ) {
+      Image(
+        imageVector = BuildConfig.FLAVOR.getToolBarLogo(Palette.Primary),
+        contentDescription = null,
+        modifier = Modifier
+          .padding(start = 16.dp, top = 8.dp)
+      )
+      Text(
+        stringResource(R.string.genai_history_body),
+        style = AGTypography.InputsM,
+        color = Palette.GreyLight,
+        modifier = Modifier.padding(top = 28.dp, bottom = 16.dp, start = 16.dp)
+      )
+
+      LazyColumn(
+        modifier = Modifier
+          .weight(1f),
+        horizontalAlignment = Alignment.CenterHorizontally
+      ) {
+        items(conversations) { conversation ->
+          ConversationHistoryBox(
+            conversation,
+            onConversationClick,
+            currentChatId == conversation.id,
+            onDeleteChat
+          )
+        }
+      }
+
+      Button(
+        onClick = { onNewChatClick() },
+        shape = RectangleShape,
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(horizontal = 16.dp)
+          .height(48.dp),
+      ) {
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.SpaceBetween,
+          modifier = Modifier
+            .fillMaxWidth()
+        ) {
+          Text(
+            text = stringResource(R.string.genai_new_chat_button),
+            style = AGTypography.ChatBold,
+            textAlign = TextAlign.Start
+          )
+          Icon(
+            imageVector = Icons.AutoMirrored.Filled.Send,
+            tint = Palette.GreyDark,
+            contentDescription = "Send Message"
+          )
+        }
+      }
+    }
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
@@ -40,6 +40,7 @@ import com.aptoide.android.aptoidegames.feature_apps.presentation.seeAllMyGamesS
 import com.aptoide.android.aptoidegames.feature_apps.presentation.seeMoreBonusScreen
 import com.aptoide.android.aptoidegames.feature_apps.presentation.seeMoreScreen
 import com.aptoide.android.aptoidegames.gamegenie.presentation.gameGenieScreen
+import com.aptoide.android.aptoidegames.gamegenie.presentation.genieRoute
 import com.aptoide.android.aptoidegames.installer.UserActionDialog
 import com.aptoide.android.aptoidegames.notifications.NotificationsPermissionRequester
 import com.aptoide.android.aptoidegames.permissions.notifications.NotificationsPermissionViewModel
@@ -67,7 +68,14 @@ fun MainView(navController: NavHostController) {
 
   val apkfyState = rememberApkfyState()
   var apkfyShown by remember { mutableStateOf(false) }
+  var showTopBar by remember { mutableStateOf(true) }
   val (promoCodeApp, clearPromoCode) = rememberPromoCodeApp()
+
+  val currentRoute = navController.currentBackStackEntryFlow.collectAsState(initial = navController.currentBackStackEntry)
+
+  LaunchedEffect(currentRoute.value?.destination?.route) {
+    showTopBar = currentRoute.value?.destination?.route?.contains(genieRoute)?.not() ?: true
+  }
 
   //Forced theme do be dark to always apply dark background, for now.
   AptoideTheme(darkTheme = true) {
@@ -91,7 +99,9 @@ fun MainView(navController: NavHostController) {
           AppGamesBottomBar(navController = navController)
         },
         topBar = {
-          AppGamesToolBar(navigate = navController::navigateTo, goBackHome)
+          if (showTopBar){
+            AppGamesToolBar(navigate = navController::navigateTo, goBackHome)
+          }
         }
       ) { padding ->
         if (showNotificationsRationaleDialog) {
@@ -243,7 +253,7 @@ private fun NavigationGraph(
       screenData = updatesScreen()
     )
 
-    animatedComposable(
+    staticComposable(
       navigate = navController::navigateTo,
       goBack = navController::navigateUp,
       screenData = gameGenieScreen()

--- a/app-games/src/main/res/drawable/more.xml
+++ b/app-games/src/main/res/drawable/more.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+  <group>
+    <clip-path
+        android:pathData="M0,0h32v32h-32z"/>
+    <path
+        android:pathData="M8,10h16v4h-16z"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M8,18h12v4h-12z"
+        android:fillColor="#ffffff"/>
+  </group>
+</vector>


### PR DESCRIPTION
**What does this PR do?**

This PR aims to add the conversation history to GameGenie
Past conversation stored on the phone should be shown.
Implemented chat deletion.

**Database changed?**

   No

**Where should the reviewer start?**

See commit.

**How should this be manually tested?**

Open GameGenie and check if chat history is correct. If you already had chats with GameGenie from the previous version it should be shown. 
Test sliding and clicking the open drawer button. 
Test deleting chat.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-188](https://aptoide.atlassian.net/browse/AND-188)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-188]: https://aptoide.atlassian.net/browse/AND-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ