### PR TITLE
[AND-859] Adapt client to streaming responses for local LLM

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/GameGenieApiService.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/GameGenieApiService.kt
@@ -20,12 +20,6 @@ interface GameGenieApiService {
     @Body request: GameGenieRequest,
   ): GameGenieResponse
 
-  @POST("v2/chat/companion")
-  suspend fun postMessageCompanion(
-    @Header("Authorization") bearerToken: String,
-    @Body request: GameGenieCompanionRequest,
-  ): GameGenieResponse
-
   @GET("v2/chat/companion/suggestions")
   suspend fun getCompanionSuggestions(
     @Header("Authorization") bearerToken: String,

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/GameGenieSseClient.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/data/GameGenieSseClient.kt
@@ -1,0 +1,187 @@
+package com.aptoide.android.aptoidegames.gamegenie.data
+
+import cm.aptoide.pt.aptoide_network.di.GameGenieOkHttp
+import com.aptoide.android.aptoidegames.BuildConfig
+import com.aptoide.android.aptoidegames.gamegenie.io_models.GameGenieCompanionRequest
+import com.aptoide.android.aptoidegames.gamegenie.io_models.GameGenieRequest
+import com.aptoide.android.aptoidegames.gamegenie.io_models.GenieAppRef
+import com.aptoide.android.aptoidegames.gamegenie.io_models.GenieSseEvent
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import retrofit2.HttpException
+import retrofit2.Response
+import timber.log.Timber
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Streaming consumer for `POST /api/genie` (general chat) and `POST /api/genie/companion`
+ * (companion chat). Bypasses Retrofit to read the `text/event-stream` body line-by-line so
+ * `delta` chunks surface to the UI as they arrive. Query params and `User-Agent` are added by
+ * the [GameGenieOkHttp] interceptor chain.
+ *
+ * Read timeout is bumped to 5 minutes since LLM generations can exceed the default 30s.
+ */
+@Singleton
+class GameGenieSseClient @Inject constructor(
+  @GameGenieOkHttp baseClient: OkHttpClient,
+) {
+
+  private val streamingClient: OkHttpClient = baseClient.newBuilder()
+    .readTimeout(STREAM_READ_TIMEOUT_MINUTES, TimeUnit.MINUTES)
+    .build()
+
+  private val gson = Gson()
+
+  /**
+   * Streams [GenieSseEvent]s for a single `/api/genie` POST (general chat).
+   */
+  fun stream(
+    bearerToken: String,
+    request: GameGenieRequest,
+  ): Flow<GenieSseEvent> = streamFromPath(bearerToken, GENIE_PATH, request)
+
+  /**
+   * Streams [GenieSseEvent]s for a single `/api/genie/companion` POST.
+   */
+  fun streamCompanion(
+    bearerToken: String,
+    request: GameGenieCompanionRequest,
+  ): Flow<GenieSseEvent> = streamFromPath(bearerToken, GENIE_COMPANION_PATH, request)
+
+  /**
+   * Shared SSE pipeline for both genie endpoints. Throws [HttpException] on non-2xx (so the
+   * manager can refresh JWT on 401) and [IOException] on mid-stream socket/parse failure.
+   * Cancels the underlying [okhttp3.Call] on flow cancellation.
+   */
+  private fun streamFromPath(
+    bearerToken: String,
+    path: String,
+    request: Any,
+  ): Flow<GenieSseEvent> = callbackFlow {
+    val url = "${BuildConfig.GAME_GENIE_API}$path"
+    val body = gson.toJson(request).toRequestBody("application/json".toMediaType())
+
+    val httpRequest = Request.Builder()
+      .url(url)
+      .post(body)
+      .addHeader("Authorization", bearerToken)
+      .addHeader("Accept", "text/event-stream")
+      .build()
+
+    val call = streamingClient.newCall(httpRequest)
+
+    // Read on a child IO coroutine so awaitClose can fire mid-generation if the user navigates
+    // away — blocking I/O directly in the builder block would defer cancellation until EOF.
+    launch(Dispatchers.IO) {
+      try {
+        call.execute().use { response ->
+          val responseBody = response.body
+          if (!response.isSuccessful) {
+            // Mirror Retrofit so upstream 401 handling stays uniform.
+            throw HttpException(Response.error<Any>(response.code, responseBody))
+          }
+          val source = responseBody.source()
+          val buffer = StringBuilder()
+
+          while (!source.exhausted()) {
+            val line = source.readUtf8Line() ?: break
+            if (line.isEmpty()) {
+              val event = parseEventBlock(buffer.toString())
+              buffer.setLength(0)
+              if (event != null) {
+                trySend(event)
+                if (event is GenieSseEvent.Done || event is GenieSseEvent.Error) break
+              }
+            } else {
+              buffer.append(line).append('\n')
+            }
+          }
+          // Defensive flush in case the server omits the trailing `\n\n`.
+          if (buffer.isNotEmpty()) {
+            parseEventBlock(buffer.toString())?.let { trySend(it) }
+          }
+        }
+        close()
+      } catch (t: Throwable) {
+        close(t)
+      }
+    }
+
+    awaitClose {
+      // Idempotent — avoids "Call cancelled" log spam on normal completion.
+      if (!call.isCanceled()) call.cancel()
+    }
+  }
+
+  // The server carries the event type inside the JSON payload (no `event:` field), so we only
+  // look at the `data:` line. Unknown blocks return null so the caller keeps consuming.
+  private fun parseEventBlock(block: String): GenieSseEvent? {
+    val dataLine = block.lineSequence()
+      .firstOrNull { it.startsWith("data:") }
+      ?: return null
+    val json = dataLine.removePrefix("data:").trim()
+    if (json.isEmpty()) return null
+    return runCatching { decode(json) }
+      .onFailure { Timber.w(it, "Failed to parse genie SSE event: %s", json) }
+      .getOrNull()
+  }
+
+  private fun decode(json: String): GenieSseEvent? {
+    val obj = gson.fromJson(json, JsonObject::class.java) ?: return null
+    return when (obj.get("type")?.asString) {
+      "meta" -> GenieSseEvent.Meta(id = obj.get("id").asString)
+      "delta" -> GenieSseEvent.Delta(text = obj.get("text")?.asString.orEmpty())
+      "apps" -> GenieSseEvent.Apps(apps = parseAppRefs(obj))
+      "video" -> GenieSseEvent.Video(
+        videoId = obj.get("video")?.takeIf { !it.isJsonNull }?.asString
+      )
+      "follow_ups" -> GenieSseEvent.FollowUps(followUps = parseFollowUps(obj))
+      "done" -> GenieSseEvent.Done(
+        id = obj.get("id").asString,
+        title = obj.get("title")?.takeIf { !it.isJsonNull }?.asString,
+        apps = parseAppRefs(obj),
+        video = obj.get("video")?.takeIf { !it.isJsonNull }?.asString,
+        followUps = parseFollowUps(obj),
+      )
+      "error" -> GenieSseEvent.Error(
+        message = obj.get("message")?.takeIf { !it.isJsonNull }?.asString
+      )
+      else -> null
+    }
+  }
+
+  // Entries without `package` are skipped — they're unusable for repo resolution downstream.
+  private fun parseAppRefs(obj: JsonObject): List<GenieAppRef> =
+    obj.get("apps")?.asJsonArray?.mapNotNull { element ->
+      val appObj = element.asJsonObject
+      val pkg = appObj.get("package")?.takeIf { !it.isJsonNull }?.asString ?: return@mapNotNull null
+      GenieAppRef(
+        name = appObj.get("name")?.takeIf { !it.isJsonNull }?.asString,
+        packageName = pkg,
+      )
+    }.orEmpty()
+
+  // Cap at 3 to match the UI strip width.
+  private fun parseFollowUps(obj: JsonObject): List<String> =
+    obj.get("follow_ups")?.asJsonArray?.mapNotNull { el ->
+      el.takeIf { it.isJsonPrimitive && !it.isJsonNull }?.asString
+    }?.take(3).orEmpty()
+
+  companion object {
+    private const val GENIE_PATH = "api/genie"
+    private const val GENIE_COMPANION_PATH = "api/genie/companion"
+    private const val STREAM_READ_TIMEOUT_MINUTES = 5L
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/di/GameGenieModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/di/GameGenieModule.kt
@@ -8,6 +8,7 @@ import cm.aptoide.pt.aptoide_network.di.RetrofitV7
 import cm.aptoide.pt.feature_apps.data.AppMapper
 import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieApiService
+import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieSseClient
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieAppRepository
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieAppRepositoryImpl
 import com.aptoide.android.aptoidegames.gamegenie.data.GameCompanionsRepository
@@ -67,10 +68,12 @@ internal object GameGenieModule {
   @Provides
   fun provideChatbotManager(
     apiService: GameGenieApiService,
+    sseClient: GameGenieSseClient,
     db: GameGenieDatabase,
   ): GameGenieManager {
     return GameGenieManager(
       apiService,
+      sseClient,
       db.getGameGenieHistoryDao(),
       db.getGameCompanionDao()
     )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/io_models/GenieSseEvent.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/io_models/GenieSseEvent.kt
@@ -1,0 +1,63 @@
+package com.aptoide.android.aptoidegames.gamegenie.io_models
+
+import androidx.annotation.Keep
+
+/**
+ * Server-Sent Events emitted by the streaming `/api/genie` endpoint.
+ *
+ * Wire format (per event, terminated by a blank line):
+ *
+ *   data: {"type": "meta",        "id": "..."}
+ *   data: {"type": "delta",       "text": "..."}
+ *   data: {"type": "apps",        "apps": [...]}
+ *   data: {"type": "video",       "video": "..." | null}
+ *   data: {"type": "follow_ups",  "follow_ups": ["...", "...", "..."]}
+ *   data: {"type": "done",        "id": "...", "title": "...", "apps": [...], "video": "...",
+ *                                 "follow_ups": [...]}
+ *   data: {"type": "error",       "message": "..."}
+ *
+ * Ordering: `meta` -> `delta` x N -> ([Apps] | [Video] | [FollowUps]) in arbitrary order, each
+ * at most once -> ([Done] | [Error]).
+ *
+ * The typed structured events ([Apps], [Video], [FollowUps]) are additive — their payloads are
+ * also duplicated inside [Done] for backwards compatibility.
+ */
+sealed class GenieSseEvent {
+  @Keep
+  data class Meta(val id: String) : GenieSseEvent()
+
+  @Keep
+  data class Delta(val text: String) : GenieSseEvent()
+
+  /**
+   * Entries may be fully enriched (icon/rating/downloads via the Aptoide bulk API) or minimal
+   * (name + package only). Callers must tolerate both by resolving via the apps repository.
+   */
+  @Keep
+  data class Apps(val apps: List<GenieAppRef>) : GenieSseEvent()
+
+  @Keep
+  data class Video(val videoId: String?) : GenieSseEvent()
+
+  @Keep
+  data class FollowUps(val followUps: List<String>) : GenieSseEvent()
+
+  /** [title] is only ever delivered here — there is no `title` typed event. */
+  @Keep
+  data class Done(
+    val id: String,
+    val title: String?,
+    val apps: List<GenieAppRef>,
+    val video: String?,
+    val followUps: List<String> = emptyList(),
+  ) : GenieSseEvent()
+
+  @Keep
+  data class Error(val message: String?) : GenieSseEvent()
+}
+
+@Keep
+data class GenieAppRef(
+  val name: String?,
+  val packageName: String,
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieManager.kt
@@ -1,6 +1,7 @@
 package com.aptoide.android.aptoidegames.gamegenie.presentation
 
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieApiService
+import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieSseClient
 import com.aptoide.android.aptoidegames.gamegenie.data.database.GameCompanionDao
 import com.aptoide.android.aptoidegames.gamegenie.data.database.GameGenieHistoryDao
 import com.aptoide.android.aptoidegames.gamegenie.data.database.model.GameCompanionEntity
@@ -12,8 +13,12 @@ import com.aptoide.android.aptoidegames.gamegenie.domain.toToken
 import com.aptoide.android.aptoidegames.gamegenie.io_models.GameGenieCompanionRequest
 import com.aptoide.android.aptoidegames.gamegenie.io_models.GameGenieRequest
 import com.aptoide.android.aptoidegames.gamegenie.io_models.GameGenieResponse
+import com.aptoide.android.aptoidegames.gamegenie.io_models.GenieSseEvent
 import com.aptoide.android.aptoidegames.gamegenie.io_models.toDomain
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import retrofit2.HttpException
 import timber.log.Timber
 import java.io.IOException
@@ -21,6 +26,7 @@ import javax.inject.Inject
 
 class GameGenieManager @Inject constructor(
   private val gameGenieApi: GameGenieApiService,
+  private val gameGenieSseClient: GameGenieSseClient,
   private val gameGenieHistoryDao: GameGenieHistoryDao,
   private val gameCompanionDao: GameCompanionDao,
 ) {
@@ -58,22 +64,41 @@ class GameGenieManager @Inject constructor(
     }
   }
 
-  suspend fun postMessageCompanion(
+  fun streamMessage(
+    token: Token,
+    request: GameGenieRequest,
+  ): Flow<GenieSseEvent> = streamWithTokenRefresh(token) { bearer ->
+    gameGenieSseClient.stream(bearer, request)
+  }
+
+  fun streamCompanionMessage(
     token: Token,
     request: GameGenieCompanionRequest,
-  ): GameGenieResponse {
-    return try {
-      gameGenieApi.postMessageCompanion("Bearer ${token.token}", request)
-    } catch (e: HttpException) {
-      if (e.code() == 401) {
-        Timber.i("Token expired, requesting a new token")
-        val newToken = fetchNewToken()
-        gameGenieApi.postMessageCompanion(
-          "Bearer ${newToken.token}", request
-        ) // Retry with new token
-      } else {
-        throw e
-      }
+  ): Flow<GenieSseEvent> = streamWithTokenRefresh(token) { bearer ->
+    gameGenieSseClient.streamCompanion(bearer, request)
+  }
+
+  private fun streamWithTokenRefresh(
+    token: Token,
+    openStream: (bearer: String) -> Flow<GenieSseEvent>,
+  ): Flow<GenieSseEvent> = flow {
+    var currentToken = token
+    var retried = false
+    while (true) {
+      var unauthorized = false
+      openStream("Bearer ${currentToken.token}")
+        .catch { e ->
+          if (!retried && e is HttpException && e.code() == 401) {
+            Timber.i("Genie SSE token expired, requesting a new token")
+            unauthorized = true
+          } else {
+            throw e
+          }
+        }
+        .let { emitAll(it) }
+      if (!unauthorized) return@flow
+      currentToken = fetchNewToken()
+      retried = true
     }
   }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieUIState.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieUIState.kt
@@ -12,6 +12,7 @@ data class GameGenieUIState(
   val token: Token?,
   val selectedGame: GameCompanion? = null,
   val suggestions: List<Suggestion> = emptyList(),
+  val isStreaming: Boolean = false,
 )
 
 enum class GameGenieUIStateType {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieUseCase.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieUseCase.kt
@@ -2,6 +2,7 @@ package com.aptoide.android.aptoidegames.gamegenie.presentation
 
 import android.util.Base64.NO_WRAP
 import android.util.Base64.encodeToString
+import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.AppMapper
 import com.aptoide.android.aptoidegames.gamegenie.data.GameGenieAppRepository
 import com.aptoide.android.aptoidegames.gamegenie.data.database.model.GameGenieHistoryEntity
@@ -18,6 +19,7 @@ import com.aptoide.android.aptoidegames.gamegenie.io_models.GameGenieCompanionRe
 import com.aptoide.android.aptoidegames.gamegenie.io_models.GameGenieMetadata
 import com.aptoide.android.aptoidegames.gamegenie.io_models.GameGenieRequest
 import com.aptoide.android.aptoidegames.gamegenie.io_models.GameGenieResponse
+import com.aptoide.android.aptoidegames.gamegenie.io_models.GenieSseEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -27,6 +29,20 @@ import java.io.File
 import javax.inject.Inject
 
 private const val MAX_CHATS = 15
+
+sealed class GameGenieStreamUpdate {
+  data class TextChunk(val delta: String) : GameGenieStreamUpdate()
+
+  data class AppsResolved(val apps: List<App>) : GameGenieStreamUpdate()
+
+  data class Video(val videoId: String?) : GameGenieStreamUpdate()
+
+  data class FollowUps(val followUps: List<String>) : GameGenieStreamUpdate()
+
+  data class Failed(val message: String?) : GameGenieStreamUpdate()
+
+  data class Completed(val chat: GameGenieChat) : GameGenieStreamUpdate()
+}
 
 private fun isBase64String(str: String): Boolean {
   if (str.contains("/") && str.length < 500) {
@@ -131,12 +147,57 @@ class GameGenieUseCase @Inject constructor(
     )
   }
 
-  suspend fun sendCompanionMessage(
+  fun streamMessage(
+    chat: GameGenieChatHistory,
+    userMessage: String,
+    installedApps: List<GameContext>,
+    imageBase64: String? = null,
+  ): Flow<GameGenieStreamUpdate> = streamInternal(
+    chat = chat,
+    userMessage = userMessage,
+    imageBase64 = imageBase64,
+    openStream = { token, conversationForApi ->
+      val request = GameGenieRequest(
+        id = chat.id.takeIf { it.isNotBlank() },
+        title = chat.title.takeIf { it.isNotBlank() },
+        conversation = conversationForApi,
+        metadata = GameGenieMetadata(installedApps),
+      )
+      gameGenieManager.streamMessage(token, request)
+    },
+    persist = { finalChat -> gameGenieManager.saveOrUpdateChat(finalChat) },
+  )
+
+  fun streamCompanionMessage(
     chat: GameGenieChatHistory,
     userMessage: String,
     selectedGame: String,
     imageBase64: String? = null,
-  ): GameGenieChat {
+  ): Flow<GameGenieStreamUpdate> = streamInternal(
+    chat = chat,
+    userMessage = userMessage,
+    imageBase64 = imageBase64,
+    openStream = { token, conversationForApi ->
+      val request = GameGenieCompanionRequest(
+        id = chat.id.takeIf { it.isNotBlank() },
+        title = chat.title.takeIf { it.isNotBlank() },
+        conversation = conversationForApi,
+        selectedGame = selectedGame,
+      )
+      gameGenieManager.streamCompanionMessage(token, request)
+    },
+    persist = { finalChat ->
+      gameGenieManager.saveOrUpdateChatCompanion(selectedGame, finalChat)
+    },
+  )
+
+  private fun streamInternal(
+    chat: GameGenieChatHistory,
+    userMessage: String,
+    imageBase64: String?,
+    openStream: suspend (Token, List<ChatInteractionHistory>) -> Flow<GenieSseEvent>,
+    persist: suspend (GameGenieChat) -> Unit,
+  ): Flow<GameGenieStreamUpdate> = flow {
     val imageForApi = encodeImageFileToBase64(imageBase64)
 
     val updatedConversation = chat.conversation.toMutableList().apply {
@@ -154,36 +215,100 @@ class GameGenieUseCase @Inject constructor(
       }
     }
 
-    return postCompanionMessage(
-      chat.id, chat.title, conversationForApi, selectedGame
-    ).fold(
-      onSuccess = { response ->
-        val convertedChat = response.toGameGenieChat(mapper)
-        val chatWithFilePaths = convertedChat.copy(
-          conversation = convertedChat.conversation.mapIndexed { index, interaction ->
-            val userImage = interaction.user?.image
-            val localInteraction = updatedConversation.getOrNull(index)
-            val localImagePath = localInteraction?.user?.image
+    val token = getToken()
 
-            if (localImagePath != null && interaction.user != null) {
-              interaction.copy(user = interaction.user.copy(image = localImagePath))
-            } else if (userImage != null && isBase64String(userImage)) {
-              if (index == convertedChat.conversation.lastIndex && imageBase64 != null) {
-                interaction.copy(user = interaction.user.copy(image = imageBase64))
-              } else {
-                interaction
-              }
-            } else {
-              interaction
-            }
+    val gptBuilder = StringBuilder()
+    var conversationId: String = chat.id
+    var done: GenieSseEvent.Done? = null
+    var failure: GenieSseEvent.Error? = null
+
+    var typedAppsResolved: List<App>? = null
+    var typedVideoReceived = false
+    var typedVideoId: String? = null
+    var typedFollowUps: List<String>? = null
+
+    openStream(token, conversationForApi).collect { event ->
+      when (event) {
+        is GenieSseEvent.Meta -> {
+          conversationId = event.id
+        }
+        is GenieSseEvent.Delta -> {
+          if (event.text.isNotEmpty()) {
+            gptBuilder.append(event.text)
+            emit(GameGenieStreamUpdate.TextChunk(event.text))
           }
-        )
-        gameGenieManager.saveOrUpdateChatCompanion(selectedGame, chatWithFilePaths)
-        chatWithFilePaths
-      },
-      onFailure = { throw it }
+        }
+        is GenieSseEvent.Apps -> {
+          val resolved = event.apps.mapNotNull { ref ->
+            runCatching { appRepository.getApp(ref.packageName).copy(hasMeta = true) }.getOrNull()
+          }
+          typedAppsResolved = resolved
+          emit(GameGenieStreamUpdate.AppsResolved(resolved))
+        }
+        is GenieSseEvent.Video -> {
+          typedVideoReceived = true
+          typedVideoId = event.videoId
+          emit(GameGenieStreamUpdate.Video(event.videoId))
+        }
+        is GenieSseEvent.FollowUps -> {
+          typedFollowUps = event.followUps
+          emit(GameGenieStreamUpdate.FollowUps(event.followUps))
+        }
+        is GenieSseEvent.Done -> {
+          done = event
+          conversationId = event.id
+        }
+        is GenieSseEvent.Error -> {
+          failure = event
+        }
+      }
+    }
+
+    failure?.let {
+      emit(GameGenieStreamUpdate.Failed(it.message))
+      return@flow
+    }
+
+    val finalDone = done ?: GenieSseEvent.Done(
+      id = conversationId,
+      title = null,
+      apps = emptyList(),
+      video = null,
     )
-  }
+
+    val resolvedApps = typedAppsResolved
+      ?: finalDone.apps.mapNotNull { ref ->
+        runCatching { appRepository.getApp(ref.packageName).copy(hasMeta = true) }.getOrNull()
+      }
+    val resolvedVideo = if (typedVideoReceived) typedVideoId else finalDone.video
+    val resolvedFollowUps = typedFollowUps ?: finalDone.followUps
+
+    val finalAssistantInteraction = ChatInteraction(
+      gpt = gptBuilder.toString(),
+      user = null,
+      videoId = resolvedVideo,
+      apps = resolvedApps,
+      followUps = resolvedFollowUps,
+    )
+
+    val persistedConversation = updatedConversation.map { history ->
+      ChatInteraction(
+        gpt = history.gpt,
+        user = history.user,
+        videoId = history.videoId,
+        apps = emptyList(),
+      )
+    } + finalAssistantInteraction
+
+    val finalChat = GameGenieChat(
+      id = finalDone.id,
+      title = finalDone.title ?: chat.title,
+      conversation = persistedConversation,
+    )
+
+    persist(finalChat)
+    emit(GameGenieStreamUpdate.Completed(finalChat))
+  }.flowOn(Dispatchers.IO)
 
   fun loadChat(id: String): Flow<GameGenieChat?> = flow {
     runCatching {
@@ -262,26 +387,6 @@ class GameGenieUseCase @Inject constructor(
           title,
           conversation,
           GameGenieMetadata(installedApps),
-        )
-      )
-    }
-  }
-
-  private suspend fun postCompanionMessage(
-    id: String,
-    title: String,
-    conversation: List<ChatInteractionHistory>,
-    selectedGame: String,
-  ): Result<GameGenieResponse> {
-    return runCatching {
-      val token = getToken()
-      gameGenieManager.postMessageCompanion(
-        token,
-        GameGenieCompanionRequest(
-          id,
-          title,
-          conversation,
-          selectedGame,
         )
       )
     }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieView.kt
@@ -349,7 +349,8 @@ fun ChatScreen(
         onSuggestionClick = onSuggestionSend,
         onFollowUpClick = onFollowUpSend,
         installedGames = if (hasUserMessages) emptyList() else installedGames,
-        onGameClick = onGameClick
+        onGameClick = onGameClick,
+        isStreaming = uiState.isStreaming,
       )
     }
     if (isLoading) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieViewModel.kt
@@ -14,6 +14,9 @@ import com.aptoide.android.aptoidegames.gamegenie.presentation.GameGenieUIStateT
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -148,25 +151,182 @@ class GameGenieViewModel @Inject constructor(
         val selectedGame = viewModelState.value.selectedGame
         updateConversation(userMessage, imagePathOrBase64)
         updateLoadingState()
-        val chat = selectedGame?.packageName?.let {
-          gameGenieUseCase.sendCompanionMessage(
-            chat = uiState.value.chat.toGameGenieChatHistory(),
-            userMessage = userMessage,
-            selectedGame = it,
-            imageBase64 = imagePathOrBase64
-          )
+        if (selectedGame != null) {
+          streamCompanionMessage(userMessage, imagePathOrBase64, selectedGame.packageName)
+        } else {
+          streamGeneralMessage(userMessage, imagePathOrBase64)
         }
-          ?: gameGenieUseCase.sendMessage(
-            chat = uiState.value.chat.toGameGenieChatHistory(),
-            userMessage = userMessage,
-            installedApps = _installedApps.value,
-            imageBase64 = imagePathOrBase64
-          )
-        updateSuccessState(chat)
       } catch (e: Throwable) {
         handleError(e)
       }
     }
+  }
+
+  private suspend fun streamGeneralMessage(
+    userMessage: String,
+    imagePathOrBase64: String?,
+  ) {
+    collectStream(
+      gameGenieUseCase.streamMessage(
+        chat = uiState.value.chat.toGameGenieChatHistory(),
+        userMessage = userMessage,
+        installedApps = _installedApps.value,
+        imageBase64 = imagePathOrBase64,
+      )
+    )
+  }
+
+  private suspend fun streamCompanionMessage(
+    userMessage: String,
+    imagePathOrBase64: String?,
+    selectedGamePackage: String,
+  ) {
+    collectStream(
+      gameGenieUseCase.streamCompanionMessage(
+        chat = uiState.value.chat.toGameGenieChatHistory(),
+        userMessage = userMessage,
+        selectedGame = selectedGamePackage,
+        imageBase64 = imagePathOrBase64,
+      )
+    )
+  }
+
+  private suspend fun collectStream(
+    stream: kotlinx.coroutines.flow.Flow<GameGenieStreamUpdate>,
+  ) = coroutineScope {
+    var assistantStarted = false
+    val pendingText = StringBuilder()
+
+    fun ensureBubble() {
+      if (!assistantStarted) {
+        assistantStarted = true
+        startStreamingAssistantBubble()
+      }
+    }
+    fun flushPending(maxChars: Int? = null) {
+      if (pendingText.isEmpty()) return
+      val take = (maxChars ?: pendingText.length).coerceAtMost(pendingText.length)
+      val chunk = pendingText.substring(0, take)
+      pendingText.delete(0, take)
+      appendStreamedText(chunk)
+    }
+
+    val flusher = launch {
+      while (isActive) {
+        delay(STREAM_FLUSH_INTERVAL_MS)
+        flushPending(STREAM_FLUSH_CHARS_PER_TICK)
+      }
+    }
+
+    suspend fun drainPending() {
+      while (pendingText.isNotEmpty()) {
+        delay(STREAM_FLUSH_INTERVAL_MS)
+        flushPending(STREAM_FLUSH_CHARS_PER_TICK)
+      }
+    }
+
+    try {
+      stream.collect { update ->
+        when (update) {
+          is GameGenieStreamUpdate.TextChunk -> {
+            ensureBubble()
+            pendingText.append(update.delta)
+          }
+          is GameGenieStreamUpdate.AppsResolved -> {
+            ensureBubble()
+            flushPending()
+            updateStreamingAssistant { it.copy(apps = update.apps) }
+          }
+          is GameGenieStreamUpdate.Video -> {
+            ensureBubble()
+            flushPending()
+            updateStreamingAssistant { it.copy(videoId = update.videoId) }
+          }
+          is GameGenieStreamUpdate.FollowUps -> {
+            ensureBubble()
+            flushPending()
+            updateStreamingAssistant { it.copy(followUps = update.followUps) }
+          }
+          is GameGenieStreamUpdate.Completed -> {
+            drainPending()
+            finalizeStream(update.chat, assistantStarted)
+          }
+          is GameGenieStreamUpdate.Failed -> {
+            flushPending()
+            Timber.w("Genie SSE failed: %s", update.message)
+            viewModelState.update {
+              it.copy(type = GameGenieUIStateType.ERROR, isStreaming = false)
+            }
+          }
+        }
+      }
+    } finally {
+      flusher.cancel()
+      flushPending()
+    }
+  }
+
+  private fun updateStreamingAssistant(transform: (ChatInteraction) -> ChatInteraction) {
+    val current = _conversation.value
+    if (current.isEmpty()) return
+    val updatedLast = transform(current.last())
+    val updated = current.dropLast(1) + updatedLast
+    _conversation.value = updated
+    viewModelState.update {
+      it.copy(
+        chat = it.chat.copy(conversation = updated),
+        apps = updatedLast.apps.map { app -> app.packageName },
+      )
+    }
+  }
+
+  private fun startStreamingAssistantBubble() {
+    val updated = _conversation.value + ChatInteraction(
+      gpt = "",
+      user = null,
+      videoId = null,
+      apps = emptyList(),
+    )
+    _conversation.value = updated
+    viewModelState.update {
+      it.copy(
+        type = GameGenieUIStateType.IDLE,
+        chat = it.chat.copy(conversation = updated),
+        isStreaming = true,
+      )
+    }
+  }
+
+  private fun finalizeStream(response: GameGenieChat, assistantStarted: Boolean) {
+    val finalAssistant = response.conversation.lastOrNull()
+    val current = _conversation.value
+    val finalConversation = when {
+      finalAssistant == null -> current
+      assistantStarted && current.isNotEmpty() -> current.dropLast(1) + finalAssistant
+      else -> current + finalAssistant
+    }
+    _conversation.value = finalConversation
+    viewModelState.update {
+      it.copy(
+        type = GameGenieUIStateType.IDLE,
+        chat = it.chat.copy(
+          id = response.id,
+          title = response.title,
+          conversation = finalConversation,
+        ),
+        apps = finalAssistant?.apps?.map { app -> app.packageName }.orEmpty(),
+        isStreaming = false,
+      )
+    }
+  }
+
+  private fun appendStreamedText(delta: String) {
+    val current = _conversation.value
+    if (current.isEmpty()) return
+    val updatedLast = current.last().copy(gpt = current.last().gpt + delta)
+    val updated = current.dropLast(1) + updatedLast
+    _conversation.value = updated
+    viewModelState.update { it.copy(chat = it.chat.copy(conversation = updated)) }
   }
 
   private fun updateConversation(
@@ -319,7 +479,7 @@ class GameGenieViewModel @Inject constructor(
   private fun handleError(e: Throwable) {
     Timber.w(e)
     viewModelState.update {
-      it.copy(type = mapErrorToState(e))
+      it.copy(type = mapErrorToState(e), isStreaming = false)
     }
   }
 
@@ -330,6 +490,9 @@ class GameGenieViewModel @Inject constructor(
     }
   }
 }
+
+private const val STREAM_FLUSH_INTERVAL_MS = 32L
+private const val STREAM_FLUSH_CHARS_PER_TICK = 2
 
 private data class GameGenieViewModelState(
   val type: GameGenieUIStateType = GameGenieUIStateType.IDLE,
@@ -349,6 +512,7 @@ private data class GameGenieViewModelState(
   val token: Token? = null,
   val selectedGame: GameCompanion? = null,
   val suggestions: List<Suggestion> = emptyList(),
+  val isStreaming: Boolean = false,
 ) {
   fun empty(
     token: Token? = null,
@@ -381,5 +545,6 @@ private data class GameGenieViewModelState(
       token = token,
       selectedGame = selectedGame,
       suggestions = suggestions,
+      isStreaming = isStreaming,
     )
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/FollowUpBox.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/FollowUpBox.kt
@@ -26,7 +26,7 @@ fun FollowUpBox(
   onClick: (String) -> Unit,
 ) {
   val density = LocalDensity.current
-  val textStyle = AGTypography.InputsXSRegular
+  val textStyle = AGTypography.InputsXXS
 
   val horizontalPaddingPx = with(density) { 16.dp.roundToPx() }
 
@@ -40,7 +40,7 @@ fun FollowUpBox(
 
   Row(
     modifier = Modifier
-      .height(48.dp)
+      .height(40.dp)
       .width(boxWidthDp)
       .background(Palette.Primary.copy(alpha = 0.1f))
       .border(0.5.dp, Palette.Primary)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/MessageBubble.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/MessageBubble.kt
@@ -54,6 +54,7 @@ fun MessageBubble(
   isCompanion: Boolean = false,
   gameName: String = "",
   image: String? = null,
+  isStreaming: Boolean = false,
 ) {
   val context = LocalContext.current
   val analytics = rememberGameGenieAnalytics()
@@ -149,7 +150,8 @@ fun MessageBubble(
                 onLinkClick = { url ->
                   UrlActivity.open(context, url)
                 },
-                isUserMessage = true
+                isUserMessage = true,
+                isStreaming = isStreaming,
               )
             }
 
@@ -208,7 +210,8 @@ fun MessageBubble(
               onLinkClick = { url ->
                 UrlActivity.open(context, url)
               },
-              isUserMessage = isUserMessage
+              isUserMessage = isUserMessage,
+              isStreaming = isStreaming,
             )
           }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/MessageList.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/MessageList.kt
@@ -3,7 +3,11 @@ package com.aptoide.android.aptoidegames.gamegenie.presentation.composables
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -27,8 +31,10 @@ import com.aptoide.android.aptoidegames.gamegenie.domain.ChatInteraction
 import com.aptoide.android.aptoidegames.gamegenie.domain.GameCompanion
 import com.aptoide.android.aptoidegames.gamegenie.domain.Suggestion
 import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views.YouTubePlayerView
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 
 @Composable
 fun MessageList(
@@ -43,7 +49,8 @@ fun MessageList(
   isCompanion: Boolean = false,
   gameName: String = "",
   installedGames: List<GameCompanion> = emptyList(),
-  onGameClick: (GameCompanion) -> Unit = {}
+  onGameClick: (GameCompanion) -> Unit = {},
+  isStreaming: Boolean = false,
 ) {
   val listState = rememberLazyListState()
   val playerCache = remember { mutableMapOf<String, YouTubePlayerView>() }
@@ -53,6 +60,9 @@ fun MessageList(
   val prevViewportHeight = remember { mutableIntStateOf(0) }
 
   val lastUserText = messages.lastOrNull()?.user?.text
+
+  val userTookControl = remember { mutableStateOf(false) }
+  LaunchedEffect(lastUserText) { userTookControl.value = false }
 
   LaunchedEffect(listState) {
     snapshotFlow { listState.layoutInfo.viewportSize.height }
@@ -96,10 +106,50 @@ fun MessageList(
     prevLastUserText.value = currentLastUserText
   }
 
+  val streamingGptLength = if (isStreaming) messages.lastOrNull()?.gpt?.length ?: 0 else 0
+  LaunchedEffect(isStreaming, streamingGptLength) {
+    if (isStreaming && messages.isNotEmpty() && !userTookControl.value) {
+      listState.scrollToItem(messages.lastIndex, Int.MAX_VALUE)
+    }
+  }
+
+  val lastAppsCount = messages.lastOrNull()?.apps?.size ?: 0
+  val lastVideoId = messages.lastOrNull()?.videoId
+  val lastFollowUpsCount = messages.lastOrNull()?.followUps?.size ?: 0
+  LaunchedEffect(isStreaming, lastAppsCount, lastVideoId, lastFollowUpsCount, messages.size) {
+    if (isStreaming || messages.isEmpty()) return@LaunchedEffect
+    if (lastAppsCount == 0 && lastVideoId == null && lastFollowUpsCount == 0) return@LaunchedEffect
+    if (userTookControl.value) return@LaunchedEffect
+
+    listState.scrollToItem(messages.lastIndex, Int.MAX_VALUE)
+
+    var settleBudget = 1_000L
+    snapshotFlow {
+      listState.layoutInfo.visibleItemsInfo.sumOf { it.size } to
+        listState.layoutInfo.totalItemsCount
+    }
+      .distinctUntilChanged()
+      .drop(1)
+      .collectLatest {
+        if (settleBudget <= 0L) return@collectLatest
+        if (!userTookControl.value) {
+          listState.scrollToItem(messages.lastIndex, Int.MAX_VALUE)
+        }
+        delay(50)
+        settleBudget -= 50
+      }
+  }
+
   LazyColumn(
     state = listState,
     modifier = modifier
-      .padding(bottom = 8.dp),
+      .padding(bottom = 8.dp)
+      .pointerInput(Unit) {
+        awaitEachGesture {
+          awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+          userTookControl.value = true
+        }
+      },
     contentPadding = PaddingValues(vertical = 8.dp)
   ) {
     itemsIndexed(
@@ -155,13 +205,15 @@ fun MessageList(
           navigateTo = navigateTo,
           playerCache = playerCache,
           gameName = gameName,
+          isStreaming = isStreaming && idx == messages.lastIndex,
         )
       }
 
       if (
         idx == messages.lastIndex &&
         message.user == null &&
-        message.followUps.isNotEmpty()
+        message.followUps.isNotEmpty() &&
+        !isStreaming
       ) {
         LazyRow(
           contentPadding = PaddingValues(top = 16.dp, bottom = 4.dp),
@@ -204,3 +256,4 @@ private suspend fun scrollLastGptToTopWithMargin(
 ) {
   listState.animateScrollToItem(lastIndex, 0)
 }
+

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/ParseStylizedText.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/ParseStylizedText.kt
@@ -1,5 +1,38 @@
 package com.aptoide.android.aptoidegames.gamegenie.presentation.composables
 
+internal fun stripPartialTrailingMarkdown(input: String): String {
+  var s = input
+
+  run {
+    val lastOpen = s.lastIndexOf('[')
+    val lastClose = s.lastIndexOf(']')
+    if (lastOpen > lastClose) s = s.substring(0, lastOpen)
+  }
+
+  run {
+    val openParenAfterClose = Regex("""]\(""").findAll(s).lastOrNull()?.range?.first
+    if (openParenAfterClose != null) {
+      val tail = s.substring(openParenAfterClose + 2)
+      if (!tail.contains(')')) {
+        val matchingBracket = s.lastIndexOf('[', openParenAfterClose)
+        s = s.substring(0, if (matchingBracket >= 0) matchingBracket else openParenAfterClose)
+      }
+    }
+  }
+
+  if (s.endsWith("*") && !s.endsWith("**")) {
+    s = s.dropLast(1)
+  }
+
+  val boldCount = Regex("\\*\\*").findAll(s).count()
+  if (boldCount % 2 == 1) {
+    val lastOpener = s.lastIndexOf("**")
+    if (lastOpener >= 0) s = s.substring(0, lastOpener)
+  }
+
+  return s
+}
+
 fun parseStylizedText(input: String): List<TextSegment> {
   val segments = mutableListOf<TextSegment>()
   val boldRegex = Regex("\\*\\*(.*?)\\*\\*")

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/StylizedMessage.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/composables/StylizedMessage.kt
@@ -1,12 +1,18 @@
 package com.aptoide.android.aptoidegames.gamegenie.presentation.composables
 
 import androidx.annotation.StringRes
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -19,22 +25,43 @@ import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.Palette
 
+private const val STREAM_FADE_DURATION_MS = 220
+
+private data class InlineSegment(
+  val text: String,
+  val style: SpanStyle?,
+  val globalStart: Int,
+)
+
 @Composable
 private fun InlineText(
-  segments: List<Pair<String, SpanStyle?>>,
+  segments: List<InlineSegment>,
   textColor: Color,
+  fadeStartOffset: Int,
+  fadeAlpha: Float,
 ) {
-  if (segments.isNotEmpty()) {
-    val annotated = buildAnnotatedString {
-      segments.forEach { (text, style) ->
-        if (style != null) withStyle(style) { append(text) } else append(text)
+  if (segments.isEmpty()) return
+  val annotated = buildAnnotatedString {
+    segments.forEach { seg ->
+      val localStart = length
+      if (seg.style != null) withStyle(seg.style) { append(seg.text) } else append(seg.text)
+      val localEnd = length
+      val segGlobalEnd = seg.globalStart + seg.text.length
+      if (fadeAlpha < 1f && segGlobalEnd > fadeStartOffset) {
+        val fadeFromGlobal = maxOf(seg.globalStart, fadeStartOffset)
+        val localFadeStart = localStart + (fadeFromGlobal - seg.globalStart)
+        addStyle(
+          SpanStyle(color = textColor.copy(alpha = fadeAlpha)),
+          localFadeStart,
+          localEnd
+        )
       }
     }
-    Text(
-      text = annotated,
-      style = AGTypography.Chat.copy(color = textColor)
-    )
   }
+  Text(
+    text = annotated,
+    style = AGTypography.Chat.copy(color = textColor)
+  )
 }
 
 @Composable
@@ -43,11 +70,46 @@ fun StylizedMessage(
   @StringRes fallbackResId: Int,
   onLinkClick: (String) -> Unit,
   isUserMessage: Boolean,
+  isStreaming: Boolean = false,
 ) {
-  val textToRender = message?.replace("\"", "") ?: stringResource(fallbackResId)
+  val rawText = message?.replace("\"", "") ?: stringResource(fallbackResId)
+  val textToRender = if (isStreaming) stripPartialTrailingMarkdown(rawText) else rawText
   val paragraphs = remember(textToRender) { textToRender.split("\n\n") }
   val parsedParagraphs = remember(paragraphs) {
     paragraphs.map { paragraphText -> parseStylizedText(paragraphText) }
+  }
+
+  val totalVisibleLength = remember(parsedParagraphs) {
+    parsedParagraphs.sumOf { segs ->
+      segs.sumOf { seg ->
+        when (seg) {
+          is TextSegment.Plain -> seg.text.length
+          is TextSegment.Bold -> seg.text.length
+          is TextSegment.Link -> 0
+        }
+      }
+    }
+  }
+
+  var stableLength by remember {
+    mutableIntStateOf(if (isStreaming) 0 else Int.MAX_VALUE)
+  }
+  val tailAlpha = remember { Animatable(if (isStreaming) 0f else 1f) }
+
+  LaunchedEffect(isStreaming) {
+    if (!isStreaming) {
+      stableLength = Int.MAX_VALUE
+      tailAlpha.snapTo(1f)
+    }
+  }
+
+  LaunchedEffect(totalVisibleLength, isStreaming) {
+    if (!isStreaming) return@LaunchedEffect
+    if (totalVisibleLength > stableLength) {
+      tailAlpha.animateTo(1f, tween(durationMillis = STREAM_FADE_DURATION_MS))
+      stableLength = totalVisibleLength
+      tailAlpha.snapTo(0f)
+    }
   }
 
   val textColor = if (isUserMessage && BuildConfig.FLAVOR_brand != "vanilla") {
@@ -55,20 +117,34 @@ fun StylizedMessage(
   } else {
     Palette.White
   }
+  val fadeStartOffset = stableLength
+  val fadeAlpha = tailAlpha.value
 
   Column {
+    var visibleOffset = 0
     parsedParagraphs.forEachIndexed { pIndex, segments ->
-      val inlineSegments = mutableListOf<Pair<String, SpanStyle?>>()
+      val inlineSegments = mutableListOf<InlineSegment>()
 
       segments.forEach { segment ->
         when (segment) {
-          is TextSegment.Plain -> inlineSegments.add(segment.text to null)
-          is TextSegment.Bold -> inlineSegments.add(
-            segment.text to SpanStyle(fontWeight = FontWeight.Bold)
-          )
+          is TextSegment.Plain -> {
+            inlineSegments.add(InlineSegment(segment.text, null, visibleOffset))
+            visibleOffset += segment.text.length
+          }
+
+          is TextSegment.Bold -> {
+            inlineSegments.add(
+              InlineSegment(
+                segment.text,
+                SpanStyle(fontWeight = FontWeight.Bold),
+                visibleOffset
+              )
+            )
+            visibleOffset += segment.text.length
+          }
 
           is TextSegment.Link -> {
-            InlineText(inlineSegments, textColor)
+            InlineText(inlineSegments, textColor, fadeStartOffset, fadeAlpha)
             inlineSegments.clear()
             Spacer(modifier = Modifier.height(4.dp))
             LinkChip(
@@ -81,7 +157,7 @@ fun StylizedMessage(
         }
       }
 
-      InlineText(inlineSegments, textColor)
+      InlineText(inlineSegments, textColor, fadeStartOffset, fadeAlpha)
 
       if (pIndex < parsedParagraphs.lastIndex) {
         Spacer(Modifier.height(8.dp))


### PR DESCRIPTION
**What does this PR do?**

This PR aims to implement streaming responses on the client to be used with local LLM backend

**Database changed?**

No

**Where should the reviewer start?**

See by commit

**How should this be manually tested?**

Test sending messages on GameGenie chat, backend is only deployed in dev

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-859](https://aptoide.atlassian.net/browse/AND-859)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-859]: https://aptoide.atlassian.net/browse/AND-859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat responses now stream in real time, showing text, suggestions, apps, and video details as they arrive.
  * Added visual streaming indicators and smoother auto-scrolling while new content is being generated.

* **Bug Fixes**
  * Improved handling of interrupted or partial text so messages render more cleanly during streaming.
  * Companion chats now continue working through the new streaming flow with better recovery after authentication refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->