### PR TITLE
[AND-669] Show Gamesfeed bundle in the first position in home

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -598,8 +598,7 @@ fun List<Bundle>.injectGamesFeed(): List<Bundle> {
   )
 
   return toMutableList().apply {
-    val insertPosition = if (size >= 1) 1 else 0
-    add(insertPosition, gamesFeedBundle)
+    add(0, gamesFeedBundle)
   }
 }
 


### PR DESCRIPTION
**What does this PR do?**

This PR aims at moving the for you bundle to the first position

**Database changed?**

No

**Where should the reviewer start?**

- See by commit

**How should this be manually tested?**

Check if for you bundle shows in home. Remember that the 

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-669](https://aptoide.atlassian.net/browse/AND-669)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-699]: https://aptoide.atlassian.net/browse/AND-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AND-669]: https://aptoide.atlassian.net/browse/AND-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the display order of game bundles in the home view. The game feed now appears at the beginning of the bundle list instead of its previous position, optimizing content visibility and ensuring users encounter this content earlier when browsing their home feed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->