### PR TITLE
[AND-380] Change the notification permission order

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/analytics/NotificationsAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/analytics/NotificationsAnalytics.kt
@@ -1,8 +1,9 @@
 package com.aptoide.android.aptoidegames.notifications.analytics
 
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
+import javax.inject.Inject
 
-class NotificationsAnalytics(
+class NotificationsAnalytics @Inject constructor(
   private val genericAnalytics: GenericAnalytics,
 ) {
 


### PR DESCRIPTION
**What does this PR do?**

   This PR aims to modify the notification permission flow. On the first launch, the app requests the native notification permission. If the user declines, a custom dialog is presented on the second launch, and on the third launch, the Ahab is activated as before.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit 

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-380](https://aptoide.atlassian.net/browse/AND-380)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-380](https://aptoide.atlassian.net/browse/AND-380)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-380]: https://aptoide.atlassian.net/browse/AND-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-380]: https://aptoide.atlassian.net/browse/AND-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ