### PR TITLE
[AND-711] Fix PaE analytics events name size issues

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/GenericAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/analytics/GenericAnalytics.kt
@@ -2,6 +2,7 @@ package com.aptoide.android.aptoidegames.analytics
 
 import android.content.Context
 import android.content.res.Configuration
+import androidx.annotation.Size
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.walletApp
 import cm.aptoide.pt.install_manager.InstallManager
@@ -45,7 +46,7 @@ class GenericAnalytics(private val analyticsSender: AnalyticsSender) {
       resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
 
   fun logEvent(
-    name: String,
+    @Size(min = 1L, max = 40L) name: String,
     params: Map<String, Any>?,
   ) = analyticsSender.logEvent(name, params)
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/analytics/PaEAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/analytics/PaEAnalytics.kt
@@ -88,14 +88,14 @@ class PaEAnalytics @Inject constructor(
 
   fun sendPaEPermissionRestrictedSettingsClick() {
     genericAnalytics.logEvent(
-      name = "playandearn_steps_permission_restricted_settings_click",
+      name = "playandearn_perms_restricted_click",
       params = null
     )
   }
 
   fun sendPaEFinalPermissionsClick() {
     genericAnalytics.logEvent(
-      name = "playandearn_steps_final_permissions_click",
+      name = "playandearn_perms_final_click",
       params = null
     )
   }


### PR DESCRIPTION
**What does this PR do?**

   - Fixes PaE analytics events name size issues, by reducing the length to respect firebase naming rules.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-711](https://aptoide.atlassian.net/browse/AND-711)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-711](https://aptoide.atlassian.net/browse/AND-711)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-711]: https://aptoide.atlassian.net/browse/AND-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-711]: https://aptoide.atlassian.net/browse/AND-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ