### PR TITLE
[AND-699] Fix ForegroundServiceDidNotStartInTimeException after P&E permission flow

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEForegroundService.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEForegroundService.kt
@@ -70,6 +70,9 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
   override fun onCreate() {
     super.onCreate()
 
+    // Start foreground immediately to prevent crash if service gets stopped on initialization
+    startForegroundWithNotification()
+
     savedStateRegistryController.performAttach()
     savedStateRegistryController.performRestore(null)
 
@@ -90,8 +93,6 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
     super.onStartCommand(intent, flags, startId)
-
-    startForegroundWithNotification()
 
     if (!applicationContext.hasUsageStatsPermissionStatus() || !applicationContext.hasOverlayPermission()) {
       stopSelf()


### PR DESCRIPTION
**What does this PR do?**

   - Moves the initialization of the P&E foreground service notification to onCreate, to avoid crashes if the service is stopped early.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-699](https://aptoide.atlassian.net/browse/AND-699)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-699](https://aptoide.atlassian.net/browse/AND-699)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-699]: https://aptoide.atlassian.net/browse/AND-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-699]: https://aptoide.atlassian.net/browse/AND-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ