### PR TITLE
[AND-457] Add extra options in settings screen

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/developer/AGDeveloperOptionsViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/developer/AGDeveloperOptionsViewModel.kt
@@ -1,0 +1,43 @@
+package com.aptoide.android.aptoidegames.developer
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AGDeveloperOptionsViewModel @Inject constructor(
+  private val agDeveloperPreferencesRepository: AGDeveloperPreferencesRepository
+) : ViewModel() {
+
+  private val viewModelState = MutableStateFlow<Boolean>(false)
+
+  val areAGDeveloperOptionsEnabled = viewModelState
+    .stateIn(
+      viewModelScope,
+      SharingStarted.Eagerly,
+      viewModelState.value
+    )
+
+  init {
+    viewModelScope.launch {
+      agDeveloperPreferencesRepository.areAGDeveloperOptionsEnabled()
+        .catch { throwable -> throwable.printStackTrace() }
+        .collect { devOptionsEnabled ->
+          viewModelState.update { devOptionsEnabled }
+        }
+    }
+  }
+
+  fun setAGDeveloperOptionsState(enabled: Boolean) {
+    viewModelScope.launch {
+      agDeveloperPreferencesRepository.setAGDeveloperOptionsState(enabled)
+    }
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/developer/AGDeveloperPreferencesRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/developer/AGDeveloperPreferencesRepository.kt
@@ -1,0 +1,33 @@
+package com.aptoide.android.aptoidegames.developer
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import com.aptoide.android.aptoidegames.developer.di.AGDeveloperPreferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AGDeveloperPreferencesRepository @Inject constructor(
+  @AGDeveloperPreferencesDataStore private val dataStore: DataStore<Preferences>,
+) {
+
+  companion object PreferencesKeys {
+    private val AG_DEVELOPER_OPTIONS_ENABLED = booleanPreferencesKey("ag_developer_options_enabled")
+  }
+
+  suspend fun setAGDeveloperOptionsState(enabled: Boolean) {
+    dataStore.edit { bundlePreferences ->
+      bundlePreferences[AG_DEVELOPER_OPTIONS_ENABLED] = enabled
+    }
+  }
+
+  fun areAGDeveloperOptionsEnabled(): Flow<Boolean> {
+    return dataStore.data.map { preferences ->
+      preferences[AG_DEVELOPER_OPTIONS_ENABLED] == true
+    }
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/developer/ViewModelProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/developer/ViewModelProvider.kt
@@ -1,0 +1,19 @@
+package com.aptoide.android.aptoidegames.developer
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import cm.aptoide.pt.extensions.runPreviewable
+
+@Composable
+fun rememberAGDeveloperOptions(): Pair<Boolean, (Boolean) -> Unit> = runPreviewable(
+  preview = { false to {} },
+  real = {
+    val vm: AGDeveloperOptionsViewModel = hiltViewModel<AGDeveloperOptionsViewModel>()
+    val uiState by vm.areAGDeveloperOptionsEnabled.collectAsState()
+    uiState.let {
+      it to vm::setAGDeveloperOptionsState
+    }
+  }
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/developer/di/RepositoryModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/developer/di/RepositoryModule.kt
@@ -1,0 +1,35 @@
+package com.aptoide.android.aptoidegames.developer.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+val Context.agDeveloperPreferencesDataStore: DataStore<Preferences> by preferencesDataStore(
+  name = "agDeveloperPreferences"
+)
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object RepositoryModule {
+
+  @Singleton
+  @Provides
+  @AGDeveloperPreferencesDataStore
+  fun provideAGDeveloperPreferencesDataStore(
+    @ApplicationContext appContext: Context,
+  ): DataStore<Preferences> {
+    return appContext.agDeveloperPreferencesDataStore
+  }
+}
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AGDeveloperPreferencesDataStore

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/firebase/FirebaseToken.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/firebase/FirebaseToken.kt
@@ -1,0 +1,27 @@
+package com.aptoide.android.aptoidegames.firebase
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import cm.aptoide.pt.extensions.getRandomString
+import cm.aptoide.pt.extensions.runPreviewable
+import com.google.firebase.messaging.FirebaseMessaging
+
+@Composable
+fun rememberFirebaseToken(): String? = runPreviewable(
+  preview = { getRandomString(10..20, "") },
+  real = {
+    var token: String? by remember { mutableStateOf(null) }
+    LaunchedEffect(Unit) {
+      FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+          token = task.result
+        }
+      }
+    }
+    token
+  }
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.aptoide.android.aptoidegames.settings
 
+import android.content.ClipData
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -23,10 +24,11 @@ import androidx.compose.material.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ClipboardManager
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -53,6 +55,7 @@ import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.theme.Palette
 import com.aptoide.android.aptoidegames.toolbar.AppGamesTopBar
+import kotlinx.coroutines.launch
 
 const val settingsRoute = "settings"
 
@@ -65,7 +68,8 @@ fun settingsScreen(showSnack: (String) -> Unit) = ScreenData(
   val downloadOnlyOverWifi by networkPreferencesViewModel.downloadOnlyOverWifi.collectAsState()
   val (autoUpdateGames, toggleAutoUpdateGames) = rememberAutoUpdate()
   val deviceInfo = rememberDeviceInfo()
-  val clipboardManager: ClipboardManager = LocalClipboardManager.current
+  val clipboard = LocalClipboard.current
+  val coroutineScope = rememberCoroutineScope()
   val copiedMessage = stringResource(R.string.settings_copied_to_clipboard_message)
 
   SettingsViewContent(
@@ -92,7 +96,9 @@ fun settingsScreen(showSnack: (String) -> Unit) = ScreenData(
       SupportActivity.openForFeedBack(context)
     },
     copyInfo = {
-      clipboardManager.setText(deviceInfo)
+      coroutineScope.launch {
+        clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("Device info", deviceInfo)))
+      }
       showSnack(copiedMessage)
     },
     navigateBack = navigateBack,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -128,7 +128,9 @@ fun SettingsViewContent(
       SettingsSection(
         title = stringResource(R.string.settings_general_title)
       ) {
-        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Column(
+          modifier = Modifier.padding(horizontal = 16.dp),
+        ) {
           SettingsSwitchItem(
             title = stringResource(R.string.wifi_settings_title),
             enabled = downloadOnlyOverWifi,
@@ -147,11 +149,12 @@ fun SettingsViewContent(
       SettingsSection(
         title = stringResource(R.string.settings_support)
       ) {
-
         val copyText = stringResource(R.string.button_copy_title)
         val hardwareSpecsText = stringResource(R.string.settings_about_hardware_title)
 
-        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Column(
+          modifier = Modifier.padding(horizontal = 16.dp),
+        ) {
           SettingsCaretItem(
             title = stringResource(R.string.settings_feedback_button),
             onClick = sendFeedback
@@ -161,8 +164,7 @@ fun SettingsViewContent(
             style = AGTypography.InputsM,
             modifier = Modifier
               .defaultMinSize(minHeight = 48.dp)
-              .wrapContentHeight()
-              .padding(horizontal = 8.dp, vertical = 8.dp),
+              .wrapContentHeight(),
             color = Palette.GreyLight
           )
           Row(
@@ -170,7 +172,6 @@ fun SettingsViewContent(
             modifier = Modifier
               .clickable(onClick = copyInfo)
               .defaultMinSize(minHeight = 48.dp)
-              .padding(start = 8.dp, top = 8.dp, bottom = 8.dp)
               .clearAndSetSemantics {
                 contentDescription = hardwareSpecsText
                 onClick(label = copyText) {
@@ -196,7 +197,9 @@ fun SettingsViewContent(
       SettingsSection(
         title = stringResource(R.string.settings_legal_title)
       ) {
-        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Column(
+          modifier = Modifier.padding(horizontal = 16.dp),
+        ) {
           SettingsCaretItem(
             title = stringResource(R.string.overflow_menu_privacy_policy),
             onClick = onPrivacyPolicyClick
@@ -207,32 +210,22 @@ fun SettingsViewContent(
           )
         }
       }
-      Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-        Row(
-          verticalAlignment = Alignment.CenterVertically,
-          horizontalArrangement = Arrangement.Center,
-          modifier = Modifier
-            .padding(start = 8.dp, top = 8.dp, bottom = 4.dp)
-            .fillMaxWidth()
-        ) {
-          Text(
-            text = stringResource(id = R.string.powered_by_title),
-            style = AGTypography.Body,
-            color = Palette.GreyLight
-          )
-        }
-        Row(
-          verticalAlignment = Alignment.CenterVertically,
-          horizontalArrangement = Arrangement.Center,
-          modifier = Modifier
-            .padding(start = 8.dp, bottom = 33.dp)
-            .fillMaxWidth()
-        ) {
-          Image(
-            imageVector = getAptoideLogo(Palette.White),
-            contentDescription = null,
-          )
-        }
+      Column(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(top = 36.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+      ) {
+        Text(
+          modifier = Modifier.padding(bottom = 4.dp),
+          text = stringResource(id = R.string.powered_by_title),
+          style = AGTypography.Body,
+          color = Palette.GreyLight
+        )
+        Image(
+          imageVector = getAptoideLogo(Palette.White),
+          contentDescription = null,
+        )
       }
     }
   }
@@ -256,14 +249,14 @@ fun SettingsSectionHeader(
   Text(
     text = title,
     style = AGTypography.Title,
-    modifier = Modifier.padding(start = 24.dp, top = 16.dp),
+    modifier = Modifier.padding(start = 16.dp, top = 24.dp),
     color = Palette.White
   )
   subTitle?.let {
     Text(
       text = it,
       style = AGTypography.SmallGames,
-      modifier = Modifier.padding(start = 24.dp),
+      modifier = Modifier.padding(start = 16.dp),
       color = Palette.GreyLight
     )
   }
@@ -272,7 +265,7 @@ fun SettingsSectionHeader(
 @Composable
 fun SettingsSectionDivider() {
   Divider(
-    modifier = Modifier.padding(top = 12.dp),
+    modifier = Modifier.padding(top = 20.dp),
     color = Palette.Grey
   )
 }
@@ -293,7 +286,6 @@ fun SettingsSwitchItem(
       )
       .defaultMinSize(minHeight = 48.dp)
       .fillMaxWidth()
-      .padding(start = 8.dp)
       .minimumInteractiveComponentSize()
       .clearAndSetSemantics {
         contentDescription = title
@@ -321,10 +313,9 @@ fun SettingsCaretItem(
   Row(
     verticalAlignment = Alignment.CenterVertically,
     modifier = Modifier
-      .clickable(onClick = onClick)
-      .defaultMinSize(minHeight = 48.dp)
       .fillMaxWidth()
-      .padding(horizontal = 8.dp, vertical = 8.dp)
+      .defaultMinSize(minHeight = 48.dp)
+      .clickable(onClick = onClick)
   ) {
     if (subtitle == null) {
       Text(
@@ -356,8 +347,7 @@ fun SettingsCaretItem(
     Image(
       imageVector = getForward(Palette.Primary),
       contentDescription = null,
-      modifier = Modifier
-        .size(32.dp)
+      modifier = Modifier.size(32.dp)
     )
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/analytics/SettingsAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/analytics/SettingsAnalytics.kt
@@ -20,4 +20,9 @@ class SettingsAnalytics(
     name = "send_feedback_clicked",
     params = emptyMap()
   )
+
+  fun sendAGDevOptionsEnabled() = genericAnalytics.logEvent(
+    name = "ag_dev_options_enabled",
+    params = emptyMap()
+  )
 }

--- a/extension/src/main/java/cm/aptoide/pt/extensions/ModifierExtensions.kt
+++ b/extension/src/main/java/cm/aptoide/pt/extensions/ModifierExtensions.kt
@@ -1,0 +1,37 @@
+package cm.aptoide.pt.extensions
+
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+
+fun Modifier.multiTap(
+  enabled: Boolean,
+  requiredTaps: Int = 5,
+  tapIntervalMillis: Long = 500L,
+  onTrigger: () -> Unit
+): Modifier = composed {
+  var tapCount by remember { mutableIntStateOf(0) }
+  var lastTapTime by remember { mutableLongStateOf(0L) }
+
+  this.then(
+    Modifier.clickable(enabled = enabled) {
+      val currentTime = System.currentTimeMillis()
+      if (currentTime - lastTapTime <= tapIntervalMillis) {
+        tapCount++
+      } else {
+        tapCount = 1
+      }
+      lastTapTime = currentTime
+
+      if (tapCount == requiredTaps) {
+        onTrigger()
+        tapCount = 0
+      }
+    }
+  )
+}


### PR DESCRIPTION
**What does this PR do?**

   - Adds extra options on the Settings screen.
   - Refactors the paddings in the Settings screen to match the design.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-457](https://aptoide.atlassian.net/browse/AND-457)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-457](https://aptoide.atlassian.net/browse/AND-457)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-457]: https://aptoide.atlassian.net/browse/AND-457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-457]: https://aptoide.atlassian.net/browse/AND-457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ