### PR TITLE
[AND-702] Fix mission UI render in app view rewards tab

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/app_view/AppRewardsView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/app_view/AppRewardsView.kt
@@ -102,29 +102,19 @@ private fun RewardsSection(
   items: List<PaEMission>,
   itemContent: @Composable (PaEMission) -> Unit
 ) {
-  // Sort items: ONGOING first, then PENDING, then COMPLETED
-  val sortedItems = items.sortedBy { mission ->
-    when (mission.progress?.status) {
-      PaEMissionStatus.IN_PROGRESS -> 0
-      PaEMissionStatus.PENDING -> 1
-      PaEMissionStatus.COMPLETED -> 2
-      null -> 1
-    }
-  }
-
   Column(
     modifier = Modifier.padding(16.dp),
     verticalArrangement = Arrangement.spacedBy(16.dp)
   ) {
     RewardsSectionHeader(title)
     Column {
-      sortedItems.forEachIndexed { index, item ->
+      items.forEachIndexed { index, item ->
         itemContent(item)
 
-        if (index < sortedItems.size - 1) {
+        if (index < items.size - 1) {
           val isCurrentCompleted = item.progress?.status == PaEMissionStatus.COMPLETED
           val isNextCompleted =
-            sortedItems[index + 1].progress?.status == PaEMissionStatus.COMPLETED
+            items[index + 1].progress?.status == PaEMissionStatus.COMPLETED
 
           if (isCurrentCompleted && isNextCompleted) {
             Divider(

--- a/play-and-earn/campaigns/src/main/java/cm/aptoide/pt/campaigns/data/DefaultPaEMissionsRepository.kt
+++ b/play-and-earn/campaigns/src/main/java/cm/aptoide/pt/campaigns/data/DefaultPaEMissionsRepository.kt
@@ -47,30 +47,34 @@ internal class DefaultPaEMissionsRepository @Inject constructor(
     }
 
   override fun observeCampaignMissions(packageName: String): Flow<Result<PaEMissions>> = flow {
-    getCachedMissions(packageName)?.let { emit(Result.success(it)) }
-
     try {
       val missions = fetchMissions(packageName)
       emit(Result.success(missions))
     } catch (e: Throwable) {
       e.printStackTrace()
-      if (getCachedMissions(packageName) == null) {
+      // Fall back to cache only when the network request fails
+      val cached = getCachedMissions(packageName)
+      if (cached != null) {
+        emit(Result.success(cached))
+      } else {
         emit(Result.failure(e))
       }
     }
   }.flowOn(dispatcher)
 
-  override suspend fun getCachedMissions(packageName: String): PaEMissions? {
+  override suspend fun getCachedMissions(packageName: String): PaEMissions? = try {
     val cachedMissions = paeMissionDao.getAppMissions(packageName)
     if (cachedMissions.isEmpty()) {
-      return null
+      null
+    } else {
+      val missions = cachedMissions.map { it.toDomain() }
+      val checkpoints = missions.filter { it.type == PaEMissionType.CHECKPOINT }
+      val regularMissions = missions.filter { it.type != PaEMissionType.CHECKPOINT }
+      PaEMissions(checkpoints = checkpoints, missions = regularMissions)
     }
-
-    val missions = cachedMissions.map { it.toDomain() }
-    val checkpoints = missions.filter { it.type == PaEMissionType.CHECKPOINT }
-    val regularMissions = missions.filter { it.type != PaEMissionType.CHECKPOINT }
-
-    return PaEMissions(checkpoints = checkpoints, missions = regularMissions)
+  } catch (e: Throwable) {
+    e.printStackTrace()
+    null
   }
 
   override suspend fun markMissionAsCompleted(packageName: String, missionTitle: String) {

--- a/play-and-earn/campaigns/src/main/java/cm/aptoide/pt/campaigns/presentation/PaEAppMissionsViewModel.kt
+++ b/play-and-earn/campaigns/src/main/java/cm/aptoide/pt/campaigns/presentation/PaEAppMissionsViewModel.kt
@@ -11,8 +11,12 @@ import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import cm.aptoide.pt.campaigns.data.PaEMissionsRepository
+import cm.aptoide.pt.campaigns.domain.PaEMission
+import cm.aptoide.pt.campaigns.domain.PaEMissionStatus
+import cm.aptoide.pt.campaigns.domain.PaEMissions
 import cm.aptoide.pt.extensions.runPreviewable
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
@@ -28,6 +32,7 @@ class PaEAppMissionsViewModel(
 ) : ViewModel() {
 
   private val viewModelState = MutableStateFlow<PaEMissionsUiState>(PaEMissionsUiState.Loading)
+  private var reloadJob: Job? = null
 
   val uiState = viewModelState
     .stateIn(
@@ -41,17 +46,23 @@ class PaEAppMissionsViewModel(
   }
 
   fun reload() {
-    viewModelScope.launch {
-      viewModelState.update { PaEMissionsUiState.Loading }
+    reloadJob?.cancel()
+    reloadJob = viewModelScope.launch {
+      // Only show Loading if no data has been loaded yet to avoid layout shifts
+      if (viewModelState.value !is PaEMissionsUiState.Idle) {
+        viewModelState.update { PaEMissionsUiState.Loading }
+      }
 
       paEMissionsRepository.observeCampaignMissions(packageName).collect { result ->
         result.fold(
           onSuccess = { missions ->
-            viewModelState.update { PaEMissionsUiState.Idle(paeMissions = missions) }
+            viewModelState.update {
+              PaEMissionsUiState.Idle(paeMissions = missions.sortedByStatus())
+            }
           },
           onFailure = { throwable ->
             Timber.w(throwable)
-            if (viewModelState.value is PaEMissionsUiState.Loading) {
+            if (viewModelState.value !is PaEMissionsUiState.Idle) {
               viewModelState.update {
                 when (throwable) {
                   is IOException -> PaEMissionsUiState.NoConnection
@@ -63,6 +74,21 @@ class PaEAppMissionsViewModel(
         )
       }
     }
+  }
+}
+
+/** Sorts checkpoints and missions: IN_PROGRESS first, then PENDING, then COMPLETED. */
+private fun PaEMissions.sortedByStatus() = PaEMissions(
+  checkpoints = checkpoints.sortedByStatus(),
+  missions = missions.sortedByStatus()
+)
+
+private fun List<PaEMission>.sortedByStatus() = sortedBy { mission ->
+  when (mission.progress?.status) {
+    PaEMissionStatus.IN_PROGRESS -> 0
+    PaEMissionStatus.PENDING -> 1
+    PaEMissionStatus.COMPLETED -> 2
+    null -> 1
   }
 }
 


### PR DESCRIPTION
**What does this PR do?**

   - Fixes the mission UI render in app view rewards tab. This is done by replacing the cache-then-network pattern in mission fetching, by a network-first pattern.
   - Also moves ordering of mission from the UI to the responsible ViewModel.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-702](https://aptoide.atlassian.net/browse/AND-702)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-702](https://aptoide.atlassian.net/browse/AND-702)


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-702]: https://aptoide.atlassian.net/browse/AND-702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-702]: https://aptoide.atlassian.net/browse/AND-702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Missions list now consistently appears sorted by status (In Progress → Pending → Completed).

* **Improvements**
  * Reloads cancel prior requests to avoid duplicate loading and unnecessary UI loading states.
  * Network fetch now preferred with a cache fallback on failure for more reliable offline behavior.

* **Behavior Change**
  * Rewards display order now follows the input/remote sequence rather than a local reordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->