### PR TITLE
[AND-845] Add sign in reward to games feed home bundle

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamesfeed/presentation/GamesFeedBundle.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamesfeed/presentation/GamesFeedBundle.kt
@@ -39,6 +39,8 @@ import com.aptoide.android.aptoidegames.gamesfeed.repository.GamesFeedItem
 import com.aptoide.android.aptoidegames.gamesfeed.repository.GamesFeedItemType
 import com.aptoide.android.aptoidegames.home.LoadingBundleView
 import com.aptoide.android.aptoidegames.home.SeeMoreView
+import com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards.SignInRewardCard
+import com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards.PaERewardType
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.Palette
 
@@ -115,6 +117,11 @@ private fun GamesFeedBundleContent(
           horizontalArrangement = Arrangement.spacedBy(16.dp),
           contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 16.dp)
         ) {
+          if (PaERewardType.fromPackageName(firstPackageName) != null) {
+            item {
+              SignInRewardCard(packageName = firstPackageName)
+            }
+          }
           items(items) { item ->
             GamesFeedPost(
               item = item,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/ClaimableRewardCard.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/ClaimableRewardCard.kt
@@ -1,0 +1,114 @@
+package com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import cm.aptoide.pt.extensions.toAnnotatedString
+import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.animations.RewardsStarsAnimation
+import com.aptoide.android.aptoidegames.play_and_earn.presentation.unit_exchange_flow.exchangeDisplayName
+import com.aptoide.android.aptoidegames.theme.AGTypography
+import com.aptoide.android.aptoidegames.theme.Palette
+
+private val CardWidth = 136.dp
+
+@Composable
+fun ClaimableRewardCard(
+  rewardType: PaERewardType,
+  formattedAmount: String,
+  onCollectClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Column(
+    modifier = modifier.width(CardWidth),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Box(
+      modifier = Modifier
+        .size(CardWidth)
+        .background(Palette.Secondary),
+      contentAlignment = Alignment.Center,
+    ) {
+      Image(
+        painter = painterResource(R.drawable.roblox_feature_graphic),
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        colorFilter = ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0f) }),
+        alpha = 0.2f,
+        modifier = Modifier.matchParentSize(),
+      )
+      Image(
+        painter = painterResource(rewardType.iconRes),
+        contentDescription = null,
+        modifier = Modifier.size(72.dp),
+      )
+      Box(
+        modifier = Modifier
+          .size(0.dp)
+          .wrapContentSize(unbounded = true)
+      ) {
+        RewardsStarsAnimation(modifier = Modifier.width(CardWidth))
+      }
+    }
+
+    val message = stringResource(
+      id = R.string.play_and_earn_reward_earned_message,
+      formattedAmount,
+      stringResource(rewardType.displayNameRes),
+    ).toAnnotatedString(
+      AGTypography.InputsL.toSpanStyle().copy(color = Palette.Yellow100)
+    )
+    Text(
+      text = message,
+      style = AGTypography.InputsL,
+      color = Palette.White,
+    )
+
+    Box(
+      modifier = Modifier
+        .fillMaxWidth()
+        .background(Palette.Secondary)
+        .clickable(onClick = onCollectClick)
+        .padding(horizontal = 16.dp, vertical = 9.dp),
+      contentAlignment = Alignment.Center,
+    ) {
+      Text(
+        text = stringResource(R.string.play_and_earn_tap_to_collect),
+        style = AGTypography.InputsS,
+        color = Palette.White,
+      )
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun ClaimableRewardCardPreview(
+  @PreviewParameter(PaERewardTypeProvider::class) rewardType: PaERewardType,
+) {
+  ClaimableRewardCard(
+    rewardType = rewardType,
+    formattedAmount = "$0.50",
+    onCollectClick = {},
+  )
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/PaERewardType.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/PaERewardType.kt
@@ -9,9 +9,21 @@ import com.aptoide.android.aptoidegames.R
 /** Default reward amount granted by the Play & Earn APKFY / earned-reward flows. */
 const val PAE_DEFAULT_REWARD_AMOUNT = "$0.50"
 
+private const val ROBLOX_PACKAGE = "com.roblox.client"
+private val FREE_FIRE_PACKAGES = setOf("com.dts.freefireth", "com.dts.freefiremax")
+
 enum class PaERewardType(@StringRes val displayNameRes: Int) {
   ROBUX(R.string.play_and_earn_currency_robux),
   DIAMONDS(R.string.play_and_earn_currency_diamonds),
+  ;
+
+  companion object {
+    fun fromPackageName(packageName: String?): PaERewardType? = when (packageName) {
+      ROBLOX_PACKAGE -> ROBUX
+      in FREE_FIRE_PACKAGES -> DIAMONDS
+      else -> null
+    }
+  }
 }
 
 fun PaERewardType.toRedeemType(): RedeemType = when (this) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/SignInRewardCard.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/SignInRewardCard.kt
@@ -1,0 +1,25 @@
+package com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun SignInRewardCard(
+  packageName: String?,
+  modifier: Modifier = Modifier,
+) {
+  val rewardType = PaERewardType.fromPackageName(packageName) ?: return
+  val viewModel = hiltViewModel<SignInRewardViewModel>()
+  val rewardState by viewModel.rewardState.collectAsState()
+  val unclaimed = rewardState as? RewardState.Unclaimed ?: return
+
+  ClaimableRewardCard(
+    rewardType = rewardType,
+    formattedAmount = unclaimed.reward.rewardAmount,
+    onCollectClick = { viewModel.claim(unclaimed.reward.copy(paERewardType = rewardType)) },
+    modifier = modifier,
+  )
+}

--- a/app-games/src/main/res/values/strings.xml
+++ b/app-games/src/main/res/values/strings.xml
@@ -509,4 +509,5 @@
   <string name="play_and_earn_exchange_email_error">Enter a valid email address</string>
   <string name="play_and_earn_exchange_success_email_sent">We\'ve sent your code to %1$s. Check your inbox within 24 hours.</string>
   <string name="play_and_earn_exchange_earn_more_button">Earn More</string>
+  <string name="play_and_earn_tap_to_collect">Tap to Collect</string>
 </resources>


### PR DESCRIPTION
**What does this PR do?**

   - Adds a P&E sign in reward component to the games feed home bundle.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-845](https://aptoide.atlassian.net/browse/AND-845)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-845](https://aptoide.atlassian.net/browse/AND-845)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-845]: https://aptoide.atlassian.net/browse/AND-845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-845]: https://aptoide.atlassian.net/browse/AND-845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ