### PR TITLE
[AND-330] Expand apkfy tracking

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
@@ -116,6 +116,7 @@ class BIAnalytics(private val analyticsSender: AnalyticsSender) {
     utmCampaign: String?,
     utmTerm: String?,
     utmContent: String?,
+    utmOemId: String?,
     utmPackageName: String?,
   ) = analyticsSender.setUserProperties(
     "utm_source" to utmSource,
@@ -123,6 +124,7 @@ class BIAnalytics(private val analyticsSender: AnalyticsSender) {
     "utm_campaign" to utmCampaign,
     "utm_term" to utmTerm,
     "utm_content" to utmContent,
+    "utm_oem_id" to utmOemId,
     "utm_package_name" to utmPackageName,
   )
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
@@ -1,12 +1,15 @@
 package com.aptoide.android.aptoidegames.apkfy.analytics
 
+import android.content.Context
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyModel
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.analytics.mapOfNonNull
+import dagger.hilt.android.qualifiers.ApplicationContext
 import jakarta.inject.Inject
 
 class ApkfyAnalytics @Inject constructor(
   private val biAnalytics: BIAnalytics,
+  @ApplicationContext private val context: Context,
 ) {
 
   fun setGuestUIDUserProperty(guestUid: String) = biAnalytics.setUserProperties(
@@ -59,14 +62,25 @@ class ApkfyAnalytics @Inject constructor(
           utmPackageName = packageName ?: APKFY_BUT_NO_APP
         )
       } else if (hasApkfy()) {
-        biAnalytics.setUTMProperties(
-          utmSource = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-          utmMedium = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-          utmCampaign = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-          utmTerm = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-          utmContent = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-          utmPackageName = packageName
-        )
+        if (packageName == context.packageName) {
+          biAnalytics.setUTMProperties(
+            utmSource = UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
+            utmMedium = UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
+            utmCampaign = UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
+            utmTerm = UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
+            utmContent = UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
+            utmPackageName = packageName
+          )
+        } else {
+          biAnalytics.setUTMProperties(
+            utmSource = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
+            utmMedium = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
+            utmCampaign = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
+            utmTerm = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
+            utmContent = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
+            utmPackageName = packageName
+          )
+        }
       } else {
         biAnalytics.setUTMProperties(
           utmSource = UTM_PROPERTY_NO_APKFY,
@@ -84,6 +98,7 @@ class ApkfyAnalytics @Inject constructor(
     private const val UTM_PROPERTY_NO_APKFY = "NO_APKFY"
     private const val UTM_PROPERTY_APKFY_WITHOUT_UTMS = "APKFY_BUT_NO_UTM"
     private const val APKFY_BUT_NO_APP = "APKFY_BUT_NO_APP"
+    private const val UTM_PROPERTY_DIRECT_WITHOUT_UTMS = "DIRECT_BUT_NO_UTM"
 
     private const val P_STATUS = "status"
     private const val P_DATA = "data"

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
@@ -59,6 +59,7 @@ class ApkfyAnalytics @Inject constructor(
           utmCampaign = utmCampaign,
           utmTerm = utmTerm,
           utmContent = utmContent,
+          utmOemId = oemId,
           utmPackageName = packageName ?: APKFY_BUT_NO_APP
         )
       } else if (hasApkfy()) {
@@ -69,6 +70,7 @@ class ApkfyAnalytics @Inject constructor(
             utmCampaign = UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
             utmTerm = UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
             utmContent = UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
+            utmOemId = oemId ?: UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
             utmPackageName = packageName
           )
         } else {
@@ -78,6 +80,7 @@ class ApkfyAnalytics @Inject constructor(
             utmCampaign = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
             utmTerm = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
             utmContent = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
+            utmOemId = oemId ?: UTM_PROPERTY_APKFY_WITHOUT_UTMS,
             utmPackageName = packageName
           )
         }
@@ -88,6 +91,7 @@ class ApkfyAnalytics @Inject constructor(
           utmCampaign = UTM_PROPERTY_NO_APKFY,
           utmTerm = UTM_PROPERTY_NO_APKFY,
           utmContent = UTM_PROPERTY_NO_APKFY,
+          utmOemId = UTM_PROPERTY_NO_APKFY,
           utmPackageName = UTM_PROPERTY_NO_APKFY
         )
       }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
@@ -56,7 +56,7 @@ class ApkfyAnalytics @Inject constructor(
           utmCampaign = utmCampaign,
           utmTerm = utmTerm,
           utmContent = utmContent,
-          utmPackageName = packageName
+          utmPackageName = packageName ?: APKFY_BUT_NO_APP
         )
       } else if (hasApkfy()) {
         biAnalytics.setUTMProperties(
@@ -83,6 +83,7 @@ class ApkfyAnalytics @Inject constructor(
   companion object {
     private const val UTM_PROPERTY_NO_APKFY = "NO_APKFY"
     private const val UTM_PROPERTY_APKFY_WITHOUT_UTMS = "APKFY_BUT_NO_UTM"
+    private const val APKFY_BUT_NO_APP = "APKFY_BUT_NO_APP"
 
     private const val P_STATUS = "status"
     private const val P_DATA = "data"


### PR DESCRIPTION
**What does this PR do?**

   - Adds direct but no utm value on apkfy utm Indicative properties, for then the package name from apkfy is equal to AG's package name.
   - Adds UTM OEMID from apkfy as an Indicative user property.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-330](https://aptoide.atlassian.net/browse/AND-330)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-330](https://aptoide.atlassian.net/browse/AND-330)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-330]: https://aptoide.atlassian.net/browse/AND-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-330]: https://aptoide.atlassian.net/browse/AND-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ