### PR TITLE
[AND-862] Omit store_name from Vanilla V10 search requests

### DIFF
--- a/app-games/src/aptoideGames/java/com/aptoide/android/aptoidegames/search/repository/SearchStoreConfig.kt
+++ b/app-games/src/aptoideGames/java/com/aptoide/android/aptoidegames/search/repository/SearchStoreConfig.kt
@@ -1,0 +1,4 @@
+package com.aptoide.android.aptoidegames.search.repository
+
+// Aptoide Games restricts search to its own store.
+internal const val SEARCH_ADD_STORE = true

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/search/repository/AppGamesSearchStoreManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/search/repository/AppGamesSearchStoreManager.kt
@@ -6,7 +6,7 @@ import cm.aptoide.pt.feature_search.domain.repository.SearchStoreManager
 class AppGamesSearchStoreManager : SearchStoreManager {
 
   override fun shouldAddStore(): Boolean {
-    return true
+    return SEARCH_ADD_STORE
   }
 
   override fun getStore(): String {

--- a/app-games/src/vanilla/java/com/aptoide/android/aptoidegames/search/repository/SearchStoreConfig.kt
+++ b/app-games/src/vanilla/java/com/aptoide/android/aptoidegames/search/repository/SearchStoreConfig.kt
@@ -1,0 +1,4 @@
+package com.aptoide.android.aptoidegames.search.repository
+
+// Vanilla V10 searches the whole index (no store filter), matching v9 behaviour.
+internal const val SEARCH_ADD_STORE = false

--- a/feature_search/src/main/java/cm/aptoide/pt/feature_search/data/network/service/SearchRetrofitService.kt
+++ b/feature_search/src/main/java/cm/aptoide/pt/feature_search/data/network/service/SearchRetrofitService.kt
@@ -35,7 +35,9 @@ class SearchRetrofitService @Inject constructor(
   }
 
   override suspend fun getTopSearchedApps(): Response<BaseV7DataListResponse<AppJSON>> {
-    return searchAppRetrofitService.getPopularSearch(searchStoreManager.getStore())
+    return searchAppRetrofitService.getPopularSearch(
+      if (searchStoreManager.shouldAddStore()) searchStoreManager.getStore() else null
+    )
   }
 
   interface SearchAppRetrofitService {


### PR DESCRIPTION
## What
Vanilla V10 (`:app-games` brand=`vanilla`) search and popular-search requests no longer send the `store_name` parameter, so they query the full index like Aptoide v9 did. Aptoide Games is unchanged and still restricts search to its own store.

Implemented via a per-source-set `SEARCH_ADD_STORE` constant (`false` for `vanilla`, `true` for `aptoideGames`) wired into `AppGamesSearchStoreManager.shouldAddStore()`, following the repo's source-set convention rather than a `FLAVOR_brand` branch. `getTopSearchedApps()` now honors the same flag.

## Why
Searching for apps like Aptoide Wallet returned results in Vanilla v9 but not in v10. The v10 request was carrying a `store_name`, scoping results to a single store and hiding valid apps.

Note: `getTopSearchedApps()` lives in shared `feature_search`, so the legacy `:app` Vanilla (already `shouldAddStore()=false`) will now also omit the store on popular-search — consistent with the fix and easily revertible.

## How to test
1. Build + install `:app-games` `vanilla` dev debug, search "aptoide wallet" → app now appears; confirm no `store_name` on the `listSearchApps` request.
2. Build + install `:app-games` `aptoideGames` dev debug, run a search → results still scoped to the games store (`store_name` still present). No regression.

Jira: AND-862


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search behavior now adapts by app version, keeping Aptoide Games searches limited to its own store while preserving the previous Vanilla search experience.

* **Bug Fixes**
  * Improved top-searched app results so store filtering is only applied when needed, helping search return the expected content in each app variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->