### PR TITLE
[AND-416] Prevent Mintegral initialization in HMD builds

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
@@ -2,7 +2,6 @@ package com.aptoide.android.aptoidegames
 
 import android.app.Application
 import android.content.Context
-import android.os.Build
 import android.os.Process
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
@@ -33,7 +32,7 @@ import com.appcoins.payments.di.paymentScreenContentProvider
 import com.appcoins.payments.di.paypalPaymentMethodFactory
 import com.appcoins.payments.di.restClientInjectParams
 import com.appcoins.payments.uri_handler.PaymentScreenContentProvider
-import com.aptoide.android.aptoidegames.Platform.isHMD
+import com.aptoide.android.aptoidegames.Platform.isHmd
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
 import com.aptoide.android.aptoidegames.feature_ad.Mintegral
@@ -144,7 +143,7 @@ class AptoideApplication : Application(), ImageLoaderFactory, Provider {
       }
     }
     AptoideMMPCampaign.init(BuildConfig.OEMID, BuildConfig.MARKET_NAME)
-    if (isHMD.not()) {
+    if (isHmd.not()) {
       initAds()
     }
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
@@ -32,7 +32,6 @@ import com.appcoins.payments.di.paymentScreenContentProvider
 import com.appcoins.payments.di.paypalPaymentMethodFactory
 import com.appcoins.payments.di.restClientInjectParams
 import com.appcoins.payments.uri_handler.PaymentScreenContentProvider
-import com.aptoide.android.aptoidegames.Platform.isHmd
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
 import com.aptoide.android.aptoidegames.feature_ad.Mintegral
@@ -143,9 +142,7 @@ class AptoideApplication : Application(), ImageLoaderFactory, Provider {
       }
     }
     AptoideMMPCampaign.init(BuildConfig.OEMID, BuildConfig.MARKET_NAME)
-    if (isHmd.not()) {
-      initAds()
-    }
+    initAds()
   }
 
   private fun initFeatureFlags() {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/Platform.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/Platform.kt
@@ -10,11 +10,9 @@ object Platform {
     get() = Build.VERSION.SDK_INT <= Build.VERSION_CODES.R && isMIUI()
       && !isMiuiOptimizationDisabled()
 
-  val isHMD: Boolean
-    get() = BuildConfig.MARKET_NAME == "aptoide-games-hmd"
-  
-  val isHMDdevice: Boolean
-    get() = Build.MANUFACTURER.lowercase().contains("hmd")
-      && (Build.MODEL.lowercase().contains("fusion") || Build.MODEL.lowercase()
-      .contains("nighthawk"))
+  val isHmd: Boolean = BuildConfig.MARKET_NAME == "aptoide-games-hmd"
+
+  val isHmdDevice: Boolean = Build.MANUFACTURER.lowercase().contains("hmd")
+    && (Build.MODEL.lowercase().contains("fusion") || Build.MODEL.lowercase()
+    .contains("nighthawk"))
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_ad/Mintegral.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_ad/Mintegral.kt
@@ -12,18 +12,25 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.emptyFlow
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import javax.inject.Inject
 import javax.inject.Singleton
 
+interface Mintegral {
+  fun initializeSdk() {}
+  fun initNativeAd(adClick: (String) -> Unit): Flow<Campaign?> = emptyFlow()
+  fun registerNativeAdView(view: View, campaign: Campaign) {}
+}
+
 @Singleton
-class Mintegral @Inject constructor(
+class MintegralImpl @Inject constructor(
   @ApplicationContext private val context: Context
-) {
+) : Mintegral {
   private var nativeHandler: MBNativeHandler? = null
 
-  fun initializeSdk() {
+  override fun initializeSdk() {
     val sdk = MBridgeSDKFactory.getMBridgeSDK()
     val configMap = sdk.getMBConfigurationMap(
       BuildConfig.MINTEGRAL_APP_ID,
@@ -44,7 +51,7 @@ class Mintegral @Inject constructor(
     })
   }
 
-  fun initNativeAd(adClick: (String) -> Unit): Flow<Campaign?> {
+  override fun initNativeAd(adClick: (String) -> Unit): Flow<Campaign?> {
     val appContext = context
     val properties = MBNativeHandler.getNativeProperties(
       BuildConfig.NATIVE_PLACEMENT_ID,
@@ -79,13 +86,13 @@ class Mintegral @Inject constructor(
     }
   }
 
-  fun registerNativeAdView(view: View, campaign: Campaign) {
+  override fun registerNativeAdView(view: View, campaign: Campaign) {
     val handler = nativeHandler
       ?: throw IllegalStateException("Native handler not initialized")
     handler.registerView(view, campaign)
   }
 
-  fun httpKnock(url: String) {
+  private fun httpKnock(url: String) {
     val client = OkHttpClient()
     val request = Request.Builder()
       .url(url)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_ad/di/AdsModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_ad/di/AdsModule.kt
@@ -1,0 +1,27 @@
+package com.aptoide.android.aptoidegames.feature_ad.di
+
+import com.aptoide.android.aptoidegames.Platform.isHmd
+import com.aptoide.android.aptoidegames.feature_ad.Mintegral
+import com.aptoide.android.aptoidegames.feature_ad.MintegralImpl
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class AdsModule {
+
+  @Singleton
+  @Provides
+  fun provideMintegral(
+    mintegralImpl: MintegralImpl,
+  ): Mintegral {
+    return if (isHmd) {
+      object : Mintegral {}
+    } else {
+      mintegralImpl
+    }
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -59,8 +59,8 @@ import cm.aptoide.pt.feature_home.presentation.BundlesViewUiState
 import cm.aptoide.pt.feature_home.presentation.BundlesViewUiStateType
 import cm.aptoide.pt.feature_home.presentation.bundlesList
 import com.aptoide.android.aptoidegames.AptoideAsyncImage
-import com.aptoide.android.aptoidegames.Platform.isHMD
-import com.aptoide.android.aptoidegames.Platform.isHMDdevice
+import com.aptoide.android.aptoidegames.Platform.isHmd
+import com.aptoide.android.aptoidegames.Platform.isHmdDevice
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.presentation.AnalyticsContext
 import com.aptoide.android.aptoidegames.analytics.presentation.OverrideAnalyticsBundleMeta
@@ -519,7 +519,7 @@ private fun Int.floorMod(other: Int): Int = when (other) {
 }
 
 private fun BundlesViewUiState.filterHMD(): BundlesViewUiState {
-  return if (isHMD && isHMDdevice) {
+  return if (isHmd && isHmdDevice) {
     this
   } else {
     this.copy(bundles = bundles.filter { it.tag != "apps-group-hmd-controller" })


### PR DESCRIPTION
**What does this PR do?**

   - Extracts a Mintegral interface to allow having different implementations or instances of anonymous objects.
   - Creates a DI provider for Mintegral, that decides which implementation to use. The DI provider will return an empty Mintegral implementation that as no initialization, through an anonymous object.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-416](https://aptoide.atlassian.net/browse/AND-416)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-416](https://aptoide.atlassian.net/browse/AND-416)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-416]: https://aptoide.atlassian.net/browse/AND-416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-416]: https://aptoide.atlassian.net/browse/AND-416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ