### PR TITLE
[AND-710] Fix reemission of installer session intents

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/UserActionDialog.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/UserActionDialog.kt
@@ -122,7 +122,8 @@ fun UserActionDialog() {
                   .getStringExtra("${BuildConfig.APPLICATION_ID}.ap").toAnalyticsPayload()
                 installAnalytics.sendInstallDialogImpressionEvent(packageName, analyticsPayload)
               }
-              val sessionId = it.intent.extras?.getInt("android.content.pm.extra.SESSION_ID")
+              val sessionId =
+                it.intent.extras?.getInt("android.content.pm.extra.SESSION_ID")?.takeIf { it != 0 }
               val sessionInfo = sessionId?.let {
                 context.packageManager.packageInstaller.getSessionInfo(it)
               }
@@ -130,6 +131,7 @@ fun UserActionDialog() {
               if (sessionId == null || sessionInfo != null) {
                 intentLauncher.launch(it.intent)
               } else {
+                //Record exception in cases where the session id is available but the session is not available anymore
                 Firebase.crashlytics.recordException(IllegalStateException("Error getting session info. Install dialog not launched"))
               }
 

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/UserActionHandler.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/UserActionHandler.kt
@@ -55,7 +55,8 @@ interface UserActionHandler {
 @Singleton
 class UserActionHandlerImpl @Inject constructor() : UserActionLauncher, UserActionHandler {
 
-  private val _requests = MutableSharedFlow<UserActionRequest?>()
+  private val _requests =
+    MutableSharedFlow<UserActionRequest?>(replay = 1, extraBufferCapacity = 10)
 
   override val requests: Flow<UserActionRequest?> = _requests
 


### PR DESCRIPTION
**What does this PR do?**

   - Fixes reemission of installer session intents, which makes intent reach UI and be launched even after process recreation.
   - Fixes check for session id presence and availability, which solves issues in case of installer related intents which don't contain session ids (for example, uninstall intents).

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: 
  - [AND-710](https://aptoide.atlassian.net/browse/AND-710)
  - [AND-680](https://aptoide.atlassian.net/browse/AND-680) 

**What are the relevant tickets?**

  Tickets related to this pull-request: 
  - [AND-710](https://aptoide.atlassian.net/browse/AND-710)
  - [AND-680](https://aptoide.atlassian.net/browse/AND-680) 

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-710]: https://aptoide.atlassian.net/browse/AND-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-680]: https://aptoide.atlassian.net/browse/AND-680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-710]: https://aptoide.atlassian.net/browse/AND-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-680]: https://aptoide.atlassian.net/browse/AND-680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid session IDs during app installation to prevent crashes.
  * Enhanced installer request processing with better buffering and subscription behavior for increased reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->