### PR TITLE
[AND-329] Add removal of Indicative properties with null values

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/IndicativeAnalyticsSender.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/IndicativeAnalyticsSender.kt
@@ -15,7 +15,11 @@ class IndicativeAnalyticsSender @Inject constructor() : AnalyticsSender {
         Timber.tag("BA").i("set UP  ${it.first} = ${it.second}")
       }
     }
+    //Add new properties
     Indicative.addProperties(props.toMap())
+
+    //Remove properties with null values
+    props.filter { it.second == null }.forEach { Indicative.removeProperty(it.first) }
   }
 
   override fun logEvent(


### PR DESCRIPTION
**What does this PR do?**

   - Adds the removal of Indicative properties with null values. Whenever setting Indicative properties, if any of the properties were to be replaced with a null value, it removes the property instead so that it shows correctly as not defined on Indicative.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] IndicativeAnalyticsSender.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-329](https://aptoide.atlassian.net/browse/AND-329)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-329](https://aptoide.atlassian.net/browse/AND-329)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-329]: https://aptoide.atlassian.net/browse/AND-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-329]: https://aptoide.atlassian.net/browse/AND-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ