### PR TITLE
[AND-849] Filter apparena editorials from showing up on AptoideGames

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -78,8 +78,6 @@ import cm.aptoide.pt.feature_apps.domain.Rating
 import cm.aptoide.pt.feature_apps.presentation.AppUiState
 import cm.aptoide.pt.feature_apps.presentation.rememberApp
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
-import cm.aptoide.pt.feature_editorial.presentation.relatedEditorialsCardViewModel
-import cm.aptoide.pt.feature_editorial.presentation.rememberRelatedEditorials
 import com.aptoide.android.aptoidegames.APP_LINK_HOST
 import com.aptoide.android.aptoidegames.APP_LINK_SCHEMA
 import com.aptoide.android.aptoidegames.AppIconImage
@@ -106,6 +104,8 @@ import com.aptoide.android.aptoidegames.drawables.icons.getLeftArrow
 import com.aptoide.android.aptoidegames.drawables.icons.getRatingStar
 import com.aptoide.android.aptoidegames.editorial.EditorialsViewCardLarge
 import com.aptoide.android.aptoidegames.editorial.buildEditorialRoute
+import com.aptoide.android.aptoidegames.editorial.relatedEditorialsCardViewModel
+import com.aptoide.android.aptoidegames.editorial.rememberRelatedEditorials
 import com.aptoide.android.aptoidegames.error_views.GenericErrorView
 import com.aptoide.android.aptoidegames.error_views.NoConnectionView
 import com.aptoide.android.aptoidegames.feature_apps.presentation.SmallEmptyView

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/AGEditorialRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/AGEditorialRepository.kt
@@ -1,0 +1,25 @@
+package com.aptoide.android.aptoidegames.editorial
+
+import cm.aptoide.pt.feature_editorial.data.EditorialRepository
+import cm.aptoide.pt.feature_editorial.domain.Article
+import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
+
+internal class AGEditorialRepository(
+  private val editorialRepository: EditorialRepository,
+) : EditorialRepository {
+
+  override suspend fun getLatestArticle(): List<ArticleMeta> =
+    editorialRepository.getLatestArticle().filterOutAppArena()
+
+  override suspend fun getArticle(editorialUrl: String): Article =
+    editorialRepository.getArticle(editorialUrl)
+
+  override suspend fun getArticlesMeta(
+    editorialWidgetUrl: String,
+    subtype: String?,
+  ): List<ArticleMeta> =
+    editorialRepository.getArticlesMeta(editorialWidgetUrl, subtype).filterOutAppArena()
+
+  override suspend fun getRelatedArticlesMeta(packageName: String): List<ArticleMeta> =
+    editorialRepository.getRelatedArticlesMeta(packageName).filterOutAppArena()
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/AGViewModelProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/AGViewModelProvider.kt
@@ -1,0 +1,123 @@
+package com.aptoide.android.aptoidegames.editorial
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import cm.aptoide.pt.aptoide_network.domain.UrlsCache
+import cm.aptoide.pt.extensions.runPreviewable
+import cm.aptoide.pt.feature_editorial.data.EditorialRepository
+import cm.aptoide.pt.feature_editorial.di.DefaultEditorialUrl
+import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
+import cm.aptoide.pt.feature_editorial.domain.randomArticleMeta
+import cm.aptoide.pt.feature_editorial.domain.usecase.ArticleUseCase
+import cm.aptoide.pt.feature_editorial.domain.usecase.ArticlesMetaUseCase
+import cm.aptoide.pt.feature_editorial.domain.usecase.RelatedArticlesMetaUseCase
+import cm.aptoide.pt.feature_editorial.presentation.ArticleListUiState
+import cm.aptoide.pt.feature_editorial.presentation.EditorialViewModel
+import cm.aptoide.pt.feature_editorial.presentation.EditorialsListViewModel
+import cm.aptoide.pt.feature_editorial.presentation.RelatedEditorialsCardViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+internal class AGInjectionsProvider @Inject constructor(
+  editorialRepository: EditorialRepository,
+  urlsCache: UrlsCache,
+  @DefaultEditorialUrl defaultEditorialUrl: String,
+  val articleUseCase: ArticleUseCase,
+) : ViewModel() {
+
+  private val agRepository = AGEditorialRepository(editorialRepository)
+
+  val articlesMetaUseCase = ArticlesMetaUseCase(agRepository, urlsCache, defaultEditorialUrl)
+  val relatedArticlesMetaUseCase = RelatedArticlesMetaUseCase(agRepository, urlsCache)
+}
+
+@Composable
+fun rememberEditorialListState(
+  tag: String,
+  subtype: String? = null,
+  salt: String? = null,
+): Pair<ArticleListUiState, () -> Unit> = runPreviewable(
+  preview = {
+    ArticleListUiState.Idle(List((0..50).random()) { randomArticleMeta }) to {}
+  },
+  real = {
+    val injectionsProvider = hiltViewModel<AGInjectionsProvider>()
+    val vm: EditorialsListViewModel = viewModel(
+      key = tag + subtype + salt,
+      factory = object : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+          @Suppress("UNCHECKED_CAST")
+          return EditorialsListViewModel(
+            tag = tag,
+            subtype = subtype,
+            articlesMetaUseCase = injectionsProvider.articlesMetaUseCase,
+          ) as T
+        }
+      }
+    )
+    val uiState by vm.uiState.collectAsState()
+    uiState to vm::reload
+  }
+)
+
+@Composable
+fun relatedEditorialsCardViewModel(packageName: String): RelatedEditorialsCardViewModel {
+  val injectionsProvider = hiltViewModel<AGInjectionsProvider>()
+  return viewModel(
+    key = "relatedEditorials/$packageName",
+    factory = object : ViewModelProvider.Factory {
+      override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        @Suppress("UNCHECKED_CAST")
+        return RelatedEditorialsCardViewModel(
+          packageName = packageName,
+          relatedArticlesMetaUseCase = injectionsProvider.relatedArticlesMetaUseCase,
+        ) as T
+      }
+    }
+  )
+}
+
+@Composable
+fun rememberRelatedEditorials(packageName: String): List<ArticleMeta>? = runPreviewable(
+  preview = { List((0..20).random()) { randomArticleMeta } },
+  real = {
+    val injectionsProvider = hiltViewModel<AGInjectionsProvider>()
+    val vm: RelatedEditorialsCardViewModel = viewModel(
+      key = "relatedEditorials/$packageName",
+      factory = object : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+          @Suppress("UNCHECKED_CAST")
+          return RelatedEditorialsCardViewModel(
+            packageName = packageName,
+            relatedArticlesMetaUseCase = injectionsProvider.relatedArticlesMetaUseCase,
+          ) as T
+        }
+      }
+    )
+    val uiState by vm.uiState.collectAsState()
+    uiState
+  }
+)
+
+@Composable
+fun editorialViewModel(source: String): EditorialViewModel {
+  val injectionsProvider = hiltViewModel<AGInjectionsProvider>()
+  return viewModel(
+    key = source,
+    factory = object : ViewModelProvider.Factory {
+      override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        @Suppress("UNCHECKED_CAST")
+        return EditorialViewModel(
+          source = source,
+          articleUseCase = injectionsProvider.articleUseCase,
+        ) as T
+      }
+    }
+  )
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialExtensions.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialExtensions.kt
@@ -1,0 +1,8 @@
+package com.aptoide.android.aptoidegames.editorial
+
+import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
+
+private const val APPARENA_MESSAGE_PREFIX = "apparena-"
+
+internal fun List<ArticleMeta>.filterOutAppArena(): List<ArticleMeta> =
+  filterNot { it.caption.startsWith(APPARENA_MESSAGE_PREFIX) }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialMoreScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialMoreScreen.kt
@@ -31,7 +31,6 @@ import cm.aptoide.pt.extensions.ScreenData
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
 import cm.aptoide.pt.feature_editorial.presentation.ArticleListUiState
 import cm.aptoide.pt.feature_editorial.presentation.previewArticlesListIdleState
-import cm.aptoide.pt.feature_editorial.presentation.rememberEditorialListState
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
 import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.analytics.dto.BundleMeta

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialView.kt
@@ -29,7 +29,6 @@ import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
 import cm.aptoide.pt.feature_editorial.presentation.ArticleListUiState
 import cm.aptoide.pt.feature_editorial.presentation.ArticleListUiStateProvider
-import cm.aptoide.pt.feature_editorial.presentation.rememberEditorialListState
 import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.randomBundle
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
@@ -54,7 +53,7 @@ fun EditorialBundle(
   navigate: (String) -> Unit,
   spaceBy: Int = 0,
 ) {
-  val (uiState, reload) = rememberEditorialListState(
+  val (uiState, _) = rememberEditorialListState(
     tag = bundle.tag,
     subtype = subtype,
     salt = bundle.timestamp

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialViewScreen.kt
@@ -38,7 +38,6 @@ import cm.aptoide.pt.feature_editorial.data.model.Media
 import cm.aptoide.pt.feature_editorial.domain.Article
 import cm.aptoide.pt.feature_editorial.domain.randomArticle
 import cm.aptoide.pt.feature_editorial.presentation.EditorialUiState
-import cm.aptoide.pt.feature_editorial.presentation.editorialViewModel
 import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.BundleSource.MANUAL
 import cm.aptoide.pt.feature_home.domain.Type.EDITORIAL

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/EventPromotionalView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/EventPromotionalView.kt
@@ -18,11 +18,11 @@ import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
 import cm.aptoide.pt.feature_editorial.presentation.ArticleListUiState
 import cm.aptoide.pt.feature_editorial.presentation.ArticleListUiStateProvider
-import cm.aptoide.pt.feature_editorial.presentation.rememberEditorialListState
 import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.randomBundle
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.editorial.buildEditorialRoute
+import com.aptoide.android.aptoidegames.editorial.rememberEditorialListState
 import com.aptoide.android.aptoidegames.home.LoadingBundleView
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
@@ -67,6 +67,7 @@ private fun EventBundleContent(
     }
 
     is ArticleListUiState.Idle -> {
+      if (uiState.articles.isEmpty()) return
       val editorialMeta = uiState.articles[0]
 
       EventCard(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/NewsPromotionalView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_promotional/NewsPromotionalView.kt
@@ -17,10 +17,10 @@ import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
 import cm.aptoide.pt.feature_editorial.presentation.ArticleListUiState
 import cm.aptoide.pt.feature_editorial.presentation.ArticleListUiStateProvider
-import cm.aptoide.pt.feature_editorial.presentation.rememberEditorialListState
 import cm.aptoide.pt.feature_home.domain.Bundle
 import cm.aptoide.pt.feature_home.domain.randomBundle
 import com.aptoide.android.aptoidegames.editorial.buildEditorialRoute
+import com.aptoide.android.aptoidegames.editorial.rememberEditorialListState
 import com.aptoide.android.aptoidegames.home.LoadingBundleView
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
@@ -65,6 +65,7 @@ private fun NewsBundleContent(
     }
 
     is ArticleListUiState.Idle -> {
+      if (uiState.articles.isEmpty()) return
       val editorialMeta = uiState.articles[0]
       NewsCard(
         bundle = bundle,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/GamesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/GamesScreen.kt
@@ -9,11 +9,11 @@ import androidx.compose.runtime.setValue
 import cm.aptoide.pt.extensions.ScreenData
 import cm.aptoide.pt.feature_apps.presentation.appsBySortType
 import cm.aptoide.pt.feature_categories.presentation.rememberAllCategories
-import cm.aptoide.pt.feature_editorial.presentation.rememberEditorialListState
 import com.aptoide.android.aptoidegames.analytics.presentation.InitialAnalyticsMeta
 import com.aptoide.android.aptoidegames.analytics.presentation.OverrideAnalyticsHomeTab
 import com.aptoide.android.aptoidegames.categories.presentation.AllCategoriesView
 import com.aptoide.android.aptoidegames.editorial.SeeMoreEditorialsContent
+import com.aptoide.android.aptoidegames.editorial.rememberEditorialListState
 import com.aptoide.android.aptoidegames.feature_apps.presentation.BONUS_SORT
 import com.aptoide.android.aptoidegames.feature_apps.presentation.MoreBonusBundleView
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.analytics.rememberPaEAnalytics


### PR DESCRIPTION
**What does this PR do?**

This PR aims at filtering app arena editorials from aptoide games.


**Database changed?**
No

**Where should the reviewer start?**


- See by commit

**How should this be manually tested?**

Use a rewrite where you have some editorials with the message "apparena-" prefix. Ask me for that rewrite if you need. Make sure those marked with the prefix dont show up on aptoide games.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-847](https://aptoide.atlassian.net/browse/AND-847)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-847]: https://aptoide.atlassian.net/browse/AND-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Editorial lists, "See more" pages, related editorials, and promotional bundles now consistently exclude "App Arena" items so featured content and metadata come only from visible articles.
  * Promotional/news/event bundles and editorial views now guard against empty article lists, preventing empty slots or errors and improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->