### PR TITLE
[AND-828] Fix infinite loading bug on GG New chat when on companion screen

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieView.kt
@@ -221,7 +221,10 @@ fun gameGenieScreen(
         viewModel.loadConversation(id)
       },
       currentChatId = uiState.chat.id,
-      newChatFn = viewModel::emptyChat,
+      newChatFn = {
+        chatMode = ChatMode.General
+        viewModel.emptyChat()
+      },
     )
   }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR aims to fix a bug on GameGenie, where the user gets stuck on an infinite loop when clicking New Chat from a companion view. This happened because viewModel::emptyChat clears selectedGame to null, but the local chatMode UI state stays ChatMode.Companion.

**Database changed?**

 No

**Where should the reviewer start?**

See by commit.

**How should this be manually tested?**

Test the described flow and check that it works

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-828](https://aptoide.atlassian.net/browse/AND-828)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-828]: https://aptoide.atlassian.net/browse/AND-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat mode initialization when starting a new conversation to ensure proper default settings are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->