### PR TITLE
[AND-842] Fix missing app view pending mission monetary value

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/PaEClientConfigManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/PaEClientConfigManager.kt
@@ -23,11 +23,6 @@ class PaEClientConfigManager @Inject constructor(
   suspend fun fetchAndSaveClientConfig() {
     withContext(Dispatchers.IO) {
       try {
-        if (!playAndEarnManager.isSignedIn()) {
-          Timber.d("PaEClientConfigManager: User not signed in, skipping config fetch")
-          return@withContext
-        }
-
         if (!playAndEarnManager.shouldShowPlayAndEarn()) {
           Timber.d("PaEClientConfigManager: Play & Earn not available, skipping config fetch")
           return@withContext

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/app_view/AppRewardsView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/app_view/AppRewardsView.kt
@@ -273,11 +273,9 @@ private fun PendingMissionItem(mission: PaEMission) {
         )
       }
 
-      Text(
+      MissionReward(
         modifier = Modifier.padding(end = 8.dp),
-        text = "+ ${mission.units} UNITS",
-        style = AGTypography.InputsXS,
-        color = Palette.SecondaryLight
+        units = mission.units
       )
     }
   }
@@ -350,8 +348,14 @@ private fun OngoingMissionItem(mission: PaEMission) {
 }
 
 @Composable
-private fun MissionReward(units: Int) {
-  Column(horizontalAlignment = Alignment.End) {
+private fun MissionReward(
+  modifier: Modifier = Modifier,
+  units: Int
+) {
+  Column(
+    modifier = modifier,
+    horizontalAlignment = Alignment.End
+  ) {
     Text(
       text = "+ $units UNITS",
       style = AGTypography.InputsS,


### PR DESCRIPTION
**What does this PR do?**

   - Adds the monetary value to the pending missions in PaE app view rewards section.
   - Also removes the sign in precondition from the PaE client config fetch, in order to update the redeem units amount without having to sign in.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: [AND-842](https://aptoide.atlassian.net/browse/AND-842)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-842](https://aptoide.atlassian.net/browse/AND-842)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-842]: https://aptoide.atlassian.net/browse/AND-842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-842]: https://aptoide.atlassian.net/browse/AND-842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Play and Earn syncing so client configuration can refresh more consistently, even after sign-out, helping keep rewards data up to date.
* **UI Improvements**
  * Updated mission reward display to use a consistent layout for points and exchange-rate value, improving readability in pending missions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->