### PR TITLE
[AND-852] Hide title if a bundle returns an error

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/CategoriesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/categories/presentation/CategoriesView.kt
@@ -60,6 +60,9 @@ fun CategoriesBundle(
   val analyticsContext = AnalyticsContext.current
   val bundleAnalytics = rememberBundleAnalytics()
 
+  // Don't show the bundle (including the title) when there are no categories to display.
+  if (!uiState.loading && uiState.categories.isEmpty()) return@let
+
   Column(
     modifier = Modifier
       .fillMaxWidth()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
@@ -75,14 +75,14 @@ private fun RealAppsGridBundle(
   spaceBy: Int = 0,
 ) {
   Column {
-    BundleHeader(
-      title = bundle.title,
-      icon = bundle.bundleIcon,
-      hasMoreAction = bundle.hasAppsListMoreAction,
-      onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate)
-    )
     when (uiState) {
       is AppsListUiState.Idle -> {
+        BundleHeader(
+          title = bundle.title,
+          icon = bundle.bundleIcon,
+          hasMoreAction = bundle.hasAppsListMoreAction,
+          onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate)
+        )
         AppsRowView(
           appsList = uiState.apps,
           navigate = navigate,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselAppView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselAppView.kt
@@ -77,15 +77,15 @@ private fun RealCarouselBundle(
   spaceBy: Int = 0
 ) {
   Column {
-    BundleHeader(
-      title = bundle.title,
-      icon = bundle.bundleIcon,
-      hasMoreAction = bundle.hasAppsListMoreAction,
-      onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate),
-      titleColor = Palette.White,
-    )
     when (uiState) {
       is AppsListUiState.Idle -> {
+        BundleHeader(
+          title = bundle.title,
+          icon = bundle.bundleIcon,
+          hasMoreAction = bundle.hasAppsListMoreAction,
+          onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate),
+          titleColor = Palette.White,
+        )
         CarouselListView(
           appsList = uiState.apps,
           bundleTag = bundle.tag,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselLargeAppView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/CarouselLargeAppView.kt
@@ -88,15 +88,15 @@ private fun RealCarouselLargeBundle(
     Column(
       modifier = Modifier.fillMaxWidth()
     ) {
-      BundleHeader(
-        title = bundle.title,
-        icon = bundle.bundleIcon,
-        hasMoreAction = bundle.hasAppsListMoreAction,
-        onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate),
-        titleColor = Palette.White,
-      )
       when (uiState) {
         is AppsListUiState.Idle -> {
+          BundleHeader(
+            title = bundle.title,
+            icon = bundle.bundleIcon,
+            hasMoreAction = bundle.hasAppsListMoreAction,
+            onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate),
+            titleColor = Palette.White,
+          )
           CarouselLargeListView(
             appsList = uiState.apps,
             navigate = navigate,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/EditorsChoiceBundle.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/EditorsChoiceBundle.kt
@@ -77,15 +77,15 @@ fun EditorsChoiceBundle(
   val (uiState, _) = rememberAppsByTag(bundle.tag, bundle.timestamp)
 
   Column {
-    BundleHeader(
-      title = bundle.title,
-      icon = bundle.bundleIcon,
-      hasMoreAction = bundle.hasAppsListMoreAction,
-      onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate),
-      titleColor = Palette.White,
-    )
     when (uiState) {
       is AppsListUiState.Idle -> {
+        BundleHeader(
+          title = bundle.title,
+          icon = bundle.bundleIcon,
+          hasMoreAction = bundle.hasAppsListMoreAction,
+          onClick = getSeeMoreRouteNavigation(bundle = bundle, navigate = navigate),
+          titleColor = Palette.White,
+        )
         EditorsChoiceListView(
           appsList = uiState.apps,
           navigate = navigate

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/PublisherTakeOverBundle.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/PublisherTakeOverBundle.kt
@@ -31,6 +31,7 @@ import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.randomApp
 import cm.aptoide.pt.feature_apps.presentation.AppsListUiState
+import cm.aptoide.pt.feature_apps.presentation.isEmptyOrError
 import cm.aptoide.pt.feature_apps.presentation.rememberAppsByTag
 import cm.aptoide.pt.feature_campaigns.toAptoideMMPCampaign
 import cm.aptoide.pt.feature_home.domain.Bundle
@@ -116,6 +117,9 @@ fun PublisherTakeOverContent(
   navigate: (String) -> Unit,
   spaceBy: Int = 0
 ) {
+  // Don't show the takeover (background + title) when neither list has content to display.
+  if (uiState.isEmptyOrError && bottomUiState.isEmptyOrError) return
+
   Column {
     Box {
       AptoideAsyncImage(

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/AppsListUiState.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/AppsListUiState.kt
@@ -14,6 +14,15 @@ sealed class AppsListUiState {
   object Error : AppsListUiState()
 }
 
+/**
+ * Terminal states with no content to show. When a bundle ends up in one of these,
+ * neither its content nor its title/header should be displayed.
+ */
+val AppsListUiState.isEmptyOrError: Boolean
+  get() = this is AppsListUiState.Empty
+    || this is AppsListUiState.Error
+    || this is AppsListUiState.NoConnection
+
 class AppsListUiStateProvider : PreviewParameterProvider<AppsListUiState> {
   override val values: Sequence<AppsListUiState> = sequenceOf(
     AppsListUiState.Idle(List(Random.nextInt(1..12)) { randomApp }),


### PR DESCRIPTION
**What does this PR do?**

This PR aims at showing bundles titles only if they didnt give an error or empty list. With the previous code if a bundle failed we would have the title with the pading and nothing else. (unless the bundle had an empty state with retry button)

**Database changed?**

No

**Where should the reviewer start?**

- [ ] See by commit 

**How should this be manually tested?**

Change the viewmodels to return empty or error and see that the bundles won't show. Also confirm the positive scenario to make sure everything is working correctly

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-852](https://aptoide.atlassian.net/browse/AND-852)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-852]: https://aptoide.atlassian.net/browse/AND-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Updated category display to hide the entire bundle UI (including the header) when categories finish loading with no results.
* Prevented bundle headers from showing on non-Idle states (loading, empty, error, or no connection) across categories, app grid, carousel, and editor’s choice.
* Improved the publisher takeover view so it doesn’t render takeover content when both the main and bottom states are empty or error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->