### PR TITLE
 [AND-714] Fix crash when the user rejects the mediaProjection dialog

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/companion/ChatScreenCompanion.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/companion/ChatScreenCompanion.kt
@@ -223,10 +223,6 @@ fun ChatScreenCompanion(
               analytics
             )
           }
-        } else {
-          coroutineScope.launch {
-            launchOverlayAndGame(selectedGame, context, targetAppLauncher, analytics = analytics)
-          }
         }
       }
 


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix the crash caused by canceling/rejecting the mediaProjection system dialog, when opening GameGenie overlay

**Database changed?**

   No

**Where should the reviewer start?**

See by commit.

**How should this be manually tested?**

Try to open GameGenie companion overlay on an app and reject the system dialog right before starting the overlay and check if it crashes

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-714](https://aptoide.atlassian.net/browse/AND-714)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-714]: https://aptoide.atlassian.net/browse/AND-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed media projection permission handling. The overlay and game will now only launch after successful permission authorization, preventing the app from attempting to proceed when permissions are denied or the request fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->