### PR TITLE
[AND-445] Add a loading screen when loading a conversation from history

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieUIState.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieUIState.kt
@@ -14,5 +14,6 @@ enum class GameGenieUIStateType {
   IDLE,
   LOADING,
   NO_CONNECTION,
-  ERROR
+  ERROR,
+  LOADING_CHAT
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieView.kt
@@ -26,6 +26,7 @@ import com.aptoide.android.aptoidegames.gamegenie.analytics.rememberGameGenieAna
 import com.aptoide.android.aptoidegames.gamegenie.presentation.composables.ChatParticipantName
 import com.aptoide.android.aptoidegames.gamegenie.presentation.composables.MessageList
 import com.aptoide.android.aptoidegames.gamegenie.presentation.composables.TextInputBar
+import com.aptoide.android.aptoidegames.home.LoadingView
 
 const val genieRoute = "chatbot"
 
@@ -93,6 +94,7 @@ fun ChatbotView(
         onMessageSend = onMessageSend,
         onSuggestionSend = onSuggestionSend
       )
+      GameGenieUIStateType.LOADING_CHAT -> LoadingView()
     }
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieViewModel.kt
@@ -101,11 +101,17 @@ class GameGenieViewModel @Inject constructor(
 
   fun loadConversation(id: String) {
     viewModelScope.launch {
+      viewModelState.update {
+        it.copy(
+          type = GameGenieUIStateType.LOADING_CHAT,
+        )
+      }
       gameGenieUseCase.loadChat(id)
         .collectLatest { newChat ->
           newChat?.let {
             viewModelState.update { state ->
               state.copy(
+                type = GameGenieUIStateType.IDLE,
                 chat = newChat,
                 apps = newChat.conversation.flatMap { interaction ->
                   interaction.apps.map { app -> app.packageName }


### PR DESCRIPTION
**What does this PR do?**

This PR aims to add a loading screen when loading a chat from the conversation history

**Database changed?**

   No

**Where should the reviewer start?**

See commit

**How should this be manually tested?**

Open chats from the history tab and check behavior of the loading

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-445](https://aptoide.atlassian.net/browse/AND-445)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-445]: https://aptoide.atlassian.net/browse/AND-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ