### PR TITLE
[AND-673] AB test to Auto Open IAB games from app view

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -97,6 +97,7 @@ import com.aptoide.android.aptoidegames.appview.AppViewHeaderConstants.FEATURE_G
 import com.aptoide.android.aptoidegames.appview.AppViewHeaderConstants.VIDEO_HEIGHT
 import com.aptoide.android.aptoidegames.appview.permissions.buildAppPermissionsRoute
 import com.aptoide.android.aptoidegames.appview.postinstall.PostInstallRecommendsView
+import com.aptoide.android.aptoidegames.design_system.AptoideGamesSwitch
 import com.aptoide.android.aptoidegames.design_system.IndeterminateCircularLoading
 import com.aptoide.android.aptoidegames.drawables.backgrounds.myiconpack.getAppViewBonusGiftBackground
 import com.aptoide.android.aptoidegames.drawables.icons.getBonusIconLeft
@@ -113,7 +114,12 @@ import com.aptoide.android.aptoidegames.feature_apps.presentation.buildSeeMoreBo
 import com.aptoide.android.aptoidegames.feature_apps.presentation.rememberBonusBundle
 import com.aptoide.android.aptoidegames.feature_rtb.presentation.isRTB
 import com.aptoide.android.aptoidegames.feature_rtb.presentation.rememberRTBCampaigns
+import com.aptoide.android.aptoidegames.installer.autoopen.rememberAutoOpenAfterInstallController
+import com.aptoide.android.aptoidegames.installer.autoopen.rememberAutoOpenAfterInstallDefault
+import com.aptoide.android.aptoidegames.installer.autoopen.rememberAutoOpenAfterInstallExperiment
+import com.aptoide.android.aptoidegames.installer.autoopen.rememberAutoOpenAfterInstallPreferences
 import com.aptoide.android.aptoidegames.installer.presentation.InstallView
+import com.aptoide.android.aptoidegames.mmp.LocalUTMInfo
 import com.aptoide.android.aptoidegames.mmp.WithUTM
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.app_view.AppRewardsView
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.PaEInstallView
@@ -362,6 +368,17 @@ fun AppViewContent(
   var selectedTab by rememberSaveable(key = tabsList.size.toString()) { mutableIntStateOf(0) }
   var showRecommends by rememberSaveable { mutableStateOf(false) }
   var hasAutoSelectedRewards by rememberSaveable { mutableStateOf(false) }
+  val autoOpenController = rememberAutoOpenAfterInstallController()
+  val autoOpenExperiment = rememberAutoOpenAfterInstallExperiment()
+  val autoOpenPreferences = rememberAutoOpenAfterInstallPreferences()
+  val autoOpenDefault = rememberAutoOpenAfterInstallDefault()
+  val autoOpenSavedChoice = remember(autoOpenPreferences) { autoOpenPreferences?.getUserChoice() }
+  val autoOpenInitial = autoOpenSavedChoice ?: autoOpenDefault
+  var autoOpenAfterInstall by rememberSaveable(autoOpenInitial) {
+    mutableStateOf(autoOpenInitial)
+  }
+
+  val autoOpenBillingEligible = !isGamified && app.isAppCoins
   val appImageString = stringResource(id = R.string.app_view_image_description_body, app.name)
 
   val scrollState = rememberScrollState()
@@ -433,8 +450,6 @@ fun AppViewContent(
         .padding(top = if (showYoutubeVideo) VIDEO_HEIGHT.dp else FEATURE_GRAPHIC_HEIGHT.dp)
         .background(Palette.Black)
     ) {
-      app.campaigns?.deepLinkUtms = utmsMap
-
       AppPresentationView(app)
 
       if (isGamified) {
@@ -444,11 +459,42 @@ fun AppViewContent(
           navigate = navigate
         )
       } else {
-        InstallView(
-          modifier = Modifier.padding(top = 24.dp, start = 16.dp, end = 16.dp),
-          app = app,
-          onInstallStarted = { showRecommends = true }
-        )
+        val autoOpenUTMMedium = if (autoOpenBillingEligible) {
+          val cohort = if (autoOpenDefault) "open-on" else "open-off"
+          val baseMedium = utmsMap[UTM_MEDIUM]?.takeIf { it.isNotEmpty() }
+            ?: LocalUTMInfo.current.utmMedium
+          "$baseMedium-$cohort"
+        } else {
+          null
+        }
+        WithUTM(medium = autoOpenUTMMedium, navigate = navigate) { _ ->
+          InstallView(
+            modifier = Modifier.padding(top = 24.dp, start = 16.dp, end = 16.dp),
+            app = app,
+            autoOpenAfterInstall = autoOpenAfterInstall.takeIf { autoOpenBillingEligible },
+            onInstallStarted = {
+              showRecommends = true
+              if (autoOpenBillingEligible) {
+                autoOpenExperiment?.sendActivationEvent()
+                if (autoOpenAfterInstall) {
+                  autoOpenController?.open(app.packageName)
+                }
+              }
+            },
+          )
+        }
+        if (autoOpenBillingEligible) {
+          AutoOpenAfterInstallToggle(
+            checked = autoOpenAfterInstall,
+            onCheckedChange = { checked ->
+              autoOpenAfterInstall = checked
+              autoOpenPreferences?.setUserChoice(checked)
+              if (checked) autoOpenController?.open(app.packageName)
+              else autoOpenController?.cancel(app.packageName)
+            },
+            modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp)
+          )
+        }
       }
 
       AnimatedVisibility(
@@ -1052,6 +1098,29 @@ fun AppRatingAndDownloads(
 private object AppViewHeaderConstants {
   const val VIDEO_HEIGHT = 200
   const val FEATURE_GRAPHIC_HEIGHT = 200
+}
+
+@Composable
+private fun AutoOpenAfterInstallToggle(
+  checked: Boolean,
+  onCheckedChange: (Boolean) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    modifier = modifier.fillMaxWidth(),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(
+      text = stringResource(R.string.appview_auto_open_when_ready),
+      style = AGTypography.InputsS,
+      color = Palette.White,
+      modifier = Modifier.weight(1f),
+    )
+    AptoideGamesSwitch(
+      checked = checked,
+      onCheckedChanged = onCheckedChange,
+    )
+  }
 }
 
 @PreviewDark

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalytics.kt
@@ -12,6 +12,7 @@ interface InstallAnalytics {
     app: App,
     analyticsContext: AnalyticsUIContext,
     networkType: String,
+    autoOpenAfterInstall: Boolean? = null,
   ) {
   }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalyticsImpl.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/analytics/InstallAnalyticsImpl.kt
@@ -57,6 +57,7 @@ class InstallAnalyticsImpl(
     app: App,
     analyticsContext: AnalyticsUIContext,
     networkType: String,
+    autoOpenAfterInstall: Boolean?,
   ) {
     when (analyticsContext.installAction) {
       InstallAction.INSTALL -> "install_clicked"
@@ -71,7 +72,8 @@ class InstallAnalyticsImpl(
         params = analyticsContext.toGenericParameters(
           *app.toGenericParameters(),
           P_UPDATE_TYPE to getUserClicks(app.packageName),
-          P_SERVICE to networkType
+          P_SERVICE to networkType,
+          P_AUTO_OPEN_AFTER_INSTALL to autoOpenAfterInstall,
         )
       )
     }
@@ -621,6 +623,7 @@ class InstallAnalyticsImpl(
     internal const val P_UPDATE_TYPE = "update_type"
     internal const val P_APP_SIZE_MB = "app_size_mb"
     internal const val P_DOWNLOAD_SPEED_MB = "download_speed_mbps"
+    internal const val P_AUTO_OPEN_AFTER_INSTALL = "auto_open_after_install"
   }
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/autoopen/AutoOpenAfterInstallController.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/autoopen/AutoOpenAfterInstallController.kt
@@ -1,0 +1,53 @@
+package com.aptoide.android.aptoidegames.installer.autoopen
+
+import cm.aptoide.pt.download_view.presentation.InstalledAppOpener
+import cm.aptoide.pt.install_manager.InstallManager
+import cm.aptoide.pt.install_manager.Task
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AutoOpenAfterInstallController @Inject constructor(
+  private val installManager: InstallManager,
+  private val installedAppOpener: InstalledAppOpener,
+) {
+
+  private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+  private val watchers = ConcurrentHashMap<String, Job>()
+
+  fun open(packageName: String) {
+    if (watchers.containsKey(packageName)) return
+    watchers[packageName] = scope.launch {
+      try {
+        val task = installManager.getApp(packageName).taskFlow.filterNotNull().first()
+        task.stateAndProgress.collect { state ->
+          if (state == Task.State.Completed) {
+            withContext(Dispatchers.Main) {
+              installedAppOpener.openInstalledApp(packageName)
+            }
+          }
+        }
+      } catch (_: CancellationException) {
+      } catch (t: Throwable) {
+        Timber.e(t, "AutoOpen watcher crashed for %s", packageName)
+      } finally {
+        watchers.remove(packageName)
+      }
+    }
+  }
+
+  fun cancel(packageName: String) {
+    watchers.remove(packageName)?.cancel()
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/autoopen/AutoOpenAfterInstallExperiment.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/autoopen/AutoOpenAfterInstallExperiment.kt
@@ -1,0 +1,60 @@
+package com.aptoide.android.aptoidegames.installer.autoopen
+
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AutoOpenAfterInstallExperiment @Inject constructor(
+  private val featureFlags: FeatureFlags,
+  private val genericAnalytics: GenericAnalytics,
+) {
+
+  private val fetchMutex = Mutex()
+
+  @Volatile
+  private var cachedDefaultOn: Boolean? = null
+
+  @Volatile
+  private var activationEventSent = false
+
+  suspend fun isDefaultOn(): Boolean = resolve() ?: false
+
+  fun sendActivationEvent() {
+    if (activationEventSent) return
+    val defaultOn = cachedDefaultOn ?: return
+    activationEventSent = true
+
+    val variant = if (defaultOn) VARIANT_ON else VARIANT_OFF
+    Timber.d("Auto-open experiment activation: variant=$variant")
+    genericAnalytics.logEvent(
+      name = ACTIVATION_EVENT,
+      params = mapOf("variant" to variant)
+    )
+  }
+
+  private suspend fun resolve(): Boolean? = cachedDefaultOn ?: fetchMutex.withLock {
+    cachedDefaultOn?.let { return it }
+
+    val flag = withTimeoutOrNull(FETCH_TIMEOUT_MS) { featureFlags.getFlag(FLAG_KEY) }
+    if (flag == null) {
+      Timber.w("Auto-open experiment flag missing or timed out")
+      null
+    } else {
+      flag.also { cachedDefaultOn = it }
+    }
+  }
+
+  companion object {
+    private const val FLAG_KEY = "exp_auto_open_after_install"
+    private const val VARIANT_ON = "on"
+    private const val VARIANT_OFF = "off"
+    private const val ACTIVATION_EVENT = "exp_auto_open_after_install_activated"
+    private const val FETCH_TIMEOUT_MS = 3_000L
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/autoopen/AutoOpenAfterInstallPreferences.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/autoopen/AutoOpenAfterInstallPreferences.kt
@@ -1,0 +1,33 @@
+package com.aptoide.android.aptoidegames.installer.autoopen
+
+import android.content.Context
+import androidx.core.content.edit
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AutoOpenAfterInstallPreferences @Inject constructor(
+  @ApplicationContext context: Context,
+) {
+
+  private val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+  fun getUserChoice(): Boolean? =
+    if (preferences.contains(KEY_AUTO_OPEN_ENABLED)) {
+      preferences.getBoolean(KEY_AUTO_OPEN_ENABLED, false)
+    } else {
+      null
+    }
+
+  fun setUserChoice(enabled: Boolean) {
+    preferences.edit {
+      putBoolean(KEY_AUTO_OPEN_ENABLED, enabled)
+    }
+  }
+
+  private companion object {
+    const val PREFERENCES_NAME = "auto_open_after_install"
+    const val KEY_AUTO_OPEN_ENABLED = "auto_open_after_install_enabled"
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/autoopen/AutoOpenRequestProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/autoopen/AutoOpenRequestProvider.kt
@@ -1,0 +1,49 @@
+package com.aptoide.android.aptoidegames.installer.autoopen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import cm.aptoide.pt.extensions.runPreviewable
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class AutoOpenAfterInstallInjectionsProvider @Inject constructor(
+  val controller: AutoOpenAfterInstallController,
+  val experiment: AutoOpenAfterInstallExperiment,
+  val preferences: AutoOpenAfterInstallPreferences,
+) : ViewModel()
+
+@Composable
+fun rememberAutoOpenAfterInstallController(): AutoOpenAfterInstallController? = runPreviewable(
+  preview = { null },
+  real = { hiltViewModel<AutoOpenAfterInstallInjectionsProvider>().controller }
+)
+
+@Composable
+fun rememberAutoOpenAfterInstallExperiment(): AutoOpenAfterInstallExperiment? = runPreviewable(
+  preview = { null },
+  real = { hiltViewModel<AutoOpenAfterInstallInjectionsProvider>().experiment }
+)
+
+@Composable
+fun rememberAutoOpenAfterInstallPreferences(): AutoOpenAfterInstallPreferences? = runPreviewable(
+  preview = { null },
+  real = { hiltViewModel<AutoOpenAfterInstallInjectionsProvider>().preferences }
+)
+
+@Composable
+fun rememberAutoOpenAfterInstallDefault(): Boolean = runPreviewable(
+  preview = { true },
+  real = {
+    val experiment = hiltViewModel<AutoOpenAfterInstallInjectionsProvider>().experiment
+    var defaultOn by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { defaultOn = experiment.isDefaultOn() }
+    defaultOn
+  }
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallView.kt
@@ -82,11 +82,13 @@ fun InstallView(
   modifier: Modifier = Modifier,
   onInstallStarted: () -> Unit = {},
   onCancel: () -> Unit = {},
+  autoOpenAfterInstall: Boolean? = null,
 ) {
   val installViewState = installViewStates(
     app = app,
     onInstallStarted = onInstallStarted,
-    onCancel = onCancel
+    onCancel = onCancel,
+    autoOpenAfterInstall = autoOpenAfterInstall,
   )
 
   InstallViewContent(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/installer/presentation/InstallViewStates.kt
@@ -62,6 +62,7 @@ fun installViewStates(
   app: App,
   onInstallStarted: () -> Unit = {},
   onCancel: () -> Unit = {},
+  autoOpenAfterInstall: Boolean? = null,
 ): InstallViewState {
   val context = LocalContext.current
   val analyticsContext = AnalyticsContext.current
@@ -94,6 +95,7 @@ fun installViewStates(
               app = app,
               networkType = context.getNetworkType(),
               analyticsContext = analyticsContext.copy(installAction = InstallAction.INSTALL),
+              autoOpenAfterInstall = autoOpenAfterInstall,
             )
 
             if (analyticsContext.currentScreen != "AppView") {

--- a/app-games/src/main/res/values/strings.xml
+++ b/app-games/src/main/res/values/strings.xml
@@ -388,6 +388,7 @@
   <string name="apkfy_multi_install_highlighted_game">Top Played on Aptoide Games</string>
   <string name="apkfy_multi_install_highlighted_game_short">Top Played</string>
   <string name="apkfy_multi_install_auto_open">Opens automatically when installation is complete.</string>
+  <string name="appview_auto_open_when_ready">Auto-open when ready</string>
 
   <!-- AB Test for Experiment 9 : GamesFeed -->
   <string name="gamesfeed_bundle_header_1">For you</string>

--- a/download-view/src/main/java/cm/aptoide/pt/download_view/di/UseCaseModule.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/di/UseCaseModule.kt
@@ -5,14 +5,16 @@ import cm.aptoide.pt.download_view.presentation.InstalledAppOpener
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ViewModelComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
 import javax.inject.Qualifier
+import javax.inject.Singleton
 
 @Module
-@InstallIn(ViewModelComponent::class)
+@InstallIn(SingletonComponent::class)
 class UseCaseModule {
 
+  @Singleton
   @Provides
   fun provideInstalledAppOpener(@ApplicationContext context: Context): InstalledAppOpener {
     return InstalledAppOpener(context)

--- a/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/InstalledAppOpener.kt
+++ b/download-view/src/main/java/cm/aptoide/pt/download_view/presentation/InstalledAppOpener.kt
@@ -1,12 +1,14 @@
 package cm.aptoide.pt.download_view.presentation
 
 import android.content.Context
+import android.content.Intent
 
 class InstalledAppOpener(private val context: Context) {
 
   fun openInstalledApp(packageName: String) {
     val intentForPackage = context.packageManager.getLaunchIntentForPackage(packageName)
     if (intentForPackage != null) {
+      intentForPackage.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
       context.startActivity(intentForPackage)
     }
   }


### PR DESCRIPTION
**What does this PR do?**

This PR aims to create an AB test to auto open IAB games on installation from the AppView. 

**Database changed?**

 No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Open the AppView on a IAB game and see if the toggle is on

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-673](https://aptoide.atlassian.net/browse/AND-673)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-673]: https://aptoide.atlassian.net/browse/AND-673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-open apps when installation completes (eligibility-based).
  * In-app toggle (shown when eligible) to enable/disable auto-open; preference is persisted.
  * Experiment with a default-on/off behavior and activation tracking.

* **Improvements**
  * Install analytics now record the auto-open choice.
  * More reliable app launch after install (ensures proper intent handling and coordinated opening).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->