### PR TITLE
[AND-388] Download Queue Handling on Cancel Action

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/InstallerQueueHandler.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/InstallerQueueHandler.kt
@@ -1,0 +1,48 @@
+package com.aptoide.android.aptoidegames.installer
+
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import cm.aptoide.pt.extensions.runPreviewable
+import cm.aptoide.pt.install_manager.InstallManager
+import com.aptoide.android.aptoidegames.installer.analytics.InstallAnalytics
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import javax.inject.Singleton
+
+interface InstallerQueueHandler {
+  //Used to clear the remaining queue after a package download in the queue is cancelled directly by the user.
+  fun clearRemainingQueue(canceledPackageName: String) {}
+}
+
+@Singleton
+class InstallerQueueHandlerImpl @Inject constructor(
+  private val installManager: InstallManager,
+  private val installAnalytics: InstallAnalytics
+) : InstallerQueueHandler {
+
+  override fun clearRemainingQueue(canceledPackageName: String) {
+    installManager.scheduledApps.forEach { app ->
+      app.takeIf { it.packageName != canceledPackageName }
+        ?.task
+        ?.run {
+          cancel()
+          installAnalytics.sendAutomaticQueueDownloadCancelEvent(packageName, installPackageInfo)
+        }
+    }
+  }
+}
+
+@HiltViewModel
+class InjectionsProvider @Inject constructor(
+  val installerQueueHandler: InstallerQueueHandlerImpl,
+) : ViewModel()
+
+@Composable
+fun rememberInstallerQueueHandler(): InstallerQueueHandler = runPreviewable(
+  preview = { object : InstallerQueueHandler {} },
+  real = {
+    val injectionsProvider = hiltViewModel<InjectionsProvider>()
+    injectionsProvider.installerQueueHandler
+  }
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -76,6 +76,12 @@ interface InstallAnalytics {
   ) {
   }
 
+  fun sendAutomaticQueueDownloadCancelEvent(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo
+  ) {
+  }
+
   fun sendInstallDialogImpressionEvent(
     packageName: String,
     analyticsPayload: AnalyticsPayload?

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalyticsImpl.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalyticsImpl.kt
@@ -245,6 +245,19 @@ class InstallAnalyticsImpl(
     )
   }
 
+  override fun sendAutomaticQueueDownloadCancelEvent(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo
+  ) {
+    logBIDownloadEvent(
+      packageName = packageName,
+      status = "cancel_queue",
+      installPackageInfo = installPackageInfo,
+      downloadedBytesPerSecond = -1.0,
+      P_ERROR_TYPE to "queue"
+    )
+  }
+
   override fun sendInstallDialogImpressionEvent(
     packageName: String,
     analyticsPayload: AnalyticsPayload?

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
@@ -38,6 +38,7 @@ import com.aptoide.android.aptoidegames.installer.analytics.rememberInstallAnaly
 import com.aptoide.android.aptoidegames.installer.analytics.rememberScheduledInstalls
 import com.aptoide.android.aptoidegames.installer.installConstraints
 import com.aptoide.android.aptoidegames.installer.notifications.rememberInstallerNotifications
+import com.aptoide.android.aptoidegames.installer.rememberInstallerQueueHandler
 import com.aptoide.android.aptoidegames.installer.wifiInstallConstraints
 import com.aptoide.android.aptoidegames.network.presentation.NetworkPreferencesViewModel
 import com.aptoide.android.aptoidegames.network.presentation.WifiPromptDialog
@@ -67,6 +68,7 @@ fun installViewStates(
   val (saveAppDetails) = rememberSaveAppDetails()
   val downloadOnlyOverWifi = rememberDownloadOverWifi()
   val scheduledInstallListener = rememberScheduledInstalls()
+  val installerQueueHandler = rememberInstallerQueueHandler()
 
   var canceled by remember { mutableStateOf(false) }
   LaunchedEffect(key1 = downloadUiState) {
@@ -330,6 +332,7 @@ fun installViewStates(
                   downloadOnlyOverWifiSetting = downloadOnlyOverWifi
                 )
                 cancel()
+                installerQueueHandler.clearRemainingQueue(app.packageName)
               }
 
               else -> { ->
@@ -347,6 +350,7 @@ fun installViewStates(
                   installPackageInfo = downloadUiState.installPackageInfo
                 )
                 cancel()
+                installerQueueHandler.clearRemainingQueue(app.packageName)
               }
             }
           }


### PR DESCRIPTION
**What does this PR do?**

   - Adds an installer queue handler that allows to cancel/clear the entire download queue after a single pending download is cancelled by the user.
   - Adds an alternative of the download analytics event with status equal to 'cancel_queue', that is sent for each package download that is automatically canceled and removed from the queue.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-388](https://aptoide.atlassian.net/browse/AND-388)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-388](https://aptoide.atlassian.net/browse/AND-388)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-388]: https://aptoide.atlassian.net/browse/AND-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-388]: https://aptoide.atlassian.net/browse/AND-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ