### PR TITLE
[AND-704] Hide checkpoints section in app view rewards if empty

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/app_view/AppRewardsView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/app_view/AppRewardsView.kt
@@ -89,11 +89,13 @@ private fun MissionsSection(missions: List<PaEMission>) {
 
 @Composable
 private fun CheckpointsSection(checkpoints: List<PaEMission>) {
-  RewardsSection(
-    title = stringResource(R.string.play_and_earn_checkpoints_title),
-    items = checkpoints,
-    itemContent = { checkpoint -> CheckpointItem(checkpoint) },
-  )
+  if (checkpoints.isNotEmpty()) {
+    RewardsSection(
+      title = stringResource(R.string.play_and_earn_checkpoints_title),
+      items = checkpoints,
+      itemContent = { checkpoint -> CheckpointItem(checkpoint) },
+    )
+  }
 }
 
 @Composable

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/app_view/AppRewardsView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/app_view/AppRewardsView.kt
@@ -40,7 +40,6 @@ import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.drawables.icons.play_and_earn.getMissionHexagonCompletedIcon
 import com.aptoide.android.aptoidegames.drawables.icons.play_and_earn.getSmallCoinIcon
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.PaEProgressIndicator
-import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.getAppXPAnnotatedString
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.Palette
 
@@ -164,16 +163,10 @@ private fun CheckpointItem(checkpoint: PaEMission) {
       if (isCompleted) {
         Column(
           modifier = Modifier.weight(1f),
-          verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
           Text(
             text = checkpoint.title,
             style = AGTypography.InputsM,
-            color = Palette.Grey
-          )
-          Text(
-            text = "${checkpoint.progress?.target ?: 0} XP",
-            style = AGTypography.InputsXS,
             color = Palette.Grey
           )
         }
@@ -215,16 +208,8 @@ private fun CheckpointItem(checkpoint: PaEMission) {
           Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
+            horizontalArrangement = Arrangement.End
           ) {
-            Text(
-              text = getAppXPAnnotatedString(
-                checkpoint.progress?.current ?: 0,
-                checkpoint.progress?.target ?: 0
-              ),
-              style = AGTypography.InputsXS,
-              color = Palette.White
-            )
             Text(
               text = "+ ${checkpoint.units} UNITS",
               style = AGTypography.InputsS,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/PaEInstallProgressText.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/PaEInstallProgressText.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import cm.aptoide.pt.campaigns.domain.PaEApp
 import cm.aptoide.pt.campaigns.domain.asNormalApp
-import cm.aptoide.pt.campaigns.domain.randomPaEApp
 import cm.aptoide.pt.download_view.presentation.DownloadUiState
 import cm.aptoide.pt.download_view.presentation.DownloadUiState.Downloading
 import cm.aptoide.pt.download_view.presentation.DownloadUiState.Error
@@ -41,7 +40,6 @@ fun PaEInstallProgressText(
 
   PaEInstallProgressTextContent(
     modifier = modifier,
-    app = app,
     state = state,
   )
 }
@@ -49,7 +47,6 @@ fun PaEInstallProgressText(
 @Composable
 private fun PaEInstallProgressTextContent(
   modifier: Modifier = Modifier,
-  app: PaEApp,
   state: DownloadUiState?,
 ) {
   val text = when (state) {
@@ -75,7 +72,7 @@ private fun PaEInstallProgressTextContent(
     is Installed,
     is Migrate,
     is MigrateAlias,
-      -> PaEAppXPText(app.progress?.current ?: 0, app.progress?.target ?: 0)
+      -> Unit
 
     is Waiting,
     is Downloading,
@@ -101,7 +98,6 @@ private fun PaEInstallProgressTextContent(
 fun ProgressTextContentInstalledPreview() {
   AptoideTheme {
     PaEInstallProgressTextContent(
-      app = randomPaEApp,
       state = Installed({}, {}),
     )
   }
@@ -112,7 +108,6 @@ fun ProgressTextContentInstalledPreview() {
 fun ProgressTextContentInstallingPreview() {
   AptoideTheme {
     PaEInstallProgressTextContent(
-      app = randomPaEApp,
       state = Downloading(randomInstallPackageInfo, Random.nextInt(0, 100), {}),
     )
   }
@@ -123,7 +118,6 @@ fun ProgressTextContentInstallingPreview() {
 fun ProgressTextContentErrorPreview() {
   AptoideTheme {
     PaEInstallProgressTextContent(
-      app = randomPaEApp,
       state = Error(retryWith = {}),
     )
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/app_items/PaECompactAppItem.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/app_items/PaECompactAppItem.kt
@@ -73,7 +73,8 @@ fun PaECompactAppItem(
           .fillMaxWidth()
           .padding(all = 16.dp)
           .align(Alignment.BottomStart),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
       ) {
         AppIconImage(
           modifier = Modifier.size(40.dp),
@@ -82,7 +83,7 @@ fun PaECompactAppItem(
         )
 
         Column(
-          verticalArrangement = Arrangement.spacedBy(4.dp)
+          verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
           Text(
             text = app.name,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/PaEHowItWorksSection.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/PaEHowItWorksSection.kt
@@ -49,10 +49,6 @@ fun PaEHowItWorksSection() {
         iconRes = R.drawable.sword
       )
       PaEHowItWorksCard(
-        text = stringResource(R.string.play_and_earn_xp_contributes_checkpoints_body),
-        iconRes = R.drawable.map
-      )
-      PaEHowItWorksCard(
         text = stringResource(R.string.play_and_earn_unlock_rewards_convert_balance_body),
         iconRes = R.drawable.chest
       )


### PR DESCRIPTION
**What does this PR do?**

   - Hides checkpoints section in app view rewards tab.
   - Removes XP text in checkpoint items.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-704](https://aptoide.atlassian.net/browse/AND-704)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-704](https://aptoide.atlassian.net/browse/AND-704)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-704]: https://aptoide.atlassian.net/browse/AND-704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-704]: https://aptoide.atlassian.net/browse/AND-704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined completed checkpoint display by removing redundant XP text and tightening spacing.
  * Adjusted alignment and spacing for in-progress checkpoints for improved visual balance.
  * Rewards section now appears only when checkpoints are present.
  * Install progress text no longer derives progress from app instances; some states show no progress indicator.
  * Minor item layout alignment tweaks and removal of one informational card in the "How it works" row.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->