### PR TITLE
[AND-826] Fix GameGenie keyboard open behaviour

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieView.kt
@@ -2,16 +2,18 @@ package com.aptoide.android.aptoidegames.gamegenie.presentation
 
 import ConversationsDrawer
 import android.net.Uri
+import android.view.WindowManager
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -107,6 +109,18 @@ fun gameGenieScreen(
   }
   var deepLinkHandled by remember(companionPackage) { mutableStateOf(false) }
   var hasSentInitialQuery by rememberSaveable(initialQuery, companionPackage) { mutableStateOf(false) }
+
+  val activity = LocalActivity.current
+  DisposableEffect(activity) {
+    val window = activity?.window
+    val previous = window?.attributes?.softInputMode
+    val newMode = WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE or
+      ((previous ?: 0) and WindowManager.LayoutParams.SOFT_INPUT_MASK_STATE)
+    window?.setSoftInputMode(newMode)
+    onDispose {
+      if (window != null && previous != null) window.setSoftInputMode(previous)
+    }
+  }
 
   WithUTM(
     medium = "gamegenie",
@@ -242,8 +256,7 @@ fun ChatbotView(
   Column(
     modifier = Modifier
       .fillMaxSize()
-      .wrapContentSize(Alignment.TopCenter)
-      .imePadding(),
+      .wrapContentSize(Alignment.TopCenter),
     horizontalAlignment = Alignment.CenterHorizontally
   ) {
     val isLoading = uiState.type == GameGenieUIStateType.LOADING

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/MessageList.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/MessageList.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -26,6 +27,8 @@ import com.aptoide.android.aptoidegames.gamegenie.domain.ChatInteraction
 import com.aptoide.android.aptoidegames.gamegenie.domain.GameCompanion
 import com.aptoide.android.aptoidegames.gamegenie.domain.Suggestion
 import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views.YouTubePlayerView
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 @Composable
 fun MessageList(
@@ -46,8 +49,21 @@ fun MessageList(
 
   val prevSize = remember { mutableIntStateOf(-1) }
   val prevLastUserText = remember { mutableStateOf<String?>(null) }
+  val prevViewportHeight = remember { mutableIntStateOf(0) }
 
   val lastUserText = messages.lastOrNull()?.user?.text
+
+  LaunchedEffect(listState) {
+    snapshotFlow { listState.layoutInfo.viewportSize.height }
+      .distinctUntilChanged()
+      .collectLatest { viewportHeight ->
+        val prev = prevViewportHeight.intValue
+        if (viewportHeight in 1 until prev && messages.isNotEmpty()) {
+          scrollToBottom(listState, messages.lastIndex)
+        }
+        prevViewportHeight.intValue = viewportHeight
+      }
+  }
 
   LaunchedEffect(firstLoad, messages.size, lastUserText) {
     if (messages.isEmpty()) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/companion/ChatbotViewCompanion.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/companion/ChatbotViewCompanion.kt
@@ -2,7 +2,6 @@ package com.aptoide.android.aptoidegames.gamegenie.presentation.composables.comp
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -38,8 +37,7 @@ fun ChatbotViewCompanion(
   Column(
     modifier = modifier
       .fillMaxSize()
-      .wrapContentSize(Alignment.TopCenter)
-      .imePadding(),
+      .wrapContentSize(Alignment.TopCenter),
     horizontalAlignment = Alignment.CenterHorizontally
   ) {
     val isLoading = uiState.type == GameGenieUIStateType.LOADING


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix an issue that has been bugging me for a while, when the user opens the GameGenie keyboard to type, the whole layout goes up to accommodate the keyboard. This is not intended behavior so I decided to fix it now.

**Database changed?**

   No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Go to GameGenie and GG companion and try to type a message, check behavior. Also check when there are multiple messages on the chat, I implemented auto scrolling when the keyboard opens to make it look nice.
Check history drawer is not affected in any case.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-826](https://aptoide.atlassian.net/browse/AND-826)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-826]: https://aptoide.atlassian.net/browse/AND-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the screen resizes correctly when the keyboard appears so content isn't obscured.
  * Improved message list auto-scrolling to follow viewport height changes and keep recent messages visible.
  * Refined chat input/keyboard interaction for more reliable input positioning while composing messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->