### PR TITLE
[AND-770] Fix GameGenie companion suggestions state

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieViewModel.kt
@@ -45,6 +45,8 @@ class GameGenieViewModel @Inject constructor(
   val firstLoad: Flow<Boolean> = _firstLoad
 
   private var sendMessageJob: Job? = null
+  private var loadCompanionChatJob: Job? = null
+  private var loadCompanionSuggestionsJob: Job? = null
 
   private val _installedGames = MutableStateFlow<List<GameCompanion>>(emptyList())
   val installedGames = _installedGames.asStateFlow()
@@ -78,6 +80,10 @@ class GameGenieViewModel @Inject constructor(
     viewModelState.update { it.copy(selectedGame = null, suggestions = emptyList()) }
     sendMessageJob?.cancel()
     sendMessageJob = null
+    loadCompanionChatJob?.cancel()
+    loadCompanionChatJob = null
+    loadCompanionSuggestionsJob?.cancel()
+    loadCompanionSuggestionsJob = null
     emptyChat()
   }
 
@@ -218,7 +224,9 @@ class GameGenieViewModel @Inject constructor(
   }
 
   fun loadCompanionChat(packageName: String) {
-    viewModelScope.launch {
+    loadCompanionChatJob?.cancel()
+    loadCompanionSuggestionsJob?.cancel()
+    loadCompanionChatJob = viewModelScope.launch {
       _firstLoad.value = true
       var gameName: String? = null
       viewModelState.update {
@@ -230,6 +238,7 @@ class GameGenieViewModel @Inject constructor(
 
       gameGenieUseCase.loadCompanionChat(packageName)
         .collectLatest { newChat ->
+          if (viewModelState.value.selectedGame?.packageName != packageName) return@collectLatest
           newChat?.let { chat ->
             _conversation.value = chat.conversation
             viewModelState.update { state ->
@@ -258,7 +267,8 @@ class GameGenieViewModel @Inject constructor(
   }
 
   private fun loadCompanionSuggestions(gameName: String) {
-    viewModelScope.launch {
+    loadCompanionSuggestionsJob?.cancel()
+    loadCompanionSuggestionsJob = viewModelScope.launch {
       runCatching {
         val locale = context.resources.configuration.locales[0]
         val lang = locale.language
@@ -266,10 +276,13 @@ class GameGenieViewModel @Inject constructor(
           selectedGame = gameName,
           lang = lang
         )
+        if (viewModelState.value.selectedGame?.name != gameName) return@launch
         viewModelState.update { it.copy(suggestions = suggestions.suggestions) }
       }.onFailure { e ->
         Timber.w(e, "Failed to load companion suggestions")
-        viewModelState.update { it.copy(suggestions = emptyList()) }
+        if (viewModelState.value.selectedGame?.name == gameName) {
+          viewModelState.update { it.copy(suggestions = emptyList()) }
+        }
       }
     }
   }


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix the companion suggestions loading state. 
If the user opens the GameGenie companion chat on a game that doesn't have cached suggestions, the request takes 1 second to be completed. If in that time the user switches companion game screen, the suggestions from game A would appear on game B.

**Database changed?**

   No

**Where should the reviewer start?**

See by commit.

**How should this be manually tested?**

Try finding a game without cached suggestions, then open that screen and immediately change to another game companion. Check the suggestions that appear are the correct ones.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-770](https://aptoide.atlassian.net/browse/AND-770)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-770]: https://aptoide.atlassian.net/browse/AND-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved companion chat and suggestions reliability when switching between games.
  * Fixed potential display of stale data during rapid game selection changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->