### PR TITLE
[AND-836] Send installed packages to RTB

### DIFF
--- a/app-games/build.gradle.kts
+++ b/app-games/build.gradle.kts
@@ -56,6 +56,12 @@ android {
 
     buildConfigField(
       type = "String",
+      name = "RTB_COLLECTOR_HOST",
+      value = "\"https://aptoide-rtb-client-collector.aptoide.com\""
+    )
+
+    buildConfigField(
+      type = "String",
       name = "DEEP_LINK_SCHEMA",
       value = "\"ag://\""
     )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
@@ -31,6 +31,7 @@ import com.aptoide.android.aptoidegames.device_info.DeviceSecurityChecker
 import com.aptoide.android.aptoidegames.device_info.analytics.DeviceInfoAnalytics
 import com.aptoide.android.aptoidegames.feature_companion_apps_notification.CompanionAppsManager
 import com.aptoide.android.aptoidegames.feature_editors_choice_recommendation.EditorsChoiceRecommendationManager
+import com.aptoide.android.aptoidegames.feature_rtb.InstalledPackagesSyncManager
 import com.aptoide.android.aptoidegames.gamegenie.presentation.CompanionGamesCachePreloader
 import com.aptoide.android.aptoidegames.home.repository.ThemePreferencesManager
 import com.aptoide.android.aptoidegames.installer.analytics.ScheduledDownloadsListenerImpl
@@ -123,6 +124,9 @@ class AptoideApplication : Application(), ImageLoaderFactory, Provider {
   lateinit var editorsChoiceRecommendationManager: EditorsChoiceRecommendationManager
 
   @Inject
+  lateinit var installedPackagesSyncManager: InstalledPackagesSyncManager
+
+  @Inject
   lateinit var deviceSecurityChecker: DeviceSecurityChecker
 
   @Inject
@@ -148,7 +152,14 @@ class AptoideApplication : Application(), ImageLoaderFactory, Provider {
     initCompanionAppsManager()
     initCompanionGamesCachePreloader()
     initTrendingAppsRecommendationManager()
+    initInstalledPackagesSyncManager()
     sendDeviceSecurityAnalytics()
+  }
+
+  private fun initInstalledPackagesSyncManager() {
+    CoroutineScope(Dispatchers.IO).launch {
+      installedPackagesSyncManager.initialize()
+    }
   }
 
   private fun sendDeviceSecurityAnalytics() {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/di/RepositoryModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/di/RepositoryModule.kt
@@ -32,6 +32,7 @@ import cm.aptoide.pt.feature_oos.di.UninstallPackagesFilter
 import cm.aptoide.pt.feature_search.data.AutoCompleteSuggestionsRepository
 import cm.aptoide.pt.feature_search.domain.repository.SearchStoreManager
 import cm.aptoide.pt.feature_updates.di.PrioritizedPackagesFilter
+import cm.aptoide.pt.install_manager.InstallManager
 import com.aptoide.android.aptoidegames.AptoideIdsRepository
 import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.LocalIdsRepository
@@ -44,8 +45,12 @@ import com.aptoide.android.aptoidegames.feature_promotional.domain.AppComingSoon
 import com.aptoide.android.aptoidegames.feature_promotional.repository.SubscribedAppsManager
 import com.aptoide.android.aptoidegames.feature_rtb.analytics.RTBErrorLogger
 import com.aptoide.android.aptoidegames.feature_rtb.di.RetrofitRTB
+import com.aptoide.android.aptoidegames.feature_rtb.di.RetrofitRTBCollector
+import com.aptoide.android.aptoidegames.feature_rtb.repository.AptoideInstalledPackagesRTBRepository
 import com.aptoide.android.aptoidegames.feature_rtb.repository.AptoideRTBRepository
+import com.aptoide.android.aptoidegames.feature_rtb.repository.InstalledPackagesRTBRepository
 import com.aptoide.android.aptoidegames.feature_rtb.repository.RTBApi
+import com.aptoide.android.aptoidegames.feature_rtb.repository.RTBCollectorApi
 import com.aptoide.android.aptoidegames.feature_rtb.repository.RTBRepository
 import com.aptoide.android.aptoidegames.home.repository.ThemePreferencesManager
 import com.aptoide.android.aptoidegames.idsDataStore
@@ -351,6 +356,20 @@ class RepositoryModule {
     featureFlags = featureFlags,
     okHttpClient = okHttpClient,
     scope = CoroutineScope(Dispatchers.IO)
+  )
+
+  @Singleton
+  @Provides
+  fun provideInstalledPackagesRTBRepository(
+    @RetrofitRTBCollector retrofit: Retrofit,
+    installManager: InstallManager,
+    aptoideIdsRepository: LocalIdsRepository,
+    featureFlags: FeatureFlags,
+  ): InstalledPackagesRTBRepository = AptoideInstalledPackagesRTBRepository(
+    rtbCollectorApi = retrofit.create(RTBCollectorApi::class.java),
+    installManager = installManager,
+    aptoideIdsRepository = aptoideIdsRepository,
+    featureFlags = featureFlags,
   )
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/InstalledPackagesSyncManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/InstalledPackagesSyncManager.kt
@@ -1,0 +1,20 @@
+package com.aptoide.android.aptoidegames.feature_rtb
+
+import com.aptoide.android.aptoidegames.feature_rtb.repository.InstalledPackagesRTBRepository
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class InstalledPackagesSyncManager @Inject constructor(
+  private val repository: InstalledPackagesRTBRepository,
+) {
+
+  suspend fun initialize() {
+    try {
+      repository.syncInstalledPackages()
+    } catch (e: Throwable) {
+      Timber.w(e, "InstalledPackagesSyncManager: sync failed")
+    }
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/di/NetworkModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/di/NetworkModule.kt
@@ -26,8 +26,23 @@ object NetworkModule {
       .addConverterFactory(GsonConverterFactory.create())
       .build()
   }
+
+  @RetrofitRTBCollector
+  @Provides
+  @Singleton
+  fun provideRetrofitRTBCollector(@RawOkHttp okHttpClient: OkHttpClient): Retrofit {
+    return Retrofit.Builder()
+      .client(okHttpClient)
+      .baseUrl(BuildConfig.RTB_COLLECTOR_HOST)
+      .addConverterFactory(GsonConverterFactory.create())
+      .build()
+  }
 }
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class RetrofitRTB
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class RetrofitRTBCollector

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/AptoideInstalledPackagesRTBRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/AptoideInstalledPackagesRTBRepository.kt
@@ -1,0 +1,48 @@
+package com.aptoide.android.aptoidegames.feature_rtb.repository
+
+import cm.aptoide.pt.extensions.ifNormalAppOrGame
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+import cm.aptoide.pt.install_manager.InstallManager
+import com.aptoide.android.aptoidegames.LocalIdsRepository
+import com.aptoide.android.aptoidegames.apkfy.analytics.ApkfyManagerProbe
+import kotlinx.coroutines.flow.first
+
+class AptoideInstalledPackagesRTBRepository(
+  private val rtbCollectorApi: RTBCollectorApi,
+  private val installManager: InstallManager,
+  private val aptoideIdsRepository: LocalIdsRepository,
+  private val featureFlags: FeatureFlags,
+) : InstalledPackagesRTBRepository {
+
+  override suspend fun syncInstalledPackages() {
+    val guestUid = aptoideIdsRepository.observeId(ApkfyManagerProbe.GUEST_UID_KEY)
+      .first { it.isNotEmpty() }
+
+    val limit = featureFlags
+      .getFlagAsString(FLAG_INSTALLED_PACKAGES_LIMIT, DEFAULT_LIMIT.toString())
+      .toIntOrNull()
+      ?.coerceAtLeast(0)
+      ?: DEFAULT_LIMIT
+
+    val packages = installManager.installedApps
+      .mapNotNull { it.packageInfo }
+      .filter { it.ifNormalAppOrGame() }
+      .sortedByDescending { it.firstInstallTime }
+      .take(limit)
+      .map {
+        InstalledPackage(
+          package_name = it.packageName,
+          install_unix_time = it.firstInstallTime,
+        )
+      }
+
+    rtbCollectorApi.sendInstalledPackages(
+      InstalledPackagesRequest(guest_uid = guestUid, packages = packages)
+    )
+  }
+
+  companion object {
+    private const val FLAG_INSTALLED_PACKAGES_LIMIT = "rtb_installed_packages_limit"
+    private const val DEFAULT_LIMIT = 100
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/InstalledPackagesRTBRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/InstalledPackagesRTBRepository.kt
@@ -1,0 +1,5 @@
+package com.aptoide.android.aptoidegames.feature_rtb.repository
+
+interface InstalledPackagesRTBRepository {
+  suspend fun syncInstalledPackages()
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/InstalledPackagesRequest.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/InstalledPackagesRequest.kt
@@ -1,0 +1,15 @@
+package com.aptoide.android.aptoidegames.feature_rtb.repository
+
+import androidx.annotation.Keep
+
+@Keep
+data class InstalledPackagesRequest(
+  val guest_uid: String,
+  val packages: List<InstalledPackage>,
+)
+
+@Keep
+data class InstalledPackage(
+  val package_name: String,
+  val install_unix_time: Long,
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/RTBCollectorApi.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/RTBCollectorApi.kt
@@ -1,0 +1,9 @@
+package com.aptoide.android.aptoidegames.feature_rtb.repository
+
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface RTBCollectorApi {
+  @POST("/installed-packages")
+  suspend fun sendInstalledPackages(@Body request: InstalledPackagesRequest)
+}


### PR DESCRIPTION
**What does this PR do?**

This PR aims to send the device's installed packages to RTB on app startup, meaning once per session. The default number of sent packages is 100, but is configurable via Firebase flag

**Database changed?**

No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Add logging or check on Charles the request is being made in the right time and with the right packages

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-836](https://aptoide.atlassian.net/browse/AND-836)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-836]: https://aptoide.atlassian.net/browse/AND-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now syncs your installed apps at startup (excludes system apps) and sends a snapshot to a remote collector to improve recommendations and services. The sync observes a configurable limit (default 100) and runs safely in background without blocking startup.

* **Chores**
  * Added configurable collector host for the installed-packages endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Aptoide/aptoide-client-v8/pull/2544?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->