### PR TITLE
[AND-413] Prevent obfuscated error types in download analytics events

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/DownloadProbe.kt
@@ -83,7 +83,11 @@ class DownloadProbe(
             installPackageInfo = installPackageInfo,
             downloadedBytesPerSecond = downloadSpeed,
             errorMessage = it.cause.message,
-            errorType = it.cause::class.simpleName,
+            errorType = if (it.cause is HttpException) {
+              "HttpException"
+            } else {
+              it.cause::class.simpleName
+            },
             errorCode = (it.cause as? HttpException)?.code(),
             errorUrl = it.url,
           )


### PR DESCRIPTION
**What does this PR do?**

   - Prevents unreadable error types in download analytics events, caused by obfuscation of HttpExceptions in package download fails.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] DownloadProbe.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-413](https://aptoide.atlassian.net/browse/AND-413)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-413](https://aptoide.atlassian.net/browse/AND-413)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-413]: https://aptoide.atlassian.net/browse/AND-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-413]: https://aptoide.atlassian.net/browse/AND-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ