### PR TITLE
[AND-432] Add apkfy screen back button click analytics event

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
@@ -56,6 +56,9 @@ class ApkfyAnalytics @Inject constructor(
 
   fun sendApkfyTimeout() = genericAnalytics.logEvent("apkfy_timeout", params = emptyMap())
 
+  fun sendApkfyScreenBackClicked() =
+    genericAnalytics.logEvent("apkfy_screen_back_clicked", params = emptyMap())
+
   fun setApkfyUTMProperties(apkfyModel: ApkfyModel) {
     apkfyModel.run {
       if (hasUTMs()) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/presentation/ApkfyScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/presentation/ApkfyScreen.kt
@@ -1,5 +1,6 @@
 package com.aptoide.android.aptoidegames.apkfy.presentation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -41,9 +42,21 @@ fun apkfyScreen() = ScreenData.withAnalytics(
   screenAnalyticsName = "Apkfy",
 ) { _, navigate, navigateBack ->
   val apkfyState = rememberApkfyState()
+  val apkfyAnalytics = rememberApkfyAnalytics()
+
+  BackHandler {
+    apkfyAnalytics.sendApkfyScreenBackClicked()
+    navigateBack()
+  }
 
   Column {
-    AppGamesTopBar(navigateBack = navigateBack, title = "")
+    AppGamesTopBar(
+      navigateBack = {
+        apkfyAnalytics.sendApkfyScreenBackClicked()
+        navigateBack()
+      },
+      title = ""
+    )
     apkfyState?.app?.let {
       ApkfyScreen(
         app = it,


### PR DESCRIPTION
**What does this PR do?**

   - Adds the apkfy screen back button click analytics event, which is sent on both the UI button and the system back button.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] ApkfyScreen.kt
- [ ] ApkfyAnalytics.kt

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-432](https://aptoide.atlassian.net/browse/AND-432)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-432](https://aptoide.atlassian.net/browse/AND-432)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-432]: https://aptoide.atlassian.net/browse/AND-432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-432]: https://aptoide.atlassian.net/browse/AND-432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ