### PR TITLE
[AND-403] Add package name parameter to promo codes analytics events

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/PromoCodeBottomSheetContent.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/PromoCodeBottomSheetContent.kt
@@ -66,6 +66,7 @@ class PromoCodeBottomSheet(
         is PromoCodeSheetUiState.Idle -> {
           LaunchedEffect(Unit) {
             promoCodeAnalytics.sendPromoCodeImpressionEvent(
+              packageName = promoCode.packageName,
               status = "success",
               isWalletInstalled = context.isAppInstalled(walletApp.packageName),
               isPromoCodeAppInstalled = context.isAppInstalled(promoCode.packageName)
@@ -85,6 +86,7 @@ class PromoCodeBottomSheet(
           LaunchedEffect(Unit) {
             if (!impressionSent) {
               promoCodeAnalytics.sendPromoCodeImpressionEvent(
+                packageName = promoCode.packageName,
                 status = "error",
                 isWalletInstalled = context.isAppInstalled(walletApp.packageName),
                 isPromoCodeAppInstalled = context.isAppInstalled(promoCode.packageName)
@@ -100,6 +102,7 @@ class PromoCodeBottomSheet(
           LaunchedEffect(Unit) {
             if (!impressionSent) {
               promoCodeAnalytics.sendPromoCodeImpressionEvent(
+                packageName = promoCode.packageName,
                 status = "error",
                 isWalletInstalled = context.isAppInstalled(walletApp.packageName),
                 isPromoCodeAppInstalled = context.isAppInstalled(promoCode.packageName)
@@ -159,6 +162,7 @@ fun PromoCodeBottomSheetContent(
           onClick = {
             showSnack(walletDisclaimer)
             promoCodeAnalytics.sendPromoCodeClickEvent(
+              packageName = promoCodeApp.packageName,
               isWalletInstalled = isWalletInstalled,
               isPromoCodeAppInstalled = isAppInstalled
             )
@@ -172,6 +176,7 @@ fun PromoCodeBottomSheetContent(
             val intent = Intent(Intent.ACTION_VIEW, uri)
             context.startActivity(intent)
             promoCodeAnalytics.sendPromoCodeClickEvent(
+              packageName = promoCodeApp.packageName,
               isWalletInstalled = isWalletInstalled,
               isPromoCodeAppInstalled = isAppInstalled
             )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/analytics/PromoCodeAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/analytics/PromoCodeAnalytics.kt
@@ -8,10 +8,12 @@ class PromoCodeAnalytics(
 ) {
 
   fun sendPromoCodeImpressionEvent(
+    packageName: String,
     status: String,
     isWalletInstalled: Boolean,
     isPromoCodeAppInstalled: Boolean
   ) = sendPromoCodeEvent(
+    packageName = packageName,
     action = "impression",
     status = status,
     isWalletInstalled = isWalletInstalled,
@@ -19,15 +21,18 @@ class PromoCodeAnalytics(
   )
 
   fun sendPromoCodeClickEvent(
+    packageName: String,
     isWalletInstalled: Boolean,
     isPromoCodeAppInstalled: Boolean
   ) = sendPromoCodeEvent(
+    packageName = packageName,
     action = "click",
     isWalletInstalled = isWalletInstalled,
     isPromoCodeAppInstalled = isPromoCodeAppInstalled
   )
 
   private fun sendPromoCodeEvent(
+    packageName: String,
     action: String,
     status: String? = null,
     isWalletInstalled: Boolean,
@@ -36,6 +41,7 @@ class PromoCodeAnalytics(
     biAnalytics.logEvent(
       name = "ag_promo_codes",
       mapOfNonNull(
+        P_PACKAGE_NAME to packageName,
         P_ACTION to action,
         P_WALLET_IS_INSTALLED to isWalletInstalled,
         P_APP_IS_INSTALLED to isPromoCodeAppInstalled,
@@ -45,6 +51,7 @@ class PromoCodeAnalytics(
   }
 
   companion object {
+    private const val P_PACKAGE_NAME = "package_name"
     private const val P_ACTION = "action"
     private const val P_WALLET_IS_INSTALLED = "wallet_is_installed"
     private const val P_APP_IS_INSTALLED = "app_is_installed"


### PR DESCRIPTION
**What does this PR do?**

   - Adds the package name parameter to promo codes analytics events, in order to identify the app to which the promo code belongs.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See commit.

**How should this be manually tested?**

- Test the normal promo code flow and check if the related analytics events send the package name parameter.

  Flow on how to test this or QA Tickets related to this use-case: [AND-403](https://aptoide.atlassian.net/browse/AND-403)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-403](https://aptoide.atlassian.net/browse/AND-403)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-403]: https://aptoide.atlassian.net/browse/AND-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-403]: https://aptoide.atlassian.net/browse/AND-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ