### PR TITLE
[AND-717] Fix home promo cards and ahab dialog UTM values

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MoreBundleView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/MoreBundleView.kt
@@ -38,7 +38,7 @@ import com.aptoide.android.aptoidegames.home.LoadingView
 import com.aptoide.android.aptoidegames.installer.presentation.InstallViewShort
 import com.aptoide.android.aptoidegames.mmp.UTMContext
 import com.aptoide.android.aptoidegames.mmp.WithUTM
-import com.aptoide.android.aptoidegames.mmp.getUTMConfig
+import com.aptoide.android.aptoidegames.mmp.getBundleSeeAllUTMInfo
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 import com.aptoide.android.aptoidegames.toolbar.AppGamesTopBar
 
@@ -53,7 +53,7 @@ fun seeMoreScreen() = ScreenData.withAnalytics(
   val bundleTag = arguments.getString("tag")!!
 
   WithUTM(
-    content = getUTMConfig(bundleTag)?.seeAllContent,
+    utmInfo = getBundleSeeAllUTMInfo(bundleTag),
     navigate = navigate
   ) { navigate ->
     MoreBundleView(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -96,7 +96,7 @@ import com.aptoide.android.aptoidegames.gamesfeed.presentation.GamesFeedBundle
 import com.aptoide.android.aptoidegames.gamesfeed.presentation.rememberGamesFeedVisibility
 import com.aptoide.android.aptoidegames.home.analytics.meta
 import com.aptoide.android.aptoidegames.mmp.WithUTM
-import com.aptoide.android.aptoidegames.mmp.getUTMConfig
+import com.aptoide.android.aptoidegames.mmp.getBundleHomeUTMInfo
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.PaEBundleView
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.home.rememberPaEHeaderState
 import com.aptoide.android.aptoidegames.play_and_earn.rememberShouldShowPlayAndEarn
@@ -212,7 +212,7 @@ fun BundlesView(
     ) {
       items(viewState.bundles) { bundle ->
         WithUTM(
-          content = getUTMConfig(bundle.tag)?.homeContent,
+          utmInfo = getBundleHomeUTMInfo(bundle.tag),
           navigate = navigate
         ) { navigate ->
           OverrideAnalyticsBundleMeta(bundle.meta, navigate) { navigateTo ->

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -212,7 +212,7 @@ fun BundlesView(
     ) {
       items(viewState.bundles) { bundle ->
         WithUTM(
-          utmInfo = getBundleHomeUTMInfo(bundle.tag),
+          utmInfo = getBundleHomeUTMInfo(bundle.tag, bundle.type),
           navigate = navigate
         ) { navigate ->
           OverrideAnalyticsBundleMeta(bundle.meta, navigate) { navigateTo ->

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/mmp/BundleUTMSetup.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/mmp/BundleUTMSetup.kt
@@ -1,17 +1,29 @@
 package com.aptoide.android.aptoidegames.mmp
 
 import cm.aptoide.pt.feature_campaigns.UTMInfo
+import cm.aptoide.pt.feature_home.domain.Type
 
 private const val MORE_SUFFIX = "-more"
 private const val APPS_GROUP_PREFIX = "apps-group-"
 
-fun getBundleHomeUTMInfo(tag: String): UTMInfo {
+private fun getPromoCardCampaign(type: Type): String? = when (type) {
+  Type.NEW_APP -> "launch"
+  Type.NEW_APP_VERSION -> "update"
+  Type.NEWS_ITEM -> "news"
+  Type.IN_GAME_EVENT -> "event"
+  else -> null
+}
+
+fun getBundleHomeUTMInfo(tag: String, type: Type? = null): UTMInfo {
+  type?.let { getPromoCardCampaign(it) }?.let { campaign ->
+    return UTMInfo(utmMedium = "promo-card", utmCampaign = campaign, utmContent = "home-promo-card")
+  }
+
   return when (val baseTag = tag.removeSuffix(MORE_SUFFIX)) {
     "apps-group-just-arrived" -> UTMInfo(utmContent = "home-just-arrived")
     "apps-group-trending" -> UTMInfo(utmContent = "home-trending")
     "apps-group-editors-choice" -> UTMInfo(utmContent = "home-editors-choice")
     "apps-group-featured-appcoins" -> UTMInfo(utmContent = "home-get-rewarded")
-    "new-app" -> UTMInfo(utmContent = "home-new-app")
     else -> if (baseTag.startsWith(APPS_GROUP_PREFIX)) {
       val suffix = baseTag.removePrefix(APPS_GROUP_PREFIX)
       UTMInfo(utmContent = "home-$suffix")

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/mmp/BundleUTMSetup.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/mmp/BundleUTMSetup.kt
@@ -1,28 +1,37 @@
 package com.aptoide.android.aptoidegames.mmp
 
-data class UTMConfig(
-  val homeContent: String,
-  val seeAllContent: String?
-)
+import cm.aptoide.pt.feature_campaigns.UTMInfo
 
 private const val MORE_SUFFIX = "-more"
 private const val APPS_GROUP_PREFIX = "apps-group-"
 
-fun getUTMConfig(bundleTag: String): UTMConfig? {
-  val baseTag = bundleTag.removeSuffix(MORE_SUFFIX)
-  return when (baseTag) {
-    "apps-group-just-arrived" -> UTMConfig("home-just-arrived", "just-arrived-seeall")
-    "apps-group-trending" -> UTMConfig("home-trending", "trending-seeall")
-    "apps-group-editors-choice" -> UTMConfig("home-editors-choice", "editors-choice-seeall")
-    "apps-group-featured-appcoins" -> UTMConfig("home-get-rewarded", "get-rewarded-seeall")
-    "new-app" -> UTMConfig("home-new-app", null)
-    else -> {
-      if (baseTag.startsWith(APPS_GROUP_PREFIX)) {
-        val suffix = baseTag.removePrefix(APPS_GROUP_PREFIX)
-        UTMConfig("home-$suffix", "$suffix-seeall")
-      } else {
-        null
-      }
+fun getBundleHomeUTMInfo(tag: String): UTMInfo {
+  return when (val baseTag = tag.removeSuffix(MORE_SUFFIX)) {
+    "apps-group-just-arrived" -> UTMInfo(utmContent = "home-just-arrived")
+    "apps-group-trending" -> UTMInfo(utmContent = "home-trending")
+    "apps-group-editors-choice" -> UTMInfo(utmContent = "home-editors-choice")
+    "apps-group-featured-appcoins" -> UTMInfo(utmContent = "home-get-rewarded")
+    "new-app" -> UTMInfo(utmContent = "home-new-app")
+    else -> if (baseTag.startsWith(APPS_GROUP_PREFIX)) {
+      val suffix = baseTag.removePrefix(APPS_GROUP_PREFIX)
+      UTMInfo(utmContent = "home-$suffix")
+    } else {
+      UTMInfo()
+    }
+  }
+}
+
+fun getBundleSeeAllUTMInfo(tag: String): UTMInfo {
+  return when (val baseTag = tag.removeSuffix(MORE_SUFFIX)) {
+    "apps-group-just-arrived" -> UTMInfo(utmContent = "just-arrived-seeall")
+    "apps-group-trending" -> UTMInfo(utmContent = "trending-seeall")
+    "apps-group-editors-choice" -> UTMInfo(utmContent = "editors-choice-seeall")
+    "apps-group-featured-appcoins" -> UTMInfo(utmContent = "get-rewarded-seeall")
+    else -> if (baseTag.startsWith(APPS_GROUP_PREFIX)) {
+      val prefix = baseTag.removePrefix(APPS_GROUP_PREFIX)
+      UTMInfo(utmContent = "$prefix-seeall")
+    } else {
+      UTMInfo()
     }
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/mmp/UTMContext.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/mmp/UTMContext.kt
@@ -50,3 +50,19 @@ fun WithUTM(
     }
   }
 }
+
+@Composable
+fun WithUTM(
+  utmInfo: UTMInfo,
+  navigate: (String) -> Unit,
+  block: @Composable ((String) -> Unit) -> Unit,
+) = WithUTM(
+  source = utmInfo.utmSource,
+  medium = utmInfo.utmMedium,
+  campaign = utmInfo.utmCampaign,
+  content = utmInfo.utmContent,
+  term = utmInfo.utmTerm,
+  shouldSendClickEvents = utmInfo.shouldSendClickEvents,
+  navigate = navigate,
+  block = block,
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/promotions/presentation/PromotionDialog.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/promotions/presentation/PromotionDialog.kt
@@ -55,9 +55,9 @@ fun PromotionDialog(navigate: (String) -> Unit) {
 
   promotionData?.let { (promotion, app) ->
     WithUTM(
-      medium = "promo-card",
+      medium = "ahab",
       campaign = promotion.uid,
-      content = "home-promo-card",
+      content = "ahab-dialog",
       navigate = navigate
     ) {
       val utmContext = UTMContext.current

--- a/feature_campaigns/src/main/java/cm/aptoide/pt/feature_campaigns/UTMInfo.kt
+++ b/feature_campaigns/src/main/java/cm/aptoide/pt/feature_campaigns/UTMInfo.kt
@@ -8,7 +8,7 @@ import java.nio.charset.StandardCharsets
  * All fields are nullable to allow partial definitions that can be merged or overridden.
  */
 data class UTMInfo(
-  val utmSource: String? = "aptoide",
+  val utmSource: String? = null,
   val utmMedium: String? = null,
   val utmCampaign: String? = null,
   val utmContent: String? = null,


### PR DESCRIPTION
**What does this PR do?**

   - Improves the bundles UTM values definition.
   - Changes the UTM values for home promo cards and for the home ahab dialogs.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-717](https://aptoide.atlassian.net/browse/AND-717)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-717](https://aptoide.atlassian.net/browse/AND-717)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-717]: https://aptoide.atlassian.net/browse/AND-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-717]: https://aptoide.atlassian.net/browse/AND-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated analytics tracking infrastructure for app bundles with refined parameter handling for home and see-all screens.
  * Improved UTM data retrieval for different bundle types, including featured, trending, editors' choice, and newly-arrived content.
  * Enhanced tracking structure for promotional dialogs with updated parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->