### PR TITLE
[AND-764] Replace AHAB promotions endpoint by json from firebase

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/promotions/data/AGPromotionsRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/promotions/data/AGPromotionsRepository.kt
@@ -1,29 +1,27 @@
 package com.aptoide.android.aptoidegames.promotions.data
 
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
 import com.aptoide.android.aptoidegames.promotions.data.model.PromotionJson
 import com.aptoide.android.aptoidegames.promotions.domain.Promotion
-import retrofit2.http.GET
-import retrofit2.http.Query
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import javax.inject.Inject
 
 internal class AGPromotionsRepository @Inject constructor(
-  private val promotionsApi: PromotionsApi,
-  private val storeName: String,
+  private val featureFlags: FeatureFlags,
 ) : PromotionsRepository {
 
   override suspend fun getAllPromotions(): List<Promotion> {
-    return promotionsApi.getPromotionsList(storeName).map {
-      it.toDomainModel()
-    }
+    val jsonString = featureFlags.getFlagAsString(PROMOTIONS_KEY) ?: return emptyList()
+    return runCatching {
+      val type = object : TypeToken<List<PromotionJson>>() {}.type
+      Gson().fromJson<List<PromotionJson>>(jsonString, type)
+        .map { it.toDomainModel() }
+    }.getOrDefault(emptyList())
   }
 
-  internal interface PromotionsApi {
-
-    @GET("list-campaigns")
-    suspend fun getPromotionsList(
-      @Query("store_name") storeName: String,
-      @Query("placement") placement: String = "HOME_DIALOG",
-    ): List<PromotionJson>
+  companion object {
+    private const val PROMOTIONS_KEY = "ahab_promotions_list"
   }
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/promotions/di/RepositoryModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/promotions/di/RepositoryModule.kt
@@ -2,10 +2,8 @@ package com.aptoide.android.aptoidegames.promotions.di
 
 import android.content.Context
 import androidx.room.Room
-import cm.aptoide.pt.aptoide_network.di.StoreName
-import com.aptoide.android.aptoidegames.ahab.di.RetrofitAhab
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
 import com.aptoide.android.aptoidegames.promotions.data.AGPromotionsRepository
-import com.aptoide.android.aptoidegames.promotions.data.AGPromotionsRepository.PromotionsApi
 import com.aptoide.android.aptoidegames.promotions.data.PromotionsRepository
 import com.aptoide.android.aptoidegames.promotions.data.database.PromotionsDatabase
 import com.aptoide.android.aptoidegames.promotions.data.database.SkippedPromotionsRepository
@@ -14,7 +12,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import retrofit2.Retrofit
 import javax.inject.Singleton
 
 @Module
@@ -24,11 +21,9 @@ class RepositoryModule {
   @Provides
   @Singleton
   fun providesPromotionsRepository(
-    @RetrofitAhab retrofitAhab: Retrofit,
-    @StoreName storeName: String,
+    featureFlags: FeatureFlags,
   ): PromotionsRepository = AGPromotionsRepository(
-    promotionsApi = retrofitAhab.create(PromotionsApi::class.java),
-    storeName = storeName,
+    featureFlags = featureFlags,
   )
 
   @Singleton


### PR DESCRIPTION
**What does this PR do?**

This PR aims at implementing ahab from firebase instead of getting the promotions from the promotions endpoint

**Database changed?**

No

**Where should the reviewer start?**

- See by commit

**How should this be manually tested?**

Open the app and check if ahab promotions are still working. Remember to have outdated versions.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-764](https://aptoide.atlassian.net/browse/AND-764)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-764]: https://aptoide.atlassian.net/browse/AND-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized promotions system architecture. Updated the delivery mechanism to use configuration management with enhanced error handling and automatic fallback. This improves reliability, flexibility for managing promotions, and overall system maintainability, while preserving the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->