### PR TITLE
[AND-768] Cancel GameGenie companion message after going back to main screen

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieViewModel.kt
@@ -13,6 +13,7 @@ import com.aptoide.android.aptoidegames.gamegenie.domain.Token
 import com.aptoide.android.aptoidegames.gamegenie.presentation.GameGenieUIStateType.NO_CONNECTION
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -42,6 +43,8 @@ class GameGenieViewModel @Inject constructor(
 
   private val _firstLoad = MutableStateFlow(true)
   val firstLoad: Flow<Boolean> = _firstLoad
+
+  private var sendMessageJob: Job? = null
 
   private val _installedGames = MutableStateFlow<List<GameCompanion>>(emptyList())
   val installedGames = _installedGames.asStateFlow()
@@ -73,6 +76,8 @@ class GameGenieViewModel @Inject constructor(
 
   fun resetSelectedGame() {
     viewModelState.update { it.copy(selectedGame = null, suggestions = emptyList()) }
+    sendMessageJob?.cancel()
+    sendMessageJob = null
     emptyChat()
   }
 
@@ -131,7 +136,8 @@ class GameGenieViewModel @Inject constructor(
     userMessage: String,
     imagePathOrBase64: String? = null,
   ) {
-    viewModelScope.launch {
+    sendMessageJob?.cancel()
+    sendMessageJob = viewModelScope.launch {
       try {
         val selectedGame = viewModelState.value.selectedGame
         updateConversation(userMessage, imagePathOrBase64)


### PR DESCRIPTION
**What does this PR do?**

This PR aims to cancel a message sent in GameGenie companion mode when the user changes the game, so that messages from companion don't appear in other companion chats nor the main chat screen

**Database changed?**

No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Send a message in companion mode and go back, wait some seconds to let a message arrive (it won't, but if it did you'd have to wait some seconds)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-768](https://aptoide.atlassian.net/browse/AND-768)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-768]: https://aptoide.atlassian.net/browse/AND-768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where multiple concurrent message sends could interfere with each other, ensuring only the most recent message is processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->