### PR TITLE
 [AND-634] Add timer and polling for GameGenie overlay screenshot availability

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieOverlay.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieOverlay.kt
@@ -43,6 +43,7 @@ fun GameGenieOverlay(
   showMenu: Boolean,
   isAptoideGamesInForeground: Boolean,
   targetAppIcon: ImageBitmap?,
+  isCaptureReady: Boolean,
   onMenuToggle: () -> Unit,
   onDrag: (dx: Int, dy: Int) -> Unit,
   onDragEnd: () -> Unit,
@@ -59,6 +60,7 @@ fun GameGenieOverlay(
       GameGenieIconFab(
         isAptoideGamesInForeground = isAptoideGamesInForeground,
         targetAppIcon = targetAppIcon,
+        isCaptureReady = isCaptureReady,
         modifier = Modifier
           .pointerInput(Unit) {
             var totalDragDistance = 0f
@@ -79,10 +81,16 @@ fun GameGenieOverlay(
             )
           },
         onClick = {
-          analytics.sendGameGenieOverlayClick()
-          onScreenshotRequest()
+          if (isCaptureReady) {
+            analytics.sendGameGenieOverlayClick()
+            onScreenshotRequest()
+          }
         },
-        onLongClick = { onMenuToggle() }
+        onLongClick = { 
+          if (isCaptureReady) {
+            onMenuToggle()
+          }
+        }
       )
     }
 
@@ -181,6 +189,7 @@ fun GameGenieIconFab(
   modifier: Modifier = Modifier,
   isAptoideGamesInForeground: Boolean,
   targetAppIcon: ImageBitmap? = null,
+  isCaptureReady: Boolean = false,
   onClick: () -> Unit = {},
   onLongClick: () -> Unit = {},
 ) {
@@ -189,16 +198,19 @@ fun GameGenieIconFab(
     contentAlignment = Alignment.Center
   ) {
     val iconSize = if (isAptoideGamesInForeground) 48.dp else 40.dp
+    val alpha = if (isCaptureReady) 1f else 0.5f
     val iconModifier = Modifier
       .size(iconSize)
       .graphicsLayer {
         shadowElevation = 4.dp.toPx()
         shape = CircleShape
+        this.alpha = alpha
         val shadowOffset = if (isAptoideGamesInForeground) - 4.dp.toPx() else 0f
         translationY = shadowOffset
         translationX = shadowOffset
       }
       .combinedClickable(
+        enabled = isCaptureReady,
         onClick = onClick,
         onLongClick = onLongClick
       )
@@ -243,7 +255,8 @@ fun GameGenieIconFab(
 private fun GameGenieIconFabForegroundPreview() {
   GameGenieIconFab(
     isAptoideGamesInForeground = true,
-    targetAppIcon = ImageBitmap(20, 20)
+    targetAppIcon = ImageBitmap(20, 20),
+    isCaptureReady = true
   )
 }
 
@@ -251,6 +264,7 @@ private fun GameGenieIconFabForegroundPreview() {
 @Composable
 private fun GameGenieIconFabBackgroundPreview() {
   GameGenieIconFab(
-    isAptoideGamesInForeground = false
+    isAptoideGamesInForeground = false,
+    isCaptureReady = true
   )
 }


### PR DESCRIPTION
**What does this PR do?**

   This PR aims to add an initial 2 seconds delay and polling mechanism to make sure users do not take screenshot as soon as the game opens and mediaProjection is not ready

**Database changed?**

   No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Try overlay and see if it works

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-634](https://aptoide.atlassian.net/browse/AND-634)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-634]: https://aptoide.atlassian.net/browse/AND-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Game Genie overlay now displays capture readiness state with visual indicators.

* **Improvements**
  * Icon opacity and interaction state are now tied to system capture availability.
  * System continuously monitors capture capability and updates the interface accordingly.
  * Disabled state provides clear visual feedback when capture is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->