### PR TITLE
[AND-387] Align unknown sources to the end of vanilla

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -108,6 +108,13 @@ interface InstallAnalytics {
   ) {
   }
 
+  fun sendInstallAbortEvent(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo,
+    errorMessage: String?,
+  ) {
+  }
+
   fun sendResumeDownloadClick(
     app: App,
     downloadOnlyOverWifiSetting: Boolean,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalyticsImpl.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalyticsImpl.kt
@@ -330,6 +330,29 @@ class InstallAnalyticsImpl(
     )
   }
 
+  override fun sendInstallAbortEvent(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo,
+    errorMessage: String?,
+  ) {
+    genericAnalytics.logEvent(
+      name = "app_installed",
+      params = installPackageInfo.toAppGenericParameters(
+        packageName = packageName,
+        P_STATUS to "fail",
+        P_ERROR_MESSAGE to (errorMessage ?: "failure")
+      )
+    )
+
+    logBIInstallEvent(
+      packageName = packageName,
+      status = "abort",
+      installPackageInfo = installPackageInfo,
+      P_ERROR_MESSAGE to errorMessage,
+      P_ERROR_TYPE to "permission",
+    )
+  }
+
   override fun sendResumeDownloadClick(
     app: App,
     downloadOnlyOverWifiSetting: Boolean,

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideDownloader.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideDownloader.kt
@@ -37,7 +37,6 @@ class AptoideDownloader @Inject constructor(
         if (installPackageInfo.hasObb()) {
           installPermissions.checkIfCanWriteExternal()
         }
-        installPermissions.checkIfCanInstall()
       }
       .flatMapMerge(concurrency = 5) { item ->
         var fileProgress = 0.0


### PR DESCRIPTION
**What does this PR do?**

This PR aims at moving the unknown sources to the end of the download.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] InstallProbe.kt

**How should this be manually tested?**

Run the app without the install from unknown sources permission and try canceling on the rationale dialog, canceling by pressing back on the settings and check that the events are correct ("abort" now on the install event and not on the download one)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-387](https://aptoide.atlassian.net/browse/AND-387)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-387]: https://aptoide.atlassian.net/browse/AND-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ