### PR TITLE
 [AND-693] Add cache for companion games list

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
@@ -39,6 +39,7 @@ import com.aptoide.android.aptoidegames.device_info.DeviceSecurityChecker
 import com.aptoide.android.aptoidegames.device_info.analytics.DeviceInfoAnalytics
 import com.aptoide.android.aptoidegames.feature_ad.Mintegral
 import com.aptoide.android.aptoidegames.feature_companion_apps_notification.CompanionAppsManager
+import com.aptoide.android.aptoidegames.gamegenie.presentation.CompanionGamesCachePreloader
 import com.aptoide.android.aptoidegames.feature_editors_choice_recommendation.EditorsChoiceRecommendationManager
 import com.aptoide.android.aptoidegames.feature_payments.analytics.AGLogger
 import com.aptoide.android.aptoidegames.home.repository.ThemePreferencesManager
@@ -135,6 +136,9 @@ class AptoideApplication : Application(), ImageLoaderFactory, Provider {
   lateinit var companionAppsManager: CompanionAppsManager
 
   @Inject
+  lateinit var companionGamesCachePreloader: CompanionGamesCachePreloader
+
+  @Inject
   lateinit var editorsChoiceRecommendationManager: EditorsChoiceRecommendationManager
 
   @Inject
@@ -163,6 +167,7 @@ class AptoideApplication : Application(), ImageLoaderFactory, Provider {
     MMPLinkerCampaign.init(BuildConfig.OEMID)
     initAds()
     initCompanionAppsManager()
+    initCompanionGamesCachePreloader()
     initTrendingAppsRecommendationManager()
     sendDeviceSecurityAnalytics()
   }
@@ -185,6 +190,12 @@ class AptoideApplication : Application(), ImageLoaderFactory, Provider {
   private fun initCompanionAppsManager() {
     CoroutineScope(Dispatchers.IO).launch {
       companionAppsManager.initialize()
+    }
+  }
+
+  private fun initCompanionGamesCachePreloader() {
+    CoroutineScope(Dispatchers.IO).launch {
+      companionGamesCachePreloader.initialize()
     }
   }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/GameCompanionsRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/GameCompanionsRepository.kt
@@ -1,0 +1,9 @@
+package com.aptoide.android.aptoidegames.gamegenie.data
+
+import com.aptoide.android.aptoidegames.gamegenie.domain.GameCompanion
+import kotlinx.coroutines.flow.Flow
+
+interface GameCompanionsRepository {
+  fun getCompanionGames(): Flow<List<GameCompanion>>
+  suspend fun warmUpCache()
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/GameCompanionsRepositoryImpl.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/GameCompanionsRepositoryImpl.kt
@@ -1,0 +1,157 @@
+package com.aptoide.android.aptoidegames.gamegenie.data
+
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import cm.aptoide.pt.feature_categories.data.CategoriesRepository
+import cm.aptoide.pt.install_manager.App
+import cm.aptoide.pt.install_manager.InstallManager
+import com.aptoide.android.aptoidegames.gamegenie.data.database.CachedCompanionGameDao
+import com.aptoide.android.aptoidegames.gamegenie.data.database.model.CachedCompanionGameEntity
+import com.aptoide.android.aptoidegames.gamegenie.data.database.model.GameCompanionEntity
+import com.aptoide.android.aptoidegames.gamegenie.domain.GameCompanion
+import com.aptoide.android.aptoidegames.gamegenie.presentation.GameGenieManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val COMPANION_GAMES_CACHE_TTL_MS = 3L * 24 * 60 * 60 * 1000
+
+private fun isCompanionGamesCacheValid(updatedAtMs: Long, nowMs: Long): Boolean =
+  updatedAtMs > 0L && (nowMs - updatedAtMs) < COMPANION_GAMES_CACHE_TTL_MS
+
+@Singleton
+class GameCompanionsRepositoryImpl @Inject constructor(
+  private val gameGenieManager: GameGenieManager,
+  private val cachedCompanionGameDao: CachedCompanionGameDao,
+  private val packageManager: PackageManager,
+  private val installManager: InstallManager,
+  private val categoriesRepository: CategoriesRepository,
+) : GameCompanionsRepository {
+
+  override fun getCompanionGames(): Flow<List<GameCompanion>> {
+    val apps = installManager.installedApps.toMutableSet()
+
+    val installedAppsFlow: Flow<List<PackageInfo>> = installManager.appsChanges
+      .map { apps.apply { add(it) } }
+      .onStart { emit(apps) }
+      .map { set -> filterGames(set.mapNotNull(App::packageInfo)) }
+
+    val liveFlow = combine(
+      gameGenieManager.getAllGameCompanions(),
+      installedAppsFlow
+    ) { companionsFromDb, installedPackages ->
+      buildGameCompanionsList(companionsFromDb, installedPackages)
+    }.onEach { games ->
+      val nowMs = System.currentTimeMillis()
+      val cacheEntries = games.map {
+        CachedCompanionGameEntity(
+          packageName = it.packageName,
+          name = it.name,
+          versionName = it.versionName,
+          cachedAtMs = nowMs,
+        )
+      }
+      cachedCompanionGameDao.replaceAll(cacheEntries)
+    }
+
+    return flow {
+      val nowMs = System.currentTimeMillis()
+      val cachedAtMs = cachedCompanionGameDao.getLatestTimestamp()
+      if (isCompanionGamesCacheValid(cachedAtMs, nowMs)) {
+        val cachedGames = cachedCompanionGameDao.getAllCachedOnce()
+          .mapNotNull(::toInstalledGameCompanion)
+        if (cachedGames.isNotEmpty()) {
+          emit(cachedGames)
+        }
+      }
+      emitAll(liveFlow)
+    }.flowOn(Dispatchers.IO)
+  }
+
+  override suspend fun warmUpCache() {
+    withContext(Dispatchers.IO) {
+      val nowMs = System.currentTimeMillis()
+      val cachedAtMs = cachedCompanionGameDao.getLatestTimestamp()
+      if (isCompanionGamesCacheValid(cachedAtMs, nowMs)) return@withContext
+      getCompanionGames().take(1).collect {}
+    }
+  }
+
+  private fun buildGameCompanionsList(
+    companionsFromDb: List<GameCompanionEntity>,
+    installedPackages: List<PackageInfo>,
+  ): List<GameCompanion> {
+    val installedMap = installedPackages.associateBy { it.packageName }
+
+    val orderedFromDb = companionsFromDb
+      .filter { installedMap.containsKey(it.gamePackageName) }
+      .map { entity ->
+        val pkg = installedMap[entity.gamePackageName]!!
+        pkg.toGameCompanion()
+      }
+
+    val missingFromDb = installedPackages
+      .filterNot { pkg -> companionsFromDb.any { it.gamePackageName == pkg.packageName } }
+      .sortedByDescending { it.firstInstallTime }
+      .map { pkg -> pkg.toGameCompanion() }
+
+    return orderedFromDb + missingFromDb
+  }
+
+  private suspend fun filterGames(appsList: List<PackageInfo>): List<PackageInfo> {
+    val gamesPackageInfoList = ArrayList<PackageInfo>()
+    val undefinedPackageInfoMap = HashMap<String, PackageInfo>()
+    appsList.forEach { packageInfo ->
+      when (packageInfo.applicationInfo?.category) {
+        ApplicationInfo.CATEGORY_GAME -> gamesPackageInfoList.add(packageInfo)
+        else -> undefinedPackageInfoMap[packageInfo.packageName] = packageInfo
+      }
+    }
+    try {
+      categoriesRepository.getAppsCategories(undefinedPackageInfoMap.keys.toList())
+        .forEach { appCategory ->
+          when (appCategory.type) {
+            "GAME" -> undefinedPackageInfoMap[appCategory.name]?.let {
+              gamesPackageInfoList.add(it)
+            }
+          }
+        }
+    } catch (e: IOException) {
+      e.printStackTrace()
+    }
+    return gamesPackageInfoList
+  }
+
+  private fun toInstalledGameCompanion(entity: CachedCompanionGameEntity): GameCompanion? {
+    val packageInfo = runCatching {
+      packageManager.getPackageInfo(entity.packageName, 0)
+    }.getOrNull() ?: return null
+
+    return packageInfo.toGameCompanion(
+      name = entity.name,
+      versionName = entity.versionName
+    )
+  }
+
+  private fun PackageInfo.toGameCompanion(
+    name: String = applicationInfo?.loadLabel(packageManager)?.toString() ?: packageName,
+    versionName: String? = this.versionName,
+  ): GameCompanion = GameCompanion(
+    name = name,
+    packageName = packageName,
+    versionName = versionName,
+    image = applicationInfo?.loadIcon(packageManager)
+  )
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/CachedCompanionGameDao.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/CachedCompanionGameDao.kt
@@ -1,0 +1,35 @@
+package com.aptoide.android.aptoidegames.gamegenie.data.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.aptoide.android.aptoidegames.gamegenie.data.database.model.CachedCompanionGameEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+abstract class CachedCompanionGameDao {
+
+  @Query("SELECT * FROM CachedCompanionGame")
+  abstract fun getAllCached(): Flow<List<CachedCompanionGameEntity>>
+
+  @Query("SELECT * FROM CachedCompanionGame")
+  abstract suspend fun getAllCachedOnce(): List<CachedCompanionGameEntity>
+
+  @Query("SELECT COALESCE(MAX(cachedAtMs), 0) FROM CachedCompanionGame")
+  abstract suspend fun getLatestTimestamp(): Long
+
+  @Transaction
+  open suspend fun replaceAll(games: List<CachedCompanionGameEntity>) {
+    if (games.isEmpty()) return
+    clearAll()
+    insertAll(games)
+  }
+
+  @Query("DELETE FROM CachedCompanionGame")
+  abstract suspend fun clearAll()
+
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  abstract suspend fun insertAll(games: List<CachedCompanionGameEntity>)
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/GameGenieDatabase.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/GameGenieDatabase.kt
@@ -5,17 +5,23 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import com.aptoide.android.aptoidegames.gamegenie.data.database.model.CachedCompanionGameEntity
 import com.aptoide.android.aptoidegames.gamegenie.data.database.model.Converters
 import com.aptoide.android.aptoidegames.gamegenie.data.database.model.GameCompanionEntity
 import com.aptoide.android.aptoidegames.gamegenie.data.database.model.GameGenieHistoryEntity
 
-@Database(entities = [GameGenieHistoryEntity::class, GameCompanionEntity::class], version = 6)
+@Database(
+  entities = [GameGenieHistoryEntity::class, GameCompanionEntity::class, CachedCompanionGameEntity::class],
+  version = 7
+)
 @TypeConverters(Converters::class)
 abstract class GameGenieDatabase : RoomDatabase() {
 
   abstract fun getGameGenieHistoryDao(): GameGenieHistoryDao
 
   abstract fun getGameCompanionDao(): GameCompanionDao
+
+  abstract fun getCachedCompanionGameDao(): CachedCompanionGameDao
 
   class FirstMigration : Migration(1, 2) {
     override fun migrate(db: SupportSQLiteDatabase) {
@@ -54,6 +60,22 @@ abstract class GameGenieDatabase : RoomDatabase() {
           ALTER TABLE GameCompanion 
             ADD COLUMN lastMessageTimestamp INTEGER NOT NULL DEFAULT 0
       """.trimIndent()
+      )
+    }
+  }
+
+  class SixthMigration : Migration(6, 7) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+      db.execSQL(
+        """
+          CREATE TABLE IF NOT EXISTS `CachedCompanionGame` (
+            `packageName` TEXT NOT NULL,
+            `name` TEXT NOT NULL,
+            `versionName` TEXT,
+            `cachedAtMs` INTEGER NOT NULL,
+            PRIMARY KEY(`packageName`)
+          )
+        """.trimIndent()
       )
     }
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/model/CachedCompanionGameEntity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/database/model/CachedCompanionGameEntity.kt
@@ -1,0 +1,12 @@
+package com.aptoide.android.aptoidegames.gamegenie.data.database.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "CachedCompanionGame")
+data class CachedCompanionGameEntity(
+  @PrimaryKey val packageName: String,
+  val name: String,
+  val versionName: String?,
+  val cachedAtMs: Long,
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/di/GameGenieModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/di/GameGenieModule.kt
@@ -10,8 +10,11 @@ import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieApiService
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieAppRepository
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieAppRepositoryImpl
+import com.aptoide.android.aptoidegames.gamegenie.data.GameCompanionsRepository
+import com.aptoide.android.aptoidegames.gamegenie.data.GameCompanionsRepositoryImpl
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieLocalRepository
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieSharedPreferencesRepository
+import com.aptoide.android.aptoidegames.gamegenie.data.database.CachedCompanionGameDao
 import com.aptoide.android.aptoidegames.gamegenie.data.database.GameGenieDatabase
 import com.aptoide.android.aptoidegames.gamegenie.data.database.GameGenieHistoryDao
 import com.aptoide.android.aptoidegames.gamegenie.presentation.GameGenieManager
@@ -37,6 +40,12 @@ internal abstract class GameGenieBindsModule {
   abstract fun bindGameGenieLocalRepository(
     impl: GameGenieSharedPreferencesRepository
   ): GameGenieLocalRepository
+
+  @Binds
+  @Singleton
+  abstract fun bindGameCompanionsRepository(
+    impl: GameCompanionsRepositoryImpl
+  ): GameCompanionsRepository
 }
 
 @Module
@@ -77,12 +86,18 @@ internal object GameGenieModule {
     "ag_game_genie.db"
   )
     .fallbackToDestructiveMigration(true)
+    .addMigrations(GameGenieDatabase.SixthMigration())
     .build()
 
   @Singleton
   @Provides
   fun provideGameGenieDao(database: GameGenieDatabase): GameGenieHistoryDao =
     database.getGameGenieHistoryDao()
+
+  @Singleton
+  @Provides
+  fun provideCachedCompanionGameDao(database: GameGenieDatabase): CachedCompanionGameDao =
+    database.getCachedCompanionGameDao()
 
   @Provides
   @Singleton

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/CompanionGamesCachePreloader.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/CompanionGamesCachePreloader.kt
@@ -1,0 +1,25 @@
+package com.aptoide.android.aptoidegames.gamegenie.presentation
+
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+import kotlinx.coroutines.CancellationException
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CompanionGamesCachePreloader @Inject constructor(
+  private val getGameCompanionsUseCase: GetGameCompanionsUseCase,
+  private val featureFlags: FeatureFlags,
+) {
+
+  suspend fun initialize() {
+    if (!featureFlags.getFlag("show_game_genie", false)) return
+    try {
+      getGameCompanionsUseCase.warmUpCache()
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Throwable) {
+      Timber.w(e, "Failed to preload companion games cache")
+    }
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieUseCase.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieUseCase.kt
@@ -1,22 +1,14 @@
 package com.aptoide.android.aptoidegames.gamegenie.presentation
 
-import android.content.pm.ApplicationInfo
-import android.content.pm.PackageInfo
-import android.content.pm.PackageManager
 import android.util.Base64.NO_WRAP
 import android.util.Base64.encodeToString
 import cm.aptoide.pt.feature_apps.data.AppMapper
-import cm.aptoide.pt.feature_categories.data.CategoriesRepository
-import cm.aptoide.pt.install_manager.App
-import cm.aptoide.pt.install_manager.InstallManager
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieAppRepository
-import com.aptoide.android.aptoidegames.gamegenie.data.database.model.GameCompanionEntity
 import com.aptoide.android.aptoidegames.gamegenie.data.database.model.GameGenieHistoryEntity
 import com.aptoide.android.aptoidegames.gamegenie.domain.ChatInteraction
 import com.aptoide.android.aptoidegames.gamegenie.domain.ChatInteractionHistory
 import com.aptoide.android.aptoidegames.gamegenie.domain.CompanionSuggestions
 import com.aptoide.android.aptoidegames.gamegenie.domain.ConversationInfo
-import com.aptoide.android.aptoidegames.gamegenie.domain.GameCompanion
 import com.aptoide.android.aptoidegames.gamegenie.domain.GameContext
 import com.aptoide.android.aptoidegames.gamegenie.domain.GameGenieChat
 import com.aptoide.android.aptoidegames.gamegenie.domain.GameGenieChatHistory
@@ -28,12 +20,10 @@ import com.aptoide.android.aptoidegames.gamegenie.io_models.GameGenieRequest
 import com.aptoide.android.aptoidegames.gamegenie.io_models.GameGenieResponse
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onStart
-import java.io.IOException
+import java.io.File
 import javax.inject.Inject
 
 private const val MAX_CHATS = 15
@@ -53,7 +43,7 @@ private fun isBase64String(str: String): Boolean {
 private fun encodeImageFileToBase64(filePath: String?): String? {
   return filePath?.let { path ->
     try {
-      val file = java.io.File(path)
+      val file = File(path)
       if (file.exists()) {
         val bytes = file.readBytes()
         encodeToString(bytes, NO_WRAP)
@@ -70,88 +60,12 @@ class GameGenieUseCase @Inject constructor(
   private val gameGenieManager: GameGenieManager,
   private val mapper: AppMapper,
   private val appRepository: GameGenieAppRepository,
-  private val packageManager: PackageManager,
-  private val installManager: InstallManager,
-  private val repository: CategoriesRepository,
 ) {
   suspend fun getToken(): Token {
     return gameGenieManager.getToken()
   }
 
   fun getInstalledApps(): Flow<List<GameContext>> = appRepository.getInstalledApps()
-
-  suspend fun getGameCompanionsList(): Flow<List<GameCompanion>> {
-    val apps = installManager.installedApps.toMutableSet()
-
-    val installedAppsFlow: Flow<List<PackageInfo>> = installManager.appsChanges
-      .map { apps.apply { add(it) } }
-      .onStart { emit(apps) }
-      .map { set -> filterGames(set.mapNotNull(App::packageInfo)) }
-
-    return combine(
-      gameGenieManager.getAllGameCompanions(),
-      installedAppsFlow
-    ) { companionsFromDb: List<GameCompanionEntity>, installedPackages: List<PackageInfo> ->
-
-      val installedMap = installedPackages.associateBy { it.packageName }
-
-      val orderedFromDb = companionsFromDb
-        .filter { installedMap.containsKey(it.gamePackageName) }
-        .map { entity ->
-          val pkg = installedMap[entity.gamePackageName]!!
-          GameCompanion(
-            name = pkg.applicationInfo?.loadLabel(packageManager).toString(),
-            packageName = pkg.packageName,
-            versionName = pkg.versionName,
-            image = pkg.applicationInfo?.loadIcon(packageManager)
-          )
-        }
-
-      val missingFromDb = installedPackages
-        .filterNot { pkg -> companionsFromDb.any { it.gamePackageName == pkg.packageName } }
-        .sortedByDescending { it.firstInstallTime }
-        .map { pkg ->
-          GameCompanion(
-            name = pkg.applicationInfo?.loadLabel(packageManager).toString(),
-            packageName = pkg.packageName,
-            versionName = pkg.versionName,
-            image = pkg.applicationInfo?.loadIcon(packageManager)
-          )
-        }
-
-      orderedFromDb + missingFromDb
-    }
-  }
-
-  private suspend fun filterGames(appsList: List<PackageInfo>): List<PackageInfo> {
-    val gamesPackageInfoList = ArrayList<PackageInfo>()
-    val undefinedPackageInfoMap = HashMap<String, PackageInfo>()
-    appsList.forEach { packageInfo ->
-      when (packageInfo.applicationInfo?.category) {
-        ApplicationInfo.CATEGORY_GAME -> gamesPackageInfoList.add(packageInfo)
-        else -> undefinedPackageInfoMap[packageInfo.packageName] = packageInfo
-      }
-    }
-    try {
-      repository.getAppsCategories(undefinedPackageInfoMap.keys.toList())
-        .map { appCategory ->
-          when (appCategory.type) {
-            "GAME" -> undefinedPackageInfoMap[appCategory.name]?.let {
-              gamesPackageInfoList.add(
-                it
-              )
-            }
-
-            else -> {}
-          }
-        }
-    } catch (e: IOException) {
-      e.printStackTrace()
-    } catch (t: Throwable) {
-      t.printStackTrace()
-    }
-    return gamesPackageInfoList
-  }
 
   suspend fun reloadConversation(
     chat: GameGenieChat,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieViewModel.kt
@@ -29,6 +29,7 @@ import javax.inject.Inject
 @HiltViewModel
 class GameGenieViewModel @Inject constructor(
   private val gameGenieUseCase: GameGenieUseCase,
+  private val getGameCompanionsUseCase: GetGameCompanionsUseCase,
   private val gameGenieLocalRepository: GameGenieLocalRepository,
   @ApplicationContext private val context: Context,
 ) : ViewModel() {
@@ -97,7 +98,7 @@ class GameGenieViewModel @Inject constructor(
 
   private fun loadInstalledGames() {
     viewModelScope.launch {
-      gameGenieUseCase.getGameCompanionsList().collect { games ->
+      getGameCompanionsUseCase.getCompanionGames().collect { games ->
         _installedGames.value = games
       }
     }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GetGameCompanionsUseCase.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GetGameCompanionsUseCase.kt
@@ -1,0 +1,17 @@
+package com.aptoide.android.aptoidegames.gamegenie.presentation
+
+import com.aptoide.android.aptoidegames.gamegenie.data.GameCompanionsRepository
+import com.aptoide.android.aptoidegames.gamegenie.domain.GameCompanion
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class GetGameCompanionsUseCase @Inject constructor(
+  private val repository: GameCompanionsRepository,
+) {
+
+  fun getCompanionGames(): Flow<List<GameCompanion>> = repository.getCompanionGames()
+
+  suspend fun warmUpCache() = repository.warmUpCache()
+}


### PR DESCRIPTION
**What does this PR do?**

This PR aims to add a cache system to the game companion apps, so that it doesn't take seconds to retrieve every user installed game then the chat screen is opened. Now we first show the cached games, and then update it with the live data result.

**Database changed?**

   No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Open GameGenie, let the games be fetched and test subsequent chat open actions to see if the games take time to load

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-693](https://aptoide.atlassian.net/browse/AND-693)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-693]: https://aptoide.atlassian.net/browse/AND-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Companion games are now served via a reactive, cached feed for faster, more reliable listings.
  * Automatic background preloading/warm-up of the companion games cache during app startup for quicker access.

* **Chores**
  * Internal data and database updates to support caching and improve performance and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->