### PR TITLE
 [AND-694] Kill overlay service after opening other game companion screen

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieOverlayService.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieOverlayService.kt
@@ -4,9 +4,13 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
 import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.content.res.Configuration
 import android.graphics.Bitmap
+import android.graphics.PixelFormat
 import android.os.Build
 import android.os.IBinder
+import android.view.Gravity
 import android.view.WindowManager
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -80,6 +84,10 @@ class GameGenieOverlayService : Service(),
 
     private val _overlayRunningState = MutableStateFlow(false)
     val overlayRunningState: StateFlow<Boolean> = _overlayRunningState.asStateFlow()
+    
+    @Volatile
+    var currentTargetPackage: String? = null
+      private set
     
     @Volatile
     var hasScreenshotPermission: Boolean = false
@@ -325,7 +333,7 @@ class GameGenieOverlayService : Service(),
     }
   }
 
-  override fun onConfigurationChanged(newConfig: android.content.res.Configuration) {
+  override fun onConfigurationChanged(newConfig: Configuration) {
     super.onConfigurationChanged(newConfig)
     handleDimensionChange()
   }
@@ -339,6 +347,7 @@ class GameGenieOverlayService : Service(),
 
     intent?.getStringExtra(EXTRA_TARGET_PACKAGE)?.let { packageName ->
       targetPackage = packageName
+      currentTargetPackage = packageName
     }
 
     val newResultCode = intent?.getIntExtra(EXTRA_MEDIA_PROJECTION_RESULT_CODE, 0) ?: 0
@@ -433,9 +442,9 @@ class GameGenieOverlayService : Service(),
       WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
         WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
         WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH,
-      android.graphics.PixelFormat.TRANSLUCENT
+      PixelFormat.TRANSLUCENT
     ).apply {
-      gravity = android.view.Gravity.TOP or android.view.Gravity.START
+      gravity = Gravity.TOP or Gravity.START
       x = menuX
       y = menuY
     }
@@ -643,9 +652,9 @@ class GameGenieOverlayService : Service(),
         WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
           WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
           WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH,
-        android.graphics.PixelFormat.TRANSLUCENT
+        PixelFormat.TRANSLUCENT
       ).apply {
-        gravity = android.view.Gravity.TOP or android.view.Gravity.START
+        gravity = Gravity.TOP or Gravity.START
         this.x = x
         this.y = y
       }
@@ -692,6 +701,7 @@ class GameGenieOverlayService : Service(),
     super.onDestroy()
     isServiceRunning = false
     hasScreenshotPermission = false
+    currentTargetPackage = null
     _overlayRunningState.value = false
 
     processLifecycleObserver?.let { ProcessLifecycleOwner.get().lifecycle.removeObserver(it) }
@@ -729,7 +739,7 @@ class GameGenieOverlayService : Service(),
       startForeground(
         NOTIFICATION_ID,
         notification,
-        android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
+        ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
       )
     } else {
       startForeground(NOTIFICATION_ID, notification)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/companion/ChatScreenCompanion.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/companion/ChatScreenCompanion.kt
@@ -140,6 +140,17 @@ fun ChatScreenCompanion(
   val isOverlayRunning by GameGenieOverlayService.overlayRunningState.collectAsState(
     initial = GameGenieOverlayService.isServiceRunning
   )
+  
+  LaunchedEffect(selectedGame.packageName, isOverlayRunning) {
+    val overlayTarget = GameGenieOverlayService.currentTargetPackage
+    if (
+      isOverlayRunning &&
+      !overlayTarget.isNullOrBlank() &&
+      overlayTarget != selectedGame.packageName
+    ) {
+      context.stopService(Intent(context, GameGenieOverlayService::class.java))
+    }
+  }
 
   val showTooltip = !hasClickedOverlayButton
 


### PR DESCRIPTION
**What does this PR do?**

This PR aims to kill the overlay service after opening a companion screen that is not the one the overlay was started on.

**Database changed?**

   No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Open the overlay, go back to AG and change companion screen to check if the service is killed.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-694](https://aptoide.atlassian.net/browse/AND-694)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-694]: https://aptoide.atlassian.net/browse/AND-694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Game Genie overlay service to automatically stop when switching between different games, ensuring proper service lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->