### PR TITLE
[AND-315] Add app migrate for ahab v2

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/dto/AnalyticsData.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/dto/AnalyticsData.kt
@@ -10,6 +10,7 @@ enum class InstallAction {
   INSTALL,
   UPDATE,
   MIGRATE,
+  MIGRATE_ALIAS,
   DOWNGRADE,
   UPDATE_ALL,
   RETRY,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/NewAppPromotionalView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/NewAppPromotionalView.kt
@@ -165,6 +165,7 @@ fun isDownloading(downloadState: DownloadUiState?): Boolean {
     is Install,
     is Outdated,
     is Migrate,
+    is DownloadUiState.MigrateAlias,
     is Installed,
     null -> false
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallView.kt
@@ -138,6 +138,12 @@ private fun InstallViewContent(
       modifier = Modifier.fillMaxWidth(),
     )
 
+    is DownloadUiState.MigrateAlias -> AccentButton(
+      title = installViewState.actionLabel,
+      onClick = state.migrateAlias,
+      modifier = Modifier.fillMaxWidth(),
+    )
+
     is DownloadUiState.Outdated -> PrimaryButton(
       title = installViewState.actionLabel,
       onClick = state.update,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewShort.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewShort.kt
@@ -77,6 +77,11 @@ private fun InstallViewShortContent(
       title = installViewState.actionLabel,
     )
 
+    is DownloadUiState.MigrateAlias -> AccentSmallButton(
+      onClick = state.migrateAlias,
+      title = installViewState.actionLabel,
+    )
+
     is DownloadUiState.Outdated -> PrimarySmallButton(
       onClick = state.update,
       title = installViewState.actionLabel,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/ProgressText.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/ProgressText.kt
@@ -12,6 +12,7 @@ import cm.aptoide.pt.download_view.presentation.DownloadUiState.Install
 import cm.aptoide.pt.download_view.presentation.DownloadUiState.Installed
 import cm.aptoide.pt.download_view.presentation.DownloadUiState.Installing
 import cm.aptoide.pt.download_view.presentation.DownloadUiState.Migrate
+import cm.aptoide.pt.download_view.presentation.DownloadUiState.MigrateAlias
 import cm.aptoide.pt.download_view.presentation.DownloadUiState.Outdated
 import cm.aptoide.pt.download_view.presentation.DownloadUiState.ReadyToInstall
 import cm.aptoide.pt.download_view.presentation.DownloadUiState.Uninstalling
@@ -73,6 +74,7 @@ private fun ProgressTextContent(
     is Outdated,
     is Installed,
     is Migrate,
+    is MigrateAlias,
       -> if (showVersionName) {
       Text(
         modifier = modifier,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/promotions/domain/CompatiblePromotionsUseCase.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/promotions/domain/CompatiblePromotionsUseCase.kt
@@ -51,5 +51,8 @@ class CompatiblePromotionsUseCase @Inject constructor(
           .packageInfo
           ?.takeIf { it.compatVersionCode <= second.versionCode }
       }
-      ?.let { this }
+      ?.let { alias ->
+        this.second.uninstallAlias = alias.packageName
+        this
+      }
 }

--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadUiState.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/DownloadUiState.kt
@@ -80,6 +80,14 @@ sealed class DownloadUiState {
       get() = { migrateWith(resolver) }
   }
 
+  data class MigrateAlias(
+    val resolver: ConstraintsResolver = defaultResolver,
+    val migrateAliasWith: (resolver: ConstraintsResolver) -> Unit,
+  ) : DownloadUiState() {
+    val migrateAlias: () -> Unit
+      get() = { migrateAliasWith(resolver) }
+  }
+
   data class ReadyToInstall(
     val installPackageInfo: InstallPackageInfo = InstallPackageInfo(0),
     val cancel: () -> Unit,

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/App.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/App.kt
@@ -53,6 +53,8 @@ data class App(
   val appSize: Long by lazy {
     file.size + (obb?.size ?: 0) + (aab?.size ?: 0)
   }
+
+  var uninstallAlias: String? = null
 }
 
 data class File(


### PR DESCRIPTION
**What does this PR do?**

   - Adds the option to migrate alias package names in ahab promotion dialogs.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

- Uninstall an alias package name of an app that has ahab/promotions through another store. The app must have a different package name.
- Launch AG and check if the dialog appears and the migration works as intended.

  Flow on how to test this or QA Tickets related to this use-case: [AND-315](https://aptoide.atlassian.net/browse/AND-315)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-315](https://aptoide.atlassian.net/browse/AND-315)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-315]: https://aptoide.atlassian.net/browse/AND-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-315]: https://aptoide.atlassian.net/browse/AND-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ