### PR TITLE
[AND-346] Auto Updates for devices above or equal to API 31

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.aptoide.android.aptoidegames.settings
 
+import android.os.Build
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -64,7 +65,11 @@ fun settingsScreen(showSnack: (String) -> Unit) = ScreenData(
   val genericAnalytics = rememberGenericAnalytics()
   val networkPreferencesViewModel = hiltViewModel<NetworkPreferencesViewModel>()
   val downloadOnlyOverWifi by networkPreferencesViewModel.downloadOnlyOverWifi.collectAsState()
-  val (autoUpdateGames, toggleAutoUpdateGames) = rememberAutoUpdate()
+  val (autoUpdateGames, toggleAutoUpdateGames) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    rememberAutoUpdate()
+  } else {
+    false to { _ -> }
+  }
   val deviceInfo = rememberDeviceInfo()
   val clipboardManager: ClipboardManager = LocalClipboardManager.current
   val copiedMessage = stringResource(R.string.settings_copied_to_clipboard_message)
@@ -135,11 +140,13 @@ fun SettingsViewContent(
             enabled = downloadOnlyOverWifi,
             onToggle = toggleDownloadOnlyOverWifi
           )
-          SettingsSwitchItem(
-            title = stringResource(R.string.settings_auto_update_button),
-            enabled = autoUpdateGames,
-            onToggle = toggleAutoUpdateGames
-          )
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            SettingsSwitchItem(
+              title = stringResource(R.string.settings_auto_update_button),
+              enabled = autoUpdateGames,
+              onToggle = toggleAutoUpdateGames
+            )
+          }
         }
       }
       SettingsSectionDivider()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesScreen.kt
@@ -1,5 +1,6 @@
 package com.aptoide.android.aptoidegames.updates.presentation
 
+import android.os.Build
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -88,10 +89,15 @@ fun UpdatesScreen(
 
 @Composable
 fun NoUpdatesScreen() {
-  val (autoUpdateGames, toggleAutoUpdate) = rememberAutoUpdate()
+  val (autoUpdateGames, toggleAutoUpdate) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    rememberAutoUpdate()
+  } else {
+    false to { _ -> }
+  }
   val showAutoUpdateToggle = remember { mutableStateOf(false) }
   LaunchedEffect(key1 = autoUpdateGames) {
-    if (!autoUpdateGames) showAutoUpdateToggle.value = true
+    if (!autoUpdateGames && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) showAutoUpdateToggle.value =
+      true
   }
 
   Column(

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/repository/UpdatesPreferencesRepository.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/repository/UpdatesPreferencesRepository.kt
@@ -1,11 +1,13 @@
 package cm.aptoide.pt.feature_updates.repository
 
+import android.os.Build
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import cm.aptoide.pt.feature_updates.di.UpdatesPreferencesDataStore
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -25,8 +27,13 @@ class UpdatesPreferencesRepository @Inject constructor(
     }
   }
 
-  fun shouldAutoUpdateGames(): Flow<Boolean> =
-    dataStore.data.map { preferences ->
-      preferences[AUTO_UPDATE_GAMES] ?: true
+  fun shouldAutoUpdateGames(): Flow<Boolean> {
+    return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+      return flowOf(false)
+    } else {
+      dataStore.data.map { preferences ->
+        preferences[AUTO_UPDATE_GAMES] ?: true
+      }
     }
+  }
 }

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/repository/AppInfoRepositoryImpl.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/repository/AppInfoRepositoryImpl.kt
@@ -46,7 +46,7 @@ internal class AppInfoRepositoryImpl(context: Context) : BroadcastReceiver(), Ap
     ?.takeIf(PackageInfo::ifNormalAppOrGame)
 
   override fun getUpdateOwnerPackageName(packageName: String): String? = runCatching {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
       pm.getInstallSourceInfo(packageName).run {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
           updateOwnerPackageName ?: installingPackageName


### PR DESCRIPTION
**What does this PR do?**

This PR aims at making auto updates only for devices with API above or equal to 31.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AppInfoRepositoryImpl.kt

**How should this be manually tested?**

Test the auto updates flow

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-346](https://aptoide.atlassian.net/browse/AND-346)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-346]: https://aptoide.atlassian.net/browse/AND-346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ