### PR TITLE
[AND-398] Fix installer notification glitch while downloading

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/InstallerNotificationsBuilder.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/InstallerNotificationsBuilder.kt
@@ -43,6 +43,7 @@ class InstallerNotificationsBuilder @Inject constructor(
     const val READY_TO_INSTALL_NOTIFICATION_CHANNEL_ID = "ready_to_install_notification_channel"
     const val READY_TO_INSTALL_NOTIFICATION_CHANNEL_NAME = "Ready To Install Notification Channel"
     const val ALLOW_METERED_DOWNLOAD_FOR_PACKAGE = "allowMeteredDownloadForPackage"
+    const val INSTALL_NOTIFICATIONS_GROUP = "install_notifications_group"
   }
 
   init {
@@ -255,6 +256,8 @@ class InstallerNotificationsBuilder @Inject constructor(
       .setPriority(NotificationCompat.PRIORITY_DEFAULT)
       .setAutoCancel(true)
       .setContentIntent(clickIntent)
+      .setOnlyAlertOnce(true)
+      .setGroup(INSTALL_NOTIFICATIONS_GROUP)
       .apply {
         when (progress) {
           null -> setStyle(


### PR DESCRIPTION
**What does this PR do?**

   - Prevents installer notifications from loading the app icon multiple times.
   - Sets installer notifications to belong to the same notification group, which prevents the notification expand glitch from happening.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-398](https://aptoide.atlassian.net/browse/AND-398)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-398](https://aptoide.atlassian.net/browse/AND-398)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-398]: https://aptoide.atlassian.net/browse/AND-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-398]: https://aptoide.atlassian.net/browse/AND-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ