### PR TITLE
[AND-291] Fix mintegral ad clicks on config changes

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
@@ -2,6 +2,7 @@ package com.aptoide.android.aptoidegames
 
 import android.app.Application
 import android.content.Context
+import android.os.Process
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
@@ -10,6 +11,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.work.Configuration
 import androidx.work.Configuration.Provider
+import cm.aptoide.pt.extensions.getProcessName
 import cm.aptoide.pt.feature_campaigns.AptoideMMPCampaign
 import cm.aptoide.pt.feature_categories.analytics.AptoideAnalyticsInfoProvider
 import cm.aptoide.pt.feature_flags.domain.FeatureFlags
@@ -140,7 +142,7 @@ class AptoideApplication : Application(), ImageLoaderFactory, Provider {
       }
     }
     AptoideMMPCampaign.init(BuildConfig.OEMID, BuildConfig.MARKET_NAME)
-    mintegral.initializeSdk()
+    initAds()
   }
 
   private fun initFeatureFlags() {
@@ -172,6 +174,15 @@ class AptoideApplication : Application(), ImageLoaderFactory, Provider {
       channel = "APTOIDEGAMES"
       paymentScreenContentProvider = psContentProvider
       adyenKey = BuildConfig.ADYEN_KEY
+    }
+  }
+
+  private fun initAds() {
+    if (applicationContext.getProcessName(
+        Process.myPid()
+      ) != "${applicationContext.packageName}:obbMoverProcess"
+    ) {
+      mintegral.initializeSdk()
     }
   }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_ad/AdViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_ad/AdViewModel.kt
@@ -17,7 +17,7 @@ class AdViewModel(
   private val appMetaUseCase: AppMetaUseCase,
 ) : ViewModel() {
 
-  private val viewModelState = MutableStateFlow<MintegralAdApp?>(null)
+  private val viewModelState = MutableStateFlow<MintegralAd?>(null)
 
   val uiState = viewModelState
     .stateIn(
@@ -35,11 +35,11 @@ class AdViewModel(
       viewModelState.update { null }
       try {
         mintegral.initNativeAd(adClick = adClick).collect { newCampaign ->
-          if(newCampaign != null){
+          if (newCampaign != null) {
             val app = appMetaUseCase
               .getMetaInfo(source = AppSource.of(null, newCampaign.packageName).asSource())
             viewModelState.update {
-              MintegralAdApp(app = app, register = { view ->
+              MintegralAd(app = app, register = { view ->
                 mintegral.registerNativeAdView(view, newCampaign)
               })
             }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_ad/MintegralAd.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_ad/MintegralAd.kt
@@ -4,3 +4,7 @@ import android.view.View
 import cm.aptoide.pt.feature_apps.data.App
 
 data class MintegralAd(val app: App, val register: (View) -> Unit)
+
+sealed class MintegralAdEvent {
+  data class AdClick(val packageName: String) : MintegralAdEvent()
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_ad/MintegralAd.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_ad/MintegralAd.kt
@@ -3,4 +3,4 @@ package com.aptoide.android.aptoidegames.feature_ad
 import android.view.View
 import cm.aptoide.pt.feature_apps.data.App
 
-data class MintegralAdApp(val app: App, val register: (View) -> Unit)
+data class MintegralAd(val app: App, val register: (View) -> Unit)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_ad/ViewModelProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_ad/ViewModelProvider.kt
@@ -17,13 +17,13 @@ import javax.inject.Inject
 
 @HiltViewModel
 class InjectionsProvider @Inject constructor(
-   val mintegral: Mintegral,
-   val appMetaUseCase: AppMetaUseCase,
+  val mintegral: Mintegral,
+  val appMetaUseCase: AppMetaUseCase,
 ) : ViewModel()
 
 @Composable
-fun rememberAd(adClick: (String) -> Unit): MintegralAdApp? = runPreviewable(
-  preview = { MintegralAdApp(randomApp, {}) },
+fun rememberMintegralAd(adClick: (String) -> Unit): MintegralAd? = runPreviewable(
+  preview = { MintegralAd(randomApp, {}) },
   real = {
     val injectionsProvider = hiltViewModel<InjectionsProvider>()
     val vm: AdViewModel = viewModel(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_ad/ViewModelProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_ad/ViewModelProvider.kt
@@ -13,6 +13,8 @@ import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.domain.AppMetaUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,8 +24,8 @@ class InjectionsProvider @Inject constructor(
 ) : ViewModel()
 
 @Composable
-fun rememberMintegralAd(adClick: (String) -> Unit): MintegralAd? = runPreviewable(
-  preview = { MintegralAd(randomApp, {}) },
+fun rememberMintegralAd(): Pair<MintegralAd?, Flow<MintegralAdEvent>> = runPreviewable(
+  preview = { MintegralAd(randomApp, {}) to emptyFlow() },
   real = {
     val injectionsProvider = hiltViewModel<InjectionsProvider>()
     val vm: AdViewModel = viewModel(
@@ -35,13 +37,12 @@ fun rememberMintegralAd(adClick: (String) -> Unit): MintegralAd? = runPreviewabl
           return AdViewModel(
             mintegral = injectionsProvider.mintegral,
             appMetaUseCase = injectionsProvider.appMetaUseCase,
-            adClick = adClick
           ) as T
         }
       }
     )
 
     val uiState by vm.uiState.collectAsState()
-    uiState
+    uiState to vm.mintegralAdEvents
   }
 )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselAppView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselAppView.kt
@@ -47,8 +47,8 @@ import com.aptoide.android.aptoidegames.analytics.presentation.AnalyticsContext
 import com.aptoide.android.aptoidegames.analytics.presentation.withItemPosition
 import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
 import com.aptoide.android.aptoidegames.drawables.icons.getBonusIconRight
-import com.aptoide.android.aptoidegames.feature_ad.MintegralAdApp
-import com.aptoide.android.aptoidegames.feature_ad.rememberAd
+import com.aptoide.android.aptoidegames.feature_ad.MintegralAd
+import com.aptoide.android.aptoidegames.feature_ad.rememberMintegralAd
 import com.aptoide.android.aptoidegames.home.BundleHeader
 import com.aptoide.android.aptoidegames.home.HorizontalPagerView
 import com.aptoide.android.aptoidegames.home.LoadingBundleView
@@ -119,7 +119,7 @@ private fun CarouselListView(
   val analyticsContext = AnalyticsContext.current
   val bundleAnalytics = rememberBundleAnalytics()
   var app: App? by remember { mutableStateOf(null) }
-  val adApp: MintegralAdApp? = rememberAd(
+  val ad: MintegralAd? = rememberMintegralAd(
     { packageName ->
       navigate(
         buildAppViewRoute(
@@ -132,13 +132,13 @@ private fun CarouselListView(
       )
     }
   )
-  LaunchedEffect(adApp) {
-    adApp?.let{
+  LaunchedEffect(ad) {
+    ad?.let {
       app = it.app
     }
   }
-  val updatedList: List<App> = remember(adApp) {
-    adApp?.let {
+  val updatedList: List<App> = remember(ad) {
+    ad?.let {
       appsList.toMutableList().apply {
         add(1, it.app)
       }.toImmutableList()
@@ -155,9 +155,9 @@ private fun CarouselListView(
         .width(280.dp)
         .background(color = Color.Transparent)
     ) {
-      if (adApp != null && page == 1) {
+      if (ad != null && page == 1) {
         MintegralNativeAdView(
-          adApp = adApp,
+          ad = ad,
           item = item,
           showVideos = showVideos,
           isCurrentPage = isCurrentPage
@@ -184,7 +184,7 @@ private fun CarouselListView(
 
 @Composable
 fun MintegralNativeAdView(
-  adApp: MintegralAdApp,
+  ad: MintegralAd,
   item: App,
   showVideos: Boolean,
   isCurrentPage: Boolean,
@@ -214,7 +214,7 @@ fun MintegralNativeAdView(
           FrameLayout.LayoutParams.WRAP_CONTENT
         )
       )
-      adApp.register(container)
+      ad.register(container)
 
       container
     }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -382,7 +383,9 @@ fun HorizontalPagerView(
     end = padding
   )
 
-  val initialItem = calculateLoopedBundleInitialItem(appsList.size)
+  val initialItem = remember(appsList) {
+    calculateLoopedBundleInitialItem(appsList.size)
+  }
 
   val pagerState = rememberPagerState(
     initialPage = initialItem,
@@ -395,6 +398,10 @@ fun HorizontalPagerView(
     scrollSpeedInSeconds = scrollSpeedInSeconds.takeIf { it > 0L } ?: DEFAULT_AUTO_SCROLL_SPEED
   )
   val currentPage by autoScrollViewModel.uiState.collectAsState()
+
+  LaunchedEffect(initialItem) {
+    pagerState.animateScrollToPage(initialItem)
+  }
 
   /*Used when the current page state is changed in the AutoScrollViewModel*/
   LaunchedEffect(currentPage) {

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/obb/OBBInstallManager.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/obb/OBBInstallManager.kt
@@ -1,9 +1,8 @@
 package cm.aptoide.pt.installer.obb
 
-import android.app.ActivityManager
-import android.app.Application.ACTIVITY_SERVICE
 import android.content.Context
 import android.os.Process
+import cm.aptoide.pt.extensions.getProcessName
 import cm.aptoide.pt.install_manager.App
 import cm.aptoide.pt.install_manager.InstallManager
 import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
@@ -28,23 +27,11 @@ class OBBInstallManager(
     installManager.getMissingFreeSpaceFor(installPackageInfo)
 
   override suspend fun restore() {
-    if (getProcessName(
-        context,
+    if (context.getProcessName(
         Process.myPid()
       ) != "${context.packageName}:obbMoverProcess"
     ) {
       installManager.restore()
     }
   }
-}
-
-fun getProcessName(cxt: Context, pid: Int): String? {
-  val am = cxt.getSystemService(ACTIVITY_SERVICE) as ActivityManager
-  val runningApps = am.runningAppProcesses ?: return null
-  for (procInfo in runningApps) {
-    if (procInfo.pid == pid) {
-      return procInfo.processName
-    }
-  }
-  return null
 }

--- a/extension/src/main/java/cm/aptoide/pt/extensions/ContextExtensions.kt
+++ b/extension/src/main/java/cm/aptoide/pt/extensions/ContextExtensions.kt
@@ -2,7 +2,9 @@ package cm.aptoide.pt.extensions
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.ActivityManager
 import android.content.Context
+import android.content.Context.ACTIVITY_SERVICE
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
@@ -65,4 +67,15 @@ fun Context.sendMail(
   } catch (t: Throwable) {
     Timber.e(t)
   }
+}
+
+fun Context.getProcessName(pid: Int): String? {
+  val am = getSystemService(ACTIVITY_SERVICE) as ActivityManager
+  val runningApps = am.runningAppProcesses ?: return null
+  for (procInfo in runningApps) {
+    if (procInfo.pid == pid) {
+      return procInfo.processName
+    }
+  }
+  return null
 }


### PR DESCRIPTION
**What does this PR do?**

   - Fixes crashes caused by clicks in mintegral ads after configuration changes.
   - Also fixes an issue with the carousel auto scroll after its list was changed.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-291](https://aptoide.atlassian.net/browse/AND-291)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-291](https://aptoide.atlassian.net/browse/AND-291)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-291]: https://aptoide.atlassian.net/browse/AND-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-291]: https://aptoide.atlassian.net/browse/AND-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ