### PR TITLE
[AND-515] Fix experiment7

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
@@ -187,7 +187,7 @@ class MainActivity : AppCompatActivity() {
       val notificationPackage = it.notificationPackage
 
       notificationsAnalytics.sendExperimentNotificationClick(notificationTag!!, notificationPackage)
-      notificationsAnalytics.sendNotificationOpened(notificationTag!!, notificationPackage)
+      notificationsAnalytics.sendNotificationClicked(notificationTag!!, notificationPackage)
 
       if (notificationTag == CompanionAppsNotificationBuilder.COMPANION_APPS_NOTIFICATION_TAG) {
         notificationsAnalytics.sendRobloxNotificationClick()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_companion_apps_notification/CompanionAppsNotificationBuilder.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_companion_apps_notification/CompanionAppsNotificationBuilder.kt
@@ -99,7 +99,7 @@ class CompanionAppsNotificationBuilder @Inject constructor(
     notificationPackage: String
   ) {
     if (context.isAllowed(Manifest.permission.POST_NOTIFICATIONS)) {
-      notificationsAnalytics.sendNotificationImpression(notificationTag, notificationPackage)
+      notificationsAnalytics.sendNotificationReceived(notificationTag, notificationPackage)
       notificationsAnalytics.sendRobloxNofiticationShown()
       NotificationManagerCompat.from(context).notify(notificationId, notification)
     }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_editors_choice_recommendation/EditorsChoiceAppsRecommendationNotificationBuilder.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_editors_choice_recommendation/EditorsChoiceAppsRecommendationNotificationBuilder.kt
@@ -94,7 +94,7 @@ class EditorsChoiceAppsRecommendationNotificationBuilder @Inject constructor(
     notificationTag: String,
   ) {
     if (context.isAllowed(Manifest.permission.POST_NOTIFICATIONS)) {
-      notificationsAnalytics.sendNotificationImpression(notificationTag, null)
+      notificationsAnalytics.sendNotificationReceived(notificationTag, null)
       notificationsAnalytics.sendEditorsChoiceNotificationShown()
       NotificationManagerCompat.from(context).notify(notificationId, notification)
     }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/AppComingSoonNotificationBuilder.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/AppComingSoonNotificationBuilder.kt
@@ -99,7 +99,7 @@ class AppComingSoonNotificationBuilder @Inject constructor(
     notificationPackage: String
   ) {
     if (context.isAllowed(Manifest.permission.POST_NOTIFICATIONS)) {
-      notificationsAnalytics.sendNotificationImpression(notificationTag, notificationPackage)
+      notificationsAnalytics.sendNotificationReceived(notificationTag, notificationPackage)
       NotificationManagerCompat.from(context).notify(notificationId, notification)
     }
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/analytics/NotificationsAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/notifications/analytics/NotificationsAnalytics.kt
@@ -27,22 +27,20 @@ class NotificationsAnalytics @Inject constructor(
     params = emptyMap()
   )
 
-  fun sendNotificationOpened(notificationTag: String, notificationPackage: String?) {
+  fun sendNotificationClicked(notificationTag: String, notificationPackage: String?) {
     genericAnalytics.logEvent(
-      name = "notification_event",
+      name = "notification_clicked",
       params = mapOf(
-        NOTIFICATION_ACTION to NOTIFICATION_ACTION_CLICK,
         NOTIFICATION_TAG to notificationTag,
         NOTIFICATION_PACKAGE to (notificationPackage ?: "n-a")
       )
     )
   }
 
-  fun sendNotificationImpression(notificationTag: String, notificationPackage: String? = null) {
+  fun sendNotificationReceived(notificationTag: String, notificationPackage: String? = null) {
     genericAnalytics.logEvent(
-      name = "notification_event",
+      name = "notification_received",
       params = mapOf(
-        NOTIFICATION_ACTION to NOTIFICATION_ACTION_IMPRESSION,
         NOTIFICATION_TAG to notificationTag,
         NOTIFICATION_PACKAGE to (notificationPackage ?: "n-a")
       )
@@ -98,7 +96,6 @@ class NotificationsAnalytics @Inject constructor(
   companion object {
     internal const val NOTIFICATION_ACTION = "action"
     internal const val NOTIFICATION_ACTION_CLICK = "click"
-    internal const val NOTIFICATION_ACTION_IMPRESSION = "impression"
     internal const val NOTIFICATION_TAG = "tag"
     internal const val NOTIFICATION_PACKAGE = "package"
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/domain/UpdatesNotificationAnalyticsManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/domain/UpdatesNotificationAnalyticsManager.kt
@@ -13,6 +13,6 @@ class UpdatesNotificationAnalyticsManager @Inject constructor(
 
   suspend fun loadUserProperty() {
     val variant = featureFlags.getFlagAsString("updates_notification_type")
-    biAnalytics.setUserProperties("experiment7_updates_notification_variant" to variant)
+    biAnalytics.setUserProperties("exp7_updates_variant" to variant)
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesNotificationBuilder.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/presentation/UpdatesNotificationBuilder.kt
@@ -162,7 +162,7 @@ class UpdatesNotificationBuilder @Inject constructor(
     notificationPackage: String
   ) {
     if (context.isAllowed(Manifest.permission.POST_NOTIFICATIONS)) {
-      notificationsAnalytics.sendNotificationImpression(notificationTag, notificationPackage)
+      notificationsAnalytics.sendNotificationReceived(notificationTag, notificationPackage)
       NotificationManagerCompat.from(context).notify(notificationId, notification)
     }
   }


### PR DESCRIPTION
**What does this PR do?**

This PR aims at applying some fixes to the experiment 7. 
Separating the notification event into two based on its action.
Renaming the user property due to the max characters.

**Database changed?**

 No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Run the app and attempt to simulate all possible combinations.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-515](https://aptoide.atlassian.net/browse/AND-515)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-515]: https://aptoide.atlassian.net/browse/AND-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ