### PR TITLE
[AND-283] Use regex to get url domain in download analytics

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalyticsImpl.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalyticsImpl.kt
@@ -602,6 +602,6 @@ private val InstallPackageInfo.domainPrefix: String?
     ?.url
     ?.toUri()
     ?.host
-    ?.replace(".apk.aptoide.com", "")
+    ?.replace("(\\.apk)?\\.aptoide\\.com".toRegex(), "")
     ?.ifEmpty { null }
     ?: "n-a"


### PR DESCRIPTION
**What does this PR do?**

   - Improves the url domain in download analytics, by using regex to also include domains that might not have the ".apk" part.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] InstallAnalyticsImpl.com

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-283](https://aptoide.atlassian.net/browse/AND-283)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-283](https://aptoide.atlassian.net/browse/AND-283)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-283]: https://aptoide.atlassian.net/browse/AND-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-283]: https://aptoide.atlassian.net/browse/AND-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ