### PR TITLE
[AND-406] Prevent emission of abandoned install session intents

### DIFF
--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/UserActionHandler.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/UserActionHandler.kt
@@ -55,8 +55,7 @@ interface UserActionHandler {
 @Singleton
 class UserActionHandlerImpl @Inject constructor() : UserActionLauncher, UserActionHandler {
 
-  private val _requests =
-    MutableSharedFlow<UserActionRequest?>(replay = 1, extraBufferCapacity = 10)
+  private val _requests = MutableSharedFlow<UserActionRequest?>()
 
   override val requests: Flow<UserActionRequest?> = _requests
 


### PR DESCRIPTION
**What does this PR do?**

   - Prevents emission of abandoned install session intents, by removing flow replay in the UserActionHandler, which is responsible for emitting the session intents to the UI.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**
 - Check ticket for steps on how to reproduce and test this flow.

  Flow on how to test this or QA Tickets related to this use-case: [AND-406](https://aptoide.atlassian.net/browse/AND-406)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-406](https://aptoide.atlassian.net/browse/AND-406)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-406]: https://aptoide.atlassian.net/browse/AND-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-406]: https://aptoide.atlassian.net/browse/AND-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ