### PR TITLE
[AND-505] experiement 7: Updates notification

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
@@ -29,6 +29,7 @@ import com.aptoide.android.aptoidegames.notifications.analytics.NotificationsAna
 import com.aptoide.android.aptoidegames.notifications.toFirebaseNotificationAnalyticsInfo
 import com.aptoide.android.aptoidegames.promo_codes.PromoCode
 import com.aptoide.android.aptoidegames.promo_codes.PromoCodeRepository
+import com.aptoide.android.aptoidegames.updates.domain.UpdatesNotificationAnalyticsManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -67,6 +68,9 @@ class MainActivity : AppCompatActivity() {
   @Inject
   lateinit var firebaseNotificationAnalytics: FirebaseNotificationAnalytics
 
+  @Inject
+  lateinit var updatesNotificationAnalyticsManager: UpdatesNotificationAnalyticsManager
+
   private var navController: NavHostController? = null
 
   private val coroutinesScope: CoroutineScope = CoroutineScope(Job() + Dispatchers.IO)
@@ -82,6 +86,8 @@ class MainActivity : AppCompatActivity() {
         coroutinesScope.launch {
           if (isGranted) {
             notificationsAnalytics.sendNotificationOptIn()
+            notificationsAnalytics.sendExperimentNotificationsAllowed()
+            updatesNotificationAnalyticsManager.loadUserProperty()
           } else {
             notificationsAnalytics.sendNotificationOptOut()
           }
@@ -111,6 +117,9 @@ class MainActivity : AppCompatActivity() {
           runCatching {
             notificationsPermissionLauncher?.launch(Manifest.permission.POST_NOTIFICATIONS)
           }
+        } else {
+          notificationsAnalytics.sendExperimentNotificationsAllowed()
+          updatesNotificationAnalyticsManager.loadUserProperty()
         }
         appLaunchPreferencesManager.setIsNotFirstLaunch()
       }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/analytics/NotificationsAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/analytics/NotificationsAnalytics.kt
@@ -7,6 +7,11 @@ class NotificationsAnalytics @Inject constructor(
   private val genericAnalytics: GenericAnalytics,
 ) {
 
+  fun sendExperimentNotificationsAllowed() = genericAnalytics.logEvent(
+    name = "experiment_notifications_allowed",
+    params = emptyMap()
+  )
+
   fun sendNotificationOptIn() = genericAnalytics.logEvent(
     name = "notification_opt_in",
     params = emptyMap()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/presentation/AnalyticsProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/presentation/AnalyticsProvider.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.ViewModel
 import cm.aptoide.pt.extensions.runPreviewable
 import com.aptoide.android.aptoidegames.analytics.AnalyticsSender
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
-import com.aptoide.android.aptoidegames.feature_apps.presentation.AnalyticsInjectionsProvider
 import com.aptoide.android.aptoidegames.notifications.analytics.NotificationsAnalytics
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/domain/UpdatesNotificationAnalyticsManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/domain/UpdatesNotificationAnalyticsManager.kt
@@ -1,0 +1,18 @@
+package com.aptoide.android.aptoidegames.updates.domain
+
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+import com.aptoide.android.aptoidegames.analytics.BIAnalytics
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UpdatesNotificationAnalyticsManager @Inject constructor(
+  private val biAnalytics: BIAnalytics,
+  private val featureFlags: FeatureFlags
+) {
+
+  suspend fun loadUserProperty() {
+    val variant = featureFlags.getFlagAsString("updates_notification_type")
+    biAnalytics.setUserProperties("experiment7_updates_notification_variant" to variant)
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesNotificationBuilder.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesNotificationBuilder.kt
@@ -47,6 +47,7 @@ class UpdatesNotificationBuilder @Inject constructor(
     const val UPDATES_NOTIFICATION_CHANNEL_NAME = "Updates Notification Channel"
     const val UPDATES_NOTIFICATION_TAG = "general_updates_notification"
     const val VIP_UPDATES_NOTIFICATION_TAG = "vip_updates_notification"
+    const val AUTO_UPDATE_SUCCESS_NOTIFICATION_TAG = "auto_update_success_update_notification"
   }
 
   init {
@@ -104,7 +105,7 @@ class UpdatesNotificationBuilder @Inject constructor(
       appSource = AppSource.of(appId = null, packageName = app.packageName)
     )
     val appIcon = imageDownloader.downloadImageFrom(app.icon)
-    val title = "${app.name} has an update"
+    val title = context.resources.getString(R.string.update_available_vip_update_notification, app.name)
     val notificationId = "VIPUpdates${app.packageName}".hashCode()
     val notification = buildNotification(
       requestCode = notificationId,
@@ -121,6 +122,33 @@ class UpdatesNotificationBuilder @Inject constructor(
         notificationId = notificationId,
         notification = notification,
         notificationTag = VIP_UPDATES_NOTIFICATION_TAG,
+        notificationPackage = app.packageName
+      )
+    }
+  }
+
+  override suspend fun showSuccessAutoUpdatedGameNotification(app: App) {
+    val deepLink = buildAppViewDeepLinkUri(
+      appSource = AppSource.of(appId = null, packageName = app.packageName)
+    )
+    val appIcon = imageDownloader.downloadImageFrom(app.icon)
+    val title = context.resources.getString(R.string.update_app_updated_notification_title, app.name)
+    val notificationId = "AutoUpdateSuccess${app.packageName}".hashCode()
+    val notification = buildNotification(
+      requestCode = notificationId,
+      contentText = context.resources.getString(R.string.update_app_updated_notification_body),
+      contentTitle = title,
+      deepLink = deepLink,
+      largeIcon = appIcon,
+      notificationTag = AUTO_UPDATE_SUCCESS_NOTIFICATION_TAG,
+      notificationPackage = app.packageName
+    )
+
+    notification?.let {
+      showNotification(
+        notificationId = notificationId,
+        notification = notification,
+        notificationTag = AUTO_UPDATE_SUCCESS_NOTIFICATION_TAG,
         notificationPackage = app.packageName
       )
     }

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/AutoUpdateGameInstallObserver.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/AutoUpdateGameInstallObserver.kt
@@ -1,0 +1,25 @@
+package cm.aptoide.pt.feature_updates.domain
+
+import cm.aptoide.pt.extensions.compatVersionCode
+import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_updates.presentation.UpdatesNotificationProvider
+import cm.aptoide.pt.install_manager.InstallManager
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AutoUpdateGameInstallObserver @Inject constructor(
+  private val updatesNotificationBuilder: UpdatesNotificationProvider,
+  private val installManager: InstallManager
+) {
+
+  suspend fun observeInstall(update: App, installedVersionCode: Long) {
+    installManager.getApp(update.packageName)
+      .packageInfoFlow
+      .filterNotNull()
+      .first { it.compatVersionCode > installedVersionCode }
+      .let { updatesNotificationBuilder.showSuccessAutoUpdatedGameNotification(update) }
+  }
+}

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/NotificationTypes.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/NotificationTypes.kt
@@ -1,0 +1,7 @@
+package cm.aptoide.pt.feature_updates.domain
+
+enum class NotificationTypes {
+  GENERAL_NOTIFICATION,
+  VIP_NOTIFICATION,
+  AUTO_UPDATE_SUCCESSFUL
+}

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/Updates.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/domain/Updates.kt
@@ -15,19 +15,25 @@ import cm.aptoide.pt.feature_updates.data.UpdatesWorker
 import cm.aptoide.pt.feature_updates.data.VIPUpdatesProvider
 import cm.aptoide.pt.feature_updates.data.VIPUpdatesWorker
 import cm.aptoide.pt.feature_updates.di.PrioritizedPackagesFilter
+import cm.aptoide.pt.feature_updates.domain.NotificationTypes.AUTO_UPDATE_SUCCESSFUL
+import cm.aptoide.pt.feature_updates.domain.NotificationTypes.GENERAL_NOTIFICATION
+import cm.aptoide.pt.feature_updates.domain.NotificationTypes.VIP_NOTIFICATION
 import cm.aptoide.pt.feature_updates.presentation.UpdatesNotificationProvider
+import cm.aptoide.pt.feature_updates.presentation.UpdatesNotificationsVisibilityManager
 import cm.aptoide.pt.feature_updates.repository.UpdatesPreferencesRepository
 import cm.aptoide.pt.install_info_mapper.domain.InstallPackageInfoMapper
 import cm.aptoide.pt.install_manager.InstallManager
 import cm.aptoide.pt.install_manager.dto.Constraints
 import cm.aptoide.pt.install_manager.dto.Constraints.NetworkType.UNMETERED
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.time.LocalDate
@@ -44,7 +50,9 @@ class Updates @Inject constructor(
   private val updatesNotificationBuilder: UpdatesNotificationProvider,
   private val installPackageInfoMapper: InstallPackageInfoMapper,
   private val updatesPreferencesRepository: UpdatesPreferencesRepository,
-  private val vipUpdatesProvider: VIPUpdatesProvider
+  private val vipUpdatesProvider: VIPUpdatesProvider,
+  private val updatesNotificationsVisibilityManager: UpdatesNotificationsVisibilityManager,
+  private val autoUpdateGameInstallObserver: AutoUpdateGameInstallObserver
 ) {
 
   val mutex: Mutex = Mutex()
@@ -114,7 +122,9 @@ class Updates @Inject constructor(
 
     appsUpdates.first().let {
       if (it.isNotEmpty()) {
-        updatesNotificationBuilder.showUpdatesNotification(it)
+        if (updatesNotificationsVisibilityManager.shouldShowNotification(GENERAL_NOTIFICATION)) {
+          updatesNotificationBuilder.showUpdatesNotification(it)
+        }
       }
     }
   }
@@ -145,40 +155,59 @@ class Updates @Inject constructor(
     val shouldInstall =
       ((shouldAutoUpdateGames == true) && hasNoRunningDownloads && hasPackageInstallsPermission)
 
-    if (shouldInstall) {
-      installedAppsToUpdate
-        .forEach { appInstaller ->
-          filteredUpdates
-            .firstOrNull { it.packageName == appInstaller.packageName }
-            ?.also {
-              if (appInstaller.updatesOwnerPackageName == myPackageName) {
-                appInstaller.install(
-                  installPackageInfo = installPackageInfoMapper.map(it),
-                  constraints = Constraints(
-                    checkForFreeSpace = false,
-                    networkType = UNMETERED
-                  )
-                )
-
-                it.campaigns?.run {
-                  toAptoideMMPCampaign().sendDownloadEvent(
-                    bundleTag = null,
-                    searchKeyword = null,
-                    currentScreen = null,
-                    isCta = false
+    if (shouldInstall && updatesNotificationsVisibilityManager.shouldAutoUpdateGames()) {
+      coroutineScope {
+        installedAppsToUpdate
+          .forEach { appInstaller ->
+            filteredUpdates
+              .firstOrNull { it.packageName == appInstaller.packageName }
+              ?.also {
+                if (appInstaller.updatesOwnerPackageName == myPackageName) {
+                  appInstaller.install(
+                    installPackageInfo = installPackageInfoMapper.map(it),
+                    constraints = Constraints(
+                      checkForFreeSpace = false,
+                      networkType = UNMETERED
+                    )
                   )
 
-                  toMMPLinkerCampaign().sendDownloadEvent()
+                  if (updatesNotificationsVisibilityManager.shouldShowNotification(
+                      AUTO_UPDATE_SUCCESSFUL
+                    )
+                  ) {
+                    launch {
+                      autoUpdateGameInstallObserver.observeInstall(
+                        it,
+                        appInstaller.packageInfo?.compatVersionCode ?: 0
+                      )
+                    }
+                  }
+
+                  it.campaigns?.run {
+                    toAptoideMMPCampaign().sendDownloadEvent(
+                      bundleTag = null,
+                      searchKeyword = null,
+                      currentScreen = null,
+                      isCta = false
+                    )
+
+                    toMMPLinkerCampaign().sendDownloadEvent()
+                  }
+                } else if (updatesNotificationsVisibilityManager.shouldShowNotification(
+                    VIP_NOTIFICATION
+                  )
+                ) {
+                  updatesNotificationBuilder.showVIPUpdateNotification(it)
                 }
-              } else {
-                updatesNotificationBuilder.showVIPUpdateNotification(it)
-              }
 
-            }
-        }
+              }
+          }
+      }
     } else {
       filteredUpdates.forEach {
-        updatesNotificationBuilder.showVIPUpdateNotification(it)
+        if (updatesNotificationsVisibilityManager.shouldShowNotification(VIP_NOTIFICATION)) {
+          updatesNotificationBuilder.showVIPUpdateNotification(it)
+        }
       }
     }
   }
@@ -215,32 +244,44 @@ class Updates @Inject constructor(
           it.modifiedDate
         }
       }
-    if (shouldAutoUpdateGames != true) {
+    if (shouldAutoUpdateGames != true || !updatesNotificationsVisibilityManager.shouldAutoUpdateGames()) {
       return
     }
-    installers.forEach { appInstaller ->
-      updates
-        .firstOrNull { it.packageName == appInstaller.packageName }
-        ?.also {
-          appInstaller.install(
-            installPackageInfo = installPackageInfoMapper.map(it),
-            constraints = Constraints(
-              checkForFreeSpace = false,
-              networkType = UNMETERED
-            )
-          )
 
-          it.campaigns?.run {
-            toAptoideMMPCampaign().sendDownloadEvent(
-              bundleTag = null,
-              searchKeyword = null,
-              currentScreen = null,
-              isCta = false
+    coroutineScope {
+      installers.forEach { appInstaller ->
+        updates
+          .firstOrNull { it.packageName == appInstaller.packageName }
+          ?.also {
+            appInstaller.install(
+              installPackageInfo = installPackageInfoMapper.map(it),
+              constraints = Constraints(
+                checkForFreeSpace = false,
+                networkType = UNMETERED
+              )
             )
 
-            toMMPLinkerCampaign().sendDownloadEvent()
+            if (updatesNotificationsVisibilityManager.shouldShowNotification(AUTO_UPDATE_SUCCESSFUL)) {
+              launch {
+                autoUpdateGameInstallObserver.observeInstall(
+                  it,
+                  appInstaller.packageInfo?.compatVersionCode ?: 0
+                )
+              }
+            }
+
+            it.campaigns?.run {
+              toAptoideMMPCampaign().sendDownloadEvent(
+                bundleTag = null,
+                searchKeyword = null,
+                currentScreen = null,
+                isCta = false
+              )
+
+              toMMPLinkerCampaign().sendDownloadEvent()
+            }
           }
-        }
+      }
     }
   }
 }

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/presentation/UpdatesNotificationProvider.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/presentation/UpdatesNotificationProvider.kt
@@ -5,4 +5,5 @@ import cm.aptoide.pt.feature_apps.data.App
 interface UpdatesNotificationProvider {
   suspend fun showUpdatesNotification(updates: List<App>) {}
   suspend fun showVIPUpdateNotification(app: App)
+  suspend fun showSuccessAutoUpdatedGameNotification(app: App)
 }

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/presentation/UpdatesNotificationsVisibilityManager.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/presentation/UpdatesNotificationsVisibilityManager.kt
@@ -1,0 +1,49 @@
+package cm.aptoide.pt.feature_updates.presentation
+
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+import cm.aptoide.pt.feature_updates.domain.NotificationTypes
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UpdatesNotificationsVisibilityManager @Inject constructor(
+  private val featureFlags: FeatureFlags,
+) {
+
+  private var cachedAllowedNotificationTags: MutableSet<NotificationTypes> = mutableSetOf()
+
+  suspend fun shouldShowNotification(type: NotificationTypes): Boolean {
+    if (cachedAllowedNotificationTags.isEmpty()) {
+      calculateAllowedNotifications()
+    }
+    return cachedAllowedNotificationTags.contains(type)
+  }
+
+  private suspend fun calculateAllowedNotifications() {
+    val variant = featureFlags.getFlagAsString("updates_notification_type")
+    when (variant) {
+      "baseline" -> cachedAllowedNotificationTags.addAll(
+        listOf(
+          NotificationTypes.GENERAL_NOTIFICATION,
+          NotificationTypes.VIP_NOTIFICATION
+        )
+      )
+
+      "generic_only" -> cachedAllowedNotificationTags.add(NotificationTypes.GENERAL_NOTIFICATION)
+      "auto_update_off" -> cachedAllowedNotificationTags.add(NotificationTypes.VIP_NOTIFICATION)
+      "auto_update_on" -> cachedAllowedNotificationTags.add(NotificationTypes.AUTO_UPDATE_SUCCESSFUL)
+
+      else -> cachedAllowedNotificationTags.addAll(
+        listOf(
+          NotificationTypes.GENERAL_NOTIFICATION,
+          NotificationTypes.VIP_NOTIFICATION
+        )
+      )
+    }
+  }
+
+  suspend fun shouldAutoUpdateGames(): Boolean {
+    val variant = featureFlags.getFlagAsString("updates_notification_type")
+    return variant != "auto_update_off" && variant != "generic_only"
+  }
+}

--- a/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/repository/UpdatesPreferencesRepository.kt
+++ b/feature_updates/src/main/java/cm/aptoide/pt/feature_updates/repository/UpdatesPreferencesRepository.kt
@@ -45,6 +45,7 @@ class UpdatesPreferencesRepository @Inject constructor(
   private fun areSilentUpdatesUnsupported() = isMIUI() && !isMiuiOptimizationDisabled()
 
   private suspend fun shouldHideAutoUpdate(): Boolean {
-    return featureFlags.getFlag("show_auto_update_feature") == false
+    val variant = featureFlags.getFlagAsString("updates_notification_type")
+    return variant == "auto_update_off" || variant == "generic_only"
   }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR aims at implementing the experiment 7 regarding updates where some users will see only certain types of updates notifications.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] UpdatesNotificationVisibilityManager.kt

**How should this be manually tested?**

Test all variants, left steps on slack.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-505](https://aptoide.atlassian.net/browse/AND-505)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-505]: https://aptoide.atlassian.net/browse/AND-505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ