### PR TITLE
[AND-299] Fix home tab row paddings

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/CustomScrollableTabRow.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/CustomScrollableTabRow.kt
@@ -53,7 +53,7 @@ fun CustomScrollableTabRow(
     contentColor = contentColor,
     backgroundColor = backgroundColor,
     modifier = Modifier
-      .padding(top = 24.dp)
+      .padding(top = 24.dp, bottom = 4.dp)
       .height(40.dp),
     edgePadding = 0.dp,
     indicator = { tabPositions ->

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/TopChartsView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/TopChartsView.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.defaultMinSize
@@ -94,9 +95,9 @@ fun TopChartsList(
   LazyColumn(
     modifier = Modifier
       .semantics { collectionInfo = CollectionInfo(apps.size, 1) }
-      .padding(horizontal = 16.dp, vertical = 24.dp)
       .wrapContentSize(Alignment.TopCenter),
-    verticalArrangement = Arrangement.spacedBy(32.dp)
+    verticalArrangement = Arrangement.spacedBy(32.dp),
+    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 24.dp)
   ) {
     itemsIndexed(apps) { index, app ->
       ChartsAppItem(


### PR DESCRIPTION
**What does this PR do?**

   - Fixes the top charts view list padding.
   - Add bottom padding to home horizontal tab row to match design.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-299](https://aptoide.atlassian.net/browse/AND-299)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-299](https://aptoide.atlassian.net/browse/AND-299)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-299]: https://aptoide.atlassian.net/browse/AND-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-299]: https://aptoide.atlassian.net/browse/AND-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ