### PR TITLE
[AND-299] Add horizontal tabs on Home Screen

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/GenericAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/GenericAnalytics.kt
@@ -205,6 +205,9 @@ class GenericAnalytics(private val analyticsSender: AnalyticsSender) {
   fun sendECVideosFlagReady() =
     analyticsSender.logEvent("ec_videos_flag_ready", params = emptyMap())
 
+  fun sendHomeTabClick(tab: String) =
+    analyticsSender.logEvent("home_tab_clicked", params = mapOf(P_NAME to tab))
+
   companion object {
     internal const val P_OPEN_TYPE = "open_type"
     internal const val P_FIRST_LAUNCH = "first_launch"
@@ -216,6 +219,7 @@ class GenericAnalytics(private val analyticsSender: AnalyticsSender) {
     internal const val P_CATEGORY = "category"
     internal const val P_APPC_BILLING = "appc_billing"
     internal const val P_SERVICE = "service"
+    internal const val P_NAME = "name"
   }
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -410,7 +410,7 @@ fun AppInfoViewPager(
   onSelectTab: (Int) -> Unit,
 ) {
   CustomScrollableTabRow(
-    tabs = tabsList,
+    tabs = tabsList.map { it.getTabName() },
     selectedTabIndex = selectedTab,
     onTabClick = onSelectTab,
     contentColor = Palette.Primary,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/CustomScrollableTabRow.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/CustomScrollableTabRow.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.extensions.PreviewDark
@@ -37,11 +38,12 @@ import kotlin.random.nextInt
 
 @Composable
 fun CustomScrollableTabRow(
-  tabs: List<AppViewTab>,
+  tabs: List<String>,
   selectedTabIndex: Int,
   onTabClick: (Int) -> Unit,
   contentColor: Color,
   backgroundColor: Color,
+  tabTextStyle: TextStyle = AGTypography.InputsL,
 ) {
   val density = LocalDensity.current
   val indicatorWidths = remember(key1 = tabs.size) { MutableList(tabs.size) { 0.dp } }
@@ -72,8 +74,8 @@ fun CustomScrollableTabRow(
         onClick = { onTabClick(tabIndex) },
         text = {
           Text(
-            text = tab.getTabName(),
-            style = AGTypography.InputsL,
+            text = tab,
+            style = tabTextStyle,
             color = if (selectedTabIndex == tabIndex) {
               Palette.Primary
             } else {
@@ -131,7 +133,7 @@ enum class AppViewTab {
 @PreviewDark
 @Composable
 fun CustomScrollableTabRowPreview() {
-  val tabsList = List(Random.nextInt(1..3)) { AppViewTab.values()[it] }
+  val tabsList = List(Random.nextInt(1..3)) { AppViewTab.entries[it].getTabName() }
 
   AptoideTheme {
     CustomScrollableTabRow(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/AllCategoriesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/AllCategoriesScreen.kt
@@ -71,7 +71,7 @@ fun allCategoriesScreen() = ScreenData.withAnalytics(
   val categoriesBundleTitle = arguments?.getString(titleArg)
   val (uiState, reload) = rememberAllCategories()
 
-  AllCategoriesView(
+  AllCategoriesScreen(
     title = categoriesBundleTitle,
     uiState = uiState,
     onError = reload,
@@ -86,7 +86,7 @@ fun buildAllCategoriesRoute(categoriesBundleTitle: String? = null) = when {
 }
 
 @Composable
-fun AllCategoriesView(
+fun AllCategoriesScreen(
   title: String?,
   uiState: AllCategoriesUiState,
   onError: () -> Unit,
@@ -104,29 +104,45 @@ fun AllCategoriesView(
       },
       title = title
     )
-    when (uiState) {
-      is AllCategoriesUiState.Loading -> LoadingView()
-      is AllCategoriesUiState.NoConnection -> NoConnectionView(onRetryClick = onError)
-      is AllCategoriesUiState.Error -> GenericErrorView(onError)
-      is AllCategoriesUiState.Idle -> CategoryList(
-        size = uiState.categories.size,
-      ) {
-        itemsIndexed(
-          uiState.categories,
-          key = { _, category -> category.name }
-        ) { index, category ->
-          CategoryLargeItem(
-            title = category.title,
-            icon = category.icon,
-            onClick = {
-              genericAnalytics.sendCategoryClick(category.name, analyticsContext)
-              navigate(
-                buildCategoryDetailRoute(category.title, category.name)
-                  .withItemPosition(index)
-              )
-            }
-          )
-        }
+    AllCategoriesView(
+      uiState = uiState,
+      navigate = navigate,
+      onError = onError
+    )
+  }
+}
+
+@Composable
+fun AllCategoriesView(
+  uiState: AllCategoriesUiState,
+  navigate: (String) -> Unit,
+  onError: () -> Unit
+) {
+  val analyticsContext = AnalyticsContext.current
+  val genericAnalytics = rememberGenericAnalytics()
+
+  when (uiState) {
+    is AllCategoriesUiState.Loading -> LoadingView()
+    is AllCategoriesUiState.NoConnection -> NoConnectionView(onRetryClick = onError)
+    is AllCategoriesUiState.Error -> GenericErrorView(onError)
+    is AllCategoriesUiState.Idle -> CategoryList(
+      size = uiState.categories.size,
+    ) {
+      itemsIndexed(
+        uiState.categories,
+        key = { _, category -> category.name }
+      ) { index, category ->
+        CategoryLargeItem(
+          title = category.title,
+          icon = category.icon,
+          onClick = {
+            genericAnalytics.sendCategoryClick(category.name, analyticsContext)
+            navigate(
+              buildCategoryDetailRoute(category.title, category.name)
+                .withItemPosition(index)
+            )
+          }
+        )
       }
     }
   }
@@ -212,7 +228,7 @@ fun PreviewAllCategoriesView(
   @PreviewParameter(AllCategoriesUiStateProvider::class) uiState: AllCategoriesUiState,
 ) {
   AptoideTheme {
-    AllCategoriesView(
+    AllCategoriesScreen(
       title = "Categories",
       uiState = uiState,
       onError = {},

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialMoreScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialMoreScreen.kt
@@ -66,7 +66,7 @@ fun seeMoreEditorialScreen() = ScreenData.withAnalytics(
     tag = tag,
     subtype = arguments.getString("subtype")
   )
-  SeeMoreEditorialsView(
+  SeeMoreEditorialsScreen(
     title = title,
     uiState = uiState,
     onError = reload,
@@ -82,14 +82,13 @@ fun buildSeeMoreEditorialsRoute(
 ) = "seeMoreEditorials/$title/$bundleTag?subtype=$subtype"
 
 @Composable
-fun SeeMoreEditorialsView(
+fun SeeMoreEditorialsScreen(
   title: String?,
   uiState: ArticleListUiState,
   onError: () -> Unit,
   navigateBack: () -> Unit,
   navigate: (String) -> Unit,
 ) {
-
   Column(
     modifier = Modifier
       .fillMaxWidth()
@@ -106,7 +105,7 @@ fun SeeMoreEditorialsView(
 }
 
 @Composable
-private fun SeeMoreEditorialsContent(
+fun SeeMoreEditorialsContent(
   uiState: ArticleListUiState,
   navigate: (String) -> Unit,
   onError: () -> Unit
@@ -206,7 +205,6 @@ fun EditorialsViewCardLarge(
     color = Palette.White
   )
 }
-
 
 @PreviewDark
 @Composable

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/BonusBundleMoreScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/BonusBundleMoreScreen.kt
@@ -75,7 +75,7 @@ fun seeMoreBonusScreen() = ScreenData.withAnalytics(
   val bundleTitle = arguments?.getString("title")!!
   val bundleTag = arguments.getString("tag")!!
 
-  MoreBonusBundleView(
+  MoreBonusBundleScreen(
     title = bundleTitle,
     bundleTag = bundleTag,
     navigateBack = navigateBack,
@@ -89,7 +89,7 @@ fun buildSeeMoreBonusRoute(
 ) = "seeMoreBonus/$title/$bundleTag"
 
 @Composable
-fun MoreBonusBundleView(
+private fun MoreBonusBundleScreen(
   title: String,
   bundleTag: String,
   navigateBack: () -> Unit,
@@ -99,7 +99,7 @@ fun MoreBonusBundleView(
   val analyticsContext = AnalyticsContext.current
   val genericAnalytics = rememberGenericAnalytics()
 
-  RealMoreBonusBundleView(
+  MoreBonusBundleScreen(
     uiState = uiState,
     title = title,
     bundleTag = bundleTag,
@@ -116,7 +116,7 @@ fun MoreBonusBundleView(
 }
 
 @Composable
-private fun RealMoreBonusBundleView(
+private fun MoreBonusBundleScreen(
   uiState: AppsListUiState,
   title: String,
   bundleTag: String,
@@ -130,26 +130,43 @@ private fun RealMoreBonusBundleView(
     horizontalAlignment = Alignment.CenterHorizontally
   ) {
     AppGamesTopBar(navigateBack = navigateBack, title = title)
-    when (uiState) {
-      AppsListUiState.Loading -> LoadingView()
-      AppsListUiState.NoConnection -> NoConnectionView(onRetryClick = noNetworkReload)
-      AppsListUiState.Error -> GenericErrorView(reload)
-      AppsListUiState.Empty -> MoreBonusBundleViewContent(
-        appList = emptyList(),
-        navigate = navigate
-      )
+    MoreBonusBundleView(
+      uiState = uiState,
+      bundleTag = bundleTag,
+      navigate = navigate,
+      reload = reload,
+      noNetworkReload = noNetworkReload
+    )
+  }
+}
 
-      is AppsListUiState.Idle -> MoreBonusBundleViewContent(
-        appList = uiState.apps.onEach {
-          it.campaigns?.run {
-            if (AptoideMMPCampaign.allowedBundleTags.keys.contains(bundleTag)) {
-              placementType = "see_all"
-            }
+@Composable
+fun MoreBonusBundleView(
+  uiState: AppsListUiState,
+  bundleTag: String,
+  navigate: (String) -> Unit,
+  reload: () -> Unit,
+  noNetworkReload: () -> Unit,
+) {
+  when (uiState) {
+    AppsListUiState.Loading -> LoadingView()
+    AppsListUiState.NoConnection -> NoConnectionView(onRetryClick = noNetworkReload)
+    AppsListUiState.Error -> GenericErrorView(reload)
+    AppsListUiState.Empty -> MoreBonusBundleViewContent(
+      appList = emptyList(),
+      navigate = navigate
+    )
+
+    is AppsListUiState.Idle -> MoreBonusBundleViewContent(
+      appList = uiState.apps.onEach {
+        it.campaigns?.run {
+          if (AptoideMMPCampaign.allowedBundleTags.keys.contains(bundleTag)) {
+            placementType = "see_all"
           }
-        },
-        navigate = navigate,
-      )
-    }
+        }
+      },
+      navigate = navigate,
+    )
   }
 }
 
@@ -357,7 +374,7 @@ private fun RealBonusBundlePreview(
   @PreviewParameter(AppsListUiStateProvider::class) uiState: AppsListUiState,
 ) {
   AptoideTheme {
-    RealMoreBonusBundleView(
+    MoreBonusBundleScreen(
       uiState = uiState,
       title = getRandomString(range = 1..5, capitalize = true),
       bundleTag = "",

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
-import cm.aptoide.pt.extensions.ScreenData
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.Type
@@ -63,7 +62,6 @@ import com.aptoide.android.aptoidegames.AptoideAsyncImage
 import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.presentation.AnalyticsContext
-import com.aptoide.android.aptoidegames.analytics.presentation.InitialAnalyticsMeta
 import com.aptoide.android.aptoidegames.analytics.presentation.OverrideAnalyticsBundleMeta
 import com.aptoide.android.aptoidegames.analytics.presentation.SwipeListener
 import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
@@ -103,21 +101,6 @@ val translatedTitles = mapOf(
   "Trending" to R.string.fixed_bundle_trending_title,
   "Categories" to R.string.categories,
 )
-
-const val gamesRoute = "gamesView"
-
-fun gamesScreen() = ScreenData(
-  route = gamesRoute,
-) { _, navigate, _ ->
-  InitialAnalyticsMeta(
-    screenAnalyticsName = "Home",
-    navigate = navigate
-  ) {
-    BundlesScreen(
-      navigate = it,
-    )
-  }
-}
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/GamesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/GamesScreen.kt
@@ -1,7 +1,21 @@
 package com.aptoide.android.aptoidegames.home
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import cm.aptoide.pt.extensions.ScreenData
+import cm.aptoide.pt.feature_apps.presentation.rememberAppsByTag
+import cm.aptoide.pt.feature_categories.presentation.rememberAllCategories
+import cm.aptoide.pt.feature_editorial.presentation.rememberEditorialListState
 import com.aptoide.android.aptoidegames.analytics.presentation.InitialAnalyticsMeta
+import com.aptoide.android.aptoidegames.analytics.presentation.rememberGenericAnalytics
+import com.aptoide.android.aptoidegames.categories.presentation.AllCategoriesView
+import com.aptoide.android.aptoidegames.editorial.SeeMoreEditorialsContent
+import com.aptoide.android.aptoidegames.feature_apps.presentation.MoreBonusBundleView
+import com.aptoide.android.aptoidegames.feature_apps.presentation.rememberBonusBundle
 
 const val gamesRoute = "games"
 
@@ -12,8 +26,92 @@ fun gamesScreen() = ScreenData(
     screenAnalyticsName = "Home",
     navigate = navigate
   ) {
-    BundlesScreen(
-      navigate = it,
+    GamesScreenContent(navigate = navigate)
+  }
+}
+
+@Composable
+private fun GamesScreenContent(
+  navigate: (String) -> Unit
+) {
+  val showHomeTabRow = rememberHomeTabRowState()
+  var selectedTab by rememberSaveable(key = defaultHomeTabs.size.toString()) { mutableIntStateOf(0) }
+
+  val genericAnalytics = rememberGenericAnalytics()
+
+  Column {
+    if (showHomeTabRow) {
+      HomeTabRow(
+        selectedTab = selectedTab,
+        tabsList = defaultHomeTabs.map { it.getTitle() },
+        onSelectTab = {
+          if (it != selectedTab) {
+            genericAnalytics.sendHomeTabClick(defaultHomeTabs[it]::class.simpleName.toString())
+          }
+          selectedTab = it
+        }
+      )
+    }
+    GamesScreenTabView(
+      navigate = navigate,
+      currentTab = defaultHomeTabs[selectedTab]
     )
   }
+}
+
+@Composable
+private fun GamesScreenTabView(
+  navigate: (String) -> Unit,
+  currentTab: HomeTab
+) {
+  when (currentTab) {
+    HomeTab.ForYou -> BundlesScreen(navigate = navigate)
+
+    HomeTab.TopCharts -> TopChartsView(navigate = navigate)
+
+    HomeTab.Bonus -> AppCoinsTabView(navigate)
+
+    HomeTab.Editorial -> EditorialTabView(navigate)
+
+    HomeTab.Categories -> CategoriesTabView(navigate)
+  }
+}
+
+@Composable
+private fun AppCoinsTabView(navigate: (String) -> Unit) {
+  val (_, bonusBundleTag) = rememberBonusBundle()
+  val (uiState, reload) = rememberAppsByTag(bonusBundleTag)
+
+  MoreBonusBundleView(
+    uiState = uiState,
+    bundleTag = bonusBundleTag,
+    navigate = navigate,
+    reload = reload,
+    noNetworkReload = reload
+  )
+}
+
+@Composable
+private fun EditorialTabView(navigate: (String) -> Unit) {
+  val (uiState, reload) = rememberEditorialListState(
+    tag = "editorials-more",
+    subtype = null
+  )
+
+  SeeMoreEditorialsContent(
+    uiState = uiState,
+    navigate = navigate,
+    onError = reload
+  )
+}
+
+@Composable
+private fun CategoriesTabView(navigate: (String) -> Unit) {
+  val (uiState, reload) = rememberAllCategories()
+
+  AllCategoriesView(
+    uiState = uiState,
+    navigate = navigate,
+    onError = reload
+  )
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/GamesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/GamesScreen.kt
@@ -1,0 +1,19 @@
+package com.aptoide.android.aptoidegames.home
+
+import cm.aptoide.pt.extensions.ScreenData
+import com.aptoide.android.aptoidegames.analytics.presentation.InitialAnalyticsMeta
+
+const val gamesRoute = "games"
+
+fun gamesScreen() = ScreenData(
+  route = gamesRoute,
+) { _, navigate, _ ->
+  InitialAnalyticsMeta(
+    screenAnalyticsName = "Home",
+    navigate = navigate
+  ) {
+    BundlesScreen(
+      navigate = it,
+    )
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/GamesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/GamesScreen.kt
@@ -34,8 +34,8 @@ fun gamesScreen() = ScreenData(
 private fun GamesScreenContent(
   navigate: (String) -> Unit
 ) {
-  val showHomeTabRow = rememberHomeTabRowState()
-  var selectedTab by rememberSaveable(key = defaultHomeTabs.size.toString()) { mutableIntStateOf(0) }
+  val (showHomeTabRow, tabs) = rememberHomeTabRowState()
+  var selectedTab by rememberSaveable(key = tabs.size.toString()) { mutableIntStateOf(0) }
 
   val genericAnalytics = rememberGenericAnalytics()
 
@@ -43,10 +43,10 @@ private fun GamesScreenContent(
     if (showHomeTabRow) {
       HomeTabRow(
         selectedTab = selectedTab,
-        tabsList = defaultHomeTabs.map { it.getTitle() },
+        tabsList = tabs.map { it.getTitle() },
         onSelectTab = {
           if (it != selectedTab) {
-            genericAnalytics.sendHomeTabClick(defaultHomeTabs[it]::class.simpleName.toString())
+            genericAnalytics.sendHomeTabClick(tabs[it]::class.simpleName.toString())
           }
           selectedTab = it
         }
@@ -54,7 +54,7 @@ private fun GamesScreenContent(
     }
     GamesScreenTabView(
       navigate = navigate,
-      currentTab = defaultHomeTabs[selectedTab]
+      currentTab = tabs[selectedTab]
     )
   }
 }
@@ -67,7 +67,7 @@ private fun GamesScreenTabView(
   when (currentTab) {
     HomeTab.ForYou -> BundlesScreen(navigate = navigate)
 
-    HomeTab.TopCharts -> TopChartsView(navigate = navigate)
+    is HomeTab.TopCharts -> TopChartsView(sort = currentTab.sort, navigate = navigate)
 
     HomeTab.Bonus -> AppCoinsTabView(navigate)
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeTabRow.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeTabRow.kt
@@ -10,7 +10,7 @@ import com.aptoide.android.aptoidegames.theme.Palette
 
 val defaultHomeTabs = listOf<HomeTab>(
   HomeTab.ForYou,
-  HomeTab.TopCharts,
+  HomeTab.TopCharts(),
   HomeTab.Bonus,
   HomeTab.Editorial,
   HomeTab.Categories,
@@ -18,7 +18,7 @@ val defaultHomeTabs = listOf<HomeTab>(
 
 sealed class HomeTab {
   object ForYou : HomeTab()
-  object TopCharts : HomeTab()
+  data class TopCharts(val sort: String = "pdownloads") : HomeTab()
   object Bonus : HomeTab()
   object Editorial : HomeTab()
   object Categories : HomeTab()
@@ -27,7 +27,7 @@ sealed class HomeTab {
   fun getTitle() = stringResource(
     when (this) {
       ForYou -> R.string.tag_for_you
-      TopCharts -> R.string.tag_top_charts
+      is TopCharts -> R.string.tag_top_charts
       Bonus -> R.string.tag_bonus
       Editorial -> R.string.tag_editorial
       Categories -> R.string.tag_categories

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeTabRow.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeTabRow.kt
@@ -1,0 +1,52 @@
+package com.aptoide.android.aptoidegames.home
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.appview.CustomScrollableTabRow
+import com.aptoide.android.aptoidegames.theme.AGTypography
+import com.aptoide.android.aptoidegames.theme.Palette
+
+val defaultHomeTabs = listOf<HomeTab>(
+  HomeTab.ForYou,
+  HomeTab.TopCharts,
+  HomeTab.Bonus,
+  HomeTab.Editorial,
+  HomeTab.Categories,
+)
+
+sealed class HomeTab {
+  object ForYou : HomeTab()
+  object TopCharts : HomeTab()
+  object Bonus : HomeTab()
+  object Editorial : HomeTab()
+  object Categories : HomeTab()
+
+  @Composable
+  fun getTitle() = stringResource(
+    when (this) {
+      ForYou -> R.string.tag_for_you
+      TopCharts -> R.string.tag_top_charts
+      Bonus -> R.string.tag_bonus
+      Editorial -> R.string.tag_editorial
+      Categories -> R.string.tag_categories
+    }
+  )
+}
+
+@Composable
+fun HomeTabRow(
+  selectedTab: Int,
+  tabsList: List<String>,
+  onSelectTab: (Int) -> Unit,
+) {
+  CustomScrollableTabRow(
+    tabs = tabsList,
+    selectedTabIndex = selectedTab,
+    onTabClick = onSelectTab,
+    contentColor = Palette.Primary,
+    backgroundColor = Color.Transparent,
+    tabTextStyle = AGTypography.InputsL
+  )
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeTabRowStateProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeTabRowStateProvider.kt
@@ -1,0 +1,34 @@
+package com.aptoide.android.aptoidegames.home
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import cm.aptoide.pt.extensions.runPreviewable
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeTabRowInjectionsProvider @Inject constructor(
+  val featureFlags: FeatureFlags,
+) : ViewModel()
+
+@Composable
+fun rememberHomeTabRowState(): Boolean = runPreviewable(
+  preview = { true },
+  real = {
+    val vm = hiltViewModel<HomeTabRowInjectionsProvider>()
+    var showHomeTabRow by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+      showHomeTabRow = vm.featureFlags.getFlag("show_home_tabs", false)
+    }
+
+    showHomeTabRow
+  }
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeTabRowStateProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeTabRowStateProvider.kt
@@ -1,5 +1,6 @@
 package com.aptoide.android.aptoidegames.home
 
+import androidx.annotation.Keep
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -10,7 +11,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+import com.google.gson.Gson
+import com.google.gson.JsonObject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,16 +23,52 @@ class HomeTabRowInjectionsProvider @Inject constructor(
 ) : ViewModel()
 
 @Composable
-fun rememberHomeTabRowState(): Boolean = runPreviewable(
-  preview = { true },
+fun rememberHomeTabRowState(): Pair<Boolean, List<HomeTab>> = runPreviewable(
+  preview = { true to defaultHomeTabs },
   real = {
     val vm = hiltViewModel<HomeTabRowInjectionsProvider>()
     var showHomeTabRow by remember { mutableStateOf(false) }
 
+    var tabs: List<HomeTab>? by remember { mutableStateOf(null) }
+
     LaunchedEffect(Unit) {
       showHomeTabRow = vm.featureFlags.getFlag("show_home_tabs", false)
+
+      try {
+        val tabsJson = vm.featureFlags.getFlagAsString("home_tabs")
+        tabs = Gson().fromJson(tabsJson, FeatureFlagTabRow::class.java).tabs.mapNotNull {
+          when (it.id) {
+            "ForYou" -> HomeTab.ForYou
+
+            "TopCharts" -> runCatching {
+              Gson().fromJson(
+                it.details,
+                HomeTab.TopCharts::class.java
+              )
+            }.getOrDefault(HomeTab.TopCharts())
+
+            "Bonus" -> HomeTab.Bonus
+            "Editorial" -> HomeTab.Editorial
+            "Categories" -> HomeTab.Categories
+            else -> null
+          }
+        }
+      } catch (e: Throwable) {
+        Timber.e(e)
+      }
     }
 
-    showHomeTabRow
+    showHomeTabRow to (tabs.takeIf { !it.isNullOrEmpty() } ?: defaultHomeTabs)
   }
+)
+
+@Keep
+data class FeatureFlagTabRow(
+  val tabs: List<FeatureFlagTab>
+)
+
+@Keep
+data class FeatureFlagTab(
+  val id: String,
+  val details: JsonObject
 )

--- a/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/presentation/AllCategoriesUiState.kt
+++ b/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/presentation/AllCategoriesUiState.kt
@@ -1,12 +1,23 @@
 package cm.aptoide.pt.feature_categories.presentation
 
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import cm.aptoide.pt.feature_categories.domain.Category
+import cm.aptoide.pt.feature_categories.domain.randomCategory
+import kotlin.random.Random
+import kotlin.random.nextInt
 
-data class AllCategoriesUiState(
-  val categoryList: List<Category>,
-  val type: AllCategoriesUiStateType,
-)
+sealed class AllCategoriesUiState {
+  data class Idle(val categories: List<Category>) : AllCategoriesUiState()
+  object Loading : AllCategoriesUiState()
+  object NoConnection : AllCategoriesUiState()
+  object Error : AllCategoriesUiState()
+}
 
-enum class AllCategoriesUiStateType {
-  IDLE, LOADING, NO_CONNECTION, ERROR
+class AllCategoriesUiStateProvider : PreviewParameterProvider<AllCategoriesUiState> {
+  override val values: Sequence<AllCategoriesUiState> = sequenceOf(
+    AllCategoriesUiState.Idle(List(Random.nextInt(1..20)) { randomCategory }),
+    AllCategoriesUiState.Loading,
+    AllCategoriesUiState.NoConnection,
+    AllCategoriesUiState.Error
+  )
 }

--- a/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/presentation/AllCategoriesViewModel.kt
+++ b/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/presentation/AllCategoriesViewModel.kt
@@ -1,14 +1,18 @@
 package cm.aptoide.pt.feature_categories.presentation
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.feature_categories.domain.CategoriesUseCase
-import cm.aptoide.pt.feature_categories.domain.Category
+import cm.aptoide.pt.feature_categories.domain.randomCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -23,13 +27,13 @@ class AllCategoriesViewModel @Inject constructor(
 ) : ViewModel() {
 
   private val categoryBundleTag: String? = savedStateHandle.get("tag")
-  private val viewModelState = MutableStateFlow(MoreCategoriesViewModelState())
+  private val viewModelState = MutableStateFlow<AllCategoriesUiState>(AllCategoriesUiState.Loading)
 
-  val uiState = viewModelState.map { it.toUiState() }
+  val uiState = viewModelState
     .stateIn(
       viewModelScope,
       SharingStarted.Eagerly,
-      viewModelState.value.toUiState()
+      viewModelState.value
     )
 
   init {
@@ -38,38 +42,33 @@ class AllCategoriesViewModel @Inject constructor(
 
   fun reload() {
     viewModelScope.launch {
-      viewModelState.update { it.copy(type = AllCategoriesUiStateType.LOADING) }
+      viewModelState.update { AllCategoriesUiState.Loading }
       try {
         val categories = categoriesUseCase.getCategories(categoryBundleTag ?: "")
         viewModelState.update {
-          it.copy(
-            categoryList = categories,
-            type = AllCategoriesUiStateType.IDLE
-          )
+          AllCategoriesUiState.Idle(categories = categories)
         }
       } catch (e: Throwable) {
         Timber.w(e)
         viewModelState.update {
-          it.copy(
-            type = when (e) {
-              is IOException -> AllCategoriesUiStateType.NO_CONNECTION
-              else -> AllCategoriesUiStateType.ERROR
-            }
-          )
+          when (e) {
+            is IOException -> AllCategoriesUiState.NoConnection
+            else -> AllCategoriesUiState.Error
+          }
         }
       }
-
     }
   }
 }
 
-private data class MoreCategoriesViewModelState(
-  val categoryList: List<Category> = emptyList(),
-  val type: AllCategoriesUiStateType = AllCategoriesUiStateType.IDLE,
-) {
-  fun toUiState(): AllCategoriesUiState =
-    AllCategoriesUiState(
-      categoryList = categoryList,
-      type = type
-    )
-}
+@Composable
+fun rememberAllCategories(): Pair<AllCategoriesUiState, () -> Unit> = runPreviewable(
+  preview = {
+    AllCategoriesUiState.Idle(List((0..50).random()) { randomCategory }) to {}
+  }, real = {
+    val vm = hiltViewModel<AllCategoriesViewModel>()
+    val uiState by vm.uiState.collectAsState()
+
+    uiState to vm::reload
+  }
+)


### PR DESCRIPTION
**What does this PR do?**

   - Adds horizontal scrollable tab row to AG's home screen.
   - Refactors some screen for convenience, so that some of those screen views can be reused as views shown in Home Screen tabs.
   - Adds fetching of firebase feature flags that control the visibility on the tab row.
   - Adds fetching of firebase feature flags that control the content and order of the tabs in the tab row.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-299](https://aptoide.atlassian.net/browse/AND-299)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-299](https://aptoide.atlassian.net/browse/AND-299)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-299]: https://aptoide.atlassian.net/browse/AND-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-299]: https://aptoide.atlassian.net/browse/AND-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ