### PR TITLE
[AND-346] remove auto updates for sdk30

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -1,6 +1,5 @@
 package com.aptoide.android.aptoidegames.settings
 
-import android.os.Build
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -65,11 +64,7 @@ fun settingsScreen(showSnack: (String) -> Unit) = ScreenData(
   val genericAnalytics = rememberGenericAnalytics()
   val networkPreferencesViewModel = hiltViewModel<NetworkPreferencesViewModel>()
   val downloadOnlyOverWifi by networkPreferencesViewModel.downloadOnlyOverWifi.collectAsState()
-  val (autoUpdateGames, toggleAutoUpdateGames) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-    rememberAutoUpdate()
-  } else {
-    false to { _ -> }
-  }
+  val (autoUpdateGames, toggleAutoUpdateGames) = rememberAutoUpdate()
   val deviceInfo = rememberDeviceInfo()
   val clipboardManager: ClipboardManager = LocalClipboardManager.current
   val copiedMessage = stringResource(R.string.settings_copied_to_clipboard_message)
@@ -109,7 +104,7 @@ fun settingsScreen(showSnack: (String) -> Unit) = ScreenData(
 fun SettingsViewContent(
   title: String = "Settings",
   downloadOnlyOverWifi: Boolean = true,
-  autoUpdateGames: Boolean = true,
+  autoUpdateGames: Boolean? = true,
   verName: String = "1.2.3",
   verCode: Int = 123,
   toggleDownloadOnlyOverWifi: (Boolean) -> Unit = {},
@@ -140,7 +135,7 @@ fun SettingsViewContent(
             enabled = downloadOnlyOverWifi,
             onToggle = toggleDownloadOnlyOverWifi
           )
-          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+          if (autoUpdateGames != null) {
             SettingsSwitchItem(
               title = stringResource(R.string.settings_auto_update_button),
               enabled = autoUpdateGames,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesScreen.kt
@@ -1,6 +1,5 @@
 package com.aptoide.android.aptoidegames.updates.presentation
 
-import android.os.Build
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -89,15 +88,11 @@ fun UpdatesScreen(
 
 @Composable
 fun NoUpdatesScreen() {
-  val (autoUpdateGames, toggleAutoUpdate) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-    rememberAutoUpdate()
-  } else {
-    false to { _ -> }
-  }
+  val (autoUpdateGames, toggleAutoUpdate) = rememberAutoUpdate()
   val showAutoUpdateToggle = remember { mutableStateOf(false) }
   LaunchedEffect(key1 = autoUpdateGames) {
-    if (!autoUpdateGames && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) showAutoUpdateToggle.value =
-      true
+    if (autoUpdateGames == false)
+      showAutoUpdateToggle.value = true
   }
 
   Column(
@@ -107,7 +102,7 @@ fun NoUpdatesScreen() {
   ) {
     if (showAutoUpdateToggle.value) {
       NoUpdatesTopSection(40)
-      NoUpdatesViewWithAutoUpdateOff(autoUpdateGames, toggleAutoUpdate)
+      autoUpdateGames?.let { NoUpdatesViewWithAutoUpdateOff(it, toggleAutoUpdate) }
     } else {
       NoUpdatesTopSection(88)
     }

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/di/ViewModelProvider.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/di/ViewModelProvider.kt
@@ -1,5 +1,6 @@
 package cm.aptoide.pt.feature_updates.di
 
+import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -19,7 +20,7 @@ class InjectionsProvider @Inject constructor(
 ) : ViewModel()
 
 @Composable
-fun rememberAutoUpdate(): Pair<Boolean, (Boolean) -> Unit> = runPreviewable(
+fun rememberAutoUpdate(): Pair<Boolean?, (Boolean) -> Unit> = runPreviewable(
   preview = { false to {} },
   real = {
     val injectionsProvider = hiltViewModel<InjectionsProvider>()
@@ -34,7 +35,11 @@ fun rememberAutoUpdate(): Pair<Boolean, (Boolean) -> Unit> = runPreviewable(
         }
       }
     )
-    val uiState by vm.shouldAutoUpdateGames.collectAsState()
-    uiState to vm::setAutoUpdateGames
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      val uiState by vm.shouldAutoUpdateGames.collectAsState()
+      uiState to vm::setAutoUpdateGames
+    } else {
+      null to { _ -> }
+    }
   }
 )


### PR DESCRIPTION
**What does this PR do?**
This PR aims at refactoring the auto updates viewmodel provider to put the API version rule inside the provider instead of every usage

**Database changed?**

 No

**Where should the reviewer start?**

- [ ] UpdatesScreen.kt

**How should this be manually tested?**

Test the flow of changing the autoupdates flag. Check also the empty state of the updates

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-346](https://aptoide.atlassian.net/browse/AND-346)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-346]: https://aptoide.atlassian.net/browse/AND-346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ