### PR TITLE
[AND-356] Use auto install location in PackageInstaller sessions

### DIFF
--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstaller.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstaller.kt
@@ -7,6 +7,7 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageInstaller.PACKAGE_SOURCE_STORE
 import android.content.pm.PackageInstaller.Session
 import android.content.pm.PackageInstaller.SessionParams.USER_ACTION_NOT_REQUIRED
+import android.content.pm.PackageManager
 import android.os.Build
 import cm.aptoide.pt.extensions.checkMd5
 import cm.aptoide.pt.extensions.hasPackageInstallsPermission
@@ -122,6 +123,7 @@ class AptoideInstaller @Inject constructor(
             }
 
             setInstallLocation(PackageInfo.INSTALL_LOCATION_AUTO)
+            setInstallReason(PackageManager.INSTALL_REASON_USER)
           }
       )
       openSession(sessionId).run {

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstaller.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstaller.kt
@@ -3,6 +3,7 @@ package cm.aptoide.pt.installer
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageInfo
 import android.content.pm.PackageInstaller.PACKAGE_SOURCE_STORE
 import android.content.pm.PackageInstaller.Session
 import android.content.pm.PackageInstaller.SessionParams.USER_ACTION_NOT_REQUIRED
@@ -119,6 +120,8 @@ class AptoideInstaller @Inject constructor(
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
               setPackageSource(PACKAGE_SOURCE_STORE)
             }
+
+            setInstallLocation(PackageInfo.INSTALL_LOCATION_AUTO)
           }
       )
       openSession(sessionId).run {


### PR DESCRIPTION
**What does this PR do?**

   - Sets the install location in the PackageInstaller session params to INSTALL_LOCATINO_AUTO, so that the device automatically handles and decides the package install location, instead of it always defaulting to the internal storage.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] AptoideInstaller.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-356](https://aptoide.atlassian.net/browse/AND-356)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-356](https://aptoide.atlassian.net/browse/AND-356)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-356]: https://aptoide.atlassian.net/browse/AND-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-356]: https://aptoide.atlassian.net/browse/AND-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ