### PR TITLE
[AND-662] Implement AI search on GameGenie countries

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/analytics/GameGenieAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/analytics/GameGenieAnalytics.kt
@@ -6,14 +6,19 @@ class GameGenieAnalytics(
   private val genericAnalytics: GenericAnalytics,
 ) {
 
+  companion object {
+    const val SOURCE_SEARCH = "search"
+    const val SOURCE_CHAT = "chat"
+  }
+
   fun sendGameGenieSuggestionClick(index: Int) = genericAnalytics.logEvent(
     name = "gamegenie_suggests_click",
     params = mapOf("position" to index)
   )
 
-  fun sendGameGenieMessageSent() = genericAnalytics.logEvent(
+  fun sendGameGenieMessageSent(source: String) = genericAnalytics.logEvent(
     name = "gamegenie_send_message",
-    params = emptyMap()
+    params = mapOf("source" to source)
   )
 
   fun sendGameGenieAppClick(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieView.kt
@@ -1,7 +1,7 @@
 package com.aptoide.android.aptoidegames.gamegenie.presentation
 
 import ConversationsDrawer
-import android.app.Activity
+import android.net.Uri
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,13 +15,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -32,6 +31,7 @@ import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
 import com.aptoide.android.aptoidegames.error_views.GenericErrorView
 import com.aptoide.android.aptoidegames.error_views.NoConnectionView
 import com.aptoide.android.aptoidegames.gamegenie.analytics.rememberGameGenieAnalytics
+import com.aptoide.android.aptoidegames.gamegenie.analytics.GameGenieAnalytics
 import com.aptoide.android.aptoidegames.gamegenie.domain.GameCompanion
 import com.aptoide.android.aptoidegames.gamegenie.domain.Suggestion
 import com.aptoide.android.aptoidegames.gamegenie.presentation.composables.ChatBackButton
@@ -42,16 +42,30 @@ import com.aptoide.android.aptoidegames.gamegenie.presentation.composables.TextI
 import com.aptoide.android.aptoidegames.gamegenie.presentation.composables.companion.ChatbotViewCompanion
 import com.aptoide.android.aptoidegames.home.LoadingView
 import com.aptoide.android.aptoidegames.mmp.WithUTM
-import android.net.Uri
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 
 const val genieRoute = "chatbot"
 private const val genieCompanionPackageArg = "companionPackage"
-private const val genieRouteWithCompanion = "$genieRoute?$genieCompanionPackageArg={$genieCompanionPackageArg}"
+private const val genieQueryArg = "query"
+private const val genieRouteWithArgs =
+  "$genieRoute?$genieCompanionPackageArg={$genieCompanionPackageArg}&$genieQueryArg={$genieQueryArg}"
 
-fun buildGameGenieRoute(companionPackage: String? = null): String =
-  companionPackage?.let { "$genieRoute?$genieCompanionPackageArg=${Uri.encode(it)}" } ?: genieRoute
+fun buildGameGenieRoute(
+  companionPackage: String? = null,
+  query: String? = null,
+): String {
+  val params = listOfNotNull(
+    companionPackage?.let { "$genieCompanionPackageArg=${Uri.encode(it)}" },
+    query?.takeIf(String::isNotBlank)?.let { "$genieQueryArg=${Uri.encode(it)}" }
+  )
+
+  return if (params.isEmpty()) {
+    genieRoute
+  } else {
+    "$genieRoute?${params.joinToString("&")}"
+  }
+}
 
 private enum class ChatMode {
   General,
@@ -61,10 +75,15 @@ private enum class ChatMode {
 fun gameGenieScreen(
   showBottomSheet: ((BottomSheetContent?) -> Unit)? = null,
 ) = ScreenData.withAnalytics(
-  route = genieRouteWithCompanion,
+  route = genieRouteWithArgs,
   screenAnalyticsName = "gamegenie",
   arguments = listOf(
     navArgument(genieCompanionPackageArg) {
+      type = NavType.StringType
+      nullable = true
+      defaultValue = null
+    },
+    navArgument(genieQueryArg) {
       type = NavType.StringType
       nullable = true
       defaultValue = null
@@ -79,6 +98,7 @@ fun gameGenieScreen(
   val analytics = rememberGameGenieAnalytics()
   val firstLoad by viewModel.firstLoad.collectAsState(true)
   val companionPackage = remember(arguments) { arguments?.getString(genieCompanionPackageArg) }
+  val initialQuery = remember(arguments) { arguments?.getString(genieQueryArg)?.trim() }
 
   var chatMode by remember(companionPackage) {
     mutableStateOf(
@@ -86,6 +106,7 @@ fun gameGenieScreen(
     )
   }
   var deepLinkHandled by remember(companionPackage) { mutableStateOf(false) }
+  var hasSentInitialQuery by rememberSaveable(initialQuery, companionPackage) { mutableStateOf(false) }
 
   WithUTM(
     medium = "gamegenie",
@@ -95,6 +116,18 @@ fun gameGenieScreen(
   ) { navigate ->
     ConversationsDrawer(
       mainScreen = {
+        LaunchedEffect(initialQuery, companionPackage, hasSentInitialQuery) {
+          val query = initialQuery.orEmpty()
+          if (
+            companionPackage.isNullOrBlank() &&
+            !hasSentInitialQuery &&
+            query.isNotBlank()
+          ) {
+            hasSentInitialQuery = true
+            viewModel.sendMessage(query)
+            analytics.sendGameGenieMessageSent(GameGenieAnalytics.SOURCE_SEARCH)
+          }
+        }
         LaunchedEffect(companionPackage, installedGames, selectedGame) {
           val packageName = companionPackage
           if (!deepLinkHandled && !packageName.isNullOrBlank()) {
@@ -128,7 +161,7 @@ fun gameGenieScreen(
               onError = viewModel::reload,
               onMessageSend = { message, image ->
                 viewModel.sendMessage(message, image)
-                analytics.sendGameGenieMessageSent()
+                analytics.sendGameGenieMessageSent(GameGenieAnalytics.SOURCE_CHAT)
               },
               setFirstLoadDone = viewModel::setFirstLoadDone,
               onSuggestionSend = { message, index ->
@@ -165,7 +198,7 @@ fun gameGenieScreen(
                 setFirstLoadDone = viewModel::setFirstLoadDone,
                 onMessageSend = { message, image ->
                   viewModel.sendMessage(message, image)
-                  analytics.sendGameGenieMessageSent()
+                  analytics.sendGameGenieMessageSent(GameGenieAnalytics.SOURCE_CHAT)
                 },
                 showBottomSheet = showBottomSheet,
                 suggestions = companionSuggestions,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GenieSearchView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GenieSearchView.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import cm.aptoide.pt.extensions.ScreenData
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
+import com.aptoide.android.aptoidegames.gamegenie.analytics.GameGenieAnalytics
 import com.aptoide.android.aptoidegames.gamegenie.analytics.rememberGameGenieAnalytics
 import com.aptoide.android.aptoidegames.mmp.WithUTM
 
@@ -37,7 +38,9 @@ fun gameGenieSearchScreen() = ScreenData.withAnalytics(
           onError = viewModel::reload,
           onMessageSend = { message, _ ->
             viewModel.sendMessage(message)
-            analytics.sendGameGenieMessageSent()
+            analytics.sendGameGenieMessageSent(
+              source = GameGenieAnalytics.SOURCE_SEARCH
+            )
           },
           setFirstLoadDone = viewModel::setFirstLoadDone,
           onSuggestionSend = { message, index ->

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/search/presentation/SearchScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/search/presentation/SearchScreen.kt
@@ -95,6 +95,8 @@ import com.aptoide.android.aptoidegames.feature_apps.presentation.rememberTrendi
 import com.aptoide.android.aptoidegames.feature_rtb.data.RTBApp
 import com.aptoide.android.aptoidegames.feature_rtb.presentation.rememberRTBAdClickHandler
 import com.aptoide.android.aptoidegames.feature_rtb.presentation.rememberSearchSponsoredApp
+import com.aptoide.android.aptoidegames.gamegenie.presentation.buildGameGenieRoute
+import com.aptoide.android.aptoidegames.gamegenie.presentation.rememberGameGenieVisibility
 import com.aptoide.android.aptoidegames.home.rememberBottomBarMenuScrollState
 import com.aptoide.android.aptoidegames.installer.presentation.InstallViewShort
 import com.aptoide.android.aptoidegames.mmp.UTMContext
@@ -133,6 +135,7 @@ fun searchScreen() = ScreenData.withAnalytics(
   val analyticsContext = AnalyticsContext.current
 
   var searchValue by rememberSaveable { mutableStateOf("") }
+  val shouldRedirectSearchToGameGenie = rememberGameGenieVisibility()
   var searchMeta by rememberSaveable(
     saver = Saver(
       save = { it.value?.toString() ?: "null" },
@@ -197,7 +200,12 @@ fun searchScreen() = ScreenData.withAnalytics(
                 )
               }
             searchValue = suggestion
-            navigateTo(buildSearchRoute(suggestion).withSearchMeta(searchMeta))
+            navigateTo(
+              buildSearchTargetRoute(
+                query = suggestion,
+                shouldRedirectToGameGenie = shouldRedirectSearchToGameGenie,
+              ).withSearchMeta(searchMeta)
+            )
           },
           onRemoveSuggestion = { searchViewModel.onRemoveSearchSuggestion(it) },
           onSearchValueChanged = {
@@ -216,7 +224,12 @@ fun searchScreen() = ScreenData.withAnalytics(
                 .also(searchAnalytics::sendSearchEvent)
               focusManager.clearFocus()
               keyboardController?.hide()
-              navigateTo(buildSearchRoute(searchValue).withSearchMeta(searchMeta))
+              navigateTo(
+                buildSearchTargetRoute(
+                  query = searchValue,
+                  shouldRedirectToGameGenie = shouldRedirectSearchToGameGenie,
+                ).withSearchMeta(searchMeta)
+              )
             }
           },
           onItemClick = { index, app ->
@@ -256,6 +269,15 @@ fun searchScreen() = ScreenData.withAnalytics(
       }
     }
   }
+}
+
+private fun buildSearchTargetRoute(
+  query: String,
+  shouldRedirectToGameGenie: Boolean,
+): String = if (shouldRedirectToGameGenie) {
+  buildGameGenieRoute(query = query)
+} else {
+  buildSearchRoute(query = query)
 }
 
 @Composable


### PR DESCRIPTION
**What does this PR do?**

This PR aims to implement GameGenie AI search on countries where GameGenie is available.
When a user searches for a term, its redirected to the GameGenie screen.

**Database changed?**

   No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Test search and check it goes to GG page

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-662](https://aptoide.atlassian.net/browse/AND-662)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-662]: https://aptoide.atlassian.net/browse/AND-662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Game Genie accepts an optional initial search query and optional companion identifier via navigation.
  * If opened without a companion and a non-empty initial query exists, that query is sent once and appears in chat.
  * Search screen can redirect queries into the Game Genie experience when available.
* **Chores**
  * Message-sent analytics now include a source flag (search vs. chat) for clearer reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->