### PR TITLE
[AND-411] Promo codes improvements

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
@@ -125,7 +125,13 @@ class MainActivity : AppCompatActivity() {
 
   private fun handleNotificationIntent(intent: Intent?) {
     intent.takeIf { it.isAhab }?.agDeepLink.takeIf { it?.scheme == "promocode" }?.run {
-      promoCodeRepository.setPromoCode(PromoCode(host!!, path!!))
+      promoCodeRepository.setPromoCode(
+        PromoCode(
+          packageName = host!!,
+          code = path!!,
+          value = getQueryParameter("value")?.toIntOrNull()?.takeIf { it in 1..100 }
+        )
+      )
     }
 
     intent.externalUrl?.takeIf { it.scheme in listOf("http", "https") }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/PromoCode.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/PromoCode.kt
@@ -4,14 +4,17 @@ import cm.aptoide.pt.extensions.getRandomString
 import cm.aptoide.pt.feature_apps.domain.AppSource
 import com.google.errorprone.annotations.Keep
 import kotlin.random.Random
+import kotlin.random.nextInt
 
 @Keep
 data class PromoCode(
   override val packageName: String,
   val code: String,
+  val value: Int? = null,
 ) : AppSource
 
 val randomPromoCode = PromoCode(
   packageName = getRandomString(range = 3..5, separator = "."),
-  code = Random.nextLong().toString()
+  code = Random.nextLong().toString(),
+  value = Random.nextInt(5..80)
 )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/PromoCodeBottomSheetContent.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/PromoCodeBottomSheetContent.kt
@@ -32,6 +32,7 @@ import cm.aptoide.pt.feature_apps.data.walletApp
 import com.aptoide.android.aptoidegames.BottomSheetContent
 import com.aptoide.android.aptoidegames.BottomSheetHeader
 import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.analytics.presentation.OverrideAnalyticsScreen
 import com.aptoide.android.aptoidegames.design_system.IndeterminateCircularLoading
 import com.aptoide.android.aptoidegames.design_system.PrimarySmallButton
 import com.aptoide.android.aptoidegames.design_system.TertiarySmallButton
@@ -53,6 +54,24 @@ class PromoCodeBottomSheet(
   @Composable override fun Draw(
     dismiss: () -> Unit,
     navigate: (String) -> Unit,
+  ) {
+    PromoCodeBottomSheet(
+      promoCode = promoCode,
+      showSnack = showSnack,
+      navigate = navigate
+    )
+  }
+}
+
+@Composable
+fun PromoCodeBottomSheet(
+  promoCode: PromoCode,
+  showSnack: (String) -> Unit,
+  navigate: (String) -> Unit,
+) {
+  OverrideAnalyticsScreen(
+    currentScreen = "promo_code",
+    navigate = navigate
   ) {
     val context = LocalContext.current
     val (promoCodeSheetState, reload) = rememberPromoCodeSheetState(promoCode)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/PromoCodeBottomSheetContent.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/promo_codes/PromoCodeBottomSheetContent.kt
@@ -94,6 +94,7 @@ fun PromoCodeBottomSheet(
 
           PromoCodeBottomSheetContent(
             promoCode = promoCode.code,
+            value = promoCode.value,
             promoCodeApp = promoCodeSheetState.promoCodeApp,
             walletApp = promoCodeSheetState.walletApp,
             showSnack = showSnack
@@ -140,6 +141,7 @@ fun PromoCodeBottomSheet(
 @Composable
 fun PromoCodeBottomSheetContent(
   promoCode: String,
+  value: Int?,
   promoCodeApp: App,
   walletApp: App,
   showSnack: (String) -> Unit
@@ -166,7 +168,7 @@ fun PromoCodeBottomSheetContent(
     modifier = Modifier.padding(top = 4.dp),
     text = stringResource(
       id = R.string.promo_code_extra_title,
-      "10" //TODO Hardcoded value (should come from backend in the future)
+      value ?: "10"
     ),
     color = Palette.White,
     style = AGTypography.Title
@@ -289,6 +291,7 @@ fun PreviewBottomSheetContent() {
       BottomSheetHeader()
       PromoCodeBottomSheetContent(
         promoCode = randomPromoCode.code,
+        value = null,
         promoCodeApp = randomApp,
         walletApp = walletApp,
         showSnack = { }


### PR DESCRIPTION
**What does this PR do?**

   - Overrides the analytics context to be "promo_code" in download and install events that start from the promo codes bottom sheet.
   - Makes the promotion value configurable in the promo codes deep link, in order to avoid showing a hardcoded value.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-411](https://aptoide.atlassian.net/browse/AND-411)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-411](https://aptoide.atlassian.net/browse/AND-411)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-411]: https://aptoide.atlassian.net/browse/AND-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-411]: https://aptoide.atlassian.net/browse/AND-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ