### PR TITLE
[AND-860] Fix redeem reward screen UI

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/unit_exchange_flow/RedeemRewardScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/unit_exchange_flow/RedeemRewardScreen.kt
@@ -144,11 +144,7 @@ private fun RedeemRewardContent(
   val unitsToGo = (targetUnits - availableUnits).coerceAtLeast(0L)
   val formattedRedeem = "$${redeemAmount.setScale(2, RoundingMode.HALF_UP).toPlainString()}"
 
-  Column(
-    modifier = Modifier
-      .fillMaxSize()
-      .verticalScroll(rememberScrollState())
-  ) {
+  Column(modifier = Modifier.fillMaxSize()) {
     Spacer(modifier = Modifier.height(24.dp))
 
     Text(
@@ -162,35 +158,42 @@ private fun RedeemRewardContent(
 
     UnitsHexagonHero(units = availableUnits, isComplete = hasEnough)
 
-    Spacer(modifier = Modifier.height(24.dp))
-
-    RedeemOfferCard(
-      rewardType = rewardType,
-      formattedRedeem = formattedRedeem,
-      costUnits = targetUnits,
-      balanceAfter = (availableUnits - targetUnits).coerceAtLeast(0L),
-      unitsToGo = unitsToGo,
-      hasEnough = hasEnough,
+    Column(
       modifier = Modifier
         .fillMaxWidth()
-        .padding(horizontal = 24.dp),
-    )
+        .weight(1f)
+        .verticalScroll(rememberScrollState())
+    ) {
+      Spacer(modifier = Modifier.height(24.dp))
 
-    Spacer(modifier = Modifier.weight(1f))
+      RedeemOfferCard(
+        rewardType = rewardType,
+        formattedRedeem = formattedRedeem,
+        costUnits = targetUnits,
+        balanceAfter = (availableUnits - targetUnits).coerceAtLeast(0L),
+        unitsToGo = unitsToGo,
+        hasEnough = hasEnough,
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(horizontal = 24.dp),
+      )
 
-    AccentButton(
-      modifier = Modifier
-        .fillMaxWidth()
-        .padding(horizontal = 24.dp)
-        .padding(bottom = 24.dp),
-      title = if (hasEnough) {
-        stringResource(R.string.play_and_earn_exchange_redeem_button, formattedRedeem)
-      } else {
-        stringResource(R.string.play_and_earn_earn_more_button)
-      },
-      enabled = true,
-      onClick = { if (hasEnough) onRedeem(formattedRedeem) else onEarnMore() },
-    )
+      Spacer(modifier = Modifier.weight(1f))
+
+      AccentButton(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(horizontal = 24.dp)
+          .padding(bottom = 24.dp),
+        title = if (hasEnough) {
+          stringResource(R.string.play_and_earn_exchange_redeem_button, formattedRedeem)
+        } else {
+          stringResource(R.string.play_and_earn_earn_more_button)
+        },
+        enabled = true,
+        onClick = { if (hasEnough) onRedeem(formattedRedeem) else onEarnMore() },
+      )
+    }
   }
 }
 
@@ -248,7 +251,7 @@ private fun RedeemOfferCard(
 ) {
   Column(
     modifier = modifier
-      .background(FixedColors.PaeExchangePurple)
+      .background(FixedColors.PaeExchangePurple.copy(alpha = 0.5f))
       .padding(16.dp),
     verticalArrangement = Arrangement.spacedBy(12.dp),
   ) {
@@ -292,7 +295,7 @@ private fun RedeemOfferCard(
         Text(
           text = stringResource(R.string.play_and_earn_exchange_units_value, balanceAfter),
           style = AGTypography.InputsL,
-          color = Palette.Primary,
+          color = Palette.Yellow100,
         )
       }
     } else {
@@ -310,6 +313,7 @@ private fun RedeemOfferCard(
           text = stringResource(R.string.play_and_earn_exchange_units_to_go, unitsToGo),
           style = AGTypography.InputsL,
           color = Palette.Yellow100,
+          textAlign = TextAlign.Center
         )
       }
     }


### PR DESCRIPTION
**What does this PR do?**

   - Fixes UI issues in the Redeem Reward screen.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-860](https://aptoide.atlassian.net/browse/AND-860)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-860](https://aptoide.atlassian.net/browse/AND-860)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-860]: https://aptoide.atlassian.net/browse/AND-860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-860]: https://aptoide.atlassian.net/browse/AND-860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the redeem reward screen layout for smoother scrolling and better use of vertical space.
  * Adjusted spacing and positioning for the reward card and action button.
  * Refined the reward card styling with a more transparent background.
  * Improved text styling for balance and “not enough balance” messaging, including centered alignment for clearer readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->