### PR TITLE
[AND-494] Implement AB Test to hide autoupdates

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
@@ -175,6 +175,7 @@ class MainActivity : AppCompatActivity() {
       val notificationTag = it.notificationTag
       val notificationPackage = it.notificationPackage
 
+      notificationsAnalytics.sendExperimentNotificationClick(notificationTag!!, notificationPackage)
       notificationsAnalytics.sendNotificationOpened(notificationTag!!, notificationPackage)
     }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/analytics/NotificationsAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/analytics/NotificationsAnalytics.kt
@@ -44,6 +44,17 @@ class NotificationsAnalytics @Inject constructor(
     )
   }
 
+  fun sendExperimentNotificationClick(notificationTag: String, notificationPackage: String?) {
+    genericAnalytics.logEvent(
+      name = "experiment3_notification_click",
+      params = mapOf(
+        NOTIFICATION_ACTION to NOTIFICATION_ACTION_CLICK,
+        NOTIFICATION_TAG to notificationTag,
+        NOTIFICATION_PACKAGE to (notificationPackage ?: "n-a")
+      )
+    )
+  }
+
   companion object {
     internal const val NOTIFICATION_ACTION = "action"
     internal const val NOTIFICATION_ACTION_CLICK = "click"

--- a/feature_updates/build.gradle.kts
+++ b/feature_updates/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
   implementation(projects.installManager)
   implementation(projects.extension)
   implementation(projects.installInfoMapper)
+  implementation(projects.featureFlags)
 
   //room
   implementation(libs.room)


### PR DESCRIPTION
**What does this PR do?**

This PR aims at implementing the ab test for auto updates.
Note that the current ab test on the code is for dev only. we will have to create another one for release and maybe change the flag values if that is the case.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] UpdatesPreferencesRepository.kt

**How should this be manually tested?**

Run the app. If the auto updates setting shows on settings, then you are on the no auto updates group. Install an app through adb, change the worker initial delay and make sure it doesnt run the auto update. Test the positive case as well.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-494](https://aptoide.atlassian.net/browse/AND-494)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-494]: https://aptoide.atlassian.net/browse/AND-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ