### PR TITLE
[AND-684] Add pre approval installer and AB test conditions

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/CoilPreApprovalIconProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/CoilPreApprovalIconProvider.kt
@@ -1,0 +1,26 @@
+package com.aptoide.android.aptoidegames.installer
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import cm.aptoide.pt.installer.PreApprovalIconProvider
+import coil.imageLoader
+import coil.request.ImageRequest
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CoilPreApprovalIconProvider @Inject constructor(
+  @ApplicationContext private val context: Context,
+) : PreApprovalIconProvider {
+
+  override suspend fun getIcon(url: String): Bitmap? {
+    val request = ImageRequest.Builder(context)
+      .data(url)
+      .build()
+
+    val result = context.imageLoader.execute(request)
+    return (result.drawable as? BitmapDrawable)?.bitmap
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/InstallerSelector.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/InstallerSelector.kt
@@ -8,6 +8,7 @@ import cm.aptoide.pt.install_manager.dto.hasSplitApks
 import cm.aptoide.pt.install_manager.workers.PackageInstaller
 import com.aptoide.android.aptoidegames.Platform
 import com.aptoide.android.aptoidegames.installer.analytics.InstallAnalytics
+import com.aptoide.android.aptoidegames.installer.ff.PreApprovalExperiment
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
@@ -17,33 +18,49 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 class InstallerSelector @Inject constructor(
   val aptoideInstaller: PackageInstaller,
+  val preApprovalInstaller: PackageInstaller,
   val legacyInstaller: PackageInstaller,
-  val installAnalytics: InstallAnalytics
+  val installAnalytics: InstallAnalytics,
+  val preApprovalExperiment: PreApprovalExperiment,
 ) : PackageInstaller {
 
   override fun requestUserPreApproval(
     packageName: String,
     installPackageInfo: InstallPackageInfo,
-  ): Flow<Unit> = flow { emit(getPackageInstaller(installPackageInfo)) }
+  ): Flow<Unit> = flow { emit(getPackageInstaller(packageName, installPackageInfo)) }
     .flatMapLatest { it.requestUserPreApproval(packageName, installPackageInfo) }
 
   override fun install(
     packageName: String,
     installPackageInfo: InstallPackageInfo
-  ): Flow<Int> = flow { emit(getPackageInstaller(installPackageInfo)) }
+  ): Flow<Int> = flow { emit(getPackageInstaller(packageName, installPackageInfo)) }
     .flatMapLatest { it.install(packageName, installPackageInfo) }
 
   override fun uninstall(packageName: String): Flow<Int> = flow { emit(getPackageUninstaller()) }
     .flatMapLatest { it.uninstall(packageName) }
 
-  fun getPackageInstaller(installPackageInfo: InstallPackageInfo): PackageInstaller =
+  suspend fun getPackageInstaller(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo,
+  ): PackageInstaller =
     if (Platform.shouldUseLegacyInstaller && !installPackageInfo.hasSplitApks()) {
       installAnalytics.setUsedInstallerProperty("legacy_installer")
       legacyInstaller
+    } else if (shouldUsePreApprovalInstaller(packageName, installPackageInfo)) {
+      installAnalytics.setUsedInstallerProperty("pre_approval_installer")
+      preApprovalInstaller
     } else {
       installAnalytics.setUsedInstallerProperty("package_installer")
       aptoideInstaller
     }
+
+  private suspend fun shouldUsePreApprovalInstaller(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo,
+  ): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return false
+    return preApprovalExperiment.shouldUsePreApprovalInstaller(packageName, installPackageInfo)
+  }
 
   fun getPackageUninstaller(): PackageInstaller =
     if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R && isMIUI()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/InstallerSelector.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/InstallerSelector.kt
@@ -21,6 +21,12 @@ class InstallerSelector @Inject constructor(
   val installAnalytics: InstallAnalytics
 ) : PackageInstaller {
 
+  override fun requestUserPreApproval(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo,
+  ): Flow<Unit> = flow { emit(getPackageInstaller(installPackageInfo)) }
+    .flatMapLatest { it.requestUserPreApproval(packageName, installPackageInfo) }
+
   override fun install(
     packageName: String,
     installPackageInfo: InstallPackageInfo

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/UserActionDialog.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/UserActionDialog.kt
@@ -52,6 +52,7 @@ import com.aptoide.android.aptoidegames.design_system.PrimaryButton
 import com.aptoide.android.aptoidegames.design_system.PrimaryTextButton
 import com.aptoide.android.aptoidegames.drawables.icons.getAptoideGamesToolbarLogo
 import com.aptoide.android.aptoidegames.installer.analytics.rememberInstallAnalytics
+import com.aptoide.android.aptoidegames.installer.analytics.rememberPreApprovalExperiment
 import com.aptoide.android.aptoidegames.installer.analytics.toAnalyticsPayload
 import com.aptoide.android.aptoidegames.permissions.AppPermissionsViewModel
 import com.aptoide.android.aptoidegames.theme.AGTypography
@@ -91,9 +92,26 @@ fun UserActionDialog() {
     }
   }
 
+  val installAnalytics = rememberInstallAnalytics()
+  val preApprovalExperiment = rememberPreApprovalExperiment()
+
   val intentLauncher = rememberLauncherForActivityResult(
     contract = ActivityResultContracts.StartActivityForResult(),
     onResult = {
+      (state as? InstallationAction)?.let { action ->
+        if (action.intent.isInstallationIntent() || action.intent.isPreApprovalIntent()) {
+          val packageName = action.intent
+            .getStringExtra("${BuildConfig.APPLICATION_ID}.pn") ?: "NaN"
+          val analyticsContext = action.intent
+            .getStringExtra("${BuildConfig.APPLICATION_ID}.ap").toAnalyticsPayload()?.context
+          
+          if (it.resultCode == Activity.RESULT_OK) {
+            preApprovalExperiment?.sendInstallDialogAcceptedEvent(packageName, analyticsContext)
+          } else {
+            preApprovalExperiment?.sendInstallDialogCanceledEvent(packageName, analyticsContext)
+          }
+        }
+      }
       viewModel.onResult(it.resultCode == Activity.RESULT_OK)
     }
   )
@@ -104,8 +122,6 @@ fun UserActionDialog() {
       viewModel.onResult(result)
     }
   )
-
-  val installAnalytics = rememberInstallAnalytics()
   LaunchedEffect(
     key1 = state,
     key2 = isOnForeground,
@@ -277,3 +293,5 @@ fun PermissionsDialogPreview() {
 //System action, we cannot access it any other way
 fun Intent.isInstallationIntent() =
   action == "android.content.pm.action.CONFIRM_INSTALL" || action == "android.intent.action.INSTALL_PACKAGE"
+
+fun Intent.isPreApprovalIntent() = action == "android.content.pm.action.CONFIRM_PRE_APPROVAL"

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/AnalyticsProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/AnalyticsProvider.kt
@@ -4,12 +4,14 @@ import androidx.compose.runtime.Composable
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import cm.aptoide.pt.extensions.runPreviewable
+import com.aptoide.android.aptoidegames.installer.ff.PreApprovalExperiment
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
 class AnalyticsInjectionsProvider @Inject constructor(
   val installAnalytics: InstallAnalytics,
+  val preApprovalExperiment: PreApprovalExperiment,
 ) : ViewModel()
 
 @Composable
@@ -18,5 +20,14 @@ fun rememberInstallAnalytics(): InstallAnalytics = runPreviewable(
   real = {
     val vm = hiltViewModel<AnalyticsInjectionsProvider>()
     vm.installAnalytics
+  }
+)
+
+@Composable
+fun rememberPreApprovalExperiment(): PreApprovalExperiment? = runPreviewable(
+  preview = { null },
+  real = {
+    val vm = hiltViewModel<AnalyticsInjectionsProvider>()
+    vm.preApprovalExperiment
   }
 )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalyticsImpl.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalyticsImpl.kt
@@ -20,6 +20,7 @@ import com.aptoide.android.aptoidegames.analytics.toBiParameters
 import com.aptoide.android.aptoidegames.analytics.toGenericParameters
 import com.aptoide.android.aptoidegames.installer.analytics.InstallAnalyticsImpl.Companion.P_APP_SIZE_MB
 import com.aptoide.android.aptoidegames.installer.analytics.InstallAnalyticsImpl.Companion.P_UPDATE_TYPE
+import com.aptoide.android.aptoidegames.installer.ff.PreApprovalExperiment
 import com.aptoide.android.aptoidegames.installer.ff.getDownloaderVariant
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -34,6 +35,7 @@ class InstallAnalyticsImpl(
   private val biAnalytics: BIAnalytics,
   private val storeName: String,
   private val silentInstallChecker: SilentInstallChecker,
+  private val preApprovalExperiment: PreApprovalExperiment,
 ) : InstallAnalytics {
 
   init {
@@ -363,6 +365,8 @@ class InstallAnalyticsImpl(
         )
       }
     }
+
+    preApprovalExperiment.sendInstallSuccessEvent(packageName, installPackageInfo)
   }
 
   override fun sendInstallErrorEvent(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallProbe.kt
@@ -17,6 +17,11 @@ class InstallProbe(
   private val analytics: InstallAnalytics,
 ) : PackageInstaller {
 
+  override fun requestUserPreApproval(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo,
+  ): Flow<Unit> = packageInstaller.requestUserPreApproval(packageName, installPackageInfo)
+
   override fun install(
     packageName: String,
     installPackageInfo: InstallPackageInfo,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/di/InstallerModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/di/InstallerModule.kt
@@ -14,11 +14,13 @@ import cm.aptoide.pt.installer.AptoideDownloader
 import cm.aptoide.pt.installer.AptoideInstallPackageInfoMapper
 import cm.aptoide.pt.installer.AptoideInstaller
 import cm.aptoide.pt.installer.LegacyInstaller
+import cm.aptoide.pt.installer.PreApprovalIconProvider
 import cm.aptoide.pt.installer.obb.OBBInstallManager
 import cm.aptoide.pt.task_info.AptoideTaskInfoRepository
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
 import com.aptoide.android.aptoidegames.apkfy.DownloadPermissionStateProbe
+import com.aptoide.android.aptoidegames.installer.CoilPreApprovalIconProvider
 import com.aptoide.android.aptoidegames.installer.DownloaderSelector
 import com.aptoide.android.aptoidegames.installer.InstallerSelector
 import com.aptoide.android.aptoidegames.installer.analytics.AnalyticsInstallPackageInfoMapper
@@ -92,6 +94,11 @@ class InstallerModule {
     featureFlags = featureFlags,
     aptoidePackageDownloader = aptoideDownloader,
   )
+
+  @Singleton
+  @Provides
+  fun provideIconProvider(coilIconProvider: CoilPreApprovalIconProvider): PreApprovalIconProvider =
+    coilIconProvider
 
   @Singleton
   @Provides

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/di/InstallerModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/di/InstallerModule.kt
@@ -15,6 +15,7 @@ import cm.aptoide.pt.installer.AptoideInstallPackageInfoMapper
 import cm.aptoide.pt.installer.AptoideInstaller
 import cm.aptoide.pt.installer.LegacyInstaller
 import cm.aptoide.pt.installer.PreApprovalIconProvider
+import cm.aptoide.pt.installer.PreApprovalInstaller
 import cm.aptoide.pt.installer.obb.OBBInstallManager
 import cm.aptoide.pt.task_info.AptoideTaskInfoRepository
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
@@ -33,6 +34,7 @@ import com.aptoide.android.aptoidegames.installer.analytics.SilentInstallChecker
 import com.aptoide.android.aptoidegames.installer.database.AppDetailsDao
 import com.aptoide.android.aptoidegames.installer.database.InstallerDatabase
 import com.aptoide.android.aptoidegames.installer.database.InstallerDatabase.FirstMigration
+import com.aptoide.android.aptoidegames.installer.ff.PreApprovalExperiment
 import com.aptoide.android.aptoidegames.installer.notifications.InstallerNotificationsManager
 import com.aptoide.android.aptoidegames.installer.notifications.RealInstallerNotificationsManager
 import com.aptoide.android.aptoidegames.installer.task_info.AptoideTaskInfoProbe
@@ -104,12 +106,16 @@ class InstallerModule {
   @Provides
   fun provideInstallerSelector(
     aptoideInstaller: AptoideInstaller,
+    preApprovalInstaller: PreApprovalInstaller,
     legacyInstaller: LegacyInstaller,
-    installAnalytics: InstallAnalytics
+    installAnalytics: InstallAnalytics,
+    preApprovalExperiment: PreApprovalExperiment,
   ): InstallerSelector = InstallerSelector(
     aptoideInstaller = aptoideInstaller,
+    preApprovalInstaller = preApprovalInstaller,
     legacyInstaller = legacyInstaller,
-    installAnalytics = installAnalytics
+    installAnalytics = installAnalytics,
+    preApprovalExperiment = preApprovalExperiment,
   )
 
   @Singleton
@@ -168,12 +174,14 @@ class InstallerModule {
     biAnalytics: BIAnalytics,
     @StoreName storeName: String,
     silentInstallChecker: SilentInstallChecker,
+    preApprovalExperiment: PreApprovalExperiment,
   ): InstallAnalytics = InstallAnalyticsImpl(
     context = context,
     featureFlags = featureFlags,
     genericAnalytics = genericAnalytics,
     biAnalytics = biAnalytics,
     storeName = storeName,
-    silentInstallChecker = silentInstallChecker
+    silentInstallChecker = silentInstallChecker,
+    preApprovalExperiment = preApprovalExperiment,
   )
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/ff/PreApprovalExperiment.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/ff/PreApprovalExperiment.kt
@@ -1,0 +1,178 @@
+package com.aptoide.android.aptoidegames.installer.ff
+
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
+import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
+import com.aptoide.android.aptoidegames.installer.analytics.toAnalyticsPayload
+import com.aptoide.android.aptoidegames.installer.ff.PreApprovalExperiment.Companion.FETCH_TIMEOUT_MS
+import com.aptoide.android.aptoidegames.installer.ff.PreApprovalExperiment.Companion.FLAG_INSTALLER_TYPE
+import com.aptoide.android.aptoidegames.installer.ff.PreApprovalExperiment.Companion.FLAG_PRE_APPROVAL_PACKAGES
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * A/B test experiment for the pre-approval installer.
+ *
+ * Relies on two remote config flags:
+ * - [FLAG_INSTALLER_TYPE]: determines the installer variant ("default" or "preapproval").
+ * - [FLAG_PRE_APPROVAL_PACKAGES]: a list of package names eligible for pre-approval install.
+ *
+ * The experiment is only active when both flags are successfully fetched.
+ * An activation event is sent once we confirm that both flags were fetched correctly.
+ */
+@Singleton
+class PreApprovalExperiment @Inject constructor(
+  private val featureFlags: FeatureFlags,
+  private val genericAnalytics: GenericAnalytics,
+) {
+
+  private val fetchMutex = Mutex()
+
+  @Volatile
+  private var cachedResult: ExperimentResult? = null
+  private var activationEventSent = false
+
+  /**
+   * Returns whether the pre-approval installer should be used for the given [packageName].
+   *
+   * The PreApprovalInstaller is selected only when:
+   * 1. The install started from AppView ([installPackageInfo] has context "AppView")
+   * 2. The installer type flag is "preapproval".
+   * 3. The pre-approval packages flag was successfully fetched.
+   * 4. The [packageName] is in the list of eligible packages.
+   *
+   * Falls back to the default installer if the flags can't be fetched within [FETCH_TIMEOUT_MS].
+   *
+   * The activation event is only sent when the user installs an eligible package,
+   * ensuring the A/B test cohort only includes users truly exposed to the experiment.
+   */
+  suspend fun shouldUsePreApprovalInstaller(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo
+  ): Boolean {
+    val isFromAppView = installPackageInfo.payload?.toAnalyticsPayload()?.context == "AppView"
+    if (!isFromAppView) return false
+
+    val result = cachedResult ?: resolveExperiment()
+
+    if (!result.isFetched) return false
+    if (packageName !in result.eligiblePackages) return false
+
+    //User eligible for AB test, since the flags are fetched and the package to download is eligible
+    sendActivationEvent(result)
+
+    return result.isPreApproval
+  }
+
+  private suspend fun resolveExperiment(): ExperimentResult = fetchMutex.withLock {
+    cachedResult?.let { return it }
+
+    val result = withTimeoutOrNull(FETCH_TIMEOUT_MS) {
+      fetchExperimentResult()
+    }
+
+    if (result == null) {
+      Timber.w("Pre-approval experiment timed out, falling back to default installer")
+    }
+
+    return (result ?: notFetched).also { cachedResult = it }
+  }
+
+  /**
+   * Checks if the install belongs to the experiment based on the cached result.
+   * Returns false if the experiment hasn't been resolved yet.
+   *
+   * An install is eligible when:
+   * 1. The install started from AppView ([analyticsContext] == "AppView").
+   * 2. The experiment flags were successfully fetched.
+   * 3. The [packageName] is in the list of eligible packages.
+   */
+  fun isEligibleInstall(
+    packageName: String,
+    analyticsContext: String?
+  ): Boolean {
+    if (analyticsContext != "AppView") return false
+    val result = cachedResult ?: return false
+    return result.isFetched && packageName in result.eligiblePackages
+  }
+
+  fun sendInstallSuccessEvent(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo
+  ) {
+    val context = installPackageInfo.payload?.toAnalyticsPayload()?.context
+    if (!isEligibleInstall(packageName, context)) return
+
+    genericAnalytics.logEvent(
+      name = INSTALL_SUCCESS_EVENT,
+      params = mapOf(
+        "variant" to (cachedResult?.variant ?: "n/a"),
+        "package_name" to packageName
+      )
+    )
+  }
+
+  private fun sendActivationEvent(result: ExperimentResult) {
+    if (activationEventSent) return
+    activationEventSent = true
+
+    Timber.d("Pre-approval experiment activation: variant=${result.variant}")
+    genericAnalytics.logEvent(
+      name = ACTIVATION_EVENT,
+      params = mapOf("variant" to result.variant)
+    )
+  }
+
+  private suspend fun fetchExperimentResult(): ExperimentResult {
+    val installerType = featureFlags.getFlagAsString(FLAG_INSTALLER_TYPE)
+    val packages = featureFlags.getStringList(FLAG_PRE_APPROVAL_PACKAGES)
+
+    val isValidVariant = installerType in VALID_VARIANTS
+    val isFetched = isValidVariant && packages.isNotEmpty()
+
+    if (isFetched) {
+      Timber.d("Pre-approval experiment fetched: type=$installerType, packages=$packages")
+    } else {
+      Timber.d("Pre-approval experiment not active: type=$installerType, packages=$packages")
+    }
+
+    return ExperimentResult(
+      isFetched = isFetched,
+      variant = installerType ?: "n/a",
+      isPreApproval = installerType == VARIANT_PRE_APPROVAL,
+      eligiblePackages = packages.toSet()
+    )
+  }
+
+  private data class ExperimentResult(
+    val isFetched: Boolean,
+    val variant: String,
+    val isPreApproval: Boolean,
+    val eligiblePackages: Set<String>,
+  )
+
+  private val notFetched = ExperimentResult(
+    isFetched = false,
+    variant = "n/a",
+    isPreApproval = false,
+    eligiblePackages = emptySet()
+  )
+
+  companion object {
+    private const val FLAG_INSTALLER_TYPE = "exp_pre_approval_installer_type"
+    private const val FLAG_PRE_APPROVAL_PACKAGES = "exp_pre_approval_packages"
+
+    private const val VARIANT_DEFAULT = "default"
+    private const val VARIANT_PRE_APPROVAL = "preapproval"
+    private val VALID_VARIANTS = setOf(VARIANT_DEFAULT, VARIANT_PRE_APPROVAL)
+
+    private const val ACTIVATION_EVENT = "exp_pre_approval_installer_activated"
+    private const val INSTALL_SUCCESS_EVENT = "exp_pre_approval_install_success"
+
+    private const val FETCH_TIMEOUT_MS = 3_000L
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/ff/PreApprovalExperiment.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/ff/PreApprovalExperiment.kt
@@ -116,6 +116,44 @@ class PreApprovalExperiment @Inject constructor(
     )
   }
 
+  /**
+   * Sends an event when the user clicks "Install" on the native install dialog,
+   * only for installs that belong to the experiment.
+   */
+  fun sendInstallDialogAcceptedEvent(
+    packageName: String,
+    analyticsContext: String?
+  ) {
+    if (!isEligibleInstall(packageName, analyticsContext)) return
+
+    genericAnalytics.logEvent(
+      name = INSTALL_DIALOG_ACCEPTED_EVENT,
+      params = mapOf(
+        "variant" to cachedResult!!.variant,
+        "package_name" to packageName
+      )
+    )
+  }
+
+  /**
+   * Sends an event when the user clicks "Cancel" on the native install dialog,
+   * only for installs that belong to the experiment.
+   */
+  fun sendInstallDialogCanceledEvent(
+    packageName: String,
+    analyticsContext: String?
+  ) {
+    if (!isEligibleInstall(packageName, analyticsContext)) return
+
+    genericAnalytics.logEvent(
+      name = INSTALL_DIALOG_CANCELED_EVENT,
+      params = mapOf(
+        "variant" to cachedResult!!.variant,
+        "package_name" to packageName
+      )
+    )
+  }
+
   private fun sendActivationEvent(result: ExperimentResult) {
     if (activationEventSent) return
     activationEventSent = true
@@ -172,6 +210,8 @@ class PreApprovalExperiment @Inject constructor(
 
     private const val ACTIVATION_EVENT = "exp_pre_approval_installer_activated"
     private const val INSTALL_SUCCESS_EVENT = "exp_pre_approval_install_success"
+    private const val INSTALL_DIALOG_ACCEPTED_EVENT = "exp_pre_approval_install_dialog_accepted"
+    private const val INSTALL_DIALOG_CANCELED_EVENT = "exp_pre_approval_install_dialog_canceled"
 
     private const val FETCH_TIMEOUT_MS = 3_000L
   }

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstallPackageInfoMapper.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstallPackageInfoMapper.kt
@@ -57,7 +57,9 @@ class AptoideInstallPackageInfoMapper @Inject constructor(
         isAab = appMeta.isAab(),
         hasObb = appMeta.hasObb(),
         trustedBadge = appMeta.malware
-      ).toString()
+      ).toString(),
+      appLabel = app.name.takeIf { it.isNotBlank() },
+      iconUrl = app.icon.takeIf { it.isNotBlank() }
     ).filter()
   }
 }

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstaller.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/AptoideInstaller.kt
@@ -1,5 +1,6 @@
 package cm.aptoide.pt.installer
 
+import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -49,17 +50,22 @@ class AptoideInstaller @Inject constructor(
   private val initialPermissionsAllowed = context.getPermissionsState()
 
   init {
-    // Clean up all old sessions on app start
+    // Clean up old non-preapproved sessions on app start
     context.packageManager.packageInstaller.mySessions.forEach {
-      try {
-        // Some times it leads to crashes that are hard to reproduce.
-        context.packageManager.packageInstaller.abandonSession(it.sessionId)
-      } catch (t: Throwable) {
-        Timber.e(t)
+      val isPreApproved = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+        && it.isPreApprovalRequested
+      if (!isPreApproved) {
+        try {
+          // Some times it leads to crashes that are hard to reproduce.
+          context.packageManager.packageInstaller.abandonSession(it.sessionId)
+        } catch (t: Throwable) {
+          Timber.e(t)
+        }
       }
     }
   }
 
+  @SuppressLint("RequestInstallPackagesPolicy")
   override fun install(
     packageName: String,
     installPackageInfo: InstallPackageInfo,

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/PreApprovalIconProvider.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/PreApprovalIconProvider.kt
@@ -1,0 +1,10 @@
+package cm.aptoide.pt.installer
+
+import android.graphics.Bitmap
+
+/**
+ * Provides app icon bitmaps, to use in installation pre approvals.
+ */
+fun interface PreApprovalIconProvider {
+  suspend fun getIcon(url: String): Bitmap?
+}

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/PreApprovalInstaller.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/PreApprovalInstaller.kt
@@ -1,0 +1,470 @@
+package cm.aptoide.pt.installer
+
+import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageInstaller.PACKAGE_SOURCE_STORE
+import android.content.pm.PackageInstaller.Session
+import android.content.pm.PackageInstaller.SessionParams.USER_ACTION_NOT_REQUIRED
+import android.content.pm.PackageManager
+import android.icu.util.ULocale
+import android.os.Build
+import androidx.annotation.RequiresApi
+import cm.aptoide.pt.install_manager.AbortException
+import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
+import cm.aptoide.pt.install_manager.dto.InstallationFile
+import cm.aptoide.pt.install_manager.dto.hasObb
+import cm.aptoide.pt.install_manager.workers.PackageInstaller
+import cm.aptoide.pt.installer.di.DownloadsPath
+import cm.aptoide.pt.installer.obb.ObbService
+import cm.aptoide.pt.installer.obb.installOBBs
+import cm.aptoide.pt.installer.obb.removeObbFromStore
+import cm.aptoide.pt.installer.platform.INSTALL_SESSION_API_COMPLETE_ACTION
+import cm.aptoide.pt.installer.platform.InstallEvents
+import cm.aptoide.pt.installer.platform.InstallPermissions
+import cm.aptoide.pt.installer.platform.InstallResult
+import cm.aptoide.pt.installer.platform.PREAPPROVAL_SESSION_API_COMPLETE_ACTION
+import cm.aptoide.pt.installer.platform.PreApprovalEvents
+import cm.aptoide.pt.installer.platform.PreApprovalResult
+import cm.aptoide.pt.installer.platform.UNINSTALL_API_COMPLETE_ACTION
+import cm.aptoide.pt.installer.platform.UninstallEvents
+import cm.aptoide.pt.installer.platform.UninstallResult
+import cm.aptoide.pt.installer.platform.copyWithProgressTo
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.withTimeoutOrNull
+import timber.log.Timber
+import java.io.File
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.random.Random
+
+@Singleton
+class PreApprovalInstaller @Inject constructor(
+  @ApplicationContext private val context: Context,
+  @DownloadsPath private val downloadsPath: File,
+  private val installEvents: InstallEvents,
+  private val preApprovalEvents: PreApprovalEvents,
+  private val uninstallEvents: UninstallEvents,
+  private val installPermissions: InstallPermissions,
+  private val preApprovalIconProvider: PreApprovalIconProvider,
+) : PackageInstaller {
+  private val initialPermissionsAllowed = context.getPermissionsState()
+  private val preApprovedSessions: MutableMap<String, Int> = ConcurrentHashMap()
+
+  override fun requestUserPreApproval(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo,
+  ): Flow<Unit> = flow {
+    //API level does not support pre-approval
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      emit(Unit)
+      return@flow
+    }
+
+    //Package name already pre-approved — verify session is still valid
+    preApprovedSessions[packageName]?.let { sessionId ->
+      if (context.packageManager.packageInstaller.getSessionInfo(sessionId) != null) {
+        emit(Unit)
+        return@flow
+      }
+      // Session is no longer valid, remove and re-request preapproval
+      Timber.w("Pre-approved session $sessionId for $packageName is no longer valid")
+      preApprovedSessions.remove(packageName)
+    }
+
+    if (installPackageInfo.hasObb()) {
+      installPermissions.checkIfCanWriteExternal()
+    }
+    installPermissions.checkIfCanInstall()
+
+    val details = buildPreapprovalDetails(
+      packageName = packageName,
+      installPackageInfo = installPackageInfo
+    )
+
+    if (details == null) {
+      Timber.w("Preapproval skipped: missing app label for $packageName")
+      emit(Unit)
+      return@flow
+    }
+
+    val sessionId = createInstallSession(packageName)
+    val preapprovalIntentSender = PendingIntent
+      .getBroadcast(
+        context,
+        PREAPPROVAL_REQUEST_CODE,
+        Intent(PREAPPROVAL_SESSION_API_COMPLETE_ACTION)
+          .setPackage(context.packageName)
+          .putExtra("${context.packageName}.pn", packageName)
+          .putExtra("${context.packageName}.ap", installPackageInfo.payload),
+        PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+      )
+      .intentSender
+
+    context.packageManager.packageInstaller.openSession(sessionId).use { session ->
+      runCatching {
+        session.requestUserPreapproval(details, preapprovalIntentSender)
+      }.onFailure { error ->
+        Timber.w(error, "Preapproval request failed for $packageName")
+        runCatching { session.abandon() }
+        preApprovedSessions.remove(packageName)
+        emit(Unit)
+        return@flow
+      }
+    }
+
+    when (val result = preApprovalEvents.events.filter { it.sessionId == sessionId }.first()) {
+      is PreApprovalResult.Success -> {
+        preApprovedSessions[packageName] = sessionId
+        emit(Unit)
+      }
+
+      is PreApprovalResult.Blocked -> {
+        Timber.i("Preapproval not available for $packageName: ${result.message}")
+        runCatching { context.packageManager.packageInstaller.abandonSession(sessionId) }
+        preApprovedSessions.remove(packageName)
+        emit(Unit)
+      }
+
+      is PreApprovalResult.Abort -> {
+        Timber.i("Preapproval aborted for $packageName: ${result.message}")
+        runCatching { context.packageManager.packageInstaller.abandonSession(sessionId) }
+        preApprovedSessions.remove(packageName)
+        throw AbortException(result.message)
+      }
+
+      is PreApprovalResult.Fail -> {
+        Timber.w("Preapproval failed for $packageName: ${result.message}")
+        runCatching { context.packageManager.packageInstaller.abandonSession(sessionId) }
+        preApprovedSessions.remove(packageName)
+        emit(Unit)
+      }
+    }
+  }
+
+  @SuppressLint("RequestInstallPackagesPolicy")
+  override fun install(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo,
+  ): Flow<Int> = flow {
+    emit(0)
+    if (installPackageInfo.hasObb()) {
+      installPermissions.checkIfCanWriteExternal()
+    }
+    installPermissions.checkIfCanInstall()
+
+    val filesDir = File(downloadsPath, packageName)
+
+    if (!filesDir.exists()) throw IllegalStateException("Necessary files do not exist for app $packageName")
+
+    val checkFraction = 49
+    val (apkFiles, obbFiles) = installPackageInfo.getCheckedFiles(filesDir) {
+      emit((it * checkFraction).toInt())
+    }
+    val totalApkSize = apkFiles.totalLength
+    val totalObbSize = obbFiles.totalLength
+    val apkFraction = 49.0 * totalApkSize / (totalApkSize + totalObbSize)
+    val obbFraction = 49.0 * totalObbSize / (totalApkSize + totalObbSize)
+    if (totalObbSize > 0) {
+      if (initialPermissionsAllowed) {
+        obbFiles.installOBBs(packageName) {
+          emit(checkFraction + (obbFraction * it / totalObbSize).toInt())
+        }
+      } else {
+        ObbService.bindServiceAndWaitForResult(
+          context = context,
+          packageName = packageName,
+          obbFilePaths = obbFiles.map { it.absolutePath }
+        ).let { movedOBBFiles ->
+          if (movedOBBFiles) {
+            //TODO: improve installation progress when using OBBService
+            emit(checkFraction + (obbFraction / totalObbSize).toInt())
+          } else {
+            throw IllegalStateException("Error moving OBB files")
+          }
+        }
+      }
+    }
+
+    val preapprovedSessionId = preApprovedSessions.remove(packageName)
+    val sessionId = preapprovedSessionId ?: createInstallSession(packageName)
+    val progressBase = checkFraction + obbFraction.toInt()
+
+    var result = commitSessionInstall(
+      sessionId = sessionId,
+      packageName = packageName,
+      installPackageInfo = installPackageInfo,
+      apkFiles = apkFiles,
+      totalApkSize = totalApkSize,
+      progressBase = progressBase,
+      apkFraction = apkFraction,
+      emitProgress = { emit(it) },
+      isPreapprovedSession = preapprovedSessionId != null,
+    )
+
+    // If the pre-approved session failed after commit, retry with a fresh session
+    // so the system prompts the user for install permission
+    if (result is InstallResult.Fail && preapprovedSessionId != null) {
+      Timber.i("Pre-approved session install failed for $packageName, retrying with standard install")
+      val freshSessionId = createInstallSession(packageName)
+      result = commitSessionInstall(
+        sessionId = freshSessionId,
+        packageName = packageName,
+        installPackageInfo = installPackageInfo,
+        apkFiles = apkFiles,
+        totalApkSize = totalApkSize,
+        progressBase = progressBase,
+        apkFraction = apkFraction,
+        emitProgress = { emit(it) },
+      )
+    }
+
+    when (result) {
+      is InstallResult.Fail -> {
+        if (totalObbSize > 0) removeObbFromStore(packageName)
+        throw Exception(result.message)
+      }
+
+      is InstallResult.Abort -> {
+        if (totalObbSize > 0) removeObbFromStore(packageName)
+        throw AbortException(result.message)
+      }
+
+      is InstallResult.Success -> {
+        emit(100)
+        filesDir.deleteRecursively()
+        obbFiles.deleteFromCache()
+      }
+    }
+  }
+    .distinctUntilChanged()
+
+  override fun uninstall(packageName: String): Flow<Int> = flow {
+    emit(0)
+    val id = Random.nextInt()
+
+    val intentSender = PendingIntent
+      .getBroadcast(
+        context,
+        UNINSTALL_REQUEST_CODE,
+        Intent(UNINSTALL_API_COMPLETE_ACTION)
+          .putExtra("${context.packageName}.uninstall_id", id)
+          .setPackage(context.packageName),
+        // This is essential to be like that for having extras in the intent
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+          PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        } else {
+          PendingIntent.FLAG_UPDATE_CURRENT
+        }
+      )
+      .intentSender
+
+    context.packageManager.packageInstaller.uninstall(packageName, intentSender)
+    emit(99)
+
+    when (val result = uninstallEvents.events.filter { it.id == id }.first()) {
+      is UninstallResult.Fail -> throw Exception(result.message)
+      is UninstallResult.Abort -> throw AbortException(result.message)
+      is UninstallResult.Success -> emit(100)
+    }
+  }
+
+  /**
+   * Opens a session, loads the APK files, commits, and waits for the install result.
+   * Returns the [InstallResult] without throwing on failure, so the caller can decide
+   * whether to retry (e.g. when a pre-approved session fails).
+   *
+   * When [isPreapprovedSession] is true, also listens for preapproval failure events
+   * since the system may report errors through that channel instead of the install channel.
+   */
+  @SuppressLint("RequestInstallPackagesPolicy")
+  private suspend fun commitSessionInstall(
+    sessionId: Int,
+    packageName: String,
+    installPackageInfo: InstallPackageInfo,
+    apkFiles: List<File>,
+    totalApkSize: Long,
+    progressBase: Int,
+    apkFraction: Double,
+    emitProgress: suspend (Int) -> Unit,
+    isPreapprovedSession: Boolean = false,
+  ): InstallResult {
+    val session = context.packageManager.packageInstaller.openSession(sessionId)
+    try {
+      session.loadFiles(apkFiles) {
+        emitProgress(progressBase + (apkFraction * it / totalApkSize).toInt())
+      }
+      session.commit(
+        PendingIntent
+          .getBroadcast(
+            context,
+            SESSION_INSTALL_REQUEST_CODE,
+            Intent(INSTALL_SESSION_API_COMPLETE_ACTION)
+              .setPackage(context.packageName)
+              .putExtra("${context.packageName}.pn", packageName)
+              .putExtra("${context.packageName}.ap", installPackageInfo.payload),
+            // This is essential to be like that for having extras in the intent
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+              PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            } else {
+              PendingIntent.FLAG_UPDATE_CURRENT
+            }
+          )
+          .intentSender
+      )
+      emitProgress(99)
+
+      val installResultFlow = installEvents.events
+        .filter { it.sessionId == sessionId }
+
+      return if (isPreapprovedSession) {
+        // Also listen for preapproval failures, since the system may report
+        // pre-approved session errors after the session commit
+        val preapprovalFailureFlow = preApprovalEvents.events
+          .filter { it.sessionId == sessionId && it !is PreApprovalResult.Success }
+          .map<PreApprovalResult, InstallResult> { preapprovalResult ->
+            when (preapprovalResult) {
+              is PreApprovalResult.Fail -> InstallResult.Fail(sessionId, preapprovalResult.message)
+              is PreApprovalResult.Blocked -> InstallResult.Fail(
+                sessionId,
+                preapprovalResult.message
+              )
+
+              is PreApprovalResult.Abort -> InstallResult.Abort(
+                sessionId,
+                preapprovalResult.message
+              )
+
+              is PreApprovalResult.Success -> error("Unreachable")
+            }
+          }
+        merge(installResultFlow, preapprovalFailureFlow).first()
+      } else {
+        installResultFlow.first()
+      }
+    } catch (e: Exception) {
+      runCatching { session.abandon() }
+      throw e
+    } finally {
+      session.close()
+    }
+  }
+
+  private suspend fun InstallPackageInfo.getCheckedFiles(
+    downloadsDir: File,
+    progress: suspend (Double) -> Unit,
+  ): Pair<List<File>, List<File>> = installationFiles.run {
+    val apks = mutableListOf<File>()
+    val obbs = mutableListOf<File>()
+    forEachIndexed { index, value ->
+      when (value.type) {
+        InstallationFile.Type.BASE,
+        InstallationFile.Type.PFD_INSTALL_TIME,
+        InstallationFile.Type.PAD_INSTALL_TIME,
+          -> apks.add(value.toCheckedFile(downloadsDir))
+
+        InstallationFile.Type.OBB_MAIN,
+        InstallationFile.Type.OBB_PATCH,
+          -> obbs.add(value.toCheckedFile(downloadsDir))
+
+        else -> {}
+      }
+
+      progress(index + 1.0 / size)
+    }
+    apks to obbs
+  }
+
+  private suspend fun Session.loadFiles(
+    files: Collection<File>,
+    progress: suspend (Long) -> Unit,
+  ) {
+    var processedSize: Long = 0
+    files.forEach { file ->
+      val size = file.length()
+      file.inputStream()
+        .use { apkStream ->
+          openWrite(file.name, 0, size)
+            .use { sessionStream ->
+              apkStream
+                .copyWithProgressTo(sessionStream)
+                .collect {
+                  progress(processedSize + it)
+                }
+              fsync(sessionStream)
+            }
+        }
+      processedSize += size
+    }
+  }
+
+  private fun createInstallSession(packageName: String): Int =
+    context.packageManager.packageInstaller.createSession(buildSessionParams(packageName))
+
+  private fun buildSessionParams(packageName: String): android.content.pm.PackageInstaller.SessionParams =
+    android.content.pm.PackageInstaller
+      .SessionParams(android.content.pm.PackageInstaller.SessionParams.MODE_FULL_INSTALL)
+      .apply {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+          setRequestUpdateOwnership(true)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+          setRequireUserAction(USER_ACTION_NOT_REQUIRED)
+        }
+        setAppPackageName(packageName)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+          setPackageSource(PACKAGE_SOURCE_STORE)
+        }
+
+        setInstallLocation(PackageInfo.INSTALL_LOCATION_AUTO)
+        setInstallReason(PackageManager.INSTALL_REASON_USER)
+      }
+
+  @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+  private suspend fun buildPreapprovalDetails(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo,
+  ): android.content.pm.PackageInstaller.PreapprovalDetails? {
+    val label = installPackageInfo.appLabel ?: getInstalledAppLabel(packageName)
+    if (label == null) return null
+
+    val icon = installPackageInfo.iconUrl?.let {
+      withTimeoutOrNull(ICON_FETCH_TIMEOUT_MS) { preApprovalIconProvider.getIcon(it) }
+    }
+
+    val builder = android.content.pm.PackageInstaller.PreapprovalDetails.Builder()
+      .setPackageName(packageName)
+      .setLabel(label)
+      .setLocale(ULocale.forLocale(Locale.getDefault()))
+
+    if (icon != null) {
+      builder.setIcon(icon)
+    }
+
+    return builder.build()
+  }
+
+  private fun getInstalledAppLabel(packageName: String): CharSequence? =
+    runCatching {
+      val appInfo = context.packageManager.getApplicationInfo(packageName, 0)
+      context.packageManager.getApplicationLabel(appInfo)
+    }.getOrNull()
+
+  companion object {
+    private const val SESSION_INSTALL_REQUEST_CODE = 18
+    private const val UNINSTALL_REQUEST_CODE = 19
+    private const val PREAPPROVAL_REQUEST_CODE = 20
+    private const val ICON_FETCH_TIMEOUT_MS = 3_000L
+  }
+}

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/PreApprovalInstaller.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/PreApprovalInstaller.kt
@@ -62,6 +62,29 @@ class PreApprovalInstaller @Inject constructor(
   private val initialPermissionsAllowed = context.getPermissionsState()
   private val preApprovedSessions: MutableMap<String, Int> = ConcurrentHashMap()
 
+  init {
+    // Restore pre-approved sessions and clean up everything else on app start
+    context.packageManager.packageInstaller.mySessions.forEach { sessionInfo ->
+      val sessionId = sessionInfo.sessionId
+      val sessionPackageName = sessionInfo.appPackageName
+      val isPreApproved = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+        && sessionInfo.isPreApprovalRequested
+
+      if (isPreApproved && sessionPackageName != null) {
+        // Restore pre-approved session to in-memory map
+        preApprovedSessions[sessionPackageName] = sessionId
+        Timber.d("Restored pre-approved session $sessionId for ${sessionPackageName}")
+      } else {
+        // Abandon non-preapproved sessions
+        try {
+          context.packageManager.packageInstaller.abandonSession(sessionId)
+        } catch (t: Throwable) {
+          Timber.e(t)
+        }
+      }
+    }
+  }
+
   override fun requestUserPreApproval(
     packageName: String,
     installPackageInfo: InstallPackageInfo,

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/di/AptoideInstallerModule.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/di/AptoideInstallerModule.kt
@@ -5,6 +5,8 @@ import cm.aptoide.pt.installer.platform.InstallEvents
 import cm.aptoide.pt.installer.platform.InstallEventsImpl
 import cm.aptoide.pt.installer.platform.InstallPermissions
 import cm.aptoide.pt.installer.platform.InstallPermissionsImpl
+import cm.aptoide.pt.installer.platform.PreApprovalEvents
+import cm.aptoide.pt.installer.platform.PreApprovalEventsImpl
 import cm.aptoide.pt.installer.platform.UninstallEvents
 import cm.aptoide.pt.installer.platform.UninstallEventsImpl
 import cm.aptoide.pt.installer.platform.UserActionHandler
@@ -32,6 +34,11 @@ object AptoideInstallerModule {
   @Singleton
   fun providesInstallEvents(installFinisherImpl: InstallEventsImpl): InstallEvents =
     installFinisherImpl
+
+  @Provides
+  @Singleton
+  fun providesPreapprovalEvents(preapprovalEventsImpl: PreApprovalEventsImpl): PreApprovalEvents =
+    preapprovalEventsImpl
 
   @Provides
   @Singleton

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/PreApprovalEvents.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/PreApprovalEvents.kt
@@ -1,0 +1,104 @@
+package cm.aptoide.pt.installer.platform
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageInstaller
+import android.os.Build
+import android.os.Bundle
+import androidx.core.content.ContextCompat
+import cm.aptoide.pt.extensions.goAsync
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.withTimeout
+import javax.inject.Inject
+import javax.inject.Singleton
+
+const val PREAPPROVAL_SESSION_API_COMPLETE_ACTION = "preapproval_session_api_complete"
+internal const val PREAPPROVAL_TIMEOUT = 300_000L
+
+interface PreApprovalEvents {
+  val events: Flow<PreApprovalResult>
+}
+
+@Singleton
+class PreApprovalEventsImpl @Inject constructor(
+  @ApplicationContext context: Context,
+  private val userActionLauncher: UserActionLauncher,
+) : BroadcastReceiver(), PreApprovalEvents {
+
+  init {
+    ContextCompat.registerReceiver(
+      context,
+      this,
+      IntentFilter(PREAPPROVAL_SESSION_API_COMPLETE_ACTION),
+      ContextCompat.RECEIVER_NOT_EXPORTED
+    )
+  }
+
+  private val _events = MutableSharedFlow<PreApprovalResult>(replay = 1, extraBufferCapacity = 10)
+
+  override val events: Flow<PreApprovalResult> = _events
+
+  override fun onReceive(
+    context: Context,
+    intent: Intent,
+  ): Unit = goAsync(Dispatchers.IO) {
+    intent.extras
+      ?.takeIf { PREAPPROVAL_SESSION_API_COMPLETE_ACTION == intent.action }
+      ?.toEvent(context)
+      ?.also { _events.emit(it) }
+  }
+
+  private suspend fun Bundle.toEvent(context: Context): PreApprovalResult? {
+    val message = getString(PackageInstaller.EXTRA_STATUS_MESSAGE, "No message")
+    val sessionId = getInt(PackageInstaller.EXTRA_SESSION_ID)
+    return when (getInt(PackageInstaller.EXTRA_STATUS, -1)) {
+      PackageInstaller.STATUS_PENDING_USER_ACTION -> intent
+        ?.putExtra("${context.packageName}.pn", getString("${context.packageName}.pn"))
+        ?.putExtra("${context.packageName}.ap", getString("${context.packageName}.ap"))
+        .toPreApprovalResult(sessionId, message)
+
+      PackageInstaller.STATUS_SUCCESS -> PreApprovalResult.Success(sessionId)
+      PackageInstaller.STATUS_FAILURE_ABORTED -> PreApprovalResult.Abort(sessionId, message)
+      PackageInstaller.STATUS_FAILURE_BLOCKED,
+        -> PreApprovalResult.Blocked(sessionId, message)
+
+      PackageInstaller.STATUS_FAILURE,
+      PackageInstaller.STATUS_FAILURE_CONFLICT,
+      PackageInstaller.STATUS_FAILURE_INCOMPATIBLE,
+      PackageInstaller.STATUS_FAILURE_INVALID,
+      PackageInstaller.STATUS_FAILURE_STORAGE,
+        -> PreApprovalResult.Fail(sessionId, message)
+
+      else -> PreApprovalResult.Fail(sessionId, message)
+    }
+  }
+
+  private val Bundle.intent
+    get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      getParcelable(Intent.EXTRA_INTENT, Intent::class.java)
+    } else {
+      @Suppress("DEPRECATION")
+      getParcelable(Intent.EXTRA_INTENT) as Intent?
+    }
+
+  private suspend fun Intent?.toPreApprovalResult(
+    sessionId: Int,
+    message: String,
+  ): PreApprovalResult? = if (this == null) {
+    PreApprovalResult.Fail(sessionId, message)
+  } else {
+    try {
+      withTimeout(PREAPPROVAL_TIMEOUT) {
+        userActionLauncher.launchIntent(this@toPreApprovalResult)
+      }
+      null
+    } catch (t: Throwable) {
+      PreApprovalResult.Fail(sessionId, t.message ?: "Unknown reason")
+    }
+  }
+}

--- a/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/PreApprovalResult.kt
+++ b/aptoide-installer/src/main/java/cm/aptoide/pt/installer/platform/PreApprovalResult.kt
@@ -1,0 +1,11 @@
+package cm.aptoide.pt.installer.platform
+
+sealed class PreApprovalResult {
+
+  abstract val sessionId: Int?
+
+  data class Success(override val sessionId: Int) : PreApprovalResult()
+  data class Blocked(override val sessionId: Int, val message: String) : PreApprovalResult()
+  data class Fail(override val sessionId: Int, val message: String) : PreApprovalResult()
+  data class Abort(override val sessionId: Int, val message: String) : PreApprovalResult()
+}

--- a/feature-flags/src/main/java/cm/aptoide/pt/feature_flags/domain/FeatureFlags.kt
+++ b/feature-flags/src/main/java/cm/aptoide/pt/feature_flags/domain/FeatureFlags.kt
@@ -5,6 +5,7 @@ import cm.aptoide.pt.feature_flags.data.FeatureFlagsRepository
 import com.google.gson.Gson
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.json.JSONArray
 import org.json.JSONObject
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -24,6 +25,8 @@ interface FeatureFlags {
   suspend fun getFlagsAsString(vararg keys: String): Map<String, String?> = emptyMap()
 
   suspend fun getStrings(key: String): List<String> = emptyList()
+
+  suspend fun getStringList(key: String): List<String> = emptyList()
 
   suspend fun <T> getObject(key: String, klass: Class<T>): T? = null
 
@@ -82,6 +85,24 @@ class FeatureFlagsImpl @Inject constructor(
       }
       result.filterNot { it.isBlank() }
     } ?: emptyList()
+  }
+
+  /**
+   * Alternative to [getStrings] that works when flag values are stored as plain strings.
+   * Unlike [getStrings], which uses `optJSONArray` and expects a native JSONArray type,
+   * this parses the string value as a JSON array, handling the string-encoded format.
+   */
+  override suspend fun getStringList(key: String): List<String> = mutex.withLock {
+    runCatching {
+      JSONArray(featureFlags.getString(key)).run {
+        val result = mutableListOf<String>()
+        val size = length()
+        for (i in 0 until size) {
+          result += optString(i)
+        }
+        result.filterNot { it.isBlank() }
+      }
+    }.getOrNull() ?: emptyList()
   }
 
   override suspend fun <T> getObject(key: String, klass: Class<T>) = mutex.withLock {

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/RealTask.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/RealTask.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flattenConcat
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onCompletion
@@ -72,6 +73,23 @@ internal class RealTask internal constructor(
   internal fun enqueue(alreadySaved: Boolean = false): Task {
     scope.launch {
       if (!alreadySaved) taskInfoRepository.saveJob(taskInfo)
+      // Run pre-approval immediately (outside the queue) so the user can approve
+      // the install even while the app waits in queue
+      if (type == Task.Type.INSTALL) {
+        try {
+          packageInstaller.requestUserPreApproval(packageName, installPackageInfo).first()
+        } catch (e: Throwable) {
+          val state = when (e) {
+            is AbortException -> Task.State.Aborted
+            is CancellationException -> Task.State.Canceled
+            else -> Task.State.Failed
+          }
+          _stateAndProgress.emit(state)
+          taskInfoRepository.remove(taskInfo)
+          appsCache.setBusy(packageName, false)
+          return@launch
+        }
+      }
       jobDispatcher.enqueue(this@RealTask)
     }
     return this

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/dto/InstallPackageInfo.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/dto/InstallPackageInfo.kt
@@ -7,6 +7,8 @@ data class InstallPackageInfo(
   val versionCode: Long,
   val installationFiles: Set<InstallationFile> = emptySet(),
   val payload: String? = null,
+  val appLabel: String? = null,
+  val iconUrl: String? = null,
 ) {
   val filesSize = installationFiles.sumOf { it.fileSize }
 }

--- a/install-manager/src/main/java/cm/aptoide/pt/install_manager/workers/PackageInstaller.kt
+++ b/install-manager/src/main/java/cm/aptoide/pt/install_manager/workers/PackageInstaller.kt
@@ -5,11 +5,25 @@ import cm.aptoide.pt.install_manager.OutOfSpaceException
 import cm.aptoide.pt.install_manager.dto.InstallPackageInfo
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 /**
  * This interface represents install logic for the package files.
  */
 interface PackageInstaller {
+
+  /**
+   * Request user preapproval before downloading or installing.
+   * Default implementation is a no-op.
+   *
+   * @param packageName - a package name
+   * @param installPackageInfo - a package info
+   * @returns Flow that completes when preapproval finishes (if supported).
+   */
+  fun requestUserPreApproval(
+    packageName: String,
+    installPackageInfo: InstallPackageInfo,
+  ): Flow<Unit> = flowOf(Unit)
 
   /**
    * Install package files.


### PR DESCRIPTION
**What does this PR do?**

   - Creates PreApprovalInstaller, which is an installer variant capable of requesting user install approval before the package files are downloaded.
   - Adds logic to select the PreApprovalInstaller in the installer selector.
   - Adds all the logic and conditions for an AB test that compares installs between the default installer and the new pre approval installer.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-684](https://aptoide.atlassian.net/browse/AND-684)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-684](https://aptoide.atlassian.net/browse/AND-684)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-684]: https://aptoide.atlassian.net/browse/AND-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-684]: https://aptoide.atlassian.net/browse/AND-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-approval installer flow: users can preview app label and icon and approve installs before committing.
  * In-app request flow to obtain user pre-approval prior to installing.

* **Enhancements**
  * Restores pre-approved sessions to avoid re-prompting.
  * Install queue integrates pre-approval and aborts cleanly on user cancel.
  * Improved install analytics and A/B experiment tracking for pre-approval outcomes.

* **Other**
  * Timeouts and safer event handling for pre-approval interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->