### PR TITLE
[HOTFIX/AND-279] App coming soon error mapping fix

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/AppComingSoonViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/AppComingSoonViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -33,11 +34,12 @@ class AppComingSoonViewModel @Inject constructor(
     viewModelScope.launch {
       viewModelState.update { Loading }
       appComingSoonManager.loadAppComingSoonCard(cardUrl)
+        .map { card -> viewModelState.update { Idle(card) } }
         .catch {
           it.printStackTrace()
           viewModelState.update { AppComingSoonUIState.Error }
         }
-        .collect { card -> viewModelState.update { Idle(card) } }
+        .collect {}
     }
   }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/domain/AppComingSoonManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/domain/AppComingSoonManager.kt
@@ -9,7 +9,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -23,7 +23,7 @@ class AppComingSoonManager @Inject constructor(
 
   @OptIn(ExperimentalCoroutinesApi::class)
   suspend fun loadAppComingSoonCard(cardUrl: String): Flow<SubscribedAppComingSoonCard> {
-    return flowOf(repository.getAppComingSoonCard(cardUrl))
+    return flow { emit(repository.getAppComingSoonCard(cardUrl)) }
       .flatMapLatest { card ->
         subscribedAppsRepository.isAppSubscribed(card.packageName)
           .map { SubscribedAppComingSoonCard(appComingSoonCard = card, isSubscribed = it) }

--- a/feauture_app_coming_soon/src/main/java/cm/aptoide/pt/appcomingsoon/repository/AptoideAppComingSoonPromotionalRepository.kt
+++ b/feauture_app_coming_soon/src/main/java/cm/aptoide/pt/appcomingsoon/repository/AptoideAppComingSoonPromotionalRepository.kt
@@ -18,11 +18,12 @@ internal class AptoideAppComingSoonPromotionalRepository @Inject constructor(
       return appComingSoonRemoteDataSource.getCard(url.split("cards/")[1])
         .datalist
         ?.list
+        .takeIf { !it.isNullOrEmpty() }
         ?.get(0)
         ?.toDomainModel()
-        ?: throw IllegalStateException()
+        ?: throw IllegalStateException("AppComingSoon Card can not be empty")
     } else {
-      throw IllegalStateException()
+      throw IllegalStateException("Invalid URL while trying to load AppComingSoon card")
     }
   }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing error mapping in the AppComingSoon card. If there was an error during the mapping of the card, it would be out of the flow meaning it wouldn't be caught by the .catch{} block from kotlin flow.

**Database changed?**

No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Put a rewrite for an AppComingSoon widget from getWidgets but don't add the rewrite for the card content, meaning we will have an empty card (current error we have in the api) and the mapping will emit an exception, which was not being caught correctly.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-279](https://aptoide.atlassian.net/browse/AND-279)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-279]: https://aptoide.atlassian.net/browse/AND-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ