### PR TITLE
[AND-378] Use legacy installer for Xiaomi devices below or equal to API 30

### DIFF
--- a/app-games/src/main/AndroidManifest.xml
+++ b/app-games/src/main/AndroidManifest.xml
@@ -107,5 +107,15 @@
           android:value="androidx.startup"
           tools:node="remove" />
     </provider>
+
+    <provider
+        android:name="androidx.core.content.FileProvider"
+        android:authorities="${applicationId}.fileProvider"
+        android:exported="false"
+        android:grantUriPermissions="true">
+      <meta-data
+          android:name="android.support.FILE_PROVIDER_PATHS"
+          android:resource="@xml/paths" />
+    </provider>
   </application>
 </manifest>

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/InstallerSelector.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/InstallerSelector.kt
@@ -1,0 +1,47 @@
+package com.aptoide.android.aptoidegames.installer
+
+import android.os.Build
+import cm.aptoide.pt.extensions.isMIUI
+import cm.aptoide.pt.extensions.isMiuiOptimizationDisabled
+import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
+import cm.aptoide.pt.install_manager.dto.hasSplitApks
+import cm.aptoide.pt.install_manager.workers.PackageInstaller
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class InstallerSelector @Inject constructor(
+  val aptoideInstaller: PackageInstaller,
+  val legacyInstaller: PackageInstaller
+) : PackageInstaller {
+
+  override fun install(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo
+  ): Flow<Int> = flow { emit(getPackageInstaller(installPackageInfo)) }
+    .flatMapLatest { it.install(packageName, installPackageInfo) }
+
+  override fun uninstall(packageName: String): Flow<Int> = flow { emit(getPackageUninstaller()) }
+    .flatMapLatest { it.uninstall(packageName) }
+
+  fun getPackageInstaller(installPackageInfo: InstallPackageInfo): PackageInstaller =
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R && isMIUI()
+      && !isMiuiOptimizationDisabled() && !installPackageInfo.hasSplitApks()
+    ) {
+      legacyInstaller
+    } else {
+      aptoideInstaller
+    }
+
+  fun getPackageUninstaller(): PackageInstaller =
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R && isMIUI()
+      && !isMiuiOptimizationDisabled()
+    ) {
+      legacyInstaller
+    } else {
+      aptoideInstaller
+    }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/UserActionDialog.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/UserActionDialog.kt
@@ -1,6 +1,7 @@
 package com.aptoide.android.aptoidegames.installer
 
 import android.app.Activity
+import android.content.Intent
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -112,8 +113,7 @@ fun UserActionDialog() {
         when (val it = state) {
           is InstallationAction -> {
             if (!installationActionLaunched) {
-              //System action, we cannot access it any other way
-              if (it.intent.action == "android.content.pm.action.CONFIRM_INSTALL") {
+              if (it.intent.isInstallationIntent()) {
                 val packageName = it.intent
                   .getStringExtra("${BuildConfig.APPLICATION_ID}.pn") ?: "NaN"
                 val analyticsPayload = it.intent
@@ -259,3 +259,7 @@ fun PermissionsDialogPreview() {
     }
   }
 }
+
+//System action, we cannot access it any other way
+fun Intent.isInstallationIntent() =
+  action == "android.content.pm.action.CONFIRM_INSTALL" || action == "android.intent.action.INSTALL_PACKAGE"

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/di/InstallerModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/di/InstallerModule.kt
@@ -13,12 +13,14 @@ import cm.aptoide.pt.install_manager.environment.NetworkConnection
 import cm.aptoide.pt.installer.AptoideDownloader
 import cm.aptoide.pt.installer.AptoideInstallPackageInfoMapper
 import cm.aptoide.pt.installer.AptoideInstaller
+import cm.aptoide.pt.installer.LegacyInstaller
 import cm.aptoide.pt.installer.obb.OBBInstallManager
 import cm.aptoide.pt.task_info.AptoideTaskInfoRepository
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
 import com.aptoide.android.aptoidegames.apkfy.DownloadPermissionStateProbe
 import com.aptoide.android.aptoidegames.installer.DownloaderSelector
+import com.aptoide.android.aptoidegames.installer.InstallerSelector
 import com.aptoide.android.aptoidegames.installer.analytics.AnalyticsInstallPackageInfoMapper
 import com.aptoide.android.aptoidegames.installer.analytics.DownloadProbe
 import com.aptoide.android.aptoidegames.installer.analytics.InstallAnalytics
@@ -54,7 +56,7 @@ class InstallerModule {
     @ApplicationContext appContext: Context,
     taskInfoRepository: AptoideTaskInfoRepository,
     downloadPermissionStateProbe: DownloadPermissionStateProbe,
-    installer: AptoideInstaller,
+    installerSelector: InstallerSelector,
     installAnalytics: InstallAnalytics,
     networkConnection: NetworkConnection,
     silentInstallChecker: SilentInstallChecker,
@@ -71,7 +73,7 @@ class InstallerModule {
         analytics = installAnalytics,
       ),
       packageInstaller = InstallProbe(
-        packageInstaller = installer,
+        packageInstaller = installerSelector,
         analytics = installAnalytics,
       ),
       networkConnection = networkConnection
@@ -89,6 +91,16 @@ class InstallerModule {
   ): DownloaderSelector = DownloaderSelector(
     featureFlags = featureFlags,
     aptoidePackageDownloader = aptoideDownloader,
+  )
+
+  @Singleton
+  @Provides
+  fun provideInstallerSelector(
+    aptoideInstaller: AptoideInstaller,
+    legacyInstaller: LegacyInstaller
+  ): InstallerSelector = InstallerSelector(
+    aptoideInstaller = aptoideInstaller,
+    legacyInstaller = legacyInstaller,
   )
 
   @Singleton

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/RealInstallerNotificationsManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/RealInstallerNotificationsManager.kt
@@ -15,6 +15,7 @@ import cm.aptoide.pt.installer.platform.UserActionRequest
 import cm.aptoide.pt.network_listener.NetworkConnectionImpl
 import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.installer.AppDetailsUseCase
+import com.aptoide.android.aptoidegames.installer.isInstallationIntent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -64,7 +65,7 @@ class RealInstallerNotificationsManager @Inject constructor(
     userActionHandler.requests.collect {
       if (isOnForeground == false
         && it is UserActionRequest.InstallationAction
-        && it.intent.action == "android.content.pm.action.CONFIRM_INSTALL"
+        && it.intent.isInstallationIntent()
       ) {
         val packageName = it.intent
           .getStringExtra("${BuildConfig.APPLICATION_ID}.pn") ?: "NaN"

--- a/app-games/src/main/res/xml/paths.xml
+++ b/app-games/src/main/res/xml/paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+  <cache-path
+      name="cache"
+      path="." />
+</paths>

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstallPackageInfoMapper.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstallPackageInfoMapper.kt
@@ -63,7 +63,7 @@ class AptoideInstallPackageInfoMapper @Inject constructor(
 }
 
 private fun File.toInstallationFile(type: InstallationFile.Type) = InstallationFile(
-  name = fileName,
+  name = fileName.takeIf { it.endsWith(".apk") } ?: "$fileName.apk",
   type = type,
   md5 = md5,
   fileSize = size,

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/InstallerUtils.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/InstallerUtils.kt
@@ -1,0 +1,26 @@
+package cm.aptoide.pt.installer
+
+import android.content.Context
+import android.os.Build
+import cm.aptoide.pt.extensions.checkMd5
+import cm.aptoide.pt.extensions.hasPackageInstallsPermission
+import cm.aptoide.pt.extensions.hasWriteExternalStoragePermission
+import cm.aptoide.pt.install_manager.dto.InstallationFile
+import java.io.File
+
+internal fun InstallationFile.toCheckedFile(parentDir: File): File =
+  File(parentDir, name)
+    .takeIf { it.checkMd5(md5) }
+    ?: throw IllegalStateException("MD5 check failed: File $name is corrupt")
+
+internal val Collection<File>.totalLength
+  get() = map(File::length).reduceOrNull { acc, l -> acc + l } ?: 0
+
+internal fun Collection<File>.deleteFromCache() = forEach(File::delete)
+
+internal fun Context.getPermissionsState() =
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+    hasPackageInstallsPermission() && hasWriteExternalStoragePermission()
+  } else {
+    hasPackageInstallsPermission()
+  }

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/LegacyInstaller.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/LegacyInstaller.kt
@@ -1,0 +1,152 @@
+package cm.aptoide.pt.installer
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import androidx.core.net.toUri
+import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
+import cm.aptoide.pt.install_manager.dto.InstallationFile
+import cm.aptoide.pt.install_manager.dto.hasObb
+import cm.aptoide.pt.install_manager.dto.hasSplitApks
+import cm.aptoide.pt.install_manager.workers.PackageInstaller
+import cm.aptoide.pt.installer.di.DownloadsPath
+import cm.aptoide.pt.installer.obb.ObbService
+import cm.aptoide.pt.installer.obb.installOBBs
+import cm.aptoide.pt.installer.platform.InstallPermissions
+import cm.aptoide.pt.installer.platform.UserActionLauncher
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Suppress("DEPRECATION")
+@Singleton
+class LegacyInstaller @Inject constructor(
+  @ApplicationContext private val context: Context,
+  @DownloadsPath private val downloadsPath: File,
+  private val installPermissions: InstallPermissions,
+  private val userActionLauncher: UserActionLauncher,
+) : PackageInstaller {
+  private val initialPermissionsAllowed = context.getPermissionsState()
+
+  override fun install(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo
+  ): Flow<Int> = flow {
+    emit(0)
+    if (installPackageInfo.hasObb()) {
+      installPermissions.checkIfCanWriteExternal()
+    }
+    installPermissions.checkIfCanInstall()
+
+    if (installPackageInfo.hasSplitApks()) {
+      throw IllegalStateException("Can't install split apks with the legacy installer")
+    }
+
+    val filesDir = File(downloadsPath, packageName)
+    if (!filesDir.exists()) throw IllegalStateException("Necessary file does not exist for app $packageName")
+
+    val checkFraction = 49
+    val (apk, obbFiles) = installPackageInfo.getCheckedFiles(filesDir) {
+      emit((it * checkFraction).toInt())
+    }
+
+    if (apk == null) {
+      throw IllegalStateException("Missing base apk")
+    }
+
+    val apkSize = apk.length()
+    val totalObbSize = obbFiles.totalLength
+    val obbFraction = 49.0 * totalObbSize / (apkSize + totalObbSize)
+
+    if (totalObbSize > 0) {
+      if (initialPermissionsAllowed) {
+        obbFiles.installOBBs(packageName) {
+          emit(checkFraction + (obbFraction * it / totalObbSize).toInt())
+        }
+      } else {
+        ObbService.bindServiceAndWaitForResult(
+          context = context,
+          packageName = packageName,
+          obbFilePaths = obbFiles.map { it.absolutePath }
+        ).let { movedOBBFiles ->
+          if (movedOBBFiles) {
+            //TODO: improve installation progress when using OBBService
+            emit(checkFraction + (obbFraction / totalObbSize).toInt())
+          } else {
+            throw IllegalStateException("Error moving OBB files")
+          }
+        }
+      }
+    }
+
+    val installIntent = Intent(Intent.ACTION_INSTALL_PACKAGE)
+      .putExtra(Intent.EXTRA_RETURN_RESULT, true)
+      .putExtra(
+        Intent.EXTRA_INSTALLER_PACKAGE_NAME,
+        context.applicationContext.packageName
+      ).putExtra(Intent.EXTRA_NOT_UNKNOWN_SOURCE, true)
+      .putExtra("${context.packageName}.pn", packageName)
+      .putExtra("${context.packageName}.ap", installPackageInfo.payload)
+
+    installIntent.data = FileProvider.getUriForFile(
+      context,
+      "${context.applicationContext.packageName}.fileProvider",
+      apk
+    )
+
+    installIntent.flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+
+    emit(99)
+    val installed = userActionLauncher.launchIntent(installIntent)
+
+    if (installed) {
+      emit(100)
+      filesDir.deleteRecursively()
+      obbFiles.deleteFromCache()
+    } else {
+      throw Exception("Failed to install with legacy installer")
+    }
+  }
+
+  override fun uninstall(packageName: String): Flow<Int> = flow {
+    emit(0)
+    val intent = Intent(Intent.ACTION_DELETE)
+      .putExtra(Intent.EXTRA_RETURN_RESULT, true)
+    intent.data = "package:$packageName".toUri()
+
+    emit(99)
+    val uninstalled = userActionLauncher.launchIntent(intent)
+
+    if (uninstalled) {
+      emit(100)
+    } else {
+      throw Exception("Failed to uninstall with legacy installer")
+    }
+  }
+
+  private suspend fun InstallPackageInfo.getCheckedFiles(
+    downloadsDir: File,
+    progress: suspend (Double) -> Unit,
+  ): Pair<File?, List<File>> = installationFiles.run {
+    var apk: File? = null
+    val obbs = mutableListOf<File>()
+    forEachIndexed { index, value ->
+      when (value.type) {
+        InstallationFile.Type.BASE,
+          -> apk = value.toCheckedFile(downloadsDir)
+
+        InstallationFile.Type.OBB_MAIN,
+        InstallationFile.Type.OBB_PATCH,
+          -> obbs.add(value.toCheckedFile(downloadsDir))
+
+        else -> {}
+      }
+
+      progress(index + 1.0 / size)
+    }
+    apk to obbs
+  }
+}

--- a/extension/src/main/java/cm/aptoide/pt/extensions/PlatformUtils.kt
+++ b/extension/src/main/java/cm/aptoide/pt/extensions/PlatformUtils.kt
@@ -1,0 +1,28 @@
+package cm.aptoide.pt.extensions
+
+import android.annotation.SuppressLint
+
+fun isMIUI(): Boolean = !getSystemProperty("ro.miui.ui.version.name").isNullOrBlank()
+
+@SuppressLint("PrivateApi")
+fun isMiuiOptimizationDisabled(): Boolean =
+  if ("0" == getSystemProperty("persist.sys.miui_optimization")) {
+    true
+  } else try {
+    Class.forName("android.miui.AppOpsUtils")
+      .getDeclaredMethod("isXOptMode")
+      .invoke(null) as Boolean
+  } catch (_: java.lang.Exception) {
+    false
+  }
+
+@SuppressLint("PrivateApi")
+private fun getSystemProperty(key: String): String? {
+  return try {
+    Class.forName("android.os.SystemProperties")
+      .getDeclaredMethod("get", String::class.java)
+      .invoke(null, key) as String
+  } catch (_: Exception) {
+    null
+  }
+}

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/dto/InstallPackageInfo.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/dto/InstallPackageInfo.kt
@@ -13,3 +13,7 @@ data class InstallPackageInfo(
 
 fun InstallPackageInfo.hasObb() =
   installationFiles.find { it.type == InstallationFile.Type.OBB_MAIN } != null
+
+fun InstallPackageInfo.hasSplitApks() =
+  installationFiles.count { it.type == InstallationFile.Type.BASE } > 1 ||
+    installationFiles.any { it.type.name.contains("PAD") || it.type.name.contains("PFD") }


### PR DESCRIPTION
**What does this PR do?**

   - Extracts some package installer functions for convenience.
   - Adds the apk file type to downloaded apk files, to avoid issues with package install intents.
   - Adds functions to check for MIUI devices and MIUI optimizations state.
   - Adds a legacy installer, that relies on ACTION_INSTALL_PACKAGE intents instead of android's PackageInstaller API.
   - Adds a package installer selector to AG.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-378](https://aptoide.atlassian.net/browse/AND-378)

- To correctly test the legacy installer and the checks for MIUI devices, a MIUI device with an API <= 30 is required.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-378](https://aptoide.atlassian.net/browse/AND-378)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-378]: https://aptoide.atlassian.net/browse/AND-378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-378]: https://aptoide.atlassian.net/browse/AND-378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ