### PR TITLE
[AND-514] Use campaign id in rtb

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/presentation/AnalyticsContext.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/presentation/AnalyticsContext.kt
@@ -284,7 +284,7 @@ fun String.withHomeTab(homeTab: String?) =
   withParameter(HOME_TAB_PARAM, homeTab)
 
 
-private fun String.withParameter(
+fun String.withParameter(
   name: String,
   value: String?,
 ) = when {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -86,6 +86,7 @@ import com.aptoide.android.aptoidegames.analytics.mapOfNonNull
 import com.aptoide.android.aptoidegames.analytics.presentation.AnalyticsContext
 import com.aptoide.android.aptoidegames.analytics.presentation.rememberGeneralAnalytics
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
+import com.aptoide.android.aptoidegames.analytics.presentation.withParameter
 import com.aptoide.android.aptoidegames.appview.AppViewHeaderConstants.FEATURE_GRAPHIC_HEIGHT
 import com.aptoide.android.aptoidegames.appview.AppViewHeaderConstants.VIDEO_HEIGHT
 import com.aptoide.android.aptoidegames.appview.permissions.buildAppPermissionsRoute
@@ -143,10 +144,11 @@ private val allAppViewArguments = listOf(
   },
 )
 
-const val appViewRoute = "${APP_PATH}/{$SOURCE}?"
+const val appViewRoute =
+  "${APP_PATH}/{$SOURCE}?"
 
 fun appViewScreen() = ScreenData.withAnalytics(
-  route = appViewRoute,
+  route = "$appViewRoute$UTM_MEDIUM={$UTM_MEDIUM}&$UTM_CONTENT={$UTM_CONTENT}&$UTM_SOURCE={$UTM_SOURCE}&$UTM_CAMPAIGN={$UTM_CAMPAIGN}",
   screenAnalyticsName = "AppView",
   arguments = allAppViewArguments,
   deepLinks = listOf(
@@ -178,8 +180,18 @@ fun appViewScreen() = ScreenData.withAnalytics(
   )
 }
 
-fun buildAppViewRoute(appSource: AppSource): String =
+fun buildAppViewRoute(
+  appSource: AppSource,
+  utmCampaign: String? = "",
+  utmMedium: String? = "",
+  utmContent: String? = "",
+  utmSource: String? = ""
+): String =
   appViewRoute.replace("{$SOURCE}", appSource.asSource())
+    .withParameter(UTM_CAMPAIGN, utmCampaign)
+    .withParameter(UTM_MEDIUM, utmMedium)
+    .withParameter(UTM_CONTENT, utmContent)
+    .withParameter(UTM_SOURCE, utmSource)
 
 fun buildAppViewDeepLinkUri(appSource: AppSource) =
   BuildConfig.DEEP_LINK_SCHEMA + buildAppViewRoute(appSource)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
@@ -132,7 +132,10 @@ internal fun AppsRowView(
             analyticsContext = analyticsContext.copy(itemPosition = index)
           )
           navigate(
-            buildAppViewRoute(item)
+            buildAppViewRoute(
+              appSource = item,
+              utmCampaign = item.campaigns?.campaignId
+            )
               .withItemPosition(index)
           )
         },

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/BonusBundleMoreScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/BonusBundleMoreScreen.kt
@@ -45,6 +45,7 @@ import cm.aptoide.pt.feature_apps.presentation.AppsListUiStateProvider
 import cm.aptoide.pt.feature_apps.presentation.rememberAppsByTag
 import cm.aptoide.pt.feature_apps.presentation.rememberWalletApp
 import cm.aptoide.pt.feature_campaigns.AptoideMMPCampaign
+import cm.aptoide.pt.feature_campaigns.toAptoideMMPCampaign
 import com.aptoide.android.aptoidegames.AptoideOutlinedText
 import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.R
@@ -176,9 +177,15 @@ fun MoreBonusBundleViewContent(
   appList: List<App>,
   navigate: (String) -> Unit,
 ) {
+  val analyticsContext = AnalyticsContext.current
+  val bundleAnalytics = rememberBundleAnalytics()
+
   val navigateToApp = { app: App, index: Int? ->
     navigate(
-      buildAppViewRoute(app).withItemPosition(index)
+      buildAppViewRoute(
+        appSource = app,
+        utmCampaign = app.campaigns?.campaignId
+      ).withItemPosition(index)
     )
   }
 
@@ -192,7 +199,14 @@ fun MoreBonusBundleViewContent(
       AppItem(
         modifier = Modifier.padding(horizontal = 16.dp),
         app = app,
-        onClick = { navigateToApp(app, index) },
+        onClick = {
+          app.campaigns?.toAptoideMMPCampaign()?.sendClickEvent(analyticsContext.bundleMeta?.tag)
+          bundleAnalytics.sendAppPromoClick(
+            app = app,
+            analyticsContext = analyticsContext.copy(itemPosition = index)
+          )
+          navigateToApp(app, index)
+        },
       ) {
         InstallViewShort(app)
       }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/AptoideRTBRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/AptoideRTBRepository.kt
@@ -71,16 +71,20 @@ private fun RTBResponse.toDomainModel(campaignRepository: CampaignRepository): A
     packageName = this.packageName,
     rating = Rating(this.rating, 0, emptyList()),
     pRating = Rating(this.rating, 0, emptyList()),
-    campaigns = this.tracking.aptoideMmp?.mapRTBMMPCampaigns(campaignRepository)
+    campaigns = this.tracking.aptoideMmp?.mapRTBMMPCampaigns(campaignRepository, this.campaignId)
   )
 }
 
-private fun AptoideMmp.mapRTBMMPCampaigns(campaignRepository: CampaignRepository): CampaignImpl? {
+private fun AptoideMmp.mapRTBMMPCampaigns(
+  campaignRepository: CampaignRepository,
+  campaignId: String
+): CampaignImpl? {
   return CampaignImpl(
     impressions = this.impression?.let { listOf(CampaignTuple("aptoide-mmp", this.impression)) }
       ?: emptyList(),
     clicks = this.click?.let { listOf(CampaignTuple("aptoide-mmp", this.click)) } ?: emptyList(),
     downloads = emptyList(),
+    campaignId = campaignId,
     repository = campaignRepository
   )
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
@@ -115,9 +115,11 @@ fun installViewStates(
             } else {
               app.campaigns?.placementType = "appview"
 
+              val campaignId = app.campaigns?.deepLinkUtms?.get("utm_campaign")
               app.campaigns?.toAptoideMMPCampaign()
                 ?.sendDownloadEvent(
                   bundleTag = analyticsContext.bundleMeta?.tag,
+                  utmCampaign = campaignId,
                   searchKeyword = analyticsContext.searchMeta?.searchKeyword,
                   currentScreen = analyticsContext.currentScreen
                 )
@@ -170,9 +172,11 @@ fun installViewStates(
             } else {
               app.campaigns?.placementType = "appview"
 
+              val campaignId = app.campaigns?.deepLinkUtms?.get("utm_campaign")
               app.campaigns?.toAptoideMMPCampaign()
                 ?.sendDownloadEvent(
                   bundleTag = analyticsContext.bundleMeta?.tag,
+                  utmCampaign = campaignId,
                   searchKeyword = analyticsContext.searchMeta?.searchKeyword,
                   currentScreen = analyticsContext.currentScreen
                 )
@@ -235,9 +239,11 @@ fun installViewStates(
             } else {
               app.campaigns?.placementType = "appview"
 
+              val campaignId = app.campaigns?.deepLinkUtms?.get("utm_campaign")
               app.campaigns?.toAptoideMMPCampaign()
                 ?.sendDownloadEvent(
                   bundleTag = analyticsContext.bundleMeta?.tag,
+                  utmCampaign = campaignId,
                   searchKeyword = analyticsContext.searchMeta?.searchKeyword,
                   currentScreen = analyticsContext.currentScreen
                 )
@@ -299,9 +305,11 @@ fun installViewStates(
             } else {
               app.campaigns?.placementType = "appview"
 
+              val campaignId = app.campaigns?.deepLinkUtms?.get("utm_campaign")
               app.campaigns?.toAptoideMMPCampaign()
                 ?.sendDownloadEvent(
                   bundleTag = analyticsContext.bundleMeta?.tag,
+                  utmCampaign = campaignId,
                   searchKeyword = analyticsContext.searchMeta?.searchKeyword,
                   currentScreen = analyticsContext.currentScreen
                 )

--- a/feature_campaigns/src/main/java/cm/aptoide/pt/feature_campaigns/AptoideMMPCampaign.kt
+++ b/feature_campaigns/src/main/java/cm/aptoide/pt/feature_campaigns/AptoideMMPCampaign.kt
@@ -33,7 +33,7 @@ class AptoideMMPCampaign(
         buildReplaceMap(packageName),
         buildBaseMap(
           utmMedium = allowedBundleTags[bundleTag]?.first,
-          utmCampaign = allowedBundleTags[bundleTag]?.second
+          utmCampaign = campaign.campaignId ?: allowedBundleTags[bundleTag]?.second
         )
       )
     }
@@ -50,7 +50,7 @@ class AptoideMMPCampaign(
         buildReplaceMap(),
         buildAppendMap(
           utmMedium = allowedBundleTags[bundleTag]?.first,
-          utmCampaign = allowedBundleTags[bundleTag]?.second,
+          utmCampaign = campaign.campaignId ?: allowedBundleTags[bundleTag]?.second,
           isCta = isCta,
         )
       )

--- a/feature_campaigns/src/main/java/cm/aptoide/pt/feature_campaigns/CampaignImpl.kt
+++ b/feature_campaigns/src/main/java/cm/aptoide/pt/feature_campaigns/CampaignImpl.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.withContext
 
 interface Campaign {
   val adListId: String?
+  val campaignId: String?
 
   //TODO Refactor This Later - Not very good architecturally
   val placementType: String?
@@ -40,6 +41,7 @@ data class CampaignImpl constructor(
   private val impressions: List<CampaignTuple>,
   private val clicks: List<CampaignTuple>,
   val downloads: List<CampaignTuple>,
+  override val campaignId: String? = null,
   private val repository: CampaignRepository,
 ) : Campaign {
   override var adListId: String? = null


### PR DESCRIPTION
**What does this PR do?**

This PR aims at implementing campaign id usage in the RTB bundle. We also had to pass it to the the appview in order to convert the download urls. 


**Database changed?**

 No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Click and make the downloads in the rtb bundle both from home and see more view.
Note that the downloads done specifically in the see more view, using that button, instead of the the appview, won't have the campaign id because we are currently not receiving the download mmp urls in the rtb response. This was already aligned with the Apptech team and will be done in the future.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-514](https://aptoide.atlassian.net/browse/AND-514)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-514]: https://aptoide.atlassian.net/browse/AND-514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ