### PR TITLE
[AND-769] Fix stacked GameGenie views on overlay click

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
@@ -272,7 +272,9 @@ class MainActivity : AppCompatActivity() {
     val companionPackage = intent?.getStringExtra(GameGenieOverlayService.EXTRA_COMPANION_PACKAGE)
     if (!companionPackage.isNullOrBlank()) {
       intent.removeExtra(GameGenieOverlayService.EXTRA_COMPANION_PACKAGE)
-      navController?.navigateTo(buildGameGenieRoute(companionPackage))
+      navController?.navigate(buildGameGenieRoute(companionPackage)) {
+        launchSingleTop = true
+      }
     }
   }
 


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix an issue with the GameGenie overlay when the user interacts with the overlay, when returning to Aptoide Games, there would be stacked GameGenie views and thus clicking the phone back button would reveal these stacked views.

**Database changed?**

No

**Where should the reviewer start?**

See by commit.

**How should this be manually tested?**

Open GameGenie overlay, take a screenshot, send a message, then click the overlay to go back to the game and take another screenshot, send a message again. Then try clicking on the phone back button (not in-app back button) and check there are no stacked views. The ticket has a video showing the previous behavior.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-769](https://aptoide.atlassian.net/browse/AND-769)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-769]: https://aptoide.atlassian.net/browse/AND-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GameGenie overlay navigation behavior to prevent duplicate screens in the back stack, resulting in a smoother back-button navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->