### PR TITLE
[AND-733] implement P&E foreground service UX improvements

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
@@ -35,6 +35,7 @@ import com.aptoide.android.aptoidegames.play_and_earn.PlayAndEarnManager
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.service.PaEForegroundService
 import com.aptoide.android.aptoidegames.promo_codes.PromoCode
 import com.aptoide.android.aptoidegames.promo_codes.PromoCodeRepository
+import com.aptoide.android.aptoidegames.settings.settingsRoute
 import com.aptoide.android.aptoidegames.updates.domain.UpdatesNotificationAnalyticsManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -82,7 +83,7 @@ class MainActivity : AppCompatActivity() {
 
   @Inject
   lateinit var playAndEarnManager: PlayAndEarnManager
-  
+
   private var navController: NavHostController? = null
 
   private val coroutinesScope: CoroutineScope = CoroutineScope(Job() + Dispatchers.IO)
@@ -123,7 +124,7 @@ class MainActivity : AppCompatActivity() {
 
   private fun startPaEServiceIfEnabled() {
     coroutinesScope.launch {
-      if (playAndEarnManager.shouldShowPlayAndEarn()) {
+      if (playAndEarnManager.shouldStartPaEService()) {
         PaEForegroundService.start(this@MainActivity)
       }
     }
@@ -206,6 +207,10 @@ class MainActivity : AppCompatActivity() {
     }
     intent.agDeepLink?.takeIf { it.scheme == "ag" }?.let {
       navController?.navigate(it)
+    }
+
+    if (intent?.getBooleanExtra(PaEForegroundService.NAVIGATE_TO_SETTINGS, false) == true) {
+      navController?.navigate(settingsRoute)
     }
 
     intent.takeIf { it.isAGNotification }?.let {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/PlayAndEarnManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/PlayAndEarnManager.kt
@@ -15,6 +15,7 @@ import cm.aptoide.pt.feature_flags.domain.FeatureFlags
 import cm.aptoide.pt.wallet.datastore.WalletCoreDataSource
 import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.device_info.DeviceSecurityChecker
+import com.aptoide.android.aptoidegames.play_and_earn.data.PaEPreferencesRepository
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.permissions.hasOverlayPermission
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.permissions.hasUsageStatsPermissionStatus
 import com.google.firebase.ktx.Firebase
@@ -29,6 +30,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -40,7 +42,8 @@ class PlayAndEarnManager @Inject constructor(
   @ApplicationContext private val context: Context,
   private val featureFlags: FeatureFlags,
   private val walletCoreDataSource: WalletCoreDataSource,
-  private val deviceSecurityChecker: DeviceSecurityChecker
+  private val deviceSecurityChecker: DeviceSecurityChecker,
+  private val paEPreferencesRepository: PaEPreferencesRepository
 ) {
 
   companion object {
@@ -90,6 +93,11 @@ class PlayAndEarnManager @Inject constructor(
       return false
     }
     return featureFlags.getFlag(PAE_VISIBILITY_FLAG_KEY, false)
+  }
+  
+  suspend fun shouldStartPaEService(): Boolean {
+    val isServiceEnabled = paEPreferencesRepository.isPaEServiceEnabled().first()
+    return isServiceEnabled && shouldShowPlayAndEarn()
   }
 
   fun observePlayAndEarnVisibility(): StateFlow<Boolean> = _playAndEarnVisibilityFlow.asStateFlow()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/data/PaEPreferencesRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/data/PaEPreferencesRepository.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import com.aptoide.android.aptoidegames.play_and_earn.di.PaEPreferencesDataStore
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -19,6 +20,7 @@ class PaEPreferencesRepository @Inject constructor(
   companion object {
     private val HAS_SHOWN_HEADER_BUNDLE = booleanPreferencesKey("has_shown_header_bundle")
     private val HEARTBEAT_INTERVAL_SECONDS = intPreferencesKey("heartbeat_interval_seconds")
+    private val PAE_SERVICE_ENABLED = booleanPreferencesKey("pae_service_enabled")
     const val MIN_HEARTBEAT_INTERVAL_SECONDS = 15
   }
 
@@ -45,6 +47,17 @@ class PaEPreferencesRepository @Inject constructor(
     dataStore.edit { preferences ->
       preferences[HEARTBEAT_INTERVAL_SECONDS] =
         intervalSeconds.coerceAtLeast(MIN_HEARTBEAT_INTERVAL_SECONDS)
+    }
+  }
+
+  fun isPaEServiceEnabled(): Flow<Boolean> =
+    dataStore.data.map { preferences ->
+      preferences[PAE_SERVICE_ENABLED] ?: true
+    }
+
+  suspend fun setPaEServiceEnabled(enabled: Boolean) {
+    dataStore.edit { preferences ->
+      preferences[PAE_SERVICE_ENABLED] = enabled
     }
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/PaEInstallView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/PaEInstallView.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
 import cm.aptoide.pt.download_view.presentation.DownloadUiState
 import cm.aptoide.pt.download_view.presentation.ExecutionBlocker.UNMETERED
 import cm.aptoide.pt.download_view.presentation.downloadUiStates
@@ -50,6 +51,7 @@ import com.aptoide.android.aptoidegames.installer.presentation.getProgressString
 import com.aptoide.android.aptoidegames.installer.presentation.installViewStates
 import com.aptoide.android.aptoidegames.installer.presentation.toInstallViewState
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.rememberPlayAndEarnSetupRoute
+import com.aptoide.android.aptoidegames.play_and_earn.presentation.service.PaEForegroundService
 import com.aptoide.android.aptoidegames.play_and_earn.rememberPlayAndEarnReady
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
@@ -247,11 +249,16 @@ private fun PaEPlayButton(
 ) {
   val isPaEReady = rememberPlayAndEarnReady()
   val paeSetupRoute = rememberPlayAndEarnSetupRoute()
+  val context = LocalContext.current
 
   PaELargeCoinButton(
     title = stringResource(string.play_and_earn_play_button),
     onClick = {
       if (isPaEReady || navigate == null) {
+        if (isPaEReady) {
+          // Start the foreground service to track playtime
+          PaEForegroundService.start(context)
+        }
         onClick()
       } else {
         navigate(paeSetupRoute)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/PaEInstallViewShort.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/PaEInstallViewShort.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import cm.aptoide.pt.campaigns.domain.PaEApp
@@ -22,6 +23,7 @@ import com.aptoide.android.aptoidegames.installer.presentation.InstallViewState
 import com.aptoide.android.aptoidegames.installer.presentation.installViewStates
 import com.aptoide.android.aptoidegames.installer.presentation.toInstallViewState
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.rememberPlayAndEarnSetupRoute
+import com.aptoide.android.aptoidegames.play_and_earn.presentation.service.PaEForegroundService
 import com.aptoide.android.aptoidegames.play_and_earn.rememberPlayAndEarnReady
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
 
@@ -144,10 +146,15 @@ private fun PaESmallPlayButton(
 ) {
   val isPaEReady = rememberPlayAndEarnReady()
   val paeSetupRoute = rememberPlayAndEarnSetupRoute()
+  val context = LocalContext.current
 
   PaESmallCoinButton(
     onClick = {
       if (isPaEReady || navigate == null) {
+        if (isPaEReady) {
+          // Start the foreground service to track playtime
+          PaEForegroundService.start(context)
+        }
         onClick()
       } else {
         navigate(paeSetupRoute)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEForegroundService.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEForegroundService.kt
@@ -218,6 +218,11 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
   private fun buildNotification(): Notification {
     setupNotificationChannel(applicationContext)
 
+    val settingsIntent = Intent(this, MainActivity::class.java).apply {
+      putExtra(NAVIGATE_TO_SETTINGS, true)
+      flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+    }
+
     val notification =
       NotificationCompat.Builder(applicationContext, PAE_USAGE_NOTIFICATION_CHANNEL_ID)
         .setContentTitle(getString(R.string.play_and_earn_notification_recording_title))
@@ -227,8 +232,8 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
           PendingIntent.getActivity(
             this,
             0,
-            Intent(this, MainActivity::class.java),
-            PendingIntent.FLAG_IMMUTABLE
+            settingsIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
           )
         )
         .build()
@@ -269,11 +274,21 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
     const val FOREGROUND_SERVICE_ID = 1001
     const val PAE_USAGE_NOTIFICATION_CHANNEL_ID = "pae_usage_notification_channel"
     const val PAE_USAGE_NOTIFICATION_CHANNEL_NAME = "Play & Earn Usage Notification Channel"
+    const val NAVIGATE_TO_SETTINGS = "navigate_to_settings"
 
     fun start(context: Context) {
       try {
         val serviceIntent = Intent(context, PaEForegroundService::class.java)
         ContextCompat.startForegroundService(context, serviceIntent)
+      } catch (e: Throwable) {
+        e.printStackTrace()
+      }
+    }
+
+    fun stop(context: Context) {
+      try {
+        val serviceIntent = Intent(context, PaEForegroundService::class.java)
+        context.stopService(serviceIntent)
       } catch (e: Throwable) {
         e.printStackTrace()
       }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEForegroundService.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEForegroundService.kt
@@ -19,6 +19,7 @@ import cm.aptoide.pt.usage_stats.PackageUsageState
 import com.aptoide.android.aptoidegames.MainActivity
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.play_and_earn.PlayAndEarnManager
+import com.aptoide.android.aptoidegames.play_and_earn.data.PaEPreferencesRepository
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.overlays.PaEOverlayViewManager
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.permissions.hasOverlayPermission
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.permissions.hasUsageStatsPermissionStatus
@@ -51,6 +52,9 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
 
   @Inject
   lateinit var playAndEarnManager: PlayAndEarnManager
+
+  @Inject
+  lateinit var paEPreferencesRepository: PaEPreferencesRepository
 
   private val savedStateRegistryController = SavedStateRegistryController.Companion.create(this)
 
@@ -99,6 +103,11 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
     if (!applicationContext.hasUsageStatsPermissionStatus() || !applicationContext.hasOverlayPermission()) {
       stopSelf()
       return START_NOT_STICKY
+    }
+
+    // Ensure preference reflects the service is running (e.g. when started from Play button)
+    lifecycleScope.launch(Dispatchers.IO) {
+      paEPreferencesRepository.setPaEServiceEnabled(true)
     }
 
     init()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEForegroundService.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEForegroundService.kt
@@ -61,6 +61,8 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
   private val pollingIntervalSec = pollingIntervalMillis.toInt() / 1_000
   private var pollingJob: Job? = null
   private var completedMissionsJob: Job? = null
+  private var idleTimeoutJob: Job? = null
+  private val idleTimeoutMillis = 30 * 60 * 1000L // 30 minutes
   private var isMonitoringStarted = false
 
   private var lastForegroundPackage: String? = null
@@ -175,6 +177,14 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
     when (packageState) {
       is PackageUsageState.ForegroundPackage -> {
         val foregroundPackage = packageState.packageName
+        val isPaEGame = availablePaEPackages?.contains(foregroundPackage) == true
+
+        // Manage idle timeout based on whether user is playing a PaE game
+        if (isPaEGame) {
+          cancelIdleTimeout()
+        } else {
+          startIdleTimeoutIfNotRunning()
+        }
 
         // New foreground package detected
         if (foregroundPackage != lastForegroundPackage) {
@@ -182,7 +192,7 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
           lastForegroundPackage = foregroundPackage
 
           // Game available in PaE. Start session
-          if (availablePaEPackages?.contains(foregroundPackage) == true) {
+          if (isPaEGame) {
             // Check if a session already exists and is not finished
             val sessionCreated = paESessionManager.createSession(foregroundPackage)
 
@@ -206,11 +216,13 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
         // No package in foreground (e.g., screen locked, all apps paused)
         // Don't sync sessions as no time should be tracked while paused
         // Sessions will handle their own expiration via TTL
+        startIdleTimeoutIfNotRunning()
       }
 
       is PackageUsageState.Error -> {
         // Error means we couldn't determine state (no events in window or OEM failure)
         // Don't sync to avoid incorrectly counting time.
+        startIdleTimeoutIfNotRunning()
       }
     }
   }
@@ -241,6 +253,23 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
     return notification
   }
 
+  private fun cancelIdleTimeout() {
+    idleTimeoutJob?.cancel()
+    idleTimeoutJob = null
+  }
+
+  private fun startIdleTimeoutIfNotRunning() {
+    if (idleTimeoutJob?.isActive == true) {
+      return // Already running
+    }
+    idleTimeoutJob = lifecycleScope.launch {
+      Timber.d("PaEForegroundService: Starting idle timeout ($idleTimeoutMillis ms)")
+      delay(idleTimeoutMillis)
+      Timber.d("PaEForegroundService: Idle timeout elapsed, stopping service")
+      stopSelf()
+    }
+  }
+
   private fun setupNotificationChannel(context: Context) {
     val notificationManager =
       context.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
@@ -248,7 +277,7 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
     if (notificationManager.getNotificationChannel(PAE_USAGE_NOTIFICATION_CHANNEL_ID) == null) {
       val name = PAE_USAGE_NOTIFICATION_CHANNEL_NAME
       val descriptionText = "Play & Earn usage notification channel"
-      val importance = NotificationManager.IMPORTANCE_DEFAULT
+      val importance = NotificationManager.IMPORTANCE_LOW
       val channel = NotificationChannel(
         PAE_USAGE_NOTIFICATION_CHANNEL_ID,
         name,
@@ -266,6 +295,7 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
     super.onDestroy()
     pollingJob?.cancel()
     completedMissionsJob?.cancel()
+    idleTimeoutJob?.cancel()
     paESessionManager.clearAllSessions()
     isMonitoringStarted = false
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEServicePreferencesViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEServicePreferencesViewModel.kt
@@ -1,0 +1,56 @@
+package com.aptoide.android.aptoidegames.play_and_earn.presentation.service
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aptoide.android.aptoidegames.play_and_earn.PlayAndEarnManager
+import com.aptoide.android.aptoidegames.play_and_earn.data.PaEPreferencesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class PaEServicePreferencesViewModel @Inject constructor(
+  @ApplicationContext private val context: Context,
+  private val paEPreferencesRepository: PaEPreferencesRepository,
+  private val playAndEarnManager: PlayAndEarnManager,
+) : ViewModel() {
+
+  private val viewModelState = MutableStateFlow(true)
+
+  val isPaEServiceEnabled = viewModelState
+    .stateIn(
+      viewModelScope,
+      SharingStarted.Eagerly,
+      viewModelState.value
+    )
+
+  init {
+    viewModelScope.launch {
+      paEPreferencesRepository.isPaEServiceEnabled()
+        .catch { throwable -> throwable.printStackTrace() }
+        .collect { enabled ->
+          viewModelState.update { enabled }
+        }
+    }
+  }
+
+  fun setPaEServiceEnabled(enabled: Boolean) {
+    viewModelScope.launch {
+      paEPreferencesRepository.setPaEServiceEnabled(enabled)
+      if (enabled) {
+        if (playAndEarnManager.shouldShowPlayAndEarn()) {
+          PaEForegroundService.start(context)
+        }
+      } else {
+        PaEForegroundService.stop(context)
+      }
+    }
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/settings/SettingsScreen.kt
@@ -48,6 +48,8 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import cm.aptoide.pt.extensions.PreviewDark
@@ -70,6 +72,7 @@ import com.aptoide.android.aptoidegames.network.presentation.NetworkPreferencesV
 import com.aptoide.android.aptoidegames.play_and_earn.di.rememberWalletAddress
 import com.aptoide.android.aptoidegames.play_and_earn.domain.UserInfo
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.PaESmallTextButton
+import com.aptoide.android.aptoidegames.play_and_earn.presentation.service.PaEServicePreferencesViewModel
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.sign_in.GoogleSignInViewModel
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.sign_in.playAndEarnSignInRoute
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.sign_in.rememberUserInfo
@@ -97,11 +100,16 @@ fun settingsScreen(showSnack: (String) -> Unit) = ScreenData(
   val coroutineScope = rememberCoroutineScope()
   val copiedMessage = stringResource(R.string.settings_copied_to_clipboard_message)
   val signInViewModel = hiltViewModel<GoogleSignInViewModel>()
+  val paEServicePreferencesViewModel = hiltViewModel<PaEServicePreferencesViewModel>()
+  val isPaEServiceEnabled by paEServicePreferencesViewModel.isPaEServiceEnabled.collectAsState()
+  val shouldShowPlayAndEarn = rememberShouldShowPlayAndEarn()
 
   SettingsViewContent(
     title = stringResource(R.string.settings_title),
     downloadOnlyOverWifi = downloadOnlyOverWifi,
     autoUpdateGames = autoUpdateGames,
+    isPaEServiceEnabled = isPaEServiceEnabled,
+    showPaEServiceToggle = shouldShowPlayAndEarn,
     verName = BuildConfig.VERSION_NAME,
     verCode = BuildConfig.VERSION_CODE,
     toggleDownloadOnlyOverWifi = { isChecked ->
@@ -114,6 +122,9 @@ fun settingsScreen(showSnack: (String) -> Unit) = ScreenData(
     },
     toggleAutoUpdateGames = { isChecked ->
       toggleAutoUpdateGames(isChecked)
+    },
+    togglePaEService = { isChecked ->
+      paEServicePreferencesViewModel.setPaEServiceEnabled(isChecked)
     },
     onPrivacyPolicyClick = { UrlActivity.open(context, ppUrl) },
     onTermsConditionsClick = { UrlActivity.open(context, tcUrl) },
@@ -138,10 +149,13 @@ fun SettingsViewContent(
   title: String = "Settings",
   downloadOnlyOverWifi: Boolean = true,
   autoUpdateGames: Boolean? = true,
+  isPaEServiceEnabled: Boolean = true,
+  showPaEServiceToggle: Boolean = false,
   verName: String = "1.2.3",
   verCode: Int = 123,
   toggleDownloadOnlyOverWifi: (Boolean) -> Unit = {},
   toggleAutoUpdateGames: (Boolean) -> Unit = {},
+  togglePaEService: (Boolean) -> Unit = {},
   sendFeedback: () -> Unit = {},
   copyInfo: () -> Unit = {},
   onPrivacyPolicyClick: () -> Unit = {},
@@ -243,6 +257,23 @@ fun SettingsViewContent(
             PrimarySmallOutlinedButton(
               onClick = copyInfo,
               title = copyText
+            )
+          }
+        }
+      }
+      if (showPaEServiceToggle) {
+        SettingsSectionDivider()
+        SettingsSection(
+          title = stringResource(R.string.play_and_earn_title)
+        ) {
+          Column(
+            modifier = Modifier.padding(horizontal = 16.dp),
+          ) {
+            SettingsSwitchItem(
+              title = stringResource(R.string.settings_play_and_earn_tracking),
+              description = stringResource(R.string.settings_play_and_earn_tracking_description),
+              enabled = isPaEServiceEnabled,
+              onToggle = togglePaEService
             )
           }
         }
@@ -494,11 +525,11 @@ fun SettingsSectionDivider() {
 @Composable
 fun SettingsSwitchItem(
   title: String,
+  description: String? = null,
   enabled: Boolean,
   onToggle: (Boolean) -> Unit,
 ) {
-  Row(
-    verticalAlignment = Alignment.CenterVertically,
+  Column(
     modifier = Modifier
       .toggleable(
         value = enabled,
@@ -512,16 +543,29 @@ fun SettingsSwitchItem(
         contentDescription = title
       }
   ) {
-    Text(
-      text = title,
-      modifier = Modifier.weight(weight = 1f),
-      style = AGTypography.InputsM,
-      color = Palette.GreyLight
-    )
-    AptoideGamesSwitch(
-      checked = enabled,
-      onCheckedChanged = onToggle
-    )
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.fillMaxWidth()
+    ) {
+      Text(
+        text = title,
+        modifier = Modifier.weight(weight = 1f),
+        style = AGTypography.InputsM,
+        color = Palette.GreyLight
+      )
+      AptoideGamesSwitch(
+        checked = enabled,
+        onCheckedChanged = onToggle
+      )
+    }
+    description?.let {
+      Text(
+        text = it,
+        style = AGTypography.InputsS.copy(fontWeight = FontWeight.Normal),
+        color = Palette.GreyLight,
+        textAlign = TextAlign.Justify,
+      )
+    }
   }
 }
 


### PR DESCRIPTION
**What does this PR do?**

   - Adds a toggle in the settings to turn off/on the P&E foreground service tracking.
   - Adds an idle timeout to the P&E foreground service, which stops the service after a certain time of not having a P&E game in foreground.
   - Reduces the priority of the P&E foreground service notification.
   - Makes the P&E play buttons start the foreground service.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-733](https://aptoide.atlassian.net/browse/AND-733)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-733](https://aptoide.atlassian.net/browse/AND-733)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-733]: https://aptoide.atlassian.net/browse/AND-733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-733]: https://aptoide.atlassian.net/browse/AND-733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Play & Earn service toggle in Settings to enable or disable the service
  * Service automatically stops after 30 minutes of inactivity when no games are active
  * Direct navigation to settings now available from Play & Earn notifications
  * Foreground service automatically starts when launching Play & Earn games
  * Enhanced notification management for better user experience
<!-- end of auto-generated comment: release notes by coderabbit.ai -->