### PR TITLE
[AND-347] Check internet connection before AutoUpdates

### DIFF
--- a/feature_updates/src/main/AndroidManifest.xml
+++ b/feature_updates/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <application
       android:allowBackup="false"
       android:fullBackupContent="false"


### PR DESCRIPTION
**What does this PR do?**

This PR aims at implementing internet availability checks before performing the auto updates. 
We had the Worker restriction for the unmetered connection, but this was not enough as it only detects if it is on wifi, not if that wifi has a stable connection and we detected several internet errors on the the auto update flow.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AutoUpdateWorker.kt

**How should this be manually tested?**

Change the code for the initial delay to be in 5 minutes so you have time to do the next step.
Run the app, install through adb with app id an older version of for example mobile legends. 
Check if the autoupdate ran correctly.
Test all cases, where the ping fails, so it needs to do a retry and confirm that it only does one retry.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-347](https://aptoide.atlassian.net/browse/AND-347)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-347]: https://aptoide.atlassian.net/browse/AND-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ