### PR TITLE
 [AND-700] Add overlay workaround for games like ML

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieOverlay.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieOverlay.kt
@@ -1,6 +1,7 @@
 package com.aptoide.android.aptoidegames.gamegenie.presentation
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectDragGestures
@@ -42,6 +43,7 @@ import kotlin.math.abs
 fun GameGenieOverlay(
   showMenu: Boolean,
   isAptoideGamesInForeground: Boolean,
+  isScreenshotReady: Boolean,
   targetAppIcon: ImageBitmap?,
   onMenuToggle: () -> Unit,
   onDrag: (dx: Int, dy: Int) -> Unit,
@@ -58,6 +60,7 @@ fun GameGenieOverlay(
     ) {
       GameGenieIconFab(
         isAptoideGamesInForeground = isAptoideGamesInForeground,
+        isScreenshotReady = isScreenshotReady,
         targetAppIcon = targetAppIcon,
         modifier = Modifier
           .pointerInput(Unit) {
@@ -78,11 +81,11 @@ fun GameGenieOverlay(
               }
             )
           },
-        onClick = {
+        onTakeScreenshot = {
           analytics.sendGameGenieOverlayClick()
           onScreenshotRequest()
         },
-        onLongClick = { onMenuToggle() }
+        onOpenMenu = { onMenuToggle() }
       )
     }
 
@@ -196,15 +199,17 @@ private fun GameGenieMenuItem(
 fun GameGenieIconFab(
   modifier: Modifier = Modifier,
   isAptoideGamesInForeground: Boolean,
+  isScreenshotReady: Boolean = true,
   targetAppIcon: ImageBitmap? = null,
-  onClick: () -> Unit = {},
-  onLongClick: () -> Unit = {},
+  onTakeScreenshot: () -> Unit = {},
+  onOpenMenu: () -> Unit = {},
 ) {
   Box(
     modifier = modifier.size(56.dp),
     contentAlignment = Alignment.Center
   ) {
     val iconSize = if (isAptoideGamesInForeground) 48.dp else 40.dp
+    val interactionSource = remember { MutableInteractionSource() }
     val iconModifier = Modifier
       .size(iconSize)
       .graphicsLayer {
@@ -213,10 +218,14 @@ fun GameGenieIconFab(
         val shadowOffset = if (isAptoideGamesInForeground) - 4.dp.toPx() else 0f
         translationY = shadowOffset
         translationX = shadowOffset
+        alpha = if (isScreenshotReady) 1f else 0.4f
       }
       .combinedClickable(
-        onClick = onClick,
-        onLongClick = onLongClick
+        interactionSource = interactionSource,
+        indication = if (isScreenshotReady) LocalIndication.current else null,
+        enabled = true,
+        onClick = { if (isScreenshotReady) onTakeScreenshot() else onOpenMenu() },
+        onLongClick = onOpenMenu
       )
 
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieOverlayService.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieOverlayService.kt
@@ -4,6 +4,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.Service
 import android.content.Intent
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
 import android.content.pm.ServiceInfo
 import android.content.res.Configuration
 import android.graphics.Bitmap
@@ -78,6 +79,8 @@ class GameGenieOverlayService : Service(),
 
     private const val SCREENSHOT_DELAY_MS = 100L
 
+    private const val OVERLAY_READY_TIMEOUT_MS = 5_000L
+
     @Volatile
     var isServiceRunning: Boolean = false
       private set
@@ -88,7 +91,7 @@ class GameGenieOverlayService : Service(),
     @Volatile
     var currentTargetPackage: String? = null
       private set
-    
+
     @Volatile
     var hasScreenshotPermission: Boolean = false
       private set
@@ -121,6 +124,9 @@ class GameGenieOverlayService : Service(),
 
   private val scope = CoroutineScope(Dispatchers.Main + Job())
 
+  private var isScreenshotReady by mutableStateOf(false)
+  private var overlayTimeoutJob: Job? = null
+
   private var onOrientationChanged: ((Int, Int) -> Unit)? = null
 
   private var pendingMediaProjectionResultCode: Int = 0
@@ -141,6 +147,7 @@ class GameGenieOverlayService : Service(),
       initializeManagers()
       setupOverlayView()
       startMonitoring()
+      startOverlayReadinessTimeout()
     } catch (e: Exception) {
       e.printStackTrace()
       stopSelf()
@@ -171,6 +178,7 @@ class GameGenieOverlayService : Service(),
     
     screenshotManager.onMediaProjectionStopped = {
       hasScreenshotPermission = false
+      isScreenshotReady = false
     }
 
     displayMonitor = OverlayDisplayMonitor(
@@ -235,7 +243,7 @@ class GameGenieOverlayService : Service(),
             actualY,
             actualX < windowManager.screenWidth / 2,
             analytics,
-            showOnlyRemove = isAptoideGamesInForeground
+            showOnlyRemove = isAptoideGamesInForeground || !isScreenshotReady
           )
         } else {
           showMenu = false
@@ -252,6 +260,7 @@ class GameGenieOverlayService : Service(),
           GameGenieOverlay(
             showMenu = showMenu,
             isAptoideGamesInForeground = isAptoideGamesInForeground,
+            isScreenshotReady = isScreenshotReady,
             targetAppIcon = targetAppIcon,
             onMenuToggle = onMenuToggle,
             onDrag = { dx, dy ->
@@ -316,6 +325,16 @@ class GameGenieOverlayService : Service(),
     displayMonitor.performForcedChecks()
   }
 
+  private fun startOverlayReadinessTimeout() {
+    overlayTimeoutJob?.cancel()
+    overlayTimeoutJob = scope.launch {
+      delay(OVERLAY_READY_TIMEOUT_MS)
+      if (!isScreenshotReady) {
+        stopSelf()
+      }
+    }
+  }
+
   private fun handleDimensionChange() {
     windowManager.updateScreenDimensions()
 
@@ -363,13 +382,34 @@ class GameGenieOverlayService : Service(),
       pendingMediaProjectionResultCode = newResultCode
       pendingMediaProjectionData = newData
       hasScreenshotPermission = true
+      isScreenshotReady = false
+      upgradeForegroundServiceToMediaProjection()
+      screenshotManager.setupMediaProjection(newResultCode, newData)
+      if (screenshotManager.hasMediaProjection()) {
+        screenshotManager.setupVirtualDisplay(
+          windowManager.screenWidth,
+          windowManager.screenHeight,
+          onFirstFrameReady = {
+            isScreenshotReady = true
+            overlayTimeoutJob?.cancel()
+          }
+        )
+        pendingMediaProjectionResultCode = 0
+        pendingMediaProjectionData = null
+      } else {
+        hasScreenshotPermission = false
+      }
+      startOverlayReadinessTimeout()
     } else if (screenshotManager.hasPermissionData()) {
       if (screenshotManager.needsRecreation()) {
         if (screenshotManager.hasMediaProjection()) {
+          isScreenshotReady = false
           screenshotManager.setupVirtualDisplay(
             windowManager.screenWidth,
             windowManager.screenHeight,
             onFirstFrameReady = {
+              isScreenshotReady = true
+              overlayTimeoutJob?.cancel()
             }
           )
         }
@@ -706,8 +746,11 @@ class GameGenieOverlayService : Service(),
     super.onDestroy()
     isServiceRunning = false
     hasScreenshotPermission = false
+    isScreenshotReady = false
     currentTargetPackage = null
     _overlayRunningState.value = false
+    overlayTimeoutJob?.cancel()
+    overlayTimeoutJob = null
 
     processLifecycleObserver?.let { ProcessLifecycleOwner.get().lifecycle.removeObserver(it) }
     processLifecycleObserver = null
@@ -718,11 +761,19 @@ class GameGenieOverlayService : Service(),
       lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
       myViewModelStore.clear()
       scope.cancel()
+      hideMenuWindow()
       windowManager.removeView(overlayView)
     } catch (e: Exception) {
       e.printStackTrace()
     }
   }
+
+  private fun buildNotification() = NotificationCompat.Builder(this, CHANNEL_ID)
+    .setContentTitle(getString(R.string.gamegenie_overlay_notification_title))
+    .setContentText(getString(R.string.gamegenie_overlay_notification_text))
+    .setSmallIcon(R.drawable.app_icon)
+    .setOngoing(true)
+    .build()
 
   private fun startAsForegroundService() {
     val channel = NotificationChannel(
@@ -733,21 +784,16 @@ class GameGenieOverlayService : Service(),
     val notificationManager = getSystemService(NotificationManager::class.java)
     notificationManager.createNotificationChannel(channel)
 
-    val notification = NotificationCompat.Builder(this, CHANNEL_ID)
-      .setContentTitle(getString(R.string.gamegenie_overlay_notification_title))
-      .setContentText(getString(R.string.gamegenie_overlay_notification_text))
-      .setSmallIcon(R.drawable.app_icon)
-      .setOngoing(true)
-      .build()
+    startForeground(NOTIFICATION_ID, buildNotification())
+  }
 
+  private fun upgradeForegroundServiceToMediaProjection() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       startForeground(
         NOTIFICATION_ID,
-        notification,
-        ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
+        buildNotification(),
+        FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
       )
-    } else {
-      startForeground(NOTIFICATION_ID, notification)
     }
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/OverlayScreenshotManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/OverlayScreenshotManager.kt
@@ -6,6 +6,7 @@ import android.graphics.Bitmap
 import android.graphics.PixelFormat
 import android.hardware.display.DisplayManager
 import android.hardware.display.VirtualDisplay
+import android.media.Image
 import android.media.ImageReader
 import android.media.projection.MediaProjection
 import android.media.projection.MediaProjectionManager
@@ -117,11 +118,23 @@ class OverlayScreenshotManager(private val context: Context) {
         ImageReader.newInstance(width, height, PixelFormat.RGBA_8888, IMAGE_READER_MAX_IMAGES)
       imageReader = reader
 
-      reader.setOnImageAvailableListener({
+      reader.setOnImageAvailableListener({ ir ->
         if (!isVirtualDisplayReady) {
-          isVirtualDisplayReady = true
-          firstFrameReceivedCallback?.invoke()
-          firstFrameReceivedCallback = null
+          val image = ir.acquireLatestImage()
+          if (image != null) {
+            val isBlack = try {
+              isImagePredominantlyBlack(image)
+            } catch (_: Exception) {
+              true
+            } finally {
+              image.close()
+            }
+            if (!isBlack) {
+              isVirtualDisplayReady = true
+              firstFrameReceivedCallback?.invoke()
+              firstFrameReceivedCallback = null
+            }
+          }
         }
       }, Handler(Looper.getMainLooper()))
 
@@ -228,6 +241,36 @@ class OverlayScreenshotManager(private val context: Context) {
       e.printStackTrace()
       return null
     }
+  }
+
+  private fun isImagePredominantlyBlack(image: Image): Boolean {
+    val planes = image.planes
+    if (planes.isEmpty()) return true
+
+    val buffer = planes[0].buffer
+    val pixelStride = planes[0].pixelStride
+    val rowStride = planes[0].rowStride
+    val width = image.width
+    val height = image.height
+
+    val sampleStep = 50
+    var blackCount = 0
+    var total = 0
+
+    for (y in 0 until height step sampleStep) {
+      for (x in 0 until width step sampleStep) {
+        val offset = y * rowStride + x * pixelStride
+        if (offset + 2 < buffer.limit()) {
+          val r = buffer.get(offset).toInt() and 0xFF
+          val g = buffer.get(offset + 1).toInt() and 0xFF
+          val b = buffer.get(offset + 2).toInt() and 0xFF
+          if (r < 20 && g < 20 && b < 20) blackCount++
+          total++
+        }
+      }
+    }
+
+    return total == 0 || (blackCount.toFloat() / total) > 0.95f
   }
 
   private fun isBitmapPredominantlyBlack(bitmap: Bitmap): Boolean {


### PR DESCRIPTION
**What does this PR do?**

This PR addresses issues with the Game Genie overlay misbehaving on certain apps, primarily caused by the overlay becoming interactive before the MediaProjection virtual display was actually ready to capture meaningful frames i.e., it was capturing black frames on first render. Now, we show a dimmed out FAB if the screenshot is not ready which is not clickable but it can be long pressed to remove it. If there 5 seconds have passed and the overlay is still not ready we close it

**Database changed?**

   No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Test the overlay on MLBB and check behavior

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-700](https://aptoide.atlassian.net/browse/AND-700)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-700]: https://aptoide.atlassian.net/browse/AND-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FAB reflects screenshot readiness and routes taps to either "take screenshot" or "open menu"; long-press opens menu.
  * Overlay service auto-stops if screenshot readiness isn't achieved within a timeout.

* **Improvements**
  * Dimmed/disabled FAB visuals and interaction when screenshots aren't ready.
  * More robust first-frame black-frame detection to avoid false readiness.
  * Cleaner foreground notification handling and tighter permission/readiness synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->