### PR TITLE
[AND-761] Add advertising id parameter to rtb request

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideIdsRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideIdsRepository.kt
@@ -12,7 +12,7 @@ import javax.inject.Singleton
 
 @Singleton
 class AptoideIdsRepository @Inject constructor(private val dataStore: DataStore<Preferences>) :
-  IdsRepository {
+  LocalIdsRepository {
 
   override suspend fun getId(key: String): String {
     return dataStore.data

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/LocalIdsRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/LocalIdsRepository.kt
@@ -2,7 +2,7 @@ package com.aptoide.android.aptoidegames
 
 import kotlinx.coroutines.flow.Flow
 
-interface IdsRepository {
+interface LocalIdsRepository {
 
   suspend fun getId(key: String): String
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyManagerProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyManagerProbe.kt
@@ -3,7 +3,7 @@ package com.aptoide.android.aptoidegames.apkfy.analytics
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyManager
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyModel
 import cm.aptoide.pt.feature_campaigns.AptoideMMPCampaign
-import com.aptoide.android.aptoidegames.IdsRepository
+import com.aptoide.android.aptoidegames.LocalIdsRepository
 import com.google.gson.Gson
 import kotlinx.coroutines.delay
 import retrofit2.HttpException
@@ -11,7 +11,7 @@ import retrofit2.HttpException
 class ApkfyManagerProbe(
   private val apkfyManager: ApkfyManager,
   private val apkfyAnalytics: ApkfyAnalytics,
-  private val idsRepository: IdsRepository,
+  private val idsRepository: LocalIdsRepository,
 ) : ApkfyManager {
 
   companion object {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/di/RepositoryModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/di/RepositoryModule.kt
@@ -3,7 +3,7 @@ package com.aptoide.android.aptoidegames.apkfy.di
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyFilter
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyManager
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyManagerImpl
-import com.aptoide.android.aptoidegames.IdsRepository
+import com.aptoide.android.aptoidegames.LocalIdsRepository
 import com.aptoide.android.aptoidegames.apkfy.AGApkfyFilter
 import com.aptoide.android.aptoidegames.apkfy.DownloadPermissionStateProbe
 import com.aptoide.android.aptoidegames.apkfy.analytics.ApkfyAnalytics
@@ -24,7 +24,7 @@ internal object RepositoryModule {
   fun provideApkfyManager(
     apkfyManager: ApkfyManagerImpl,
     apkfyAnalytics: ApkfyAnalytics,
-    idsRepository: IdsRepository
+    idsRepository: LocalIdsRepository
   ): ApkfyManager =
     ApkfyManagerProbe(
       apkfyManager = apkfyManager,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/di/RepositoryModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/di/RepositoryModule.kt
@@ -34,7 +34,7 @@ import cm.aptoide.pt.feature_search.domain.repository.SearchStoreManager
 import cm.aptoide.pt.feature_updates.di.PrioritizedPackagesFilter
 import com.aptoide.android.aptoidegames.AptoideIdsRepository
 import com.aptoide.android.aptoidegames.BuildConfig
-import com.aptoide.android.aptoidegames.IdsRepository
+import com.aptoide.android.aptoidegames.LocalIdsRepository
 import com.aptoide.android.aptoidegames.ahab.di.AhabDomain
 import com.aptoide.android.aptoidegames.appLaunchDataStore
 import com.aptoide.android.aptoidegames.dataStore
@@ -54,6 +54,7 @@ import com.aptoide.android.aptoidegames.network.AptoideAABInterceptor
 import com.aptoide.android.aptoidegames.network.AptoideGetHeaders
 import com.aptoide.android.aptoidegames.network.AptoideQLogicInterceptor
 import com.aptoide.android.aptoidegames.network.AptoideQueryLangInterceptor
+import com.aptoide.android.aptoidegames.network.repository.AdvertisingIdsRepository
 import com.aptoide.android.aptoidegames.networkPreferencesDataStore
 import com.aptoide.android.aptoidegames.permissions.AppPermissionsManager
 import com.aptoide.android.aptoidegames.search.repository.AppGamesAutoCompleteSuggestionsRepository
@@ -295,7 +296,7 @@ class RepositoryModule {
 
   @Singleton
   @Provides
-  fun provideIdsManager(@IdsDataStore dataStore: DataStore<Preferences>): IdsRepository =
+  fun provideIdsManager(@IdsDataStore dataStore: DataStore<Preferences>): LocalIdsRepository =
     AptoideIdsRepository(dataStore)
 
   @Singleton
@@ -327,13 +328,15 @@ class RepositoryModule {
   fun provideRTBRepository(
     @RetrofitRTB retrofit: Retrofit,
     deviceInfo: DeviceInfo,
-    idsRepository: IdsRepository,
+    aptoideIdsRepository: LocalIdsRepository,
+    idsRepository: AdvertisingIdsRepository,
     campaignRepository: CampaignRepository,
   ): RTBRepository {
     return AptoideRTBRepository(
       rtbApi = retrofit.create(RTBApi::class.java),
       scope = CoroutineScope(Dispatchers.IO),
       deviceInfo = deviceInfo,
+      aptoideIdsRepository = aptoideIdsRepository,
       idsRepository = idsRepository,
       campaignRepository = campaignRepository,
     )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/EventPromotionalView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/EventPromotionalView.kt
@@ -68,6 +68,7 @@ private fun EventBundleContent(
 
     is ArticleListUiState.Idle -> {
       val editorialMeta = uiState.articles[0]
+
       EventCard(
         bundle = bundle,
         modifier = modifier,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/AptoideRTBRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/AptoideRTBRepository.kt
@@ -8,9 +8,10 @@ import cm.aptoide.pt.feature_campaigns.CampaignImpl
 import cm.aptoide.pt.feature_campaigns.CampaignRepository
 import cm.aptoide.pt.feature_campaigns.CampaignTuple
 import com.aptoide.android.aptoidegames.BuildConfig
-import com.aptoide.android.aptoidegames.IdsRepository
+import com.aptoide.android.aptoidegames.LocalIdsRepository
 import com.aptoide.android.aptoidegames.apkfy.analytics.ApkfyManagerProbe
 import com.aptoide.android.aptoidegames.feature_rtb.data.RTBApp
+import com.aptoide.android.aptoidegames.network.repository.AdvertisingIdsRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -20,7 +21,8 @@ class AptoideRTBRepository @Inject constructor(
   private val rtbApi: RTBApi,
   private val scope: CoroutineScope,
   private val deviceInfo: DeviceInfo,
-  private val idsRepository: IdsRepository,
+  private val aptoideIdsRepository: LocalIdsRepository,
+  private val idsRepository: AdvertisingIdsRepository,
   private val campaignRepository: CampaignRepository,
 ) : RTBRepository {
 
@@ -32,7 +34,7 @@ class AptoideRTBRepository @Inject constructor(
         return@withContext it
       }
 
-      val guestUid = idsRepository.observeId(ApkfyManagerProbe.GUEST_UID_KEY)
+      val guestUid = aptoideIdsRepository.observeId(ApkfyManagerProbe.GUEST_UID_KEY)
         .first { it.isNotEmpty() }
 
       val result = rtbApi.getApps(
@@ -53,6 +55,7 @@ class AptoideRTBRepository @Inject constructor(
             deviceInfo.getScreenHeight(),
             deviceInfo.getScreenDensity()
           ),
+          gaid = idsRepository.advertisingId,
         )
       )
       val apps = if (result.isEmpty()) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/RTBRequest.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/RTBRequest.kt
@@ -9,7 +9,8 @@ data class RTBRequest(
   val app_package: String,
   val language: String,
   val device: Device,
-  val screen: Screen
+  val screen: Screen,
+  val gaid: String? = null
 )
 
 @Keep

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/network/AptoideGetHeaders.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/network/AptoideGetHeaders.kt
@@ -9,7 +9,7 @@ import cm.aptoide.pt.extensions.calculateMD5
 import cm.aptoide.pt.extensions.getPackageInfo
 import com.appcoins.payments.network.RestClientInjectParams
 import com.aptoide.android.aptoidegames.BuildConfig
-import com.aptoide.android.aptoidegames.network.repository.IdsRepository
+import com.aptoide.android.aptoidegames.network.repository.AdvertisingIdsRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import javax.inject.Inject
@@ -19,7 +19,7 @@ import javax.inject.Singleton
 class AptoideGetHeaders @Inject constructor(
   @ApplicationContext private val context: Context,
   private val packageManager: PackageManager,
-  private val idsRepository: IdsRepository,
+  private val idsRepository: AdvertisingIdsRepository,
   private val deviceInfo: DeviceInfo,
 ) : GetUserAgent, GetAcceptLanguage, RestClientInjectParams {
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/network/repository/AdvertisingIdsRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/network/repository/AdvertisingIdsRepository.kt
@@ -12,11 +12,13 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class IdsRepository @Inject constructor(
+class AdvertisingIdsRepository @Inject constructor(
   @ApplicationContext private val context: Context,
 ) {
 
   val aptoideClientUuid by lazy { getUniqueIdentifier() }
+
+  val advertisingId: String? by lazy { getGoogleAdvertisingId() }
 
   private fun getUniqueIdentifier(): String =
     getGoogleAdvertisingId()?.takeIf { it.isNotEmpty() } ?: UUID.randomUUID().toString()


### PR DESCRIPTION
**What does this PR do?**

This PR aims at adding the advertising id to the rtb request

**Database changed?**

   Yes 

**Where should the reviewer start?**

- [ ] AptoideRtbRepository.kt


**How should this be manually tested?**

Check the request on charles to confirm that everything is correct. 

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-761](https://aptoide.atlassian.net/browse/AND-761)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-761]: https://aptoide.atlassian.net/browse/AND-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Split ID responsibilities into separate local and advertising repositories for clearer separation of concerns.
* **New Features**
  * Advertising requests can now include GAID (advertising identifier) and the advertising repo exposes a cached advertisingId.
* **Style**
  * Minor spacing adjustment in promotional view rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->