### PR TITLE
[AND-701] Hide login if PaE is not available or unsupported

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -73,6 +73,7 @@ import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.Pa
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.sign_in.GoogleSignInViewModel
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.sign_in.playAndEarnSignInRoute
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.sign_in.rememberUserInfo
+import com.aptoide.android.aptoidegames.play_and_earn.rememberShouldShowPlayAndEarn
 import com.aptoide.android.aptoidegames.terms_and_conditions.ppUrl
 import com.aptoide.android.aptoidegames.terms_and_conditions.tcUrl
 import com.aptoide.android.aptoidegames.theme.AGTypography
@@ -303,20 +304,24 @@ private fun CurrentUserHeader(
   modifier: Modifier = Modifier,
   onLetsGoClick: () -> Unit,
 ) {
-  userInfo?.let {
+  val shouldShowPlayAndEarn = rememberShouldShowPlayAndEarn()
+
+  if (userInfo != null) {
     Column(
       modifier = modifier.fillMaxWidth(),
     ) {
       CurrentUserInfoSection(
-        userInfo = it,
+        userInfo = userInfo,
         modifier = Modifier.padding(horizontal = 16.dp)
       )
       SettingsSectionDivider()
     }
-  } ?: PaESettingsLetsGoCard(
-    modifier = modifier.padding(horizontal = 16.dp),
-    onLetsGoClick = onLetsGoClick
-  )
+  } else if (shouldShowPlayAndEarn) {
+    PaESettingsLetsGoCard(
+      modifier = modifier.padding(horizontal = 16.dp),
+      onLetsGoClick = onLetsGoClick
+    )
+  }
 }
 
 @Composable


### PR DESCRIPTION
**What does this PR do?**

   - Hides the login entry point in the Settings screen, in case the PaE feature is not available or is unsupported on the device.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-701](https://aptoide.atlassian.net/browse/AND-701)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-701](https://aptoide.atlassian.net/browse/AND-701)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-701]: https://aptoide.atlassian.net/browse/AND-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-701]: https://aptoide.atlassian.net/browse/AND-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ