### PR TITLE
[AND-692] Fix session sync after heartbeat exception responses

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEForegroundService.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEForegroundService.kt
@@ -57,7 +57,8 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
   override val savedStateRegistry: SavedStateRegistry
     get() = savedStateRegistryController.savedStateRegistry
 
-  private val pollingInterval = 6_000L
+  private val pollingIntervalMillis = 10_000L
+  private val pollingIntervalSec = pollingIntervalMillis.toInt() / 1_000
   private var pollingJob: Job? = null
   private var completedMissionsJob: Job? = null
   private var isMonitoringStarted = false
@@ -157,7 +158,7 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
       pollingJob = lifecycleScope.launch(Dispatchers.IO) {
         while (isActive) {
           syncService()
-          delay(pollingInterval)
+          delay(pollingIntervalMillis)
         }
       }
     }
@@ -196,7 +197,7 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
           }
         } else {
           // Same package still in foreground - sync active sessions
-          paESessionManager.syncSessions(lastForegroundPackage)
+          paESessionManager.syncSessions(lastForegroundPackage, pollingIntervalSec)
         }
       }
 


### PR DESCRIPTION
**What does this PR do?**

   - Fixes session sync after heartbeat exception responses, by updating the last sync time and incrementing heartbeat sequence even after failure responses.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-692](https://aptoide.atlassian.net/browse/AND-692)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-692](https://aptoide.atlassian.net/browse/AND-692)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-692]: https://aptoide.atlassian.net/browse/AND-692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-692]: https://aptoide.atlassian.net/browse/AND-692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session state management to properly handle both successful and failed synchronization scenarios, ensuring consistent tracking of session data even when network operations encounter issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->