### PR TITLE
[HOTFIX/AND-389] fix ofuscation on hometabs

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeTabRow.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeTabRow.kt
@@ -1,5 +1,6 @@
 package com.aptoide.android.aptoidegames.home
 
+import androidx.annotation.Keep
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -16,12 +17,13 @@ val defaultHomeTabs = listOf<HomeTab>(
   HomeTab.Categories,
 )
 
+@Keep
 sealed class HomeTab {
-  object ForYou : HomeTab()
-  data class TopCharts(val sort: String = "pdownloads") : HomeTab()
-  object Bonus : HomeTab()
-  object Editorial : HomeTab()
-  object Categories : HomeTab()
+  @Keep object ForYou : HomeTab()
+  @Keep data class TopCharts(val sort: String = "pdownloads") : HomeTab()
+  @Keep object Bonus : HomeTab()
+  @Keep object Editorial : HomeTab()
+  @Keep object Categories : HomeTab()
 
   @Composable
   fun getTitle() = stringResource(


### PR DESCRIPTION
**What does this PR do?**

This PR aims at fixing obfuscation of home tabs on the analytics events. 
Had to add the keep annotation to sealed class subclasses.

**Database changed?**

 No

**Where should the reviewer start?**

- [ ] HomeTabRow.kt

**How should this be manually tested?**

Run in release to make sure the tabs are ok on the download events of the respective tabs for example.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-389](https://aptoide.atlassian.net/browse/AND-389)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
