### PR TITLE
 [AND-725] Fix duplicated game icon on GameGenie companion games top strip

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/CompanionGameIcon.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/CompanionGameIcon.kt
@@ -79,7 +79,7 @@ fun GameCompanionIcon(
         contentAlignment = Alignment.Center
       ) {
         if (game.image != null) {
-          val painter = remember {
+          val painter = remember(game.packageName, game.image, imagePxSize) {
             BitmapPainter(game.image.toBitmap(imagePxSize, imagePxSize).asImageBitmap())
           }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/CompanionGamesStrip.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/CompanionGamesStrip.kt
@@ -133,7 +133,10 @@ fun CompanionGamesStrip(
                 horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.End),
                 verticalAlignment = Alignment.CenterVertically
               ) {
-                items(games) { game ->
+                items(
+                  items = games,
+                  key = { it.packageName }
+                ) { game ->
                   GameCompanionIcon(
                     game = game,
                     onClick = onGameClick,


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix a visual bug that happens when a user installs a game through GameGenie, the companion games top strip would have a duplicated icon of its last game instead of updating with the newly installed games

**Database changed?**

 No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Open GameGenie, install a game and check top games strip behavior

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-725](https://aptoide.atlassian.net/browse/AND-725)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-725]: https://aptoide.atlassian.net/browse/AND-725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved rendering stability for game icons and companion game list items.
  * Enhanced display accuracy when game information updates by ensuring proper item identification and refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->