### PR TITLE
[AND-841] Adapt P&E rewards screen

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/CustomScrollableTabRow.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/CustomScrollableTabRow.kt
@@ -46,6 +46,7 @@ fun CustomScrollableTabRow(
   modifier: Modifier = Modifier,
   tabTextStyle: TextStyle = AGTypography.InputsL,
   tabBadges: List<(@Composable BoxScope.() -> Unit)?> = List(tabs.size) { null },
+  selectedTabContentColor: (Int) -> Color = { contentColor },
   onTabPositioned: (index: Int, x: Float, width: Float) -> Unit = { _, _, _ -> },
 ) {
   val density = LocalDensity.current
@@ -62,7 +63,8 @@ fun CustomScrollableTabRow(
         modifier = Modifier.customTabIndicatorOffset(
           currentTabPosition = tabPositions[selectedTabIndex],
           tabWidth = indicatorWidths[selectedTabIndex]
-        )
+        ),
+        color = selectedTabContentColor(selectedTabIndex),
       )
     },
     divider = {
@@ -87,7 +89,7 @@ fun CustomScrollableTabRow(
               text = tab,
               style = tabTextStyle,
               color = if (selectedTabIndex == tabIndex) {
-                contentColor
+                selectedTabContentColor(tabIndex)
               } else {
                 Palette.White
               },

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/GamesScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/GamesScreen.kt
@@ -2,10 +2,13 @@ package com.aptoide.android.aptoidegames.home
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
 import cm.aptoide.pt.extensions.ScreenData
 import cm.aptoide.pt.feature_apps.presentation.appsBySortType
 import cm.aptoide.pt.feature_categories.presentation.rememberAllCategories
@@ -18,26 +21,63 @@ import com.aptoide.android.aptoidegames.feature_apps.presentation.BONUS_SORT
 import com.aptoide.android.aptoidegames.feature_apps.presentation.MoreBonusBundleView
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.analytics.rememberPaEAnalytics
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards.PlayAndEarnRewardsScreen
+import com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards.playAndEarnRewardsRoute
 
 const val gamesRoute = "games"
+const val INITIAL_HOME_TAB_PARAM = "initialHomeTab"
+
+fun buildGamesRoute(initialTab: HomeTab? = null): String =
+  if (initialTab == null) gamesRoute
+  else "$gamesRoute?$INITIAL_HOME_TAB_PARAM=${initialTab.id}"
+
+/**
+ * Resolves where a "go to rewards" action should navigate: the Rewards home tab when it is
+ * available, otherwise the standalone rewards screen as a fallback.
+ */
+@Composable
+fun rememberRewardsDestination(): String {
+  val (showHomeTabRow, tabs) = rememberHomeTabRowState()
+  return if (showHomeTabRow && tabs.any { it is HomeTab.Rewards }) {
+    buildGamesRoute(HomeTab.Rewards)
+  } else {
+    playAndEarnRewardsRoute
+  }
+}
 
 fun gamesScreen() = ScreenData(
-  route = gamesRoute,
-) { _, navigate, _ ->
+  route = "$gamesRoute?$INITIAL_HOME_TAB_PARAM={$INITIAL_HOME_TAB_PARAM}",
+  arguments = listOf(
+    navArgument(INITIAL_HOME_TAB_PARAM) {
+      type = NavType.StringType
+      nullable = true
+    }
+  ),
+) { args, navigate, _ ->
   InitialAnalyticsMeta(
     screenAnalyticsName = "Home",
     navigate = navigate
   ) {
-    GamesScreenContent(navigate = navigate)
+    GamesScreenContent(
+      navigate = navigate,
+      initialHomeTabId = args?.getString(INITIAL_HOME_TAB_PARAM)
+    )
   }
 }
 
 @Composable
 private fun GamesScreenContent(
-  navigate: (String) -> Unit
+  navigate: (String) -> Unit,
+  initialHomeTabId: String? = null,
 ) {
   val (showHomeTabRow, tabs) = rememberHomeTabRowState()
   var selectedTab by rememberSaveable(key = tabs.size.toString()) { mutableIntStateOf(0) }
+
+  LaunchedEffect(initialHomeTabId, tabs) {
+    initialHomeTabId
+      ?.let { id -> tabs.indexOfFirst { it.id == id } }
+      ?.takeIf { it >= 0 }
+      ?.let { selectedTab = it }
+  }
 
   val homeAnalytics = rememberHomeAnalytics()
   val paeAnalytics = rememberPaEAnalytics()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeTabRow.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeTabRow.kt
@@ -50,6 +50,8 @@ sealed class HomeTab {
   @Keep
   object Rewards : HomeTab()
 
+  val id: String get() = this::class.simpleName.orEmpty()
+
   @Composable
   fun getTitle() = stringResource(
     when (this) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeTabRow.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/HomeTabRow.kt
@@ -89,7 +89,10 @@ fun HomeTabRow(
     contentColor = Palette.Primary,
     backgroundColor = Color.Transparent,
     tabTextStyle = AGTypography.InputsL,
-    tabBadges = tabBadges
+    tabBadges = tabBadges,
+    selectedTabContentColor = { index ->
+      if (tabsList[index] == rewardsTabName) Palette.Yellow100 else Palette.Primary
+    },
   )
 }
 
@@ -99,7 +102,7 @@ fun BoxScope.NewBadge() {
     modifier = Modifier
       .align(Alignment.TopEnd)
       .offset(x = 5.dp, y = (-14).dp)
-      .background(color = Palette.Primary),
+      .background(color = Palette.Yellow100),
     contentAlignment = Alignment.Center
   ) {
     Text(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
@@ -214,6 +214,15 @@ private fun NavBackStackEntry.lifecycleIsResumed() =
 private fun String.getRouteScreenName() = this.substringBefore("/")
 
 fun NavHostController.navigateTo(route: String) {
+  if (route.substringBefore("?") == graph.startDestinationRoute?.substringBefore("?")) {
+    //Navigating to the start destination (home): if it's already on top (e.g. opening a specific
+    //home tab from within home) reuse it in place; otherwise push it on top, preserving the
+    //back stack below so the user can return to where they came from.
+    navigate(route) {
+      launchSingleTop = true
+    }
+    return
+  }
   currentBackStackEntry?.let {
     if (!it.lifecycleIsResumed()
       && currentDestination?.route?.getRouteScreenName() == route.getRouteScreenName()
@@ -460,11 +469,7 @@ private fun NavigationGraph(
     animatedComposable(
       navigate = navController::navigateTo,
       goBack = navController::navigateUp,
-      screenData = exchangeSuccessScreen(
-        onEarnMore = {
-          navController.popBackStack(navController.graph.startDestinationId, false)
-        }
-      )
+      screenData = exchangeSuccessScreen()
     )
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/PaEBundleView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/PaEBundleView.kt
@@ -22,11 +22,11 @@ import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.presentation.OverrideAnalyticsPlayAndEarn
 import com.aptoide.android.aptoidegames.analytics.presentation.withItemPosition
 import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
+import com.aptoide.android.aptoidegames.home.rememberRewardsDestination
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.analytics.rememberPaEAnalytics
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.app_items.PaECompactAppItem
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.layout.PaEHorizontalCarousel
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards.PaERewardType
-import com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards.playAndEarnRewardsRoute
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards.rememberPreferredPaEReward
 import com.aptoide.android.aptoidegames.theme.Palette
 
@@ -42,6 +42,7 @@ fun PaEBundleView(
 
   val paeAnalytics = rememberPaEAnalytics()
   val rewardType = rememberPreferredPaEReward()
+  val rewardsDestination = rememberRewardsDestination()
 
   if (bundle != null) {
     OverrideAnalyticsPlayAndEarn(
@@ -72,7 +73,7 @@ fun PaEBundleView(
             rewardType = rewardType,
             onClick = {
               paeAnalytics.sendPaEHomeEarnNowClick()
-              navigateTo(playAndEarnRewardsRoute)
+              navigateTo(rewardsDestination)
             }
           )
           PaEHorizontalCarousel(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/app_items/PaECompactAppItem.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/app_items/PaECompactAppItem.kt
@@ -24,6 +24,7 @@ import cm.aptoide.pt.campaigns.domain.PaEApp
 import cm.aptoide.pt.campaigns.domain.asNormalApp
 import cm.aptoide.pt.campaigns.domain.randomPaEApp
 import cm.aptoide.pt.download_view.presentation.rememberDownloadState
+import cm.aptoide.pt.play_and_earn.exchange.presentation.rememberExchangeRate
 import com.aptoide.android.aptoidegames.AppIconImage
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.PaEInstallProgressText
@@ -40,6 +41,7 @@ fun PaECompactAppItem(
 ) {
   val state = rememberDownloadState(app.asNormalApp())
   val colorFilter = rememberDownloadGraphicFilter(state)
+  val rewardAmount = rememberExchangeRate(app.totalPrizes.toLong())
 
   Column(
     modifier = modifier.clickable(onClick = onClick)
@@ -68,6 +70,14 @@ fun PaECompactAppItem(
             alpha = 0.5f
           )
       )
+      rewardAmount?.let {
+        PaERewardBadge(
+          amount = it,
+          modifier = Modifier
+            .align(Alignment.TopStart)
+            .padding(8.dp),
+        )
+      }
       Row(
         modifier = Modifier
           .fillMaxWidth()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/app_items/PaEDefaultAppItem.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/app_items/PaEDefaultAppItem.kt
@@ -21,6 +21,7 @@ import cm.aptoide.pt.campaigns.domain.PaEApp
 import cm.aptoide.pt.campaigns.domain.asNormalApp
 import cm.aptoide.pt.campaigns.domain.randomPaEApp
 import cm.aptoide.pt.download_view.presentation.rememberDownloadState
+import cm.aptoide.pt.play_and_earn.exchange.presentation.rememberExchangeRate
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.PaEInstallProgressText
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.PaEInstallViewShort
@@ -38,6 +39,7 @@ fun PaEDefaultAppItem(
 ) {
   val state = rememberDownloadState(app.asNormalApp())
   val colorFilter = rememberDownloadGraphicFilter(state)
+  val rewardAmount = rememberExchangeRate(app.totalPrizes.toLong())
 
   Column(
     modifier = modifier
@@ -56,6 +58,14 @@ fun PaEDefaultAppItem(
         contentDescription = null,
         colorFilter = colorFilter
       )
+      rewardAmount?.let {
+        PaERewardBadge(
+          amount = it,
+          modifier = Modifier
+            .align(Alignment.TopStart)
+            .padding(8.dp),
+        )
+      }
     }
     PaEProgressIndicator(
       progress = app.progress?.getNormalizedProgress() ?: 0f,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/app_items/PaELargeAppItem.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/app_items/PaELargeAppItem.kt
@@ -24,6 +24,7 @@ import cm.aptoide.pt.campaigns.domain.PaEApp
 import cm.aptoide.pt.campaigns.domain.asNormalApp
 import cm.aptoide.pt.campaigns.domain.randomPaEApp
 import cm.aptoide.pt.download_view.presentation.rememberDownloadState
+import cm.aptoide.pt.play_and_earn.exchange.presentation.rememberExchangeRate
 import com.aptoide.android.aptoidegames.AptoideFeatureGraphicImage
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.PaEInstallProgressText
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.PaEInstallViewShort
@@ -41,6 +42,7 @@ fun PaELargeAppItem(
 ) {
   val state = rememberDownloadState(app.asNormalApp())
   val colorFilter = rememberDownloadGraphicFilter(state)
+  val rewardAmount = rememberExchangeRate(app.totalPrizes.toLong())
 
   Column(
     modifier = modifier.clickable(onClick = onClick)
@@ -70,6 +72,14 @@ fun PaELargeAppItem(
             alpha = 0.5f
           )
       )
+      rewardAmount?.let {
+        PaERewardBadge(
+          amount = it,
+          modifier = Modifier
+            .align(Alignment.TopStart)
+            .padding(8.dp),
+        )
+      }
       Row(
         modifier = Modifier
           .wrapContentWidth()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/app_items/PaERewardBadge.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/app_items/PaERewardBadge.kt
@@ -1,0 +1,39 @@
+package com.aptoide.android.aptoidegames.play_and_earn.presentation.components.app_items
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.theme.AGTypography
+import com.aptoide.android.aptoidegames.theme.Palette
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@Composable
+fun PaERewardBadge(
+  amount: BigDecimal,
+  modifier: Modifier = Modifier,
+) {
+  Text(
+    text = stringResource(R.string.play_and_earn_earn_amount_badge, amount.format()),
+    style = AGTypography.BodyBold,
+    color = Palette.Black,
+    modifier = modifier
+      .background(Palette.Yellow100)
+      .padding(horizontal = 8.dp, vertical = 4.dp),
+  )
+}
+
+private fun BigDecimal.format(): String =
+  "$${setScale(2, RoundingMode.HALF_UP).toPlainString()}"
+
+@Preview
+@Composable
+private fun PaERewardBadgePreview() {
+  PaERewardBadge(amount = BigDecimal("4.50"))
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/home/PaEHeaderBundle.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/home/PaEHeaderBundle.kt
@@ -19,11 +19,11 @@ import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.presentation.OverrideAnalyticsPlayAndEarn
 import com.aptoide.android.aptoidegames.analytics.presentation.withItemPosition
 import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
+import com.aptoide.android.aptoidegames.home.rememberRewardsDestination
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.analytics.rememberPaEAnalytics
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.PaEBundleHeader
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.app_items.PaECompactAppItem
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.layout.PaEHorizontalCarousel
-import com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards.playAndEarnRewardsRoute
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards.rememberPreferredPaEReward
 
 @Composable
@@ -33,6 +33,7 @@ fun PaEHeaderBundle(
   navigate: (String) -> Unit
 ) {
   val paeAnalytics = rememberPaEAnalytics()
+  val rewardsDestination = rememberRewardsDestination()
 
   OverrideAnalyticsPlayAndEarn(
     navigate = navigate
@@ -55,7 +56,7 @@ fun PaEHeaderBundle(
           rewardType = rememberPreferredPaEReward(),
           onClick = {
             paeAnalytics.sendPaEHomeEarnNowClick()
-            navigateTo(playAndEarnRewardsRoute)
+            navigateTo(rewardsDestination)
           }
         )
         PaEHorizontalCarousel(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/ClaimedRewardDialog.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/ClaimedRewardDialog.kt
@@ -35,6 +35,7 @@ import cm.aptoide.pt.extensions.toAnnotatedString
 import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.design_system.AccentButton
 import com.aptoide.android.aptoidegames.drawables.icons.play_and_earn.getCorrectHexagon
+import com.aptoide.android.aptoidegames.home.rememberRewardsDestination
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.animations.RewardsStarsAnimation
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
@@ -43,6 +44,7 @@ import com.aptoide.android.aptoidegames.theme.Palette
 @Composable
 fun ClaimedRewardDialog(navigate: (String) -> Unit) {
   val viewModel = hiltViewModel<SignInRewardViewModel>()
+  val rewardsDestination = rememberRewardsDestination()
   var activeReward by remember { mutableStateOf<PendingPaEReward?>(null) }
   LaunchedEffect(viewModel) {
     viewModel.claimSuccessEvent.collect { activeReward = it }
@@ -54,7 +56,7 @@ fun ClaimedRewardDialog(navigate: (String) -> Unit) {
       onDismiss = { activeReward = null },
       onEarnMore = {
         activeReward = null
-        navigate(playAndEarnRewardsRoute)
+        navigate(rewardsDestination)
       },
     )
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/PlayAndEarnRewardsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/PlayAndEarnRewardsScreen.kt
@@ -1,16 +1,21 @@
 package com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -25,15 +30,13 @@ import com.aptoide.android.aptoidegames.analytics.presentation.withItemPosition
 import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
 import com.aptoide.android.aptoidegames.drawables.icons.play_and_earn.getPlayPauseIcon
 import com.aptoide.android.aptoidegames.drawables.icons.play_and_earn.getThumbUpIcon
-import com.aptoide.android.aptoidegames.play_and_earn.presentation.analytics.rememberPaEAnalytics
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.PaESectionHeader
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.app_items.PaEDefaultAppItem
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.components.app_items.PaELargeAppItem
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.layout.PaEHorizontalCarousel
-import com.aptoide.android.aptoidegames.play_and_earn.presentation.level_up.levelUpRoute
-import com.aptoide.android.aptoidegames.play_and_earn.presentation.level_up.rememberCurrentPaELevel
-import com.aptoide.android.aptoidegames.play_and_earn.presentation.rememberPlayAndEarnSetupRoute
-import com.aptoide.android.aptoidegames.play_and_earn.rememberPlayAndEarnReady
+import com.aptoide.android.aptoidegames.play_and_earn.presentation.unit_exchange_flow.exchangeDisplayName
+import com.aptoide.android.aptoidegames.theme.AGTypography
+import com.aptoide.android.aptoidegames.theme.Palette
 
 const val playAndEarnRewardsRoute = "playAndEarnRewards"
 
@@ -49,13 +52,9 @@ fun playAndEarnRewardsScreen() = ScreenData.withAnalytics(
 fun PlayAndEarnRewardsScreen(
   navigate: (String) -> Unit
 ) {
-  val analytics = rememberPaEAnalytics()
-  val isPaEReady = rememberPlayAndEarnReady()
-  val currentLevel = rememberCurrentPaELevel()
-  val paeSetupRoute = rememberPlayAndEarnSetupRoute()
-
   val scrollState = rememberScrollState()
   val uiState = rememberPaEBundles()
+  val rewardType = rememberPreferredPaEReward()
   val trendingBundle = uiState
     .let { it as? PaEBundlesUiState.Idle }
     ?.bundles?.trending
@@ -76,33 +75,48 @@ fun PlayAndEarnRewardsScreen(
       verticalArrangement = Arrangement.spacedBy(8.dp),
       horizontalAlignment = Alignment.CenterHorizontally
     ) {
-      PaEHowItWorksSection()
-      if (isPaEReady) {
-        currentLevel?.let { level ->
-          PaEKnowMoreCard(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            currentLevel = level + 1,
-            onClick = {
-              navigateTo(levelUpRoute)
-              analytics.sendPaERewardsHubKnowMoreClick()
-            }
-          )
-        }
-      } else {
-        PaELetsGoCard(
-          modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-          onLetsGoClick = {
-            navigateTo(paeSetupRoute)
-            analytics.sendPaERewardsHubLetsGoClick()
-          }
-        )
-      }
+      RewardsHeader(rewardType = rewardType)
+
       keepPlayingBundle?.let {
         PaEHorizontalBundleView(it, navigateTo)
       }
       trendingBundle?.let {
         PaEVerticalBundleView(it, navigateTo)
       }
+    }
+  }
+}
+
+@Composable
+private fun RewardsHeader(rewardType: PaERewardType) {
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 16.dp, vertical = 16.dp),
+    verticalArrangement = Arrangement.spacedBy(4.dp),
+  ) {
+    Text(
+      text = stringResource(R.string.play_and_earn_rewards_install_play_title),
+      style = AGTypography.Title,
+      color = Palette.White,
+    )
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+      Text(
+        text = stringResource(
+          R.string.play_and_earn_earn_title,
+          rewardType.exchangeDisplayName,
+        ),
+        style = AGTypography.Title,
+        color = Palette.Yellow100,
+      )
+      Image(
+        painter = painterResource(rewardType.iconRes),
+        contentDescription = null,
+        modifier = Modifier.height(24.dp),
+      )
     }
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/unit_exchange_flow/ExchangeSuccessScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/unit_exchange_flow/ExchangeSuccessScreen.kt
@@ -28,6 +28,7 @@ import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
 import com.aptoide.android.aptoidegames.design_system.AccentButton
 import com.aptoide.android.aptoidegames.drawables.backgrounds.getExchangeSuccessBackground
+import com.aptoide.android.aptoidegames.home.rememberRewardsDestination
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards.PaERewardSuccessArt
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards.PaERewardType
 import com.aptoide.android.aptoidegames.theme.AGTypography
@@ -47,9 +48,7 @@ fun buildExchangeSuccessRoute(
   email: String,
 ) = "$exchangeSuccessBase/${rewardType.name}/${Uri.encode(formattedAmount)}/${Uri.encode(email)}"
 
-fun exchangeSuccessScreen(
-  onEarnMore: () -> Unit,
-) = ScreenData.withAnalytics(
+fun exchangeSuccessScreen() = ScreenData.withAnalytics(
   route = exchangeSuccessRoute,
   screenAnalyticsName = "ExchangeSuccess",
   arguments = listOf(
@@ -57,19 +56,20 @@ fun exchangeSuccessScreen(
     navArgument(amountArg) { type = NavType.StringType },
     navArgument(emailArg) { type = NavType.StringType },
   ),
-) { args, _, navigateBack ->
+) { args, navigate, navigateBack ->
   val rewardType = args?.getString(rewardTypeArg)
     ?.let { runCatching { PaERewardType.valueOf(it) }.getOrNull() }
     ?: PaERewardType.ROBUX
   val formattedAmount = args?.getString(amountArg)?.let { Uri.decode(it) }.orEmpty()
   val email = args?.getString(emailArg)?.let { Uri.decode(it) }.orEmpty()
+  val rewardsDestination = rememberRewardsDestination()
 
   ExchangeSuccessScreen(
     rewardType = rewardType,
     formattedAmount = formattedAmount,
     email = email,
     navigateBack = navigateBack,
-    onEarnMore = onEarnMore,
+    onEarnMore = { navigate(rewardsDestination) },
   )
 }
 

--- a/app-games/src/main/res/values/strings.xml
+++ b/app-games/src/main/res/values/strings.xml
@@ -512,4 +512,5 @@
   <string name="play_and_earn_tap_to_collect">Tap to Collect</string>
   <string name="play_and_earn_earn_title">Earn %1$s</string>
   <string name="play_and_earn_more_games_more">More games. More %1$s.</string>
+  <string name="play_and_earn_rewards_install_play_title">Install Games. Play your favourite.</string>
 </resources>

--- a/app-games/src/main/res/values/strings.xml
+++ b/app-games/src/main/res/values/strings.xml
@@ -513,4 +513,5 @@
   <string name="play_and_earn_earn_title">Earn %1$s</string>
   <string name="play_and_earn_more_games_more">More games. More %1$s.</string>
   <string name="play_and_earn_rewards_install_play_title">Install Games. Play your favourite.</string>
+  <string name="play_and_earn_earn_amount_badge">Earn %1$s</string>
 </resources>

--- a/play-and-earn/campaigns/src/main/java/cm/aptoide/pt/campaigns/data/DefaultPaECampaignsRepository.kt
+++ b/play-and-earn/campaigns/src/main/java/cm/aptoide/pt/campaigns/data/DefaultPaECampaignsRepository.kt
@@ -73,7 +73,8 @@ private fun PaEAppJson.toDomainModel() = PaEApp(
   graphic = appInfo.graphic,
   name = appInfo.name,
   uname = appInfo.uname,
-  progress = progress?.toDomainModel()
+  progress = progress?.toDomainModel(),
+  totalPrizes = totalPrizes,
 )
 
 private fun PaEProgressJson.toDomainModel() = PaEProgress(

--- a/play-and-earn/campaigns/src/main/java/cm/aptoide/pt/campaigns/data/FakeCampaignsData.kt
+++ b/play-and-earn/campaigns/src/main/java/cm/aptoide/pt/campaigns/data/FakeCampaignsData.kt
@@ -10,6 +10,8 @@ import cm.aptoide.pt.campaigns.domain.PaEMissionType
 import cm.aptoide.pt.campaigns.domain.PaEMissions
 import cm.aptoide.pt.campaigns.domain.PaEProgress
 import com.google.gson.JsonObject
+import kotlin.random.Random
+import kotlin.random.nextInt
 
 val paEApp1 = PaEApp(
   packageName = "com.mobile.legends",
@@ -22,7 +24,8 @@ val paEApp1 = PaEApp(
     target = 50,
     type = "Mission",
     status = "Ongoing"
-  )
+  ),
+  totalPrizes = Random.nextInt(0..500),
 )
 
 val paEApp2 = PaEApp(
@@ -36,7 +39,8 @@ val paEApp2 = PaEApp(
     target = 50,
     type = "Mission",
     status = "Ongoing"
-  )
+  ),
+  totalPrizes = Random.nextInt(0..500),
 )
 
 val paEApp3 = PaEApp(
@@ -45,7 +49,8 @@ val paEApp3 = PaEApp(
   graphic = "https://cdn6.aptoide.com/imgs/c/e/f/ceffc555296046d89ca0c3e69b4c9439_fgraphic.jpg",
   name = "Aptoide Diceroll SDK Dev",
   uname = "aptoide-diceroll-sdk-dev",
-  progress = null
+  progress = null,
+  totalPrizes = Random.nextInt(0..500),
 )
 
 val paeCampaigns = PaEBundles(

--- a/play-and-earn/campaigns/src/main/java/cm/aptoide/pt/campaigns/data/model/PaECampaignJson.kt
+++ b/play-and-earn/campaigns/src/main/java/cm/aptoide/pt/campaigns/data/model/PaECampaignJson.kt
@@ -12,7 +12,8 @@ internal data class PaECampaignJson(
 @Keep
 internal data class PaEAppJson(
   @SerializedName("app_info") val appInfo: PaEAppInfoJson,
-  val progress: PaEProgressJson?
+  val progress: PaEProgressJson?,
+  @SerializedName("total_prizes") val totalPrizes: Int = 0
 )
 
 @Keep

--- a/play-and-earn/campaigns/src/main/java/cm/aptoide/pt/campaigns/domain/PaEApp.kt
+++ b/play-and-earn/campaigns/src/main/java/cm/aptoide/pt/campaigns/domain/PaEApp.kt
@@ -13,7 +13,8 @@ data class PaEApp(
   val graphic: String,
   val name: String,
   val uname: String,
-  val progress: PaEProgress?
+  val progress: PaEProgress?,
+  val totalPrizes: Int = 0,
 ) : AppSource
 
 data class PaEProgress(
@@ -41,7 +42,8 @@ val randomPaEApp
       graphic = it.featureGraphic,
       name = it.name,
       uname = getRandomString(range = 1..3, separator = "-"),
-      progress = randomPaEProgress
+      progress = randomPaEProgress,
+      totalPrizes = Random.nextInt(0..500),
     )
   }
 

--- a/play-and-earn/exchange/src/main/java/cm/aptoide/pt/play_and_earn/exchange/data/DefaultExchangeRepository.kt
+++ b/play-and-earn/exchange/src/main/java/cm/aptoide/pt/play_and_earn/exchange/data/DefaultExchangeRepository.kt
@@ -1,8 +1,12 @@
 package cm.aptoide.pt.play_and_earn.exchange.data
 
+import cm.aptoide.pt.play_and_earn.exchange.data.model.ExchangeRateJson
 import cm.aptoide.pt.play_and_earn.exchange.data.model.ExchangeUnitsRequestJson
+import cm.aptoide.pt.play_and_earn.exchange.domain.ExchangeRate
 import cm.aptoide.pt.play_and_earn.exchange.domain.RedeemType
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -13,7 +17,11 @@ internal class DefaultExchangeRepository @Inject constructor(
 
   private companion object {
     const val DEFAULT_COUNTRY_CODE = "PT"
+    const val DEFAULT_EXCHANGE_RATE_COUNTRY_CODE = "US"
   }
+
+  private val exchangeRateMutex = Mutex()
+  private val cachedExchangeRates = mutableMapOf<String, ExchangeRate>()
 
   @Deprecated(
     "Use exchangeUnits(email, redeemType) instead.",
@@ -55,6 +63,33 @@ internal class DefaultExchangeRepository @Inject constructor(
         Result.failure(e)
       }
     }
+
+  override suspend fun getExchangeRate(): Result<ExchangeRate> =
+    withContext(dispatcher) {
+      val countryCode = DEFAULT_EXCHANGE_RATE_COUNTRY_CODE
+
+      cachedExchangeRates[countryCode]?.let { return@withContext Result.success(it) }
+
+      exchangeRateMutex.withLock {
+        // Re-check inside the lock in case another caller fetched it while we waited.
+        cachedExchangeRates[countryCode]?.let { return@withLock Result.success(it) }
+
+        try {
+          val rate = exchangeApi.getExchangeRate(countryCode).toDomainModel()
+          cachedExchangeRates[countryCode] = rate
+          Result.success(rate)
+        } catch (e: Throwable) {
+          e.printStackTrace()
+          Result.failure(e)
+        }
+      }
+    }
 }
+
+private fun ExchangeRateJson.toDomainModel() = ExchangeRate(
+  countryCode = countryCode.orEmpty(),
+  rate = rate ?: 0.0,
+  creditsAmount = creditsAmount ?: 0
+)
 
 class ExchangeException(message: String) : Throwable(message)

--- a/play-and-earn/exchange/src/main/java/cm/aptoide/pt/play_and_earn/exchange/data/ExchangeApi.kt
+++ b/play-and-earn/exchange/src/main/java/cm/aptoide/pt/play_and_earn/exchange/data/ExchangeApi.kt
@@ -1,9 +1,12 @@
 package cm.aptoide.pt.play_and_earn.exchange.data
 
+import cm.aptoide.pt.play_and_earn.exchange.data.model.ExchangeRateJson
 import cm.aptoide.pt.play_and_earn.exchange.data.model.ExchangeResponseJson
 import cm.aptoide.pt.play_and_earn.exchange.data.model.ExchangeUnitsRequestJson
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 internal interface ExchangeApi {
@@ -17,4 +20,9 @@ internal interface ExchangeApi {
   suspend fun exchangeUnitsV2(
     @Body request: ExchangeUnitsRequestJson
   ): ExchangeResponseJson
+
+  @GET("api/exchange/rate/{country_code}")
+  suspend fun getExchangeRate(
+    @Path("country_code") countryCode: String
+  ): ExchangeRateJson
 }

--- a/play-and-earn/exchange/src/main/java/cm/aptoide/pt/play_and_earn/exchange/data/ExchangeRepository.kt
+++ b/play-and-earn/exchange/src/main/java/cm/aptoide/pt/play_and_earn/exchange/data/ExchangeRepository.kt
@@ -1,5 +1,6 @@
 package cm.aptoide.pt.play_and_earn.exchange.data
 
+import cm.aptoide.pt.play_and_earn.exchange.domain.ExchangeRate
 import cm.aptoide.pt.play_and_earn.exchange.domain.RedeemType
 
 interface ExchangeRepository {
@@ -11,4 +12,6 @@ interface ExchangeRepository {
   suspend fun exchangeUnits(): Result<Unit>
 
   suspend fun exchangeUnits(email: String, redeemType: RedeemType): Result<Unit>
+
+  suspend fun getExchangeRate(): Result<ExchangeRate>
 }

--- a/play-and-earn/exchange/src/main/java/cm/aptoide/pt/play_and_earn/exchange/data/model/ExchangeRateJson.kt
+++ b/play-and-earn/exchange/src/main/java/cm/aptoide/pt/play_and_earn/exchange/data/model/ExchangeRateJson.kt
@@ -1,0 +1,11 @@
+package cm.aptoide.pt.play_and_earn.exchange.data.model
+
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
+
+@Keep
+internal data class ExchangeRateJson(
+  @SerializedName("country_code") val countryCode: String?,
+  val rate: Double?,
+  @SerializedName("credits_amount") val creditsAmount: Int?
+)

--- a/play-and-earn/exchange/src/main/java/cm/aptoide/pt/play_and_earn/exchange/domain/ExchangeRate.kt
+++ b/play-and-earn/exchange/src/main/java/cm/aptoide/pt/play_and_earn/exchange/domain/ExchangeRate.kt
@@ -1,0 +1,20 @@
+package cm.aptoide.pt.play_and_earn.exchange.domain
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+data class ExchangeRate(
+  val countryCode: String,
+  // How much money [creditsAmount] units are worth.
+  val rate: Double,
+  // The amount of units the [rate] refers to (e.g. 100 units -> [rate] money).
+  val creditsAmount: Int
+) {
+  // Returns how much money the given number of [units] is worth, according to this rate.
+  fun moneyValueOf(units: Long): BigDecimal {
+    if (creditsAmount <= 0) return BigDecimal.ZERO
+    return BigDecimal.valueOf(units)
+      .multiply(BigDecimal.valueOf(rate))
+      .divide(BigDecimal.valueOf(creditsAmount.toLong()), 2, RoundingMode.HALF_UP)
+  }
+}

--- a/play-and-earn/exchange/src/main/java/cm/aptoide/pt/play_and_earn/exchange/domain/GetExchangeRateUseCase.kt
+++ b/play-and-earn/exchange/src/main/java/cm/aptoide/pt/play_and_earn/exchange/domain/GetExchangeRateUseCase.kt
@@ -1,0 +1,13 @@
+package cm.aptoide.pt.play_and_earn.exchange.domain
+
+import cm.aptoide.pt.play_and_earn.exchange.data.ExchangeRepository
+import javax.inject.Inject
+
+class GetExchangeRateUseCase @Inject constructor(
+  private val exchangeRepository: ExchangeRepository
+) {
+
+  suspend operator fun invoke(): Result<ExchangeRate> {
+    return exchangeRepository.getExchangeRate()
+  }
+}

--- a/play-and-earn/exchange/src/main/java/cm/aptoide/pt/play_and_earn/exchange/presentation/ExchangeRateViewModel.kt
+++ b/play-and-earn/exchange/src/main/java/cm/aptoide/pt/play_and_earn/exchange/presentation/ExchangeRateViewModel.kt
@@ -1,0 +1,55 @@
+package cm.aptoide.pt.play_and_earn.exchange.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import cm.aptoide.pt.exception_handler.ExceptionHandler
+import cm.aptoide.pt.extensions.runPreviewable
+import cm.aptoide.pt.play_and_earn.exchange.domain.ExchangeRate
+import cm.aptoide.pt.play_and_earn.exchange.domain.GetExchangeRateUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.math.BigDecimal
+import javax.inject.Inject
+
+@HiltViewModel
+class ExchangeRateViewModel @Inject constructor(
+  private val getExchangeRateUseCase: GetExchangeRateUseCase,
+  private val exceptionHandler: ExceptionHandler
+) : ViewModel() {
+
+  private val _exchangeRate = MutableStateFlow<ExchangeRate?>(null)
+  val exchangeRate: StateFlow<ExchangeRate?> = _exchangeRate.asStateFlow()
+
+  init {
+    reload()
+  }
+
+  fun reload() {
+    viewModelScope.launch {
+      getExchangeRateUseCase().fold(
+        onSuccess = { rate -> _exchangeRate.update { rate } },
+        onFailure = { error -> exceptionHandler.recordException(error) }
+      )
+    }
+  }
+}
+
+// Returns how much money the given [units] are worth, or null until the rate is available.
+@Composable
+fun rememberExchangeRate(units: Long): BigDecimal? = runPreviewable(
+  preview = { ExchangeRate(countryCode = "US", rate = 1.0, creditsAmount = 100).moneyValueOf(units) },
+  real = {
+    val vm = hiltViewModel<ExchangeRateViewModel>()
+
+    val exchangeRate by vm.exchangeRate.collectAsState()
+    exchangeRate?.moneyValueOf(units)
+  }
+)


### PR DESCRIPTION
**What does this PR do?**

   - Adapts the P&E rewards screen to the new reward system.
   - Adds logic to fetch the units exchange rate.
   - Adds support for specific home tab navigations, including the rewards tab.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-841](https://aptoide.atlassian.net/browse/AND-841)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-841](https://aptoide.atlassian.net/browse/AND-841)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-841]: https://aptoide.atlassian.net/browse/AND-841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-841]: https://aptoide.atlassian.net/browse/AND-841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ