### PR TITLE
[AND-864] Add new P&E analytics events

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/MainActivity.kt
@@ -33,7 +33,6 @@ import com.aptoide.android.aptoidegames.notifications.analytics.FirebaseNotifica
 import com.aptoide.android.aptoidegames.notifications.analytics.NotificationsAnalytics
 import com.aptoide.android.aptoidegames.notifications.toFirebaseNotificationAnalyticsInfo
 import com.aptoide.android.aptoidegames.play_and_earn.PaEClientConfigManager
-import com.aptoide.android.aptoidegames.play_and_earn.PlayAndEarnManager
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.service.PaEForegroundService
 import com.aptoide.android.aptoidegames.promo_codes.PromoCode
 import com.aptoide.android.aptoidegames.promo_codes.PromoCodeRepository
@@ -83,9 +82,6 @@ class MainActivity : AppCompatActivity() {
   @Inject
   lateinit var paEClientConfigManager: PaEClientConfigManager
 
-  @Inject
-  lateinit var playAndEarnManager: PlayAndEarnManager
-
   private var navController: NavHostController? = null
 
   private val coroutinesScope: CoroutineScope = CoroutineScope(Job() + Dispatchers.IO)
@@ -118,16 +114,6 @@ class MainActivity : AppCompatActivity() {
 
       LaunchedEffect(key1 = navController) {
         handleNotificationIntent(intent = intent)
-      }
-    }
-
-    startPaEServiceIfEnabled()
-  }
-
-  private fun startPaEServiceIfEnabled() {
-    coroutinesScope.launch {
-      if (playAndEarnManager.shouldStartPaEService()) {
-        PaEForegroundService.start(this@MainActivity)
       }
     }
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/analytics/PaEAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/analytics/PaEAnalytics.kt
@@ -101,6 +101,20 @@ class PaEAnalytics @Inject constructor(
     )
   }
 
+  fun sendPaEUsageAccessPermissionGranted() {
+    genericAnalytics.logEvent(
+      name = "pae_perms_usageaccess_granted",
+      params = null
+    )
+  }
+
+  fun sendPaEOverlayPermissionGranted() {
+    genericAnalytics.logEvent(
+      name = "pae_perms_overlay_granted",
+      params = null
+    )
+  }
+
   fun sendPaEExchangeNowClick() {
     genericAnalytics.logEvent(
       name = "pae_exchangenow_click",
@@ -197,6 +211,29 @@ class PaEAnalytics @Inject constructor(
 
   fun sendPaEExchangeSuccessEarnMoreClick() {
     genericAnalytics.logEvent(name = "pae_exchangesuccess_click_earnmore", params = null)
+  }
+
+  fun sendPaEBalanceScreenShown() {
+    genericAnalytics.logEvent(
+      name = "pae_balance_screen_shown",
+      params = null
+    )
+  }
+
+  // --- Play session lifecycle ---
+
+  fun sendPaESessionStart(packageName: String) {
+    genericAnalytics.logEvent(
+      name = "pae_session_start",
+      params = mapOfNonNull(P_PACKAGE_NAME to packageName)
+    )
+  }
+
+  fun sendPaEMissionCompleted(packageName: String) {
+    genericAnalytics.logEvent(
+      name = "pae_mission_completed",
+      params = mapOfNonNull(P_PACKAGE_NAME to packageName)
+    )
   }
 
   companion object {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/permissions/OverlayPermissionActivity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/permissions/OverlayPermissionActivity.kt
@@ -8,20 +8,29 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
+import com.aptoide.android.aptoidegames.play_and_earn.presentation.analytics.PaEAnalytics
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class OverlayPermissionActivity : AppCompatActivity() {
+
+  @Inject
+  lateinit var paEAnalytics: PaEAnalytics
 
   private lateinit var appOps: AppOpsManager
 
   private var permissionCheckJob: Job? = null
   private val checkInterval = 600L
+  private var grantedReported = false
 
   val overlayPermissionLauncher =
     registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+      reportGrantedIfNeeded()
       bringAppToForeground()
     }
 
@@ -50,6 +59,7 @@ class OverlayPermissionActivity : AppCompatActivity() {
     permissionCheckJob = lifecycleScope.launch(Dispatchers.Main.immediate) {
       while (true) {
         if (hasOverlayPermission()) {
+          reportGrantedIfNeeded()
           if (hasUsageStatsPermissionStatus(appOps)) {
             bringAppToForeground()
             break
@@ -60,6 +70,13 @@ class OverlayPermissionActivity : AppCompatActivity() {
         }
         delay(checkInterval)
       }
+    }
+  }
+
+  private fun reportGrantedIfNeeded() {
+    if (!grantedReported && hasOverlayPermission()) {
+      grantedReported = true
+      paEAnalytics.sendPaEOverlayPermissionGranted()
     }
   }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/permissions/UsageStatsPermissionActivity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/permissions/UsageStatsPermissionActivity.kt
@@ -8,20 +8,29 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
+import com.aptoide.android.aptoidegames.play_and_earn.presentation.analytics.PaEAnalytics
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class UsageStatsPermissionActivity : AppCompatActivity() {
+
+  @Inject
+  lateinit var paEAnalytics: PaEAnalytics
 
   private lateinit var appOps: AppOpsManager
 
   private var permissionCheckJob: Job? = null
   private val checkInterval = 600L
+  private var grantedReported = false
 
   val overlayPermissionLauncher =
     registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+      reportGrantedIfNeeded()
       bringAppToForeground()
     }
 
@@ -44,12 +53,20 @@ class UsageStatsPermissionActivity : AppCompatActivity() {
     permissionCheckJob = lifecycleScope.launch(Dispatchers.Main.immediate) {
       while (true) {
         if (hasUsageStatsPermissionStatus(appOps)) {
+          reportGrantedIfNeeded()
           bringAppToForeground()
           break
         }
 
         delay(checkInterval)
       }
+    }
+  }
+
+  private fun reportGrantedIfNeeded() {
+    if (!grantedReported && hasUsageStatsPermissionStatus(appOps)) {
+      grantedReported = true
+      paEAnalytics.sendPaEUsageAccessPermissionGranted()
     }
   }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEForegroundService.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEForegroundService.kt
@@ -66,7 +66,7 @@ class PaEForegroundService : LifecycleService(), SavedStateRegistryOwner {
   private var pollingJob: Job? = null
   private var completedMissionsJob: Job? = null
   private var idleTimeoutJob: Job? = null
-  private val idleTimeoutMillis = 30 * 60 * 1000L // 30 minutes
+  private val idleTimeoutMillis = 5 * 60 * 1000L // 30 minutes
   private var isMonitoringStarted = false
 
   private var lastForegroundPackage: String? = null

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEServicePreferencesViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/service/PaEServicePreferencesViewModel.kt
@@ -3,7 +3,6 @@ package com.aptoide.android.aptoidegames.play_and_earn.presentation.service
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.aptoide.android.aptoidegames.play_and_earn.PlayAndEarnManager
 import com.aptoide.android.aptoidegames.play_and_earn.data.PaEPreferencesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -19,7 +18,6 @@ import javax.inject.Inject
 class PaEServicePreferencesViewModel @Inject constructor(
   @ApplicationContext private val context: Context,
   private val paEPreferencesRepository: PaEPreferencesRepository,
-  private val playAndEarnManager: PlayAndEarnManager,
 ) : ViewModel() {
 
   private val viewModelState = MutableStateFlow(true)
@@ -44,11 +42,7 @@ class PaEServicePreferencesViewModel @Inject constructor(
   fun setPaEServiceEnabled(enabled: Boolean) {
     viewModelScope.launch {
       paEPreferencesRepository.setPaEServiceEnabled(enabled)
-      if (enabled) {
-        if (playAndEarnManager.shouldShowPlayAndEarn()) {
-          PaEForegroundService.start(context)
-        }
-      } else {
+      if (!enabled) {
         PaEForegroundService.stop(context)
       }
     }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/sessions/PaESessionManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/sessions/PaESessionManager.kt
@@ -7,6 +7,7 @@ import cm.aptoide.pt.play_and_earn.sessions.data.SessionExpiredException
 import cm.aptoide.pt.play_and_earn.sessions.domain.SessionInfo
 import com.aptoide.android.aptoidegames.play_and_earn.data.PaEPreferencesRepository
 import com.aptoide.android.aptoidegames.play_and_earn.domain.sessions.PaESession
+import com.aptoide.android.aptoidegames.play_and_earn.presentation.analytics.PaEAnalytics
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.missions.PaEMissionManager
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -18,7 +19,8 @@ class PaESessionManager @Inject constructor(
   private val paESessionsRepository: PaESessionsRepository,
   private val paeMissionsRepository: PaEMissionsRepository,
   private val paeMissionManager: PaEMissionManager,
-  private val paEPreferencesRepository: PaEPreferencesRepository
+  private val paEPreferencesRepository: PaEPreferencesRepository,
+  private val paEAnalytics: PaEAnalytics
 ) {
 
   val activeSessions = mutableListOf<PaESession>()
@@ -55,6 +57,8 @@ class PaESessionManager @Inject constructor(
         heartbeatIntervalSeconds = heartbeatIntervalSeconds
       )
     )
+
+    paEAnalytics.sendPaESessionStart(packageName)
 
     return true
   }
@@ -172,6 +176,8 @@ class PaESessionManager @Inject constructor(
                 packageName = session.packageName,
                 missionTitle = missionEvent.missionTitle
               )
+
+              paEAnalytics.sendPaEMissionCompleted(session.packageName)
 
               _completedMissions.emit(completedMission)
             }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/unit_exchange_flow/RedeemRewardScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/unit_exchange_flow/RedeemRewardScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -66,6 +67,10 @@ fun redeemRewardScreen(
   val uiState = rememberUnitsBalanceUiState()
   val rewardsDestination = rememberRewardsDestination()
   val paeAnalytics = rememberPaEAnalytics()
+
+  LaunchedEffect(Unit) {
+    paeAnalytics.sendPaEBalanceScreenShown()
+  }
 
   RedeemRewardScreen(
     rewardType = rewardType,


### PR DESCRIPTION
**What does this PR do?**

   - Adds new P&E analytics events.
   - Changes the P&E foreground service idle timeout to 5 minutes.
   - Stops the P&E foreground service from being initialized on the app startup and on the settings screen toggle.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] See by commit.

**How should this be manually tested?**

  Flow on how to test this or QA Tickets related to this use-case: 
  - [AND-864](https://aptoide.atlassian.net/browse/AND-864)
  - [AND-865](https://aptoide.atlassian.net/browse/AND-865)

**What are the relevant tickets?**

  Tickets related to this pull-request: 
  - [AND-864](https://aptoide.atlassian.net/browse/AND-864)
  - [AND-865](https://aptoide.atlassian.net/browse/AND-865)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-864]: https://aptoide.atlassian.net/browse/AND-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-865]: https://aptoide.atlassian.net/browse/AND-865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-864]: https://aptoide.atlassian.net/browse/AND-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-865]: https://aptoide.atlassian.net/browse/AND-865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved tracking for permission grants, play sessions, completed missions, and reward-balance screen views.
  * Permission flows now reliably record when usage access and overlay permissions are granted.

* **Improvements**
  * Play-and-Earn background activity now stops after 5 minutes of inactivity instead of 30 minutes.
  * Updated Play-and-Earn service controls for more consistent enablement behavior.

* **Bug Fixes**
  * Removed automatic service-start behavior from the main activity to prevent unintended background activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->