### PR TITLE
[AND-457] Fix datastore rules allowing to get firebase token

### DIFF
--- a/app-games/proguard-rules.pro
+++ b/app-games/proguard-rules.pro
@@ -39,6 +39,10 @@
 -keep class com.google.firebase.installations.** {
   *;
 }
+-keepclassmembers class androidx.datastore.preferences.** {
+    <fields>;
+    <init>(...);
+}
 
 -keep interface com.google.firebase.installations.** {
   *;


### PR DESCRIPTION
**What does this PR do?**

This PR aims at adding proguard rules to fix a bug where we cant get the firebase token on release

**Database changed?**

No

**Where should the reviewer start?**

- [ ] proguard-rules.pro

**How should this be manually tested?**

Build on release.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-457](https://aptoide.atlassian.net/browse/AND-457)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-457]: https://aptoide.atlassian.net/browse/AND-457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ