### PR TITLE
[AND-422] Stop post notifications permission request on API levels below 33

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
@@ -106,7 +106,9 @@ class MainActivity : AppCompatActivity() {
 
       if (isFirstLaunch) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-          notificationsPermissionLauncher?.launch(Manifest.permission.POST_NOTIFICATIONS)
+          runCatching {
+            notificationsPermissionLauncher?.launch(Manifest.permission.POST_NOTIFICATIONS)
+          }
         }
         appLaunchPreferencesManager.setIsNotFirstLaunch()
       }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
@@ -2,6 +2,7 @@ package com.aptoide.android.aptoidegames
 
 import android.Manifest
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResultLauncher
@@ -104,7 +105,9 @@ class MainActivity : AppCompatActivity() {
       sendAGStartAnalytics(isFirstLaunch)
 
       if (isFirstLaunch) {
-        notificationsPermissionLauncher?.launch(Manifest.permission.POST_NOTIFICATIONS)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+          notificationsPermissionLauncher?.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
         appLaunchPreferencesManager.setIsNotFirstLaunch()
       }
     }


### PR DESCRIPTION
**What does this PR do?**

   - Adds a check for the API level in MainActivity, to prevent requesting the POST_NOTIFICATIONS request on devices with API level below 33, since this permission is only supported on API levels above 33.
   - Adds exception catching on the permission launcher, to prevent possible unnecessary crashes on the first launch.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] MainActivity.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-422](https://aptoide.atlassian.net/browse/AND-422)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-422](https://aptoide.atlassian.net/browse/AND-422)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-422]: https://aptoide.atlassian.net/browse/AND-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-422]: https://aptoide.atlassian.net/browse/AND-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ