### PR TITLE
[AND-444] Send mmp linker events on auto updates

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
@@ -13,6 +13,7 @@ import androidx.work.Configuration
 import androidx.work.Configuration.Provider
 import cm.aptoide.pt.extensions.getProcessName
 import cm.aptoide.pt.feature_campaigns.AptoideMMPCampaign
+import cm.aptoide.pt.feature_campaigns.MMPLinkerCampaign
 import cm.aptoide.pt.feature_categories.analytics.AptoideAnalyticsInfoProvider
 import cm.aptoide.pt.feature_flags.domain.FeatureFlags
 import cm.aptoide.pt.feature_updates.domain.Updates
@@ -142,6 +143,7 @@ class AptoideApplication : Application(), ImageLoaderFactory, Provider {
       }
     }
     AptoideMMPCampaign.init(BuildConfig.OEMID, BuildConfig.MARKET_NAME)
+    MMPLinkerCampaign.init(BuildConfig.OEMID)
     initAds()
   }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
@@ -27,7 +27,6 @@ import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_campaigns.toAptoideMMPCampaign
 import cm.aptoide.pt.feature_campaigns.toMMPLinkerCampaign
 import cm.aptoide.pt.install_manager.dto.Constraints
-import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.dto.InstallAction
 import com.aptoide.android.aptoidegames.analytics.presentation.AnalyticsContext
@@ -123,7 +122,7 @@ fun installViewStates(
                   currentScreen = analyticsContext.currentScreen
                 )
             }
-            app.campaigns?.toMMPLinkerCampaign()?.sendDownloadEvent(BuildConfig.OEMID)
+            app.campaigns?.toMMPLinkerCampaign()?.sendDownloadEvent()
             onInstallStarted()
             scheduledInstallListener.listenToWifiStart(app.packageName)
             saveAppDetails(app) {
@@ -178,7 +177,7 @@ fun installViewStates(
                   currentScreen = analyticsContext.currentScreen
                 )
             }
-            app.campaigns?.toMMPLinkerCampaign()?.sendDownloadEvent(BuildConfig.OEMID)
+            app.campaigns?.toMMPLinkerCampaign()?.sendDownloadEvent()
             onInstallStarted()
             scheduledInstallListener.listenToWifiStart(app.packageName)
             saveAppDetails(app) {
@@ -243,7 +242,7 @@ fun installViewStates(
                   currentScreen = analyticsContext.currentScreen
                 )
             }
-            app.campaigns?.toMMPLinkerCampaign()?.sendDownloadEvent(BuildConfig.OEMID)
+            app.campaigns?.toMMPLinkerCampaign()?.sendDownloadEvent()
             onInstallStarted()
             scheduledInstallListener.listenToWifiStart(app.packageName)
             saveAppDetails(app) {
@@ -307,7 +306,7 @@ fun installViewStates(
                   currentScreen = analyticsContext.currentScreen
                 )
             }
-            app.campaigns?.toMMPLinkerCampaign()?.sendDownloadEvent(BuildConfig.OEMID)
+            app.campaigns?.toMMPLinkerCampaign()?.sendDownloadEvent()
             onInstallStarted()
             scheduledInstallListener.listenToWifiStart(app.packageName)
             saveAppDetails(app) {

--- a/feature_campaigns/src/main/java/cm/aptoide/pt/feature_campaigns/MMPLinkerCampaign.kt
+++ b/feature_campaigns/src/main/java/cm/aptoide/pt/feature_campaigns/MMPLinkerCampaign.kt
@@ -7,11 +7,19 @@ import kotlinx.coroutines.launch
 class MMPLinkerCampaign(
   private val campaign: Campaign,
 ) {
+  companion object {
+    private lateinit var oemId: String
+
+    fun init(oemId: String) {
+      this.oemId = oemId
+    }
+  }
+
   val campaignType = "mmp-linker"
 
-  fun sendDownloadEvent(oemid: String) {
+  fun sendDownloadEvent() {
     CoroutineScope(Dispatchers.Main).launch {
-      campaign.sendDownloadEvent(type = campaignType, toReplace = mapOf("{{OEMID}}" to oemid))
+      campaign.sendDownloadEvent(type = campaignType, toReplace = mapOf("{{OEMID}}" to oemId))
     }
   }
 }

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/Updates.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/Updates.kt
@@ -8,6 +8,7 @@ import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.AppsListMapper
 import cm.aptoide.pt.feature_apps.data.model.AppJSON
 import cm.aptoide.pt.feature_campaigns.toAptoideMMPCampaign
+import cm.aptoide.pt.feature_campaigns.toMMPLinkerCampaign
 import cm.aptoide.pt.feature_updates.data.AutoUpdateWorker
 import cm.aptoide.pt.feature_updates.data.UpdatesRepository
 import cm.aptoide.pt.feature_updates.data.UpdatesWorker
@@ -155,13 +156,16 @@ class Updates @Inject constructor(
             )
           )
 
-          it.campaigns?.toAptoideMMPCampaign()
-            ?.sendDownloadEvent(
+          it.campaigns?.run {
+            toAptoideMMPCampaign().sendDownloadEvent(
               bundleTag = null,
               searchKeyword = null,
               currentScreen = null,
               isCta = false
             )
+
+            toMMPLinkerCampaign().sendDownloadEvent()
+          }
         }
     }
   }


### PR DESCRIPTION
**What does this PR do?**

   - Saves the provided OEM id in mmp-linker campaigns, for direct usage in its download events.
   - Makes the app auto updates send mmp-linker campaign events, if present.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-444](https://aptoide.atlassian.net/browse/AND-444)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-444](https://aptoide.atlassian.net/browse/AND-444)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-444]: https://aptoide.atlassian.net/browse/AND-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-444]: https://aptoide.atlassian.net/browse/AND-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ