### PR TITLE
[AND-501] fix bonus banner

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/BonusBundleMoreScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/BonusBundleMoreScreen.kt
@@ -117,7 +117,7 @@ private fun MoreBonusBundleScreen(
 }
 
 @Composable
-private fun MoreBonusBundleScreen(
+fun MoreBonusBundleScreen(
   uiState: AppsListUiState,
   title: String,
   bundleTag: String,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/BonusSectionView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/BonusSectionView.kt
@@ -54,18 +54,30 @@ fun BonusSectionView(
   spaceBy: Int = 0,
 ) {
   val context = LocalContext.current
-  BonusSectionGeneralizedView(
-    onHeaderClick = getBonusRouteNavigation(
-      context = context,
-      bundle = bundle,
-      navigate = navigate
-    ),
-    spaceBy = spaceBy,
-  ) {
-    BonusBundleView(
-      bundle = bundle,
-      navigate = navigate
-    )
+  val (uiState, _) = rememberAppsByTag(bundle.tag)
+  when (uiState) {
+    is AppsListUiState.Idle -> {
+      BonusSectionGeneralizedView(
+        onHeaderClick = getBonusRouteNavigation(
+          context = context,
+          bundle = bundle,
+          navigate = navigate
+        ),
+        spaceBy = spaceBy,
+      ) {
+        AppsRowView(
+          appsList = uiState.apps,
+          navigate = navigate,
+        )
+      }
+    }
+
+    AppsListUiState.Empty,
+    AppsListUiState.Error,
+    AppsListUiState.NoConnection,
+      -> Unit
+
+    AppsListUiState.Loading -> LoadingBundleView(height = 184.dp)
   }
 }
 
@@ -181,27 +193,6 @@ fun BonusSectionHeader(
     }
 
     Spacer(Modifier.width(16.dp))
-  }
-}
-
-@Composable
-fun BonusBundleView(
-  bundle: Bundle,
-  navigate: (String) -> Unit
-) {
-  val (uiState, _) = rememberAppsByTag(bundle.tag)
-  when (uiState) {
-    is AppsListUiState.Idle -> AppsRowView(
-      appsList = uiState.apps,
-      navigate = navigate,
-    )
-
-    AppsListUiState.Empty,
-    AppsListUiState.Error,
-    AppsListUiState.NoConnection,
-      -> Unit
-
-    AppsListUiState.Loading -> LoadingBundleView(height = 184.dp)
   }
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/presentation/RTBSectionMoreView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/presentation/RTBSectionMoreView.kt
@@ -1,0 +1,90 @@
+package com.aptoide.android.aptoidegames.feature_rtb.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.navDeepLink
+import cm.aptoide.pt.extensions.ScreenData
+import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
+import cm.aptoide.pt.feature_campaigns.toAptoideMMPCampaign
+import com.aptoide.android.aptoidegames.BuildConfig
+import com.aptoide.android.aptoidegames.analytics.presentation.AnalyticsContext
+import com.aptoide.android.aptoidegames.analytics.presentation.rememberGeneralAnalytics
+import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
+import com.aptoide.android.aptoidegames.feature_apps.presentation.MoreBonusBundleScreen
+
+const val rtbSeeMoreRoute = "rtbSeeMore/{title}/{tag}"
+private var hasSentImpression = false
+
+fun rtbSeeMoreScreen() = ScreenData.withAnalytics(
+  route = rtbSeeMoreRoute,
+  screenAnalyticsName = "SeeAll",
+  deepLinks = listOf(navDeepLink { uriPattern = BuildConfig.DEEP_LINK_SCHEMA + rtbSeeMoreRoute })
+) { arguments, navigate, navigateBack ->
+  val bundleTitle = arguments?.getString("title")!!
+  val bundleTag = arguments.getString("tag")!!
+
+  RtbMoreBundleScreen(
+    title = bundleTitle,
+    bundleTag = bundleTag,
+    navigateBack = navigateBack,
+    navigate = navigate,
+  )
+}
+
+fun buildRtbSeeMoreRoute(
+  title: String,
+  bundleTag: String,
+) = "rtbSeeMore/$title/$bundleTag"
+
+@Composable
+private fun RTBMoreAptoideMMPController(
+  uiState: AppsListUiState,
+  bundleTag: String,
+  placement: String,
+) {
+  when (uiState) {
+    is AppsListUiState.Idle ->
+      uiState.apps.forEachIndexed { index, rtbApp ->
+        if (!hasSentImpression) {
+          rtbApp.campaigns?.toAptoideMMPCampaign()
+            ?.sendImpressionEvent(bundleTag, rtbApp.packageName)
+          rtbApp.campaigns?.run {
+            placementType = placement
+          }
+          if (index == uiState.apps.size - 1) {
+            hasSentImpression = true
+          }
+        }
+      }
+
+    else -> {}
+  }
+}
+
+@Composable
+private fun RtbMoreBundleScreen(
+  title: String,
+  bundleTag: String,
+  navigateBack: () -> Unit,
+  navigate: (String) -> Unit,
+) {
+  val (uiState, reload) = rememberRTBApps(bundleTag)
+  val analyticsContext = AnalyticsContext.current
+  val generalAnalytics = rememberGeneralAnalytics()
+
+  RTBMoreAptoideMMPController(uiState, bundleTag, "home-bundle")
+
+  MoreBonusBundleScreen(
+    uiState = uiState,
+    title = title,
+    bundleTag = bundleTag,
+    reload = reload,
+    noNetworkReload = {
+      reload()
+    },
+    navigateBack = {
+      generalAnalytics.sendBackButtonClick(analyticsContext.copy(itemPosition = null))
+      navigateBack()
+    },
+    navigate = navigate,
+  )
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/presentation/RTBSectionMoreView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/presentation/RTBSectionMoreView.kt
@@ -26,7 +26,7 @@ fun rtbSeeMoreScreen() = ScreenData.withAnalytics(
 ) { arguments, navigate, navigateBack ->
   val bundleTag = arguments?.getString("tag")!!
 
-  RtbMoreBundleScreen(
+  RTBMoreBundleScreen(
     bundleTag = bundleTag,
     navigateBack = navigateBack,
     navigate = navigate,
@@ -63,7 +63,7 @@ private fun RTBMoreAptoideMMPController(
 }
 
 @Composable
-private fun RtbMoreBundleScreen(
+fun RTBMoreBundleScreen(
   bundleTag: String,
   navigateBack: () -> Unit,
   navigate: (String) -> Unit,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/presentation/RTBSectionMoreView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/presentation/RTBSectionMoreView.kt
@@ -1,17 +1,22 @@
 package com.aptoide.android.aptoidegames.feature_rtb.presentation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import androidx.navigation.navDeepLink
 import cm.aptoide.pt.extensions.ScreenData
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
 import cm.aptoide.pt.feature_campaigns.toAptoideMMPCampaign
+import cm.aptoide.pt.feature_home.domain.Bundle
 import com.aptoide.android.aptoidegames.BuildConfig
+import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.presentation.AnalyticsContext
 import com.aptoide.android.aptoidegames.analytics.presentation.rememberGeneralAnalytics
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
+import com.aptoide.android.aptoidegames.analytics.presentation.withBundleMeta
 import com.aptoide.android.aptoidegames.feature_apps.presentation.MoreBonusBundleScreen
+import com.aptoide.android.aptoidegames.home.analytics.meta
 
-const val rtbSeeMoreRoute = "rtbSeeMore/{title}/{tag}"
+const val rtbSeeMoreRoute = "rtbSeeMore/{tag}"
 private var hasSentImpression = false
 
 fun rtbSeeMoreScreen() = ScreenData.withAnalytics(
@@ -19,11 +24,9 @@ fun rtbSeeMoreScreen() = ScreenData.withAnalytics(
   screenAnalyticsName = "SeeAll",
   deepLinks = listOf(navDeepLink { uriPattern = BuildConfig.DEEP_LINK_SCHEMA + rtbSeeMoreRoute })
 ) { arguments, navigate, navigateBack ->
-  val bundleTitle = arguments?.getString("title")!!
-  val bundleTag = arguments.getString("tag")!!
+  val bundleTag = arguments?.getString("tag")!!
 
   RtbMoreBundleScreen(
-    title = bundleTitle,
     bundleTag = bundleTag,
     navigateBack = navigateBack,
     navigate = navigate,
@@ -31,9 +34,8 @@ fun rtbSeeMoreScreen() = ScreenData.withAnalytics(
 }
 
 fun buildRtbSeeMoreRoute(
-  title: String,
   bundleTag: String,
-) = "rtbSeeMore/$title/$bundleTag"
+) = "rtbSeeMore/$bundleTag"
 
 @Composable
 private fun RTBMoreAptoideMMPController(
@@ -62,7 +64,6 @@ private fun RTBMoreAptoideMMPController(
 
 @Composable
 private fun RtbMoreBundleScreen(
-  title: String,
   bundleTag: String,
   navigateBack: () -> Unit,
   navigate: (String) -> Unit,
@@ -75,7 +76,7 @@ private fun RtbMoreBundleScreen(
 
   MoreBonusBundleScreen(
     uiState = uiState,
-    title = title,
+    title = stringResource(R.string.bonus_banner_title, "20"),
     bundleTag = bundleTag,
     reload = reload,
     noNetworkReload = {
@@ -86,5 +87,16 @@ private fun RtbMoreBundleScreen(
       navigateBack()
     },
     navigate = navigate,
+  )
+}
+
+@Composable
+fun getRTBMoreRouteNavigation(
+  bundle: Bundle,
+  navigate: (String) -> Unit,
+): () -> Unit = {
+  navigate(
+    buildRtbSeeMoreRoute("${bundle.tag}-more")
+      .withBundleMeta(bundle.meta.copy(tag = "${bundle.tag}-more"))
   )
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/presentation/RTBSectionView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/presentation/RTBSectionView.kt
@@ -1,5 +1,6 @@
 package com.aptoide.android.aptoidegames.feature_rtb.presentation
 
+import android.net.Uri.encode
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.unit.dp
@@ -10,15 +11,17 @@ import cm.aptoide.pt.feature_campaigns.AptoideMMPCampaign
 import cm.aptoide.pt.feature_campaigns.toAptoideMMPCampaign
 import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.randomBundle
+import com.aptoide.android.aptoidegames.analytics.presentation.withBundleMeta
 import com.aptoide.android.aptoidegames.feature_apps.presentation.AppsRowView
 import com.aptoide.android.aptoidegames.feature_apps.presentation.BonusSectionGeneralizedView
 import com.aptoide.android.aptoidegames.home.LoadingBundleView
+import com.aptoide.android.aptoidegames.home.analytics.meta
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 
-internal var hasSentImpression = false
+private var hasSentImpression = false
 
 @Composable
-private fun RTBAptoideMMPController(
+fun RTBAptoideMMPController(
   apps: List<App>,
   bundleTag: String,
   placement: String,
@@ -47,10 +50,14 @@ fun RTBSectionView(
 
   when (uiState) {
     is AppsListUiState.Idle -> {
+
       BonusSectionGeneralizedView(
-        onHeaderClick = {},
+        onHeaderClick = getRTBMoreRouteNavigation(
+          bundle = bundle,
+          navigate = navigate
+        ),
         spaceBy = spaceBy,
-        showMoreButton = false
+        showMoreButton = true
       ) {
         RTBBundleView(
           bundle = bundle,
@@ -81,10 +88,22 @@ fun RTBBundleView(
   navigate: (String) -> Unit,
   apps: List<App>,
 ) {
-  RTBAptoideMMPController(apps, bundle.tag, "home-bundle")
+  val homeApps = apps.take(9)
+  RTBAptoideMMPController(homeApps, bundle.tag, "home-bundle")
   AppsRowView(
-    appsList = apps,
+    appsList = homeApps,
     navigate = navigate,
+  )
+}
+
+@Composable
+fun getRTBMoreRouteNavigation(
+  bundle: Bundle,
+  navigate: (String) -> Unit,
+): () -> Unit = {
+  navigate(
+    buildRtbSeeMoreRoute(encode(bundle.title), "${bundle.tag}-more")
+      .withBundleMeta(bundle.meta.copy(tag = "${bundle.tag}-more"))
   )
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/presentation/RTBSectionView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/presentation/RTBSectionView.kt
@@ -1,6 +1,5 @@
 package com.aptoide.android.aptoidegames.feature_rtb.presentation
 
-import android.net.Uri.encode
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.unit.dp
@@ -11,11 +10,9 @@ import cm.aptoide.pt.feature_campaigns.AptoideMMPCampaign
 import cm.aptoide.pt.feature_campaigns.toAptoideMMPCampaign
 import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.randomBundle
-import com.aptoide.android.aptoidegames.analytics.presentation.withBundleMeta
 import com.aptoide.android.aptoidegames.feature_apps.presentation.AppsRowView
 import com.aptoide.android.aptoidegames.feature_apps.presentation.BonusSectionGeneralizedView
 import com.aptoide.android.aptoidegames.home.LoadingBundleView
-import com.aptoide.android.aptoidegames.home.analytics.meta
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 
 private var hasSentImpression = false
@@ -93,17 +90,6 @@ fun RTBBundleView(
   AppsRowView(
     appsList = homeApps,
     navigate = navigate,
-  )
-}
-
-@Composable
-fun getRTBMoreRouteNavigation(
-  bundle: Bundle,
-  navigate: (String) -> Unit,
-): () -> Unit = {
-  navigate(
-    buildRtbSeeMoreRoute(encode(bundle.title), "${bundle.tag}-more")
-      .withBundleMeta(bundle.meta.copy(tag = "${bundle.tag}-more"))
   )
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/GamesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/GamesScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import cm.aptoide.pt.extensions.ScreenData
-import cm.aptoide.pt.feature_apps.presentation.rememberAppsByTag
 import cm.aptoide.pt.feature_categories.presentation.rememberAllCategories
 import cm.aptoide.pt.feature_editorial.presentation.rememberEditorialListState
 import com.aptoide.android.aptoidegames.analytics.presentation.InitialAnalyticsMeta
@@ -15,7 +14,7 @@ import com.aptoide.android.aptoidegames.analytics.presentation.OverrideAnalytics
 import com.aptoide.android.aptoidegames.categories.presentation.AllCategoriesView
 import com.aptoide.android.aptoidegames.editorial.SeeMoreEditorialsContent
 import com.aptoide.android.aptoidegames.feature_apps.presentation.MoreBonusBundleView
-import com.aptoide.android.aptoidegames.feature_apps.presentation.rememberBonusBundle
+import com.aptoide.android.aptoidegames.feature_rtb.presentation.rememberRTBApps
 
 const val gamesRoute = "games"
 
@@ -84,12 +83,10 @@ private fun GamesScreenTabView(
 
 @Composable
 private fun AppCoinsTabView(navigate: (String) -> Unit) {
-  val (_, bonusBundleTag) = rememberBonusBundle()
-  val (uiState, reload) = rememberAppsByTag(bonusBundleTag)
-
+  val (uiState, reload) = rememberRTBApps("rtb-promo")
   MoreBonusBundleView(
     uiState = uiState,
-    bundleTag = bonusBundleTag,
+    bundleTag = "rtb-promo",
     navigate = navigate,
     reload = reload,
     noNetworkReload = reload

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
@@ -43,6 +43,7 @@ import com.aptoide.android.aptoidegames.editorial.seeMoreEditorialScreen
 import com.aptoide.android.aptoidegames.feature_apps.presentation.seeAllMyGamesScreen
 import com.aptoide.android.aptoidegames.feature_apps.presentation.seeMoreBonusScreen
 import com.aptoide.android.aptoidegames.feature_apps.presentation.seeMoreScreen
+import com.aptoide.android.aptoidegames.feature_rtb.presentation.rtbSeeMoreScreen
 import com.aptoide.android.aptoidegames.gamegenie.presentation.gameGenieScreen
 import com.aptoide.android.aptoidegames.gamegenie.presentation.genieRoute
 import com.aptoide.android.aptoidegames.installer.UserActionDialog
@@ -220,6 +221,12 @@ private fun NavigationGraph(
       navigate = navController::navigateTo,
       goBack = navController::navigateUp,
       screenData = seeMoreBonusScreen()
+    )
+
+    animatedComposable(
+      navigate = navController::navigateTo,
+      goBack = navController::navigateUp,
+      screenData = rtbSeeMoreScreen()
     )
 
     animatedComposable(


### PR DESCRIPTION
**What does this PR do?**

This PR aims at implementing some fixes on the rtb and bonus appc bundle views. 
Fixes the title, adds see more to the rtb bundle and fixes a bug where if the bundle failed to load, the header of the bundle would stay visible.

**Database changed?**

No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Using rewrites check if both bundles are ok (both rtb and bonus).

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-501](https://aptoide.atlassian.net/browse/AND-501)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-501]: https://aptoide.atlassian.net/browse/AND-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ