### PR TITLE
[AND-341] Fix search meta null safety in search analytics

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/search/analytics/SearchAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/search/analytics/SearchAnalytics.kt
@@ -27,7 +27,7 @@ class SearchAnalytics(
   fun sendSearchResultClickEvent(
     app: App,
     position: Int,
-    searchMeta: SearchMeta,
+    searchMeta: SearchMeta?,
   ) {
     genericAnalytics.sendAppPromoClick(
       app = app,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/search/presentation/SearchView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/search/presentation/SearchView.kt
@@ -157,7 +157,7 @@ fun searchScreen() = ScreenData.withAnalytics(
         searchAnalytics.sendSearchResultClickEvent(
           app = app,
           position = index,
-          searchMeta = searchMeta!!,
+          searchMeta = searchMeta,
         )
         navigateTo(
           buildAppViewRoute(app).withItemPosition(index)


### PR DESCRIPTION
**What does this PR do?**

   - Fixes null safety in search analytics for the search meta instances used in the search view, in order to avoid possible NullPointerExceptions.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] SearchAnalytics.kt
- [ ] SearchView.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-341](https://aptoide.atlassian.net/browse/AND-341)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-341](https://aptoide.atlassian.net/browse/AND-341)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-341]: https://aptoide.atlassian.net/browse/AND-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-341]: https://aptoide.atlassian.net/browse/AND-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ