### PR TITLE
[AND-36] Remove aptoide_uid usage from editorial endpoints

### DIFF
--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/AptoideEditorialRepository.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/AptoideEditorialRepository.kt
@@ -57,25 +57,25 @@ internal class AptoideEditorialRepository @Inject constructor(
       ?: throw IllegalStateException()
 
   internal interface Retrofit {
-    @GET("cards/get/type=CURATION_1/aptoide_uid=0/limit=1")
+    @GET("cards/get/type=CURATION_1/limit=1")
     suspend fun getLatestEditorial(
       @Query("aab") aab: Int = 1,
     ): BaseV7DataListResponse<EditorialJson>
 
-    @GET("cards/{widgetUrl}/aptoide_uid=0/")
+    @GET("cards/{widgetUrl}")
     suspend fun getArticlesMeta(
       @Path("widgetUrl", encoded = true) widgetUrl: String,
       @Query("subtype") subtype: String?,
       @Query("aab") aab: Int = 1,
     ): BaseV7DataListResponse<EditorialJson>
 
-    @GET("card/{widgetUrl}/aptoide_uid=0/")
+    @GET("card/{widgetUrl}/")
     suspend fun getArticleDetail(
       @Path("widgetUrl", encoded = true) widgetUrl: String,
       @Query("aab") aab: Int = 1,
     ): EditorialDetailJson
 
-    @GET("cards/get/type=CURATION_1/aptoide_uid=0/limit=10")
+    @GET("cards/get/type=CURATION_1/limit=10")
     suspend fun getRelatedArticlesMeta(
       @Query(value = "package_name", encoded = true) packageName: String,
       @Query("store_name") storeName: String,


### PR DESCRIPTION
**What does this PR do?**

   - Removes aptoide_uid usage from editorial endpoints.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AptoideEditorialRepository.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-36](https://aptoide.atlassian.net/browse/AND-36)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-36](https://aptoide.atlassian.net/browse/AND-36)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-36]: https://aptoide.atlassian.net/browse/AND-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-36]: https://aptoide.atlassian.net/browse/AND-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ