### PR TITLE
Feed existing editorial UI from new Editorial service (dev/test only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,16 @@ This file provides guidance to Claude Code when working with code in this reposi
 ./gradlew clean
 ```
 
+### Missing Gradle properties (local builds)
+
+A local build may fail at configuration with `Could not get unknown property 'GOOGLE_AUTH_CLIENT_ID_DEV'` (and `…_PROD`) — these keys aren't in the checked-in `gradle.properties` (CI injects them). Both the `dev` and `prod` flavor blocks are evaluated at configuration time regardless of which variant you build, so supply **both** as dummy values via `-P` (they're Google OAuth client IDs, only used at runtime for Google sign-in — irrelevant to most features):
+
+```bash
+./gradlew :app-games:installAptoideGamesDevDebug :app-games:installVanillaDevDebug \
+  -PGOOGLE_AUTH_CLIENT_ID_DEV=dummy.apps.googleusercontent.com \
+  -PGOOGLE_AUTH_CLIENT_ID_PROD=dummy.apps.googleusercontent.com
+```
+
 ## Architecture Overview
 
 This is a **multi-module Android app** using **Clean Architecture with MVVM** and **Jetpack Compose**.

--- a/app-games/build.gradle.kts
+++ b/app-games/build.gradle.kts
@@ -190,6 +190,16 @@ android {
         name = "GOOGLE_AUTH_CLIENT_ID",
         value = "\"${project.property("GOOGLE_AUTH_CLIENT_ID_DEV")}\""
       )
+      buildConfigField(
+        type = "String",
+        name = "EDITORIAL_API_DOMAIN",
+        value = "\"https://api.dev.aptoide.com/\""
+      )
+      buildConfigField(
+        type = "boolean",
+        name = "EDITORIAL_DEMO_ENABLED",
+        value = "true"
+      )
     }
 
     create("prod") {
@@ -239,6 +249,16 @@ android {
         type = "String",
         name = "GOOGLE_AUTH_CLIENT_ID",
         value = "\"${project.property("GOOGLE_AUTH_CLIENT_ID_PROD")}\""
+      )
+      buildConfigField(
+        type = "String",
+        name = "EDITORIAL_API_DOMAIN",
+        value = "\"https://api.aptoide.com/\""
+      )
+      buildConfigField(
+        type = "boolean",
+        name = "EDITORIAL_DEMO_ENABLED",
+        value = "false"
       )
     }
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/AGViewModelProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/AGViewModelProvider.kt
@@ -7,10 +7,12 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
+import cm.aptoide.pt.aptoide_network.di.StoreName
 import cm.aptoide.pt.aptoide_network.domain.UrlsCache
 import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.feature_editorial.data.EditorialRepository
 import cm.aptoide.pt.feature_editorial.di.DefaultEditorialUrl
+import com.aptoide.android.aptoidegames.editorial.di.EditorialApi
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
 import cm.aptoide.pt.feature_editorial.domain.randomArticleMeta
 import cm.aptoide.pt.feature_editorial.domain.usecase.ArticleUseCase
@@ -25,16 +27,17 @@ import javax.inject.Inject
 
 @HiltViewModel
 internal class AGInjectionsProvider @Inject constructor(
-  editorialRepository: EditorialRepository,
+  @EditorialApi editorialRepository: EditorialRepository,
   urlsCache: UrlsCache,
   @DefaultEditorialUrl defaultEditorialUrl: String,
-  val articleUseCase: ArticleUseCase,
+  @StoreName storeName: String,
 ) : ViewModel() {
 
   private val agRepository = AGEditorialRepository(editorialRepository)
 
   val articlesMetaUseCase = ArticlesMetaUseCase(agRepository, urlsCache, defaultEditorialUrl)
   val relatedArticlesMetaUseCase = RelatedArticlesMetaUseCase(agRepository, urlsCache)
+  val articleUseCase = ArticleUseCase(editorialRepository, urlsCache, storeName)
 }
 
 @Composable

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/AGViewModelProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/AGViewModelProvider.kt
@@ -12,7 +12,6 @@ import cm.aptoide.pt.aptoide_network.domain.UrlsCache
 import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.feature_editorial.data.EditorialRepository
 import cm.aptoide.pt.feature_editorial.di.DefaultEditorialUrl
-import com.aptoide.android.aptoidegames.editorial.di.EditorialApi
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
 import cm.aptoide.pt.feature_editorial.domain.randomArticleMeta
 import cm.aptoide.pt.feature_editorial.domain.usecase.ArticleUseCase
@@ -22,6 +21,7 @@ import cm.aptoide.pt.feature_editorial.presentation.ArticleListUiState
 import cm.aptoide.pt.feature_editorial.presentation.EditorialViewModel
 import cm.aptoide.pt.feature_editorial.presentation.EditorialsListViewModel
 import cm.aptoide.pt.feature_editorial.presentation.RelatedEditorialsCardViewModel
+import com.aptoide.android.aptoidegames.editorial.di.EditorialApi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialMarkdown.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialMarkdown.kt
@@ -1,0 +1,56 @@
+package com.aptoide.android.aptoidegames.editorial
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.text.withStyle
+
+// Editorial paragraphs from the new service may contain INLINE markdown only:
+// **bold**, *italic*, [label](https://url). There is never block-level markdown or raw HTML.
+private val INLINE_MARKDOWN = Regex(
+  """\[([^\]]+)]\((https?://[^)\s]+)\)""" + // [label](url)
+    """|\*\*([^*]+)\*\*""" + //               **bold**
+    """|\*([^*]+)\*""" //                      *italic*
+)
+
+/**
+ * Renders the supported inline marks as spans. Well-formed marks become styled (and, for
+ * links, clickable) spans; anything else is left verbatim, so plain text is unchanged.
+ */
+fun String.toEditorialAnnotatedString(
+  linkColor: Color,
+  onLinkClick: (String) -> Unit,
+): AnnotatedString {
+  val source = this
+  return buildAnnotatedString {
+    var cursor = 0
+    for (match in INLINE_MARKDOWN.findAll(source)) {
+      if (match.range.first > cursor) append(source.substring(cursor, match.range.first))
+      val (linkLabel, linkUrl, bold, italic) = match.destructured
+      when {
+        linkUrl.isNotEmpty() -> withLink(
+          LinkAnnotation.Clickable(
+            tag = linkUrl,
+            linkInteractionListener = { onLinkClick(linkUrl) },
+          )
+        ) {
+          withStyle(SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline)) {
+            append(linkLabel)
+          }
+        }
+
+        bold.isNotEmpty() -> withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(bold) }
+
+        italic.isNotEmpty() -> withStyle(SpanStyle(fontStyle = FontStyle.Italic)) { append(italic) }
+      }
+      cursor = match.range.last + 1
+    }
+    if (cursor < source.length) append(source.substring(cursor))
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialMarkdown.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialMarkdown.kt
@@ -13,8 +13,9 @@ import androidx.compose.ui.text.withStyle
 
 // Editorial paragraphs from the new service may contain INLINE markdown only:
 // **bold**, *italic*, [label](https://url). There is never block-level markdown or raw HTML.
+// Links are restricted to https:// so insecure (cleartext) URLs never become tappable spans.
 private val INLINE_MARKDOWN = Regex(
-  """\[([^\]]+)]\((https?://[^)\s]+)\)""" + // [label](url)
+  """\[([^\]]+)]\((https://[^)\s]+)\)""" + // [label](https url only)
     """|\*\*([^*]+)\*\*""" + //               **bold**
     """|\*([^*]+)\*""" //                      *italic*
 )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialView.kt
@@ -105,18 +105,22 @@ private fun EditorialBundleContent(
     }
 
     is ArticleListUiState.Idle -> {
+      // Filtering out the current article can empty the list (e.g. the only article of its
+      // subtype); when nothing remains, hide the whole bundle so no orphan header shows.
       val items = uiState.articles.filter { it.id != filterId }
-      val lazyListState = rememberLazyListState()
-      RealEditorialBundle(
-        modifier = modifier,
-        bundle = bundle,
-        items = items,
-        listenForPosition = listenForPosition,
-        lazyListState = lazyListState,
-        navigate = navigate,
-        subtype = subtype,
-      )
-      Spacer(Modifier.size(spaceBy.dp))
+      if (items.isNotEmpty()) {
+        val lazyListState = rememberLazyListState()
+        RealEditorialBundle(
+          modifier = modifier,
+          bundle = bundle,
+          items = items,
+          listenForPosition = listenForPosition,
+          lazyListState = lazyListState,
+          navigate = navigate,
+          subtype = subtype,
+        )
+        Spacer(Modifier.size(spaceBy.dp))
+      }
     }
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/EditorialViewScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
@@ -56,7 +57,7 @@ import com.aptoide.android.aptoidegames.analytics.presentation.rememberGeneralAn
 import com.aptoide.android.aptoidegames.analytics.presentation.withAnalytics
 import com.aptoide.android.aptoidegames.appview.buildAppViewRoute
 import com.aptoide.android.aptoidegames.design_system.IndeterminateCircularLoading
-import com.aptoide.android.aptoidegames.design_system.SecondaryButton
+import com.aptoide.android.aptoidegames.design_system.PrimaryButton
 import com.aptoide.android.aptoidegames.drawables.icons.getLeftArrow
 import com.aptoide.android.aptoidegames.error_views.GenericErrorView
 import com.aptoide.android.aptoidegames.error_views.NoConnectionView
@@ -213,10 +214,20 @@ private fun ArticleViewContent(
               )
             }
           }
-          content.message?.ifBlank { null }?.let {
+          content.message?.ifBlank { null }?.let { message ->
             item {
+              val context = LocalContext.current
               Text(
-                text = it,
+                // Render the new contract's inline markdown (**bold**, *italic*, [label](url))
+                // as spans; on prod (flag off) paragraphs render verbatim as before.
+                text = if (BuildConfig.EDITORIAL_DEMO_ENABLED) {
+                  message.toEditorialAnnotatedString(
+                    linkColor = Palette.Primary,
+                    onLinkClick = { url -> UrlActivity.open(context, url) },
+                  )
+                } else {
+                  AnnotatedString(message)
+                },
                 style = AGTypography.ArticleText,
                 color = Palette.White,
                 modifier = Modifier
@@ -303,7 +314,7 @@ private fun ActionButton(
   url: String,
 ) {
   val context = LocalContext.current
-  SecondaryButton(
+  PrimaryButton(
     onClick = { UrlActivity.open(context, url) },
     modifier = modifier,
     title = title,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/data/BlockDeserializer.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/data/BlockDeserializer.kt
@@ -1,0 +1,33 @@
+package com.aptoide.android.aptoidegames.editorial.data
+
+import com.aptoide.android.aptoidegames.editorial.data.model.Block
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import java.lang.reflect.Type
+
+/**
+ * Resolves the editorial [Block] discriminated union on its `kind` field. Unrecognized
+ * kinds return null (the contract is additive-only) so callers can [List.mapNotNull] them
+ * away and never crash on a future block type.
+ */
+class BlockDeserializer : JsonDeserializer<Block?> {
+
+  override fun deserialize(
+    json: JsonElement,
+    typeOfT: Type,
+    context: JsonDeserializationContext,
+  ): Block? {
+    val obj = json.takeIf { it.isJsonObject }?.asJsonObject ?: return null
+    val kind = obj.get("kind")?.takeIf { it.isJsonPrimitive }?.asString ?: return null
+    return when (kind) {
+      "heading" -> context.deserialize(obj, Block.Heading::class.java)
+      "paragraph" -> context.deserialize(obj, Block.Paragraph::class.java)
+      "image" -> context.deserialize(obj, Block.Image::class.java)
+      "app_embed" -> context.deserialize(obj, Block.AppEmbed::class.java)
+      "video" -> context.deserialize(obj, Block.Video::class.java)
+      "cta_action" -> context.deserialize(obj, Block.CtaAction::class.java)
+      else -> null
+    }
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/data/EditorialServiceApi.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/data/EditorialServiceApi.kt
@@ -1,0 +1,31 @@
+package com.aptoide.android.aptoidegames.editorial.data
+
+import com.aptoide.android.aptoidegames.editorial.data.model.EditorialListResponse
+import com.aptoide.android.aptoidegames.editorial.data.model.EditorialResponse
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * Retrofit service for the new public Editorial read API. Anonymous, no auth.
+ * Base URL comes from BuildConfig.EDITORIAL_API_DOMAIN.
+ *
+ * - [getEditorials] is CDN-cacheable (honor server Cache-Control).
+ * - [getEditorial] is served as Cache-Control: no-store (do not cache).
+ */
+interface EditorialServiceApi {
+
+  @GET("editorials")
+  suspend fun getEditorials(
+    @Query("locale") locale: String = "en",
+    @Query("limit") limit: Int = 25,
+    @Query("cursor") cursor: String? = null,
+    @Query("app") app: String? = null,
+    @Query("subtype") subtype: String? = null,
+  ): EditorialListResponse
+
+  @GET("editorials/{slug}")
+  suspend fun getEditorial(
+    @Path("slug") slug: String,
+  ): EditorialResponse
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/data/EditorialServiceRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/data/EditorialServiceRepository.kt
@@ -1,0 +1,172 @@
+package com.aptoide.android.aptoidegames.editorial.data
+
+import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_apps.data.AppRepository
+import cm.aptoide.pt.feature_apps.data.emptyApp
+import cm.aptoide.pt.feature_editorial.data.EditorialRepository
+import cm.aptoide.pt.feature_editorial.data.model.Media
+import cm.aptoide.pt.feature_editorial.domain.Action
+import cm.aptoide.pt.feature_editorial.domain.Article
+import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
+import cm.aptoide.pt.feature_editorial.domain.ArticleType
+import cm.aptoide.pt.feature_editorial.domain.Paragraph
+import cm.aptoide.pt.feature_editorial.domain.RELATED_ARTICLE_CACHE_ID_PREFIX
+import com.aptoide.android.aptoidegames.editorial.data.model.Block
+import com.aptoide.android.aptoidegames.editorial.data.model.EditorialListItem
+import com.aptoide.android.aptoidegames.editorial.data.model.EditorialResponse
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+/**
+ * Backs the existing [EditorialRepository] contract with the new public Editorial service,
+ * mapping the new DTOs onto the existing domain models ([Article]/[ArticleMeta]/[Paragraph])
+ * so the whole existing editorial UI works unchanged. Wired only on the dev/test build.
+ */
+class EditorialServiceRepository(
+  private val api: EditorialServiceApi,
+  private val appRepository: AppRepository,
+) : EditorialRepository {
+
+  override suspend fun getLatestArticle(): List<ArticleMeta> =
+    api.getEditorials(limit = 1).items.map { it.toArticleMeta() }
+
+  override suspend fun getArticlesMeta(
+    editorialWidgetUrl: String,
+    subtype: String?,
+  ): List<ArticleMeta> =
+    // The v7 widget url is irrelevant to this service; only the (optional) subtype filter maps.
+    api.getEditorials(subtype = subtype.toContractSubtype()).items.map { it.toArticleMeta() }
+
+  override suspend fun getRelatedArticlesMeta(packageName: String): List<ArticleMeta> =
+    api.getEditorials(app = packageName).items.map { it.toArticleMeta() }
+
+  override suspend fun getArticle(editorialUrl: String): Article =
+    api.getEditorial(extractSlug(editorialUrl)).toArticle()
+
+  private suspend fun EditorialResponse.toArticle(): Article = Article(
+    id = slug,
+    title = title,
+    caption = summary.orEmpty(),
+    subtype = subtype.toArticleType(),
+    image = coverImageUrl.orEmpty(),
+    date = publishedAt.toUiDate(),
+    views = viewCount,
+    relatedTag = RELATED_ARTICLE_CACHE_ID_PREFIX + slug,
+    content = blocks.filterNotNull().toParagraphs(),
+  )
+
+  /** One [Paragraph] per block, in order. app_embed apps are resolved in parallel. */
+  private suspend fun List<Block>.toParagraphs(): List<Paragraph> = coroutineScope {
+    val blocks = this@toParagraphs
+    val resolvedApps: Map<String, Deferred<App>> = blocks.filterIsInstance<Block.AppEmbed>()
+      .distinctBy { it.packageName }
+      .associate { embed -> embed.packageName to async { embed.resolveApp() } }
+
+    blocks.map { block ->
+      when (block) {
+        is Block.Heading -> paragraphOf(title = block.text)
+        is Block.Paragraph -> paragraphOf(message = block.text)
+        is Block.Image -> paragraphOf(
+          media = listOf(Media(type = "image", description = block.alt, image = block.url, url = null))
+        )
+        is Block.Video -> paragraphOf(
+          media = listOf(Media(type = "video_webview", description = null, image = null, url = block.url))
+        )
+        is Block.CtaAction -> paragraphOf(action = Action(title = block.label, url = block.url))
+        is Block.AppEmbed -> paragraphOf(
+          app = resolvedApps[block.packageName]?.await() ?: block.toApp()
+        )
+      }
+    }
+  }
+
+  /** Full store app for a working card (install + detail); falls back to the embed on failure. */
+  private suspend fun Block.AppEmbed.resolveApp(): App =
+    runCatching { appRepository.getApp(packageName) }.getOrElse { toApp() }
+
+  private fun Block.AppEmbed.toApp(): App = emptyApp.copy(
+    name = name,
+    packageName = packageName,
+    icon = iconUrl.orEmpty(),
+    description = summary,
+  )
+
+  private fun EditorialListItem.toArticleMeta(): ArticleMeta {
+    val type = subtype.toArticleType()
+    return ArticleMeta(
+      id = slug,
+      title = title,
+      url = slug,
+      caption = type.toCaptionLabel(),
+      summary = summary.orEmpty(),
+      image = coverImageUrl.orEmpty(),
+      subtype = type,
+      date = publishedAt.toUiDate(),
+      views = viewCount,
+    )
+  }
+}
+
+private fun paragraphOf(
+  title: String? = null,
+  message: String? = null,
+  action: Action? = null,
+  media: List<Media> = emptyList(),
+  app: App? = null,
+): Paragraph = Paragraph(title = title, message = message, action = action, media = media, app = app)
+
+private val UI_DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+/**
+ * The existing editorial UI parses dates as "yyyy-MM-dd HH:mm:ss" (device tz); the new service
+ * returns ISO-8601 instants. Always returns a parseable date so the detail screen can't crash.
+ */
+private fun String?.toUiDate(): String {
+  val instant = this?.let { runCatching { Instant.parse(it) }.getOrNull() } ?: Instant.now()
+  return UI_DATE_FORMATTER.format(instant.atZone(ZoneId.systemDefault()))
+}
+
+private fun String?.toArticleType(): ArticleType = when (this?.lowercase()) {
+  "app_of_the_week" -> ArticleType.APP_OF_THE_WEEK
+  "game_of_the_week" -> ArticleType.GAME_OF_THE_WEEK
+  "collection" -> ArticleType.COLLECTION
+  "news" -> ArticleType.NEWS
+  "new_app" -> ArticleType.NEW_APP
+  else -> ArticleType.OTHER
+}
+
+/** Maps an [ArticleType]-style name (e.g. "COLLECTION") to the contract enum, dropping unknowns. */
+private fun String?.toContractSubtype(): String? = this?.lowercase()?.takeIf {
+  it in CONTRACT_SUBTYPES
+}
+
+private val CONTRACT_SUBTYPES =
+  setOf("app_of_the_week", "game_of_the_week", "collection", "news", "new_app")
+
+// No caption/flair exists in the contract; the existing card chip shows a category label.
+// Build is dev-only and locale=en, so English labels are acceptable here.
+private fun ArticleType.toCaptionLabel(): String = when (this) {
+  ArticleType.APP_OF_THE_WEEK -> "App of the Week"
+  ArticleType.GAME_OF_THE_WEEK -> "Game of the Week"
+  ArticleType.COLLECTION -> "Collection"
+  ArticleType.NEWS -> "News"
+  ArticleType.NEW_APP -> "New App"
+  ArticleType.OTHER -> "Editorial"
+}
+
+/**
+ * Recovers the bare slug from whatever [cm.aptoide.pt.feature_editorial.domain.usecase.ArticleUseCase]
+ * passes: a cached value, or "card/get/<id|slug>=<slug>/store_name=<store>".
+ */
+private fun extractSlug(editorialUrl: String): String =
+  editorialUrl
+    .substringAfter("card/get/", editorialUrl)
+    .substringBefore("/store_name")
+    .substringAfter("id=")
+    .substringAfter("slug=")
+    .substringBefore("/")
+    .trim()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/data/EditorialServiceRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/data/EditorialServiceRepository.kt
@@ -29,6 +29,9 @@ import kotlinx.coroutines.coroutineScope
 class EditorialServiceRepository(
   private val api: EditorialServiceApi,
   private val appRepository: AppRepository,
+  // Resolves the card's category chip from a localized resource at the composition root, so no
+  // user-facing strings live in this data layer (the contract carries no caption/flair field).
+  private val captionLabeler: (ArticleType) -> String,
 ) : EditorialRepository {
 
   override suspend fun getLatestArticle(): List<ArticleMeta> =
@@ -101,7 +104,7 @@ class EditorialServiceRepository(
       id = slug,
       title = title,
       url = slug,
-      caption = type.toCaptionLabel(),
+      caption = captionLabeler(type),
       summary = summary.orEmpty(),
       image = coverImageUrl.orEmpty(),
       subtype = type,
@@ -123,10 +126,12 @@ private val UI_DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("
 
 /**
  * The existing editorial UI parses dates as "yyyy-MM-dd HH:mm:ss" (device tz); the new service
- * returns ISO-8601 instants. Always returns a parseable date so the detail screen can't crash.
+ * returns ISO-8601 instants. Always returns a parseable date so the detail screen can't crash;
+ * a missing/malformed date falls back to a deterministic sentinel (EPOCH) rather than "now", so
+ * undated content never looks freshly published or reorders by wall-clock.
  */
 private fun String?.toUiDate(): String {
-  val instant = this?.let { runCatching { Instant.parse(it) }.getOrNull() } ?: Instant.now()
+  val instant = this?.let { runCatching { Instant.parse(it) }.getOrNull() } ?: Instant.EPOCH
   return UI_DATE_FORMATTER.format(instant.atZone(ZoneId.systemDefault()))
 }
 
@@ -146,17 +151,6 @@ private fun String?.toContractSubtype(): String? = this?.lowercase()?.takeIf {
 
 private val CONTRACT_SUBTYPES =
   setOf("app_of_the_week", "game_of_the_week", "collection", "news", "new_app")
-
-// No caption/flair exists in the contract; the existing card chip shows a category label.
-// Build is dev-only and locale=en, so English labels are acceptable here.
-private fun ArticleType.toCaptionLabel(): String = when (this) {
-  ArticleType.APP_OF_THE_WEEK -> "App of the Week"
-  ArticleType.GAME_OF_THE_WEEK -> "Game of the Week"
-  ArticleType.COLLECTION -> "Collection"
-  ArticleType.NEWS -> "News"
-  ArticleType.NEW_APP -> "New App"
-  ArticleType.OTHER -> "Editorial"
-}
 
 /**
  * Recovers the bare slug from whatever [cm.aptoide.pt.feature_editorial.domain.usecase.ArticleUseCase]

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/data/model/EditorialServiceModels.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/data/model/EditorialServiceModels.kt
@@ -1,0 +1,85 @@
+package com.aptoide.android.aptoidegames.editorial.data.model
+
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
+
+/**
+ * DTOs for the new public Editorial read API (api.dev.aptoide.com / api.aptoide.com).
+ * Modeled exactly per the frozen OpenAPI contract (additive-only). Nullable fields mirror
+ * the contract's optional (`?`) fields. Parsed with Gson ([BlockDeserializer] for [Block]).
+ */
+@Keep
+data class EditorialListResponse(
+  @SerializedName("items") val items: List<EditorialListItem> = emptyList(),
+  @SerializedName("next_cursor") val nextCursor: String? = null,
+)
+
+@Keep
+data class EditorialListItem(
+  @SerializedName("slug") val slug: String,
+  @SerializedName("locale") val locale: String? = null,
+  @SerializedName("subtype") val subtype: String? = null,
+  @SerializedName("title") val title: String = "",
+  @SerializedName("summary") val summary: String? = null,
+  @SerializedName("cover_image_url") val coverImageUrl: String? = null,
+  @SerializedName("published_at") val publishedAt: String? = null,
+  @SerializedName("view_count") val viewCount: Long = 0,
+)
+
+@Keep
+data class EditorialResponse(
+  @SerializedName("slug") val slug: String,
+  @SerializedName("locale") val locale: String? = null,
+  @SerializedName("subtype") val subtype: String? = null,
+  @SerializedName("title") val title: String = "",
+  @SerializedName("summary") val summary: String? = null,
+  @SerializedName("cover_image_url") val coverImageUrl: String? = null,
+  // Nullable elements: unrecognized future `kind`s deserialize to null and are filtered out.
+  @SerializedName("blocks") val blocks: List<Block?> = emptyList(),
+  @SerializedName("published_at") val publishedAt: String? = null,
+  @SerializedName("view_count") val viewCount: Long = 0,
+)
+
+/**
+ * Discriminated union on the `kind` field. See [BlockDeserializer]. The contract is
+ * additive-only, so unknown kinds must be skipped gracefully (parsed as null).
+ */
+@Keep
+sealed interface Block {
+
+  @Keep
+  data class Heading(
+    @SerializedName("text") val text: String = "",
+    @SerializedName("level") val level: Int = 1,
+  ) : Block
+
+  @Keep
+  data class Paragraph(
+    @SerializedName("text") val text: String = "",
+  ) : Block
+
+  @Keep
+  data class Image(
+    @SerializedName("url") val url: String = "",
+    @SerializedName("alt") val alt: String? = null,
+  ) : Block
+
+  @Keep
+  data class AppEmbed(
+    @SerializedName("package_name") val packageName: String = "",
+    @SerializedName("name") val name: String = "",
+    @SerializedName("icon_url") val iconUrl: String? = null,
+    @SerializedName("summary") val summary: String? = null,
+  ) : Block
+
+  @Keep
+  data class Video(
+    @SerializedName("url") val url: String = "",
+  ) : Block
+
+  @Keep
+  data class CtaAction(
+    @SerializedName("label") val label: String = "",
+    @SerializedName("url") val url: String = "",
+  ) : Block
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/di/EditorialApiModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/di/EditorialApiModule.kt
@@ -1,10 +1,13 @@
 package com.aptoide.android.aptoidegames.editorial.di
 
 import android.content.Context
+import androidx.annotation.StringRes
 import cm.aptoide.pt.aptoide_network.data.network.UserAgentInterceptor
 import cm.aptoide.pt.feature_apps.data.AppRepository
 import cm.aptoide.pt.feature_editorial.data.EditorialRepository
+import cm.aptoide.pt.feature_editorial.domain.ArticleType
 import com.aptoide.android.aptoidegames.BuildConfig
+import com.aptoide.android.aptoidegames.R
 import com.aptoide.android.aptoidegames.editorial.data.BlockDeserializer
 import com.aptoide.android.aptoidegames.editorial.data.EditorialServiceApi
 import com.aptoide.android.aptoidegames.editorial.data.EditorialServiceRepository
@@ -43,12 +46,17 @@ internal object EditorialApiModule {
   @Singleton
   @EditorialApi
   fun provideEditorialApiRepository(
+    @ApplicationContext context: Context,
     default: EditorialRepository,
     editorialServiceApi: Lazy<EditorialServiceApi>,
     appRepository: AppRepository,
   ): EditorialRepository =
     if (BuildConfig.EDITORIAL_DEMO_ENABLED) {
-      EditorialServiceRepository(api = editorialServiceApi.get(), appRepository = appRepository)
+      EditorialServiceRepository(
+        api = editorialServiceApi.get(),
+        appRepository = appRepository,
+        captionLabeler = { type -> context.getString(type.captionLabelRes()) },
+      )
     } else {
       default
     }
@@ -86,3 +94,14 @@ internal object EditorialApiModule {
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 internal annotation class EditorialApi
+
+/** Localized category-chip label for an editorial card; the contract carries no caption field. */
+@StringRes
+private fun ArticleType.captionLabelRes(): Int = when (this) {
+  ArticleType.APP_OF_THE_WEEK -> R.string.editorial_subtype_app_of_the_week
+  ArticleType.GAME_OF_THE_WEEK -> R.string.editorial_subtype_game_of_the_week
+  ArticleType.COLLECTION -> R.string.editorial_subtype_collection
+  ArticleType.NEWS -> R.string.editorial_subtype_news
+  ArticleType.NEW_APP -> R.string.editorial_subtype_new_app
+  ArticleType.OTHER -> R.string.fixed_bundle_editorial_title
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/di/EditorialApiModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/editorial/di/EditorialApiModule.kt
@@ -1,0 +1,88 @@
+package com.aptoide.android.aptoidegames.editorial.di
+
+import android.content.Context
+import cm.aptoide.pt.aptoide_network.data.network.UserAgentInterceptor
+import cm.aptoide.pt.feature_apps.data.AppRepository
+import cm.aptoide.pt.feature_editorial.data.EditorialRepository
+import com.aptoide.android.aptoidegames.BuildConfig
+import com.aptoide.android.aptoidegames.editorial.data.BlockDeserializer
+import com.aptoide.android.aptoidegames.editorial.data.EditorialServiceApi
+import com.aptoide.android.aptoidegames.editorial.data.EditorialServiceRepository
+import com.aptoide.android.aptoidegames.editorial.data.model.Block
+import com.google.gson.GsonBuilder
+import dagger.Lazy
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import okhttp3.Cache
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.io.File
+import java.util.concurrent.TimeUnit.SECONDS
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+/**
+ * Selects the editorial data source for app-games. On the dev/test build
+ * ([BuildConfig.EDITORIAL_DEMO_ENABLED]) the existing editorial UI is fed by the new
+ * Editorial service; on prod the binding falls through to the v7 [EditorialRepository],
+ * which stays byte-for-byte unchanged (the new path is compile-time dead and stripped).
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal object EditorialApiModule {
+
+  private const val EDITORIAL_HTTP_CACHE_SIZE = 5L * 1024 * 1024
+  private const val EDITORIAL_TIMEOUT_SECONDS = 15L
+
+  @Provides
+  @Singleton
+  @EditorialApi
+  fun provideEditorialApiRepository(
+    default: EditorialRepository,
+    editorialServiceApi: Lazy<EditorialServiceApi>,
+    appRepository: AppRepository,
+  ): EditorialRepository =
+    if (BuildConfig.EDITORIAL_DEMO_ENABLED) {
+      EditorialServiceRepository(api = editorialServiceApi.get(), appRepository = appRepository)
+    } else {
+      default
+    }
+
+  @Provides
+  @Singleton
+  fun provideEditorialServiceApi(
+    @ApplicationContext context: Context,
+    userAgentInterceptor: UserAgentInterceptor,
+    httpLoggingInterceptor: HttpLoggingInterceptor,
+  ): EditorialServiceApi {
+    // Dedicated cache dir (separate from the base client) so the list's Cache-Control is
+    // honored; the detail's `no-store` is then respected automatically. No v7 interceptors.
+    val okHttpClient = OkHttpClient.Builder()
+      .cache(Cache(File(context.cacheDir, "editorial-http"), EDITORIAL_HTTP_CACHE_SIZE))
+      .connectTimeout(EDITORIAL_TIMEOUT_SECONDS, SECONDS)
+      .readTimeout(EDITORIAL_TIMEOUT_SECONDS, SECONDS)
+      .addInterceptor(userAgentInterceptor)
+      .addInterceptor(httpLoggingInterceptor)
+      .build()
+
+    val gson = GsonBuilder()
+      .registerTypeAdapter(Block::class.java, BlockDeserializer())
+      .create()
+
+    return Retrofit.Builder()
+      .client(okHttpClient)
+      .baseUrl(BuildConfig.EDITORIAL_API_DOMAIN)
+      .addConverterFactory(GsonConverterFactory.create(gson))
+      .build()
+      .create(EditorialServiceApi::class.java)
+  }
+}
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+internal annotation class EditorialApi

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/BundlesView.kt
@@ -56,8 +56,13 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_editorial.domain.EDITORIAL_DEFAULT_TAG
+import cm.aptoide.pt.feature_editorial.domain.EDITORIAL_MORE_TAG
 import cm.aptoide.pt.feature_home.domain.Bundle
+import cm.aptoide.pt.feature_home.domain.BundleSource.MANUAL
 import cm.aptoide.pt.feature_home.domain.Type
+import cm.aptoide.pt.feature_home.domain.WidgetAction
+import cm.aptoide.pt.feature_home.domain.WidgetActionType.BUTTON
 import cm.aptoide.pt.feature_home.presentation.BundlesViewUiState
 import cm.aptoide.pt.feature_home.presentation.BundlesViewUiStateType
 import cm.aptoide.pt.feature_home.presentation.bundlesList
@@ -194,6 +199,24 @@ fun BundlesScreen(
   }
 }
 
+// Dev/test only: a guaranteed editorial row at the top of the For You feed, fed by the new
+// Editorial service through the existing EDITORIAL bundle path (inert in prod — flag is false).
+@Composable
+private fun bundlesWithEditorialDemoRow(bundles: List<Bundle>): List<Bundle> {
+  if (!BuildConfig.EDITORIAL_DEMO_ENABLED) return bundles
+  return listOf(
+    Bundle(
+      title = stringResource(R.string.fixed_bundle_editorial_title),
+      actions = listOf(WidgetAction(type = BUTTON, tag = EDITORIAL_MORE_TAG, url = "null")),
+      type = Type.EDITORIAL,
+      tag = EDITORIAL_DEFAULT_TAG,
+      view = "",
+      bundleSource = MANUAL,
+      timestamp = "0",
+    )
+  ) + bundles
+}
+
 @Composable
 fun BundlesView(
   viewState: BundlesViewUiState,
@@ -207,6 +230,7 @@ fun BundlesView(
       .wrapContentSize(Alignment.TopCenter)
       .padding(top = 16.dp)
   ) {
+    val bundles = bundlesWithEditorialDemoRow(viewState.bundles)
     LazyColumn(
       state = rememberBottomBarMenuScrollState(state = rememberLazyListState(), route = gamesRoute),
       modifier = Modifier
@@ -214,7 +238,7 @@ fun BundlesView(
         .wrapContentSize(Alignment.TopCenter),
       contentPadding = PaddingValues(bottom = 72.dp)
     ) {
-      items(viewState.bundles) { bundle ->
+      items(bundles) { bundle ->
         WithUTM(
           utmInfo = getBundleHomeUTMInfo(bundle.tag, bundle.type),
           navigate = navigate

--- a/app-games/src/main/res/values/strings.xml
+++ b/app-games/src/main/res/values/strings.xml
@@ -55,6 +55,12 @@
   <string name="wifi_disclaimer_title">Are you sure?</string>
   <!-- Fixed bundles -->
   <string name="editorial_more_articles_title">More articles</string>
+  <!-- Editorial card category chips (subtype labels) -->
+  <string name="editorial_subtype_app_of_the_week">App of the Week</string>
+  <string name="editorial_subtype_game_of_the_week">Game of the Week</string>
+  <string name="editorial_subtype_collection">Collection</string>
+  <string name="editorial_subtype_news">News</string>
+  <string name="editorial_subtype_new_app">New App</string>
   <string name="fixed_bundle_just_arrived_title">Just Arrived</string>
   <string name="fixed_bundle_my_games_title">My Games</string>
   <string name="fixed_bundle_editors_choice_title">Editor\'s Choice</string>


### PR DESCRIPTION
Feeds the existing editorial experience (home row + detail screen) from the new public Editorial read API, gated behind the dev/test flavor so the production v7 path is untouched. A new data layer — DTOs, a discriminated-union `kind` Block deserializer that skips unknown kinds, a Retrofit API (`GET /editorials`, `/editorials/{slug}`), and an `EditorialRepository` implementation — maps the new contract onto the existing `Article`/`ArticleMeta`/`Paragraph` domain models so all current editorial screens render unchanged, swapped in via an `@EditorialApi` qualifier and gated by `BuildConfig.EDITORIAL_DEMO_ENABLED` (dev → `api.dev.aptoide.com`; prod stays on the v7 path). Paragraph blocks now render inline markdown (**bold**, *italic*, links) and `app_embed` cards reuse the existing app-card / app-detail flow. Also includes UX fixes surfaced during review: the CTA uses the brand-accent `PrimaryButton` (lime/orange) instead of grey, the "More articles" bundle hides its header when no related articles remain, and a guaranteed editorial row is injected at the top of the For You feed (inert in prod). Verified on-device on both aptoideGames and vanilla dev builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer editorial article rendering with inline links, bold, and italics.
  * Enabled an editorial demo bundle for supported builds to preview editorial content.
  * Introduced a public Editorial read API to load editorial lists and individual editorials.
  * Added new subtype chip labels for editorial categories.
* **Bug Fixes**
  * Prevented empty editorial sections from showing orphan bundle headers by skipping rendering when there’s no content.
* **Documentation**
  * Added guidance for missing local Gradle properties when building.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->