### PR TITLE
[AND-736] Remove number of views from event promotional cards

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/EventPromotionalView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/EventPromotionalView.kt
@@ -1,10 +1,8 @@
 package com.aptoide.android.aptoidegames.feature_promotional
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -108,34 +106,19 @@ private fun EventBundleContent(
   Text(
     modifier = modifier,
     text = articleMeta.title,
-    maxLines = 1,
+    maxLines = 2,
     overflow = TextOverflow.Ellipsis,
     style = AGTypography.InputsL,
     color = Palette.White
   )
-  Row(
-    modifier = modifier.fillMaxWidth(),
-    horizontalArrangement = Arrangement.SpaceBetween
-  ) {
-    Text(
-      modifier = modifier,
-      text = stringResource(
-        id = R.string.editorial_card_views_short, articleMeta.views
-      ),
-      maxLines = 1,
-      overflow = TextOverflow.Ellipsis,
-      style = AGTypography.InputsXS,
-      color = Palette.GreyLight
-    )
-    Text(
-      modifier = modifier,
-      text = stringResource(id = R.string.promotional_on_going_event),
-      maxLines = 1,
-      overflow = TextOverflow.Ellipsis,
-      style = AGTypography.InputsXS,
-      color = Palette.Primary
-    )
-  }
+  Text(
+    modifier = modifier,
+    text = stringResource(id = R.string.promotional_on_going_event),
+    maxLines = 1,
+    overflow = TextOverflow.Ellipsis,
+    style = AGTypography.InputsXS,
+    color = Palette.Primary
+  )
 }
 
 @PreviewDark


### PR DESCRIPTION
**What does this PR do?**

This PR aims at removing the number of views from the event promotional cards

**Database changed?**

No

**Where should the reviewer start?**

- [ ] EventPromotionalCard.java

**How should this be manually tested?**

Open home and check that there is no promotional card with 0 views.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-736](https://aptoide.atlassian.net/browse/AND-736)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-736]: https://aptoide.atlassian.net/browse/AND-736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * EventCard titles now display across two lines instead of one for better text visibility
  * Removed article view count display from promotional events
  * Simplified the promotional event information layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->