### PR TITLE
[AND-407] Ready to install after timeout

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/InstallerNotificationsBuilder.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/notifications/InstallerNotificationsBuilder.kt
@@ -166,9 +166,11 @@ class InstallerNotificationsBuilder @Inject constructor(
     appDetails: AppDetails?,
     appIcon: Bitmap?
   ) {
-    val notificationId = stringToIntConverter.getStringId(packageName)
+    val notificationId = stringToIntConverter.getStringId(packageName + READY_TO_INSTALL_NOTIFICATION_CHANNEL_ID)
+    val otherNotificationsId = stringToIntConverter.getStringId(packageName)
 
     cancelNotification(notificationId)
+    cancelNotification(otherNotificationsId)
 
     val notification = buildNotification(
       requestCode = notificationId,


### PR DESCRIPTION
**What does this PR do?**

This PR aims at keeping the notification of ready to install even after the install has timeout

**Database changed?**

No

**Where should the reviewer start?**

- [ ] RealInstallerNotificationsManager.kt

**How should this be manually tested?**

Try to install, put app in background. Test the notification for ready to install with the app in the background, also after killing the app. Check if the retry or the install works correctly.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-407](https://aptoide.atlassian.net/browse/AND-407)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
