### PR TITLE
[AND-724] Add safe check to avoid recomposition in PaE bundle

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
@@ -117,7 +117,7 @@ fun MainView(navController: NavHostController) {
         navigate = navigate
       ) { showBottomSheet ->
         PaEHomeLayout(navController = navController) {
-          Scaffold(
+        Scaffold(
             snackbarHost = {
               SnackbarHost(hostState = snackBarHostState) {
                 Popup {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/home/PaEHomeLayout.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/home/PaEHomeLayout.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -55,6 +56,11 @@ fun PaEHomeLayout(
 
   val shouldShowPlayAndEarn = rememberShouldShowPlayAndEarn()
   val (hasShownHeader, markHeaderAsShown) = rememberPaEHeaderState()
+
+  // Use movableContentOf to preserve the content's composition state (ViewModels, remember,
+  // LaunchedEffects, etc.) when it moves between the if/else branches. Without this, switching
+  // branches destroys and recreates the entire content subtree, causing a full reload.
+  val movableContent = remember { movableContentOf { content() } }
 
   if (bundle != null && shouldShowPlayAndEarn && hasShownHeader == false) {
     val coroutineScope = rememberCoroutineScope()
@@ -160,7 +166,7 @@ fun PaEHomeLayout(
         }
 
         Box(modifier = Modifier.height(maxHeight)) {
-          content()
+          movableContent()
         }
       }
 
@@ -175,6 +181,6 @@ fun PaEHomeLayout(
       }
     }
   } else {
-    content()
+    movableContent()
   }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR comes from an investigation on the home reload. During that investigation we discovered also this possible 
vulnerability (eventhough not really probable).

PaEHomeLayout uses an if/else branch to decide whether to show the Play & Earn header. The content() composable which contains the Scaffold, NavHost, and all screens was placed at different positions in the composition tree depending on the branch — inside BoxWithConstraints > Column > Box in the if branch vs. directly in the else branch. When the async states shouldShowPlayAndEarn, hasShownHeader, PaE bundles resolved and caused showHeader to change, Compose treated the two slots as different compositions and destroyed the entire content subtree, recreating all ViewModels and triggering a full network reload.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] PaEHomeLayout.kt

**How should this be manually tested?**

Open the app and check if the flow of loading the pae bundle works correctly.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-724](https://aptoide.atlassian.net/browse/AND-724)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-724]: https://aptoide.atlassian.net/browse/AND-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI state preservation when switching between different view layouts to ensure consistent behavior and prevent unintended state loss.

* **Refactor**
  * Internal code optimizations to enhance composition state handling and overall application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->