### PR TITLE
[AND-381] Disable silent updates on MIUI devices with optimizations on

### DIFF
--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/di/ViewModelProvider.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/di/ViewModelProvider.kt
@@ -1,6 +1,5 @@
 package cm.aptoide.pt.feature_updates.di
 
-import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -35,11 +34,9 @@ fun rememberAutoUpdate(): Pair<Boolean?, (Boolean) -> Unit> = runPreviewable(
         }
       }
     )
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-      val uiState by vm.shouldAutoUpdateGames.collectAsState()
-      uiState to vm::setAutoUpdateGames
-    } else {
-      null to { _ -> }
-    }
+    val uiState by vm.shouldAutoUpdateGames.collectAsState()
+    uiState?.let {
+      it to vm::setAutoUpdateGames
+    } ?: (null to {})
   }
 )

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/Updates.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/Updates.kt
@@ -140,7 +140,7 @@ class Updates @Inject constructor(
           it.modifiedDate
         }
       }
-    if (!shouldAutoUpdateGames) {
+    if (shouldAutoUpdateGames != true) {
       return
     }
     installers.forEach { appInstaller ->

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/presentation/UpdatesPreferencesViewModel.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/presentation/UpdatesPreferencesViewModel.kt
@@ -17,7 +17,7 @@ class UpdatesPreferencesViewModel @Inject constructor(
   private val updatesPreferencesRepository: UpdatesPreferencesRepository
 ) : ViewModel() {
 
-  private val viewModelState = MutableStateFlow(true)
+  private val viewModelState = MutableStateFlow<Boolean?>(null)
 
   val shouldAutoUpdateGames = viewModelState
     .stateIn(

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/repository/UpdatesPreferencesRepository.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/repository/UpdatesPreferencesRepository.kt
@@ -5,6 +5,8 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import cm.aptoide.pt.extensions.isMIUI
+import cm.aptoide.pt.extensions.isMiuiOptimizationDisabled
 import cm.aptoide.pt.feature_updates.di.UpdatesPreferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -28,7 +30,7 @@ class UpdatesPreferencesRepository @Inject constructor(
   }
 
   fun shouldAutoUpdateGames(): Flow<Boolean?> {
-    return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+    return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || areSilentUpdatesUnsupported()) {
       return flowOf(null)
     } else {
       dataStore.data.map { preferences ->
@@ -36,4 +38,6 @@ class UpdatesPreferencesRepository @Inject constructor(
       }
     }
   }
+
+  private fun areSilentUpdatesUnsupported() = isMIUI() && !isMiuiOptimizationDisabled()
 }

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/repository/UpdatesPreferencesRepository.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/repository/UpdatesPreferencesRepository.kt
@@ -27,9 +27,9 @@ class UpdatesPreferencesRepository @Inject constructor(
     }
   }
 
-  fun shouldAutoUpdateGames(): Flow<Boolean> {
+  fun shouldAutoUpdateGames(): Flow<Boolean?> {
     return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-      return flowOf(false)
+      return flowOf(null)
     } else {
       dataStore.data.map { preferences ->
         preferences[AUTO_UPDATE_GAMES] ?: true


### PR DESCRIPTION
**What does this PR do?**

   - Prevents silent updates on MIUI devices that have MIUI optimizations turned on.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

- To correctly test this, a MIUI device with API >= 31 (API levels from which silent updates are allowed) is required and the MIUI optimizations must be turned on.

  Flow on how to test this or QA Tickets related to this use-case: [AND-381](https://aptoide.atlassian.net/browse/AND-381)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-381](https://aptoide.atlassian.net/browse/AND-381)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-381]: https://aptoide.atlassian.net/browse/AND-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-381]: https://aptoide.atlassian.net/browse/AND-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ