### PR TITLE
[AND-335] Add notification permissions result handling

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/repository/AppComingSoonPromotionalWorker.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/repository/AppComingSoonPromotionalWorker.kt
@@ -10,7 +10,6 @@ import androidx.work.NetworkType.CONNECTED
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
-import cm.aptoide.pt.extensions.hasNotificationsPermission
 import cm.aptoide.pt.feature_apps.domain.AppMetaUseCase
 import cm.aptoide.pt.feature_apps.domain.AppSource
 import cm.aptoide.pt.feature_apps.domain.AppSource.Companion.appendIfRequired
@@ -33,20 +32,17 @@ class AppComingSoonPromotionalWorker @AssistedInject constructor(
   override suspend fun doWork(): Result {
     val packageName = inputData.getString(PACKAGE_NAME)
     packageName?.let {
-      if (!applicationContext.hasNotificationsPermission()) {
-        appComingSoonManager.updateSubscribedApp(it, false)
-      } else {
-        try {
-          val app = appMetaUseCase.getMetaInfo(
-            source = AppSource.of(null, packageName).asSource()
-              .appendIfRequired(BuildConfig.MARKET_NAME)
-          )
-          appComingSoonNotificationBuilder.showAppComingSoonNotification(app)
-          appComingSoonManager.updateSubscribedApp(app.packageName, false)
-        } catch (t: Throwable) {
-          t.printStackTrace()
-        }
+      try {
+        val app = appMetaUseCase.getMetaInfo(
+          source = AppSource.of(null, packageName).asSource()
+            .appendIfRequired(BuildConfig.MARKET_NAME)
+        )
+        appComingSoonNotificationBuilder.showAppComingSoonNotification(app)
+        appComingSoonManager.updateSubscribedApp(app.packageName, false)
+      } catch (t: Throwable) {
+        t.printStackTrace()
       }
+
     }
     return Result.success()
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
@@ -71,7 +71,8 @@ fun MainView(navController: NavHostController) {
   var showTopBar by remember { mutableStateOf(true) }
   val (promoCodeApp, clearPromoCode) = rememberPromoCodeApp()
 
-  val currentRoute = navController.currentBackStackEntryFlow.collectAsState(initial = navController.currentBackStackEntry)
+  val currentRoute =
+    navController.currentBackStackEntryFlow.collectAsState(initial = navController.currentBackStackEntry)
 
   LaunchedEffect(currentRoute.value?.destination?.route) {
     showTopBar = currentRoute.value?.destination?.route?.contains(genieRoute)?.not() ?: true
@@ -99,16 +100,17 @@ fun MainView(navController: NavHostController) {
           AppGamesBottomBar(navController = navController)
         },
         topBar = {
-          if (showTopBar){
+          if (showTopBar) {
             AppGamesToolBar(navigate = navController::navigateTo, goBackHome)
           }
         }
       ) { padding ->
-        if (showNotificationsRationaleDialog) {
-          NotificationsPermissionRequester(
-            onDismiss = { notificationsPermissionViewModel.dismissDialog() }
-          )
-        }
+        NotificationsPermissionRequester(
+          showDialog = showNotificationsRationaleDialog,
+          onDismiss = { notificationsPermissionViewModel.dismissDialog() },
+          onPermissionResult = {}
+        )
+
         PromotionDialog(navigate = navController::navigateTo)
 
         Box(modifier = Modifier.padding(padding)) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/toolbar/AppGamesToolBar.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/toolbar/AppGamesToolBar.kt
@@ -190,9 +190,12 @@ private fun AppGamesToolBar(
       }
     }
   )
-  if (showNotificationsDialog) {
-    NotificationsPermissionRequester({ onDismissPermissionRequesterDialog() })
-  }
+
+  NotificationsPermissionRequester(
+    showDialog = showNotificationsDialog,
+    onDismiss = { onDismissPermissionRequesterDialog() },
+    onPermissionResult = {}
+  )
 }
 
 @Composable


### PR DESCRIPTION
**What does this PR do?**

   - Improves the notifications permission requester by adding result handling and returning.
   - Refactors the app coming soon card notify button to only change state depending on the notification permissions result.
   - Removes the notifications permissions check from the app coming soon worker.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-335](https://aptoide.atlassian.net/browse/AND-335)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-335](https://aptoide.atlassian.net/browse/AND-335)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-335]: https://aptoide.atlassian.net/browse/AND-335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-335]: https://aptoide.atlassian.net/browse/AND-335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ