### PR TITLE
[AND-527] refactor user properties

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/AnalyticsSender.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/AnalyticsSender.kt
@@ -3,7 +3,7 @@ package com.aptoide.android.aptoidegames.analytics
 import androidx.annotation.Size
 
 interface AnalyticsSender {
-  fun setUserProperties(vararg props: Pair<String, Any?>) {}
+  fun setUserProperties(vararg props: UserProperty) {}
 
   fun logEvent(
     @Size(min = 1L, max = 40L) name: String,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/BIAnalytics.kt
@@ -23,12 +23,12 @@ import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_APP_OB
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_APP_VERSION_CODE
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_CONTEXT
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_INSERTED_KEYWORD
-import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_TAB
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_PACKAGE_NAME
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_PREVIOUS_CONTEXT
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_SEARCH_TERM
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_SEARCH_TERM_POSITION
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_SEARCH_TERM_SOURCE
+import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_TAB
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics.Companion.P_TAG
 import com.aptoide.android.aptoidegames.analytics.dto.AnalyticsUIContext
 import com.aptoide.android.aptoidegames.analytics.dto.SearchMeta
@@ -59,42 +59,42 @@ class BIAnalytics(private val analyticsSender: AnalyticsSender) {
       Indicative.setUniqueID(analyticsInfoProvider.getAnalyticsId())
 
       analyticsSender.setUserProperties(
-        "android_api_level" to VERSION.SDK_INT,
-        "aptoide_version_code" to BuildConfig.VERSION_CODE,
-        "android_brand" to Build.MANUFACTURER,
-        "android_model" to Build.MODEL,
-        "aptoide_package" to BuildConfig.APPLICATION_ID,
-        "aptoide_store" to BuildConfig.MARKET_NAME,
-        "android_language" to "${locale.language}-${locale.country}",
-        "theme" to "dark",
-        "logged_in" to "NA",
-        "gms" to context.getGMSValue()
+        UserProperty("android_api_level", VERSION.SDK_INT),
+        UserProperty("aptoide_version_code", BuildConfig.VERSION_CODE),
+        UserProperty("android_brand", Build.MANUFACTURER),
+        UserProperty("android_model", Build.MODEL),
+        UserProperty("aptoide_package", BuildConfig.APPLICATION_ID),
+        UserProperty("aptoide_store", BuildConfig.MARKET_NAME),
+        UserProperty("android_language", "${locale.language}-${locale.country}"),
+        UserProperty("theme", "dark"),
+        UserProperty("logged_in", "NA"),
+        UserProperty("gms", context.getGMSValue())
       )
       installManager
         .getApp("com.dti.folderlauncher")
         .packageInfoFlow
         .map { it != null }
-        .onEach { setUserProperties("is_gh_installed" to it) }
+        .onEach { setUserProperties(UserProperty("is_gh_installed", it)) }
         .launchIn(this)
       installManager
         .getApp("cm.aptoide.pt")
         .packageInfoFlow
         .map { it != null }
-        .onEach { setUserProperties("is_vanilla_installed" to it) }
+        .onEach { setUserProperties(UserProperty("is_vanilla_installed", it)) }
         .launchIn(this)
       installManager
         .getApp(walletApp.packageName)
         .packageInfoFlow
         .map { it != null }
-        .onEach { setUserProperties("is_wallet_app_installed" to it) }
+        .onEach { setUserProperties(UserProperty("is_wallet_app_installed", it)) }
         .launchIn(this)
 
-      setUserProperties("first_session" to isFirstLaunch)
+      setUserProperties(UserProperty("first_session", isFirstLaunch))
       setFeatureFlagsProperties(featureFlags)
     }
   }
 
-  fun setUserProperties(vararg props: Pair<String, Any?>) =
+  fun setUserProperties(vararg props: UserProperty) =
     analyticsSender.setUserProperties(*props)
 
   private suspend fun setFeatureFlagsProperties(featureFlags: FeatureFlags) {
@@ -108,7 +108,7 @@ class BIAnalytics(private val analyticsSender: AnalyticsSender) {
         else -> "NA"
       }
 
-    analyticsSender.setUserProperties("ab_test_apkfy_may_21" to testGroup)
+    analyticsSender.setUserProperties(UserProperty("ab_test_apkfy_may_21", testGroup))
   }
 
   fun setUTMProperties(
@@ -120,13 +120,13 @@ class BIAnalytics(private val analyticsSender: AnalyticsSender) {
     utmOemId: String?,
     utmPackageName: String?,
   ) = analyticsSender.setUserProperties(
-    "utm_source" to utmSource,
-    "utm_medium" to utmMedium,
-    "utm_campaign" to utmCampaign,
-    "utm_term" to utmTerm,
-    "utm_content" to utmContent,
-    "utm_oem_id" to utmOemId,
-    "utm_package_name" to utmPackageName,
+    UserProperty("utm_source", utmSource),
+    UserProperty("utm_medium", utmMedium),
+    UserProperty("utm_campaign", utmCampaign),
+    UserProperty("utm_term", utmTerm),
+    UserProperty("utm_content", utmContent),
+    UserProperty("utm_oem_id", utmOemId),
+    UserProperty("utm_package_name", utmPackageName),
   )
 
   fun sendFirstLaunchEvent() = analyticsSender.logEvent(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/FirebaseAnalyticsSender.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/FirebaseAnalyticsSender.kt
@@ -12,11 +12,11 @@ import javax.inject.Singleton
 class FirebaseAnalyticsSender @Inject constructor(
   private val firebaseAnalytics: FirebaseAnalytics,
 ) : AnalyticsSender {
-  override fun setUserProperties(vararg props: Pair<String, Any?>) = props.forEach {
+  override fun setUserProperties(vararg props: UserProperty) = props.forEach {
     if (BuildConfig.DEBUG) {
-      Timber.tag("GA").i("set UP  ${it.first} = ${it.second}")
+      Timber.tag("GA").i("set UP  ${it.name} = ${it.value}")
     }
-    firebaseAnalytics.setUserProperty(it.first, it.second?.toString())
+    firebaseAnalytics.setUserProperty(it.name, it.value?.toString())
   }
 
   override fun logEvent(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/GenericAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/GenericAnalytics.kt
@@ -30,13 +30,13 @@ class GenericAnalytics(private val analyticsSender: AnalyticsSender) {
     themePreferencesManager
       .isDarkTheme()
       .map { if (it ?: context.isNightMode) "system_dark" else "system_light" }
-      .onEach { analyticsSender.setUserProperties("theme" to it) }
+      .onEach { analyticsSender.setUserProperties(UserProperty("theme", it)) }
       .launchIn(CoroutineScope(Dispatchers.IO))
     installManager
       .getApp(walletApp.packageName)
       .packageInfoFlow
       .map { (it != null).toString() }
-      .onEach { analyticsSender.setUserProperties("wallet_installed" to it) }
+      .onEach { analyticsSender.setUserProperties(UserProperty("wallet_installed", it)) }
       .launchIn(CoroutineScope(Dispatchers.IO))
   }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/IndicativeAnalyticsSender.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/IndicativeAnalyticsSender.kt
@@ -9,17 +9,18 @@ import javax.inject.Singleton
 
 @Singleton
 class IndicativeAnalyticsSender @Inject constructor() : AnalyticsSender {
-  override fun setUserProperties(vararg props: Pair<String, Any?>) {
+  override fun setUserProperties(vararg props: UserProperty) {
     if (BuildConfig.DEBUG) {
       props.forEach {
-        Timber.tag("BA").i("set UP  ${it.first} = ${it.second}")
+        Timber.tag("BA").i("set UP  ${it.name} = ${it.value}")
       }
     }
     //Add new properties
-    Indicative.addProperties(props.toMap())
+    val map = props.associate { it.name to it.value }
+    Indicative.addProperties(map)
 
     //Remove properties with null values
-    props.filter { it.second == null }.forEach { Indicative.removeProperty(it.first) }
+    props.filter { it.value == null }.forEach { Indicative.removeProperty(it.name) }
   }
 
   override fun logEvent(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/MultipleAnalyticsSender.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/MultipleAnalyticsSender.kt
@@ -9,7 +9,7 @@ class MultipleAnalyticsSender @Inject constructor(
   private val analyticsSenderList: List<AnalyticsSender>
 ) : AnalyticsSender {
 
-  override fun setUserProperties(vararg props: Pair<String, Any?>) {
+  override fun setUserProperties(vararg props: UserProperty) {
     for (analyticsSender in analyticsSenderList) {
       analyticsSender.setUserProperties(*props)
     }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/UserProperty.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/UserProperty.kt
@@ -1,0 +1,8 @@
+package com.aptoide.android.aptoidegames.analytics
+
+import androidx.annotation.Size
+
+data class UserProperty(
+  @Size(min = 1L, max = 24L) val name: String,
+  @Size(min = 1L, max = 36L) val value: Any?
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyModel
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
+import com.aptoide.android.aptoidegames.analytics.UserProperty
 import com.aptoide.android.aptoidegames.analytics.mapOfNonNull
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -14,9 +15,8 @@ class ApkfyAnalytics @Inject constructor(
   @ApplicationContext private val context: Context,
 ) {
 
-  fun setGuestUIDUserProperty(guestUid: String) = biAnalytics.setUserProperties(
-    "aptoide_mmp_guest_id" to guestUid
-  )
+  fun setGuestUIDUserProperty(guestUid: String) =
+    biAnalytics.setUserProperties(UserProperty("aptoide_mmp_guest_id", guestUid))
 
   fun sendApkfySuccessEvent(
     data: String,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/analytics/HomeAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/analytics/HomeAnalytics.kt
@@ -3,6 +3,7 @@ package com.aptoide.android.aptoidegames.home.analytics
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics.Companion.P_NAME
+import com.aptoide.android.aptoidegames.analytics.UserProperty
 
 class HomeAnalytics(
   private val genericAnalytics: GenericAnalytics,
@@ -10,7 +11,7 @@ class HomeAnalytics(
 ) {
 
   fun setECVideoFlagProperty(variant: String) =
-    biAnalytics.setUserProperties("ab_test_ec_videos_jan_29" to variant)
+    biAnalytics.setUserProperties(UserProperty("ab_test_ec_videos_jan_29", variant))
 
   fun sendECVideosFlagReady() =
     genericAnalytics.logEvent("ec_videos_flag_ready", params = emptyMap())

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalyticsImpl.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalyticsImpl.kt
@@ -10,6 +10,7 @@ import cm.aptoide.pt.feature_flags.domain.FeatureFlags
 import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
+import com.aptoide.android.aptoidegames.analytics.UserProperty
 import com.aptoide.android.aptoidegames.analytics.asNullableParameter
 import com.aptoide.android.aptoidegames.analytics.dto.AnalyticsUIContext
 import com.aptoide.android.aptoidegames.analytics.dto.InstallAction
@@ -37,12 +38,17 @@ class InstallAnalyticsImpl(
 
   init {
     CoroutineScope(Dispatchers.Main).launch {
-      biAnalytics.setUserProperties("downloader_variant" to featureFlags.getDownloaderVariant())
+      biAnalytics.setUserProperties(
+        UserProperty(
+          "downloader_variant",
+          featureFlags.getDownloaderVariant()
+        )
+      )
     }
   }
 
   override fun setUsedInstallerProperty(installerUsed: String) {
-    biAnalytics.setUserProperties("installer" to installerUsed)
+    biAnalytics.setUserProperties(UserProperty("installer", installerUsed))
   }
 
   override fun sendClickEvent(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/domain/UpdatesNotificationAnalyticsManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/updates/domain/UpdatesNotificationAnalyticsManager.kt
@@ -2,6 +2,7 @@ package com.aptoide.android.aptoidegames.updates.domain
 
 import cm.aptoide.pt.feature_flags.domain.FeatureFlags
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
+import com.aptoide.android.aptoidegames.analytics.UserProperty
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -13,6 +14,6 @@ class UpdatesNotificationAnalyticsManager @Inject constructor(
 
   suspend fun loadUserProperty() {
     val variant = featureFlags.getFlagAsString("updates_notification_type")
-    biAnalytics.setUserProperties("exp7_updates_variant" to variant)
+    biAnalytics.setUserProperties(UserProperty("exp7_updates_variant", variant))
   }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR aims at refactoring the user properties so that we can add a warning to character limit, since firebase only allows user properties with max 24 characters 

**Database changed?**

No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Confirm if all user properties are working fine. 
Try to edit a user property to make it longer than 24 characters and confirm that it shows an error.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-527](https://aptoide.atlassian.net/browse/AND-527)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-527]: https://aptoide.atlassian.net/browse/AND-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ