### PR TITLE
[AND-465] Create support for new GameGenie search AB test using Booleans

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
@@ -31,6 +31,7 @@ import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.runPreviewable
 import com.aptoide.android.aptoidegames.analytics.presentation.rememberGeneralAnalytics
 import com.aptoide.android.aptoidegames.gamegenie.presentation.rememberGameGenieVisibility
+import com.aptoide.android.aptoidegames.gamegenie.presentation.rememberSearchGameGenie
 import com.aptoide.android.aptoidegames.home.BottomBarMenuHandler
 import com.aptoide.android.aptoidegames.home.BottomBarMenus
 import com.aptoide.android.aptoidegames.home.Icon
@@ -58,7 +59,9 @@ fun AppGamesBottomBarPreview() {
 fun AppGamesBottomBar(navController: NavController) {
   val generalAnalytics = rememberGeneralAnalytics()
   val shouldShowGameGenie = rememberGameGenieVisibility()
-  val filteredBottomNavigationItems = bottomNavigationItems.filter(shouldShowGameGenie)
+  val shouldSearchGameGenie = rememberSearchGameGenie()
+  val filteredBottomNavigationItems =
+    bottomNavigationItems.filter(shouldShowGameGenie, shouldSearchGameGenie)
   val selection =
     selectionIndex(items = filteredBottomNavigationItems, navController = navController)
   if (selection >= 0) {
@@ -74,6 +77,7 @@ fun AppGamesBottomBar(navController: NavController) {
             when (item) {
               BottomBarMenus.Games -> generalAnalytics.sendBottomBarHomeClick()
               BottomBarMenus.Search -> generalAnalytics.sendBottomBarSearchClick()
+              BottomBarMenus.GenieSearch -> generalAnalytics.sendBottomBarSearchClick()
               BottomBarMenus.Categories -> generalAnalytics.sendBottomBarCategoriesClick()
               BottomBarMenus.Updates -> generalAnalytics.sendBottomBarUpdatesClick()
               BottomBarMenus.GameGenie -> generalAnalytics.sendBottomBarGameGenieClick()
@@ -96,12 +100,17 @@ fun AppGamesBottomBar(navController: NavController) {
   }
 }
 
-fun List<BottomBarMenus>.filter(shouldShowGameGenie: Boolean) =
+fun List<BottomBarMenus>.filter(
+  shouldShowGameGenie: Boolean,
+  shouldSearchGameGenie: Boolean,
+) =
   filter {
-    if (shouldShowGameGenie) {
-      it != BottomBarMenus.Categories
-    } else {
-      it != BottomBarMenus.GameGenie
+    when (it) {
+      BottomBarMenus.Categories -> shouldShowGameGenie.not()
+      BottomBarMenus.GameGenie -> shouldShowGameGenie
+      BottomBarMenus.Search -> shouldSearchGameGenie.not()
+      BottomBarMenus.GenieSearch -> shouldSearchGameGenie
+      else -> true
     }
   }
 
@@ -159,6 +168,7 @@ private fun selectionIndex(
 val bottomNavigationItems = listOf(
   BottomBarMenus.Games,
   BottomBarMenus.Search,
+  BottomBarMenus.GenieSearch,
   BottomBarMenus.Categories,
   BottomBarMenus.GameGenie,
   BottomBarMenus.Updates,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieFeatureProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieFeatureProvider.kt
@@ -36,3 +36,19 @@ fun rememberGameGenieVisibility(): Boolean = runPreviewable(
     state
   }
 )
+
+@Composable
+fun rememberSearchGameGenie(): Boolean = runPreviewable(
+  preview = { Random.nextBoolean() },
+  real = {
+    val coroutineScope = rememberCoroutineScope()
+    var state by remember { mutableStateOf(false) }
+    val vm = hiltViewModel<GameGenieInjectionsProvider>()
+    LaunchedEffect(key1 = Unit) {
+      coroutineScope.launch {
+        state = vm.featureFlags.getFlag("search_game_genie", false)
+      }
+    }
+    state
+  }
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GenieSearchView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GenieSearchView.kt
@@ -1,0 +1,43 @@
+package com.aptoide.android.aptoidegames.gamegenie.presentation
+
+import ConversationsDrawer
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import cm.aptoide.pt.extensions.ScreenData
+import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
+import com.aptoide.android.aptoidegames.gamegenie.analytics.rememberGameGenieAnalytics
+
+const val genieSearchRoute = "genieSearch"
+
+fun gameGenieSearchScreen() = ScreenData.withAnalytics(
+  route = genieSearchRoute,
+  screenAnalyticsName = "gamegenie",
+  arguments = emptyList()
+) { _, navigate, _ ->
+
+  val viewModel = hiltViewModel<GameGenieViewModel>()
+  val uiState by viewModel.uiState.collectAsState()
+  val analytics = rememberGameGenieAnalytics()
+
+  ConversationsDrawer(
+    mainScreen = {
+      ChatbotView(
+        uiState = uiState,
+        navigateTo = navigate,
+        onError = viewModel::reload,
+        onMessageSend = { message ->
+          viewModel.sendMessage(message)
+          analytics.sendGameGenieMessageSent()
+        },
+        onSuggestionSend = { message, index ->
+          viewModel.sendMessage(message)
+          analytics.sendGameGenieSuggestionClick(index)
+        },
+      )
+    },
+    loadConversationFn = viewModel::loadConversation,
+    currentChatId = uiState.chat.id,
+    newChatFn = viewModel::createNewChat,
+  )
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BottomBarMenus.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BottomBarMenus.kt
@@ -26,6 +26,7 @@ import com.aptoide.android.aptoidegames.drawables.icons.getGameGenie
 import com.aptoide.android.aptoidegames.drawables.icons.getGamesIcon
 import com.aptoide.android.aptoidegames.drawables.icons.getSearch
 import com.aptoide.android.aptoidegames.gamegenie.presentation.genieRoute
+import com.aptoide.android.aptoidegames.gamegenie.presentation.genieSearchRoute
 import com.aptoide.android.aptoidegames.search.presentation.buildSearchRoute
 import com.aptoide.android.aptoidegames.theme.Palette
 import com.aptoide.android.aptoidegames.updates.presentation.updatesRoute
@@ -40,8 +41,12 @@ sealed class BottomBarMenus(
   )
 
   object Search : BottomBarMenus(
-    route = buildSearchRoute()
-      .withBundleMeta(BundleMeta("search", "app")),
+    route = buildSearchRoute().withBundleMeta(BundleMeta("search", "app")),
+    titleId = R.string.search
+  )
+
+  object GenieSearch : BottomBarMenus(
+    route = genieSearchRoute.withBundleMeta(BundleMeta("geniesearch", "app")),
     titleId = R.string.search
   )
 
@@ -66,6 +71,7 @@ sealed class BottomBarMenus(
 fun BottomBarMenus.Icon() = when (this) {
   BottomBarMenus.Games -> getGamesIcon(Palette.GreyLight).AsBottomBarIcon()
   BottomBarMenus.Search -> getSearch(Palette.GreyLight).AsBottomBarIcon()
+  BottomBarMenus.GenieSearch -> getSearch(Palette.GreyLight).AsBottomBarIcon()
   BottomBarMenus.Categories -> getCategories(Palette.GreyLight).AsBottomBarIcon()
   BottomBarMenus.Updates -> {
     val updatesUiState = rememberUpdates()
@@ -101,7 +107,6 @@ fun BottomBarMenus.Icon() = when (this) {
       }
     }
   }
-
 }
 
 @Composable

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
@@ -44,7 +44,9 @@ import com.aptoide.android.aptoidegames.feature_apps.presentation.seeAllMyGamesS
 import com.aptoide.android.aptoidegames.feature_apps.presentation.seeMoreBonusScreen
 import com.aptoide.android.aptoidegames.feature_apps.presentation.seeMoreScreen
 import com.aptoide.android.aptoidegames.gamegenie.presentation.gameGenieScreen
+import com.aptoide.android.aptoidegames.gamegenie.presentation.gameGenieSearchScreen
 import com.aptoide.android.aptoidegames.gamegenie.presentation.genieRoute
+import com.aptoide.android.aptoidegames.gamegenie.presentation.genieSearchRoute
 import com.aptoide.android.aptoidegames.installer.UserActionDialog
 import com.aptoide.android.aptoidegames.notifications.NotificationsPermissionRequester
 import com.aptoide.android.aptoidegames.permissions.notifications.NotificationsPermissionViewModel
@@ -79,7 +81,7 @@ fun MainView(navController: NavHostController) {
   LaunchedEffect(currentRoute.value?.destination?.route) {
     val currentRoute = currentRoute.value?.destination?.route
     showTopBar = if (currentRoute != null) {
-      !currentRoute.contains(genieRoute) && !currentRoute.contains(detailedApkfyRoute)
+      !currentRoute.contains(genieRoute) && !currentRoute.contains(detailedApkfyRoute) && !currentRoute.contains(genieSearchRoute)
         && !currentRoute.contains(robloxApkfyRoute)
     } else {
       true
@@ -262,6 +264,12 @@ private fun NavigationGraph(
       navigate = navController::navigateTo,
       goBack = navController::navigateUp,
       screenData = gameGenieScreen()
+    )
+
+    staticComposable(
+      navigate = navController::navigateTo,
+      goBack = navController::navigateUp,
+      screenData = gameGenieSearchScreen()
     )
 
     animatedComposable(


### PR DESCRIPTION
**What does this PR do?**

  This PR creates support for GameGenie AB Test using booleans instead of the 3 variants. The search screen is fully substituted by the GameGenie chat screen

**Database changed?**

   No

**Where should the reviewer start?**

See commit

**How should this be manually tested?**

Check various times if the search opens the search view or GameGenie view

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-465](https://aptoide.atlassian.net/browse/AND-465)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-465]: https://aptoide.atlassian.net/browse/AND-465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ