### PR TITLE
[AND-863] Ask P&E permissions before restricted settings instructions

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/analytics/PaEAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/analytics/PaEAnalytics.kt
@@ -115,6 +115,13 @@ class PaEAnalytics @Inject constructor(
     )
   }
 
+  fun sendPaELockedDialogShowMeHowClick() {
+    genericAnalytics.logEvent(
+      name = "pae_lockeddialog_click_showmehow",
+      params = null
+    )
+  }
+
   fun sendPaEExchangeNowClick() {
     genericAnalytics.logEvent(
       name = "pae_exchangenow_click",

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/permissions/PermissionUtils.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/permissions/PermissionUtils.kt
@@ -5,6 +5,7 @@ import android.app.AppOpsManager
 import android.content.Context
 import android.content.Context.APP_OPS_SERVICE
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Process
 import android.provider.Settings
 
@@ -24,3 +25,5 @@ fun Context.hasUsageStatsPermissionStatus(appOpsManager: AppOpsManager? = null):
 }
 
 fun Context.hasOverlayPermission() = Settings.canDrawOverlays(this)
+
+fun requiresRestrictedSettings() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/permissions/PlayAndEarnPermissionsScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/permissions/PlayAndEarnPermissionsScreen.kt
@@ -1,7 +1,6 @@
 package com.aptoide.android.aptoidegames.play_and_earn.presentation.permissions
 
 import android.content.Intent
-import android.os.Build
 import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -28,6 +27,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -92,7 +92,9 @@ private fun PlayAndEarnPermissionsScreen(
   val paEClientConfigManager = rememberPaEClientConfigManager()
 
   var allowedRestrictedSettings by remember { mutableStateOf(false) }
-  var showPermissionDeniedDialog by remember { mutableStateOf(false) }
+  var showPermissionDeniedDialog by rememberSaveable { mutableStateOf(false) }
+  var showPermissionsLockedDialog by rememberSaveable { mutableStateOf(false) }
+  var showRestrictedSettingsSection by rememberSaveable { mutableStateOf(false) }
 
   // Check if permissions are already granted on screen resume
   DisposableEffect(lifecycleOwner) {
@@ -121,8 +123,22 @@ private fun PlayAndEarnPermissionsScreen(
   val permissionActivityLauncher = rememberLauncherForActivityResult(
     contract = ActivityResultContracts.StartActivityForResult()
   ) { result ->
-    if (!context.hasOverlayPermission() || !context.hasUsageStatsPermissionStatus()) {
-      showPermissionDeniedDialog = true
+    val hasOverlay = context.hasOverlayPermission()
+    val hasUsageStats = context.hasUsageStatsPermissionStatus()
+    if (!hasOverlay || !hasUsageStats) {
+      // Both permissions still missing before the restricted settings instructions were shown:
+      // the OS is likely blocking them until the user allows restricted settings.
+      val likelyBlockedByRestrictedSettings =
+        requiresRestrictedSettings() &&
+          !showRestrictedSettingsSection &&
+          !hasOverlay &&
+          !hasUsageStats
+
+      if (likelyBlockedByRestrictedSettings) {
+        showPermissionsLockedDialog = true
+      } else {
+        showPermissionDeniedDialog = true
+      }
     }
   }
 
@@ -156,16 +172,34 @@ private fun PlayAndEarnPermissionsScreen(
     PaERestrictedPermissionsScreenContent(
       onRestrictedSettingsClick = onRestrictedSettingsClick,
       onFinalPermissionsClick = onPermissionClick,
-      allowedRestrictedSettings = allowedRestrictedSettings
+      allowedRestrictedSettings = allowedRestrictedSettings,
+      showRestrictedSettingsSection = showRestrictedSettingsSection
     )
   }
 
   if (showPermissionDeniedDialog) {
-    PermissionDeniedDialog(
+    PaEPermissionsDialog(
+      title = stringResource(R.string.play_and_earn_permissions_denied_dialog_title),
+      body = stringResource(R.string.play_and_earn_permissions_denied_dialog_body),
+      primaryButtonTitle = stringResource(R.string.play_and_earn_permissions_enable_now_button),
       onDismiss = { showPermissionDeniedDialog = false },
-      onRetry = {
+      onPrimaryClick = {
         showPermissionDeniedDialog = false
         onPermissionClick()
+      }
+    )
+  }
+
+  if (showPermissionsLockedDialog) {
+    PaEPermissionsDialog(
+      title = stringResource(R.string.play_and_earn_permissions_locked_dialog_title),
+      body = stringResource(R.string.play_and_earn_permissions_locked_dialog_body),
+      primaryButtonTitle = stringResource(R.string.play_and_earn_permissions_show_me_how_button),
+      onDismiss = { showPermissionsLockedDialog = false },
+      onPrimaryClick = {
+        paeAnalytics.sendPaELockedDialogShowMeHowClick()
+        showPermissionsLockedDialog = false
+        showRestrictedSettingsSection = true
       }
     )
   }
@@ -175,7 +209,8 @@ private fun PlayAndEarnPermissionsScreen(
 private fun PaERestrictedPermissionsScreenContent(
   onRestrictedSettingsClick: () -> Unit,
   onFinalPermissionsClick: () -> Unit,
-  allowedRestrictedSettings: Boolean
+  allowedRestrictedSettings: Boolean,
+  showRestrictedSettingsSection: Boolean,
 ) {
   val composition by rememberLottieComposition(
     LottieCompositionSpec.RawRes(R.raw.play_and_earn_permissions_animation)
@@ -233,7 +268,7 @@ private fun PaERestrictedPermissionsScreenContent(
       )
     }
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+    if (requiresRestrictedSettings() && showRestrictedSettingsSection) {
       if (allowedRestrictedSettings) {
         RestrictedSettingsAllowedSection()
       } else {
@@ -469,9 +504,12 @@ private fun TrustedAppBadge(modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun PermissionDeniedDialog(
+private fun PaEPermissionsDialog(
+  title: String,
+  body: String,
+  primaryButtonTitle: String,
   onDismiss: () -> Unit,
-  onRetry: () -> Unit
+  onPrimaryClick: () -> Unit,
 ) {
   Dialog(
     onDismissRequest = onDismiss,
@@ -492,14 +530,14 @@ private fun PermissionDeniedDialog(
         horizontalAlignment = Alignment.CenterHorizontally,
       ) {
         Text(
-          text = stringResource(R.string.play_and_earn_permissions_denied_dialog_title),
+          text = title,
           style = AGTypography.Title,
           color = Palette.Primary,
           textAlign = TextAlign.Center
         )
 
         Text(
-          text = stringResource(R.string.play_and_earn_permissions_denied_dialog_body),
+          text = body,
           color = Palette.White,
           textAlign = TextAlign.Center,
           style = AGTypography.SubHeadingS
@@ -508,8 +546,8 @@ private fun PermissionDeniedDialog(
         Column {
           PrimaryButton(
             modifier = Modifier.fillMaxWidth(),
-            onClick = onRetry,
-            title = stringResource(R.string.play_and_earn_permissions_enable_now_button)
+            onClick = onPrimaryClick,
+            title = primaryButtonTitle
           )
           PrimaryTextButton(
             modifier = Modifier.padding(vertical = 8.dp),
@@ -532,8 +570,23 @@ private fun PlayAndEarnPermissionsScreenPreview() {
 @Preview
 @Composable
 private fun PermissionDeniedDialogPreview() {
-  PermissionDeniedDialog(
+  PaEPermissionsDialog(
+    title = stringResource(R.string.play_and_earn_permissions_denied_dialog_title),
+    body = stringResource(R.string.play_and_earn_permissions_denied_dialog_body),
+    primaryButtonTitle = stringResource(R.string.play_and_earn_permissions_enable_now_button),
     onDismiss = {},
-    onRetry = {}
+    onPrimaryClick = {}
+  )
+}
+
+@Preview
+@Composable
+private fun PermissionsLockedDialogPreview() {
+  PaEPermissionsDialog(
+    title = stringResource(R.string.play_and_earn_permissions_locked_dialog_title),
+    body = stringResource(R.string.play_and_earn_permissions_locked_dialog_body),
+    primaryButtonTitle = stringResource(R.string.play_and_earn_permissions_show_me_how_button),
+    onDismiss = {},
+    onPrimaryClick = {}
   )
 }

--- a/app-games/src/main/res/values-ar-rSA/strings.xml
+++ b/app-games/src/main/res/values-ar-rSA/strings.xml
@@ -464,6 +464,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">لا يمكننا حساب وقت اللعب الخاص بك بعد. قم بتمكين هذا الإعداد لبدء الكسب.</string>
   <string name="play_and_earn_permissions_enable_now_button">تمكين الآن</string>
   <string name="play_and_earn_permissions_not_now_button">ليس الآن</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">الأذونات مقفلة؟</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">قد تحتاج إلى السماح بالإعدادات المقيدة أولاً. سنوضح لك الطريقة.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">أرني الطريقة</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">اسأل عن أي شيء</string>
   <string name="gamegenie_overlay_ask_screenshot">اسأل عن ما أراه الآن</string>

--- a/app-games/src/main/res/values-de-rDE/strings.xml
+++ b/app-games/src/main/res/values-de-rDE/strings.xml
@@ -420,6 +420,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Wir können Ihre Spielzeit noch nicht zählen. Aktivieren Sie diese Einstellung, um mit dem Sammeln von Punkten zu beginnen.</string>
   <string name="play_and_earn_permissions_enable_now_button">Jetzt aktivieren</string>
   <string name="play_and_earn_permissions_not_now_button">Nicht jetzt</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Berechtigungen gesperrt?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Möglicherweise müssen Sie zuerst eingeschränkte Einstellungen zulassen. Wir zeigen Ihnen, wie es geht.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">So geht\'s</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Fragen Sie alles</string>
   <string name="gamegenie_overlay_ask_screenshot">Fragen Sie mich, was ich gerade sehe.</string>

--- a/app-games/src/main/res/values-el-rGR/strings.xml
+++ b/app-games/src/main/res/values-el-rGR/strings.xml
@@ -420,6 +420,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Δεν μπορούμε να μετρήσουμε ακόμα τον χρόνο παιχνιδιού σας. Ενεργοποιήστε αυτή τη ρύθμιση για να αρχίσετε να κερδίζετε.</string>
   <string name="play_and_earn_permissions_enable_now_button">Ενεργοποίηση τώρα</string>
   <string name="play_and_earn_permissions_not_now_button">Όχι τώρα</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Κλειδωμένα δικαιώματα;</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Ίσως χρειαστεί πρώτα να επιτρέψετε τις περιορισμένες ρυθμίσεις. Θα σας δείξουμε πώς.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Δείξτε μου πώς</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Ρωτήστε οτιδήποτε</string>
   <string name="gamegenie_overlay_ask_screenshot">Ρώτα για αυτό που βλέπω τώρα</string>

--- a/app-games/src/main/res/values-es-rES/strings.xml
+++ b/app-games/src/main/res/values-es-rES/strings.xml
@@ -420,6 +420,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Aún no podemos contabilizar tu tiempo de juego. Activa esta configuración para empezar a ganar.</string>
   <string name="play_and_earn_permissions_enable_now_button">Habilitar ahora</string>
   <string name="play_and_earn_permissions_not_now_button">Ahora no</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">¿Permisos bloqueados?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Puede que primero tengas que permitir la configuración restringida. Te mostramos cómo.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Muéstrame cómo</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Pregunta lo que quieras.</string>
   <string name="gamegenie_overlay_ask_screenshot">Pregunta sobre lo que estoy viendo ahora.</string>

--- a/app-games/src/main/res/values-fa-rIR/strings.xml
+++ b/app-games/src/main/res/values-fa-rIR/strings.xml
@@ -420,6 +420,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">We can\'t count your playtime yet. Enable this setting to start earning.</string>
   <string name="play_and_earn_permissions_enable_now_button">Enable Now</string>
   <string name="play_and_earn_permissions_not_now_button">Not Now</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Permissions locked?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">You may need to allow restricted settings first. We\'ll show you how.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Show Me How</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Ask anything</string>
   <string name="gamegenie_overlay_ask_screenshot">Ask about what I\'m seeing now</string>

--- a/app-games/src/main/res/values-fi-rFI/strings.xml
+++ b/app-games/src/main/res/values-fi-rFI/strings.xml
@@ -420,6 +420,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Emme voi vielä laskea peliaikaasi. Ota tämä asetus käyttöön, jotta voit alkaa ansaita pisteitä.</string>
   <string name="play_and_earn_permissions_enable_now_button">Ota käyttöön nyt</string>
   <string name="play_and_earn_permissions_not_now_button">Ei nyt</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Käyttöoikeudet lukittu?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Sinun on ehkä ensin sallittava rajoitetut asetukset. Näytämme, miten se tehdään.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Näytä miten</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Kysy mitä tahansa</string>
   <string name="gamegenie_overlay_ask_screenshot">Kysy, mitä näen nyt</string>

--- a/app-games/src/main/res/values-fr-rFR/strings.xml
+++ b/app-games/src/main/res/values-fr-rFR/strings.xml
@@ -420,6 +420,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Nous ne pouvons pas encore compter votre temps de jeu. Activez ce paramètre pour commencer à gagner des points.</string>
   <string name="play_and_earn_permissions_enable_now_button">Activer maintenant</string>
   <string name="play_and_earn_permissions_not_now_button">Pas maintenant</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Autorisations verrouillées ?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Vous devrez peut-être d\'abord autoriser les paramètres restreints. Nous vous montrons comment faire.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Me montrer comment</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Demandez n\'importe quoi</string>
   <string name="gamegenie_overlay_ask_screenshot">Demandez-moi ce que je vois en ce moment</string>

--- a/app-games/src/main/res/values-hi-rIN/strings.xml
+++ b/app-games/src/main/res/values-hi-rIN/strings.xml
@@ -420,6 +420,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">We can\'t count your playtime yet. Enable this setting to start earning.</string>
   <string name="play_and_earn_permissions_enable_now_button">Enable Now</string>
   <string name="play_and_earn_permissions_not_now_button">Not Now</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Permissions locked?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">You may need to allow restricted settings first. We\'ll show you how.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Show Me How</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Ask anything</string>
   <string name="gamegenie_overlay_ask_screenshot">Ask about what I\'m seeing now</string>

--- a/app-games/src/main/res/values-hu-rHU/strings.xml
+++ b/app-games/src/main/res/values-hu-rHU/strings.xml
@@ -420,6 +420,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Még nem tudjuk számolni a játékidőt. Engedélyezze ezt a beállítást, hogy elkezdhesse a pontgyűjtést.</string>
   <string name="play_and_earn_permissions_enable_now_button">Most engedélyezés</string>
   <string name="play_and_earn_permissions_not_now_button">Most nem</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Zárolt engedélyek?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Előfordulhat, hogy először engedélyeznie kell a korlátozott beállításokat. Megmutatjuk, hogyan.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Mutasd meg, hogyan</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Kérdezzen bármit</string>
   <string name="gamegenie_overlay_ask_screenshot">Kérdezz arról, amit most látok</string>

--- a/app-games/src/main/res/values-in-rID/strings.xml
+++ b/app-games/src/main/res/values-in-rID/strings.xml
@@ -409,6 +409,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Kami belum dapat menghitung waktu bermain Anda. Aktifkan pengaturan ini untuk mulai mendapatkan poin.</string>
   <string name="play_and_earn_permissions_enable_now_button">Aktifkan Sekarang</string>
   <string name="play_and_earn_permissions_not_now_button">Tidak Sekarang</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Izin terkunci?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Anda mungkin perlu mengizinkan pengaturan terbatas terlebih dahulu. Kami akan menunjukkan caranya.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Tunjukkan Caranya</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Tanyakan apa saja</string>
   <string name="gamegenie_overlay_ask_screenshot">Tanyakan tentang apa yang saya lihat sekarang.</string>

--- a/app-games/src/main/res/values-it-rIT/strings.xml
+++ b/app-games/src/main/res/values-it-rIT/strings.xml
@@ -420,6 +420,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Non possiamo ancora contare il tuo tempo di gioco. Abilita questa impostazione per iniziare a guadagnare.</string>
   <string name="play_and_earn_permissions_enable_now_button">Abilita ora</string>
   <string name="play_and_earn_permissions_not_now_button">Non ora</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Autorizzazioni bloccate?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Potrebbe essere necessario consentire prima le impostazioni limitate. Ti mostriamo come fare.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Mostrami come</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Chiedi qualsiasi cosa</string>
   <string name="gamegenie_overlay_ask_screenshot">Chiedimi cosa sto vedendo adesso</string>

--- a/app-games/src/main/res/values-ja-rJP/strings.xml
+++ b/app-games/src/main/res/values-ja-rJP/strings.xml
@@ -410,6 +410,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">プレイ時間の計測はまだ開始できません。この設定を有効にして、獲得を開始してください。</string>
   <string name="play_and_earn_permissions_enable_now_button">今すぐ有効にする</string>
   <string name="play_and_earn_permissions_not_now_button">今はだめ</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">権限がロックされていますか？</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">先に制限付き設定を許可する必要がある場合があります。手順をご案内します。</string>
+  <string name="play_and_earn_permissions_show_me_how_button">手順を見る</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">何でも聞いてください</string>
   <string name="gamegenie_overlay_ask_screenshot">今、私が見ているものについて尋ねてください</string>

--- a/app-games/src/main/res/values-ko-rKR/strings.xml
+++ b/app-games/src/main/res/values-ko-rKR/strings.xml
@@ -409,6 +409,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">아직 플레이 시간을 집계할 수 없습니다. 수익을 얻으려면 이 설정을 활성화하세요.</string>
   <string name="play_and_earn_permissions_enable_now_button">지금 활성화</string>
   <string name="play_and_earn_permissions_not_now_button">지금은 안 돼</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">권한이 잠겨 있나요?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">먼저 제한된 설정을 허용해야 할 수 있습니다. 방법을 알려드릴게요.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">방법 보기</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">뭐든지 물어보세요</string>
   <string name="gamegenie_overlay_ask_screenshot">지금 내가 보고 있는 것에 대해 물어보세요</string>

--- a/app-games/src/main/res/values-mr-rIN/strings.xml
+++ b/app-games/src/main/res/values-mr-rIN/strings.xml
@@ -420,6 +420,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">We can\'t count your playtime yet. Enable this setting to start earning.</string>
   <string name="play_and_earn_permissions_enable_now_button">Enable Now</string>
   <string name="play_and_earn_permissions_not_now_button">Not Now</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Permissions locked?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">You may need to allow restricted settings first. We\'ll show you how.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Show Me How</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Ask anything</string>
   <string name="gamegenie_overlay_ask_screenshot">Ask about what I\'m seeing now</string>

--- a/app-games/src/main/res/values-ms-rMY/strings.xml
+++ b/app-games/src/main/res/values-ms-rMY/strings.xml
@@ -410,6 +410,9 @@ Promosi khas dan ganjaran dalam permainan kegemaran anda.</string>
   <string name="play_and_earn_permissions_denied_dialog_body">We can\'t count your playtime yet. Enable this setting to start earning.</string>
   <string name="play_and_earn_permissions_enable_now_button">Enable Now</string>
   <string name="play_and_earn_permissions_not_now_button">Not Now</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Permissions locked?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">You may need to allow restricted settings first. We\'ll show you how.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Show Me How</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Ask anything</string>
   <string name="gamegenie_overlay_ask_screenshot">Ask about what I\'m seeing now</string>

--- a/app-games/src/main/res/values-my-rMM/strings.xml
+++ b/app-games/src/main/res/values-my-rMM/strings.xml
@@ -409,6 +409,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">We can\'t count your playtime yet. Enable this setting to start earning.</string>
   <string name="play_and_earn_permissions_enable_now_button">Enable Now</string>
   <string name="play_and_earn_permissions_not_now_button">Not Now</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Permissions locked?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">You may need to allow restricted settings first. We\'ll show you how.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Show Me How</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Ask anything</string>
   <string name="gamegenie_overlay_ask_screenshot">Ask about what I\'m seeing now</string>

--- a/app-games/src/main/res/values-nl-rNL/strings.xml
+++ b/app-games/src/main/res/values-nl-rNL/strings.xml
@@ -420,6 +420,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">We kunnen je speeltijd nog niet tellen. Schakel deze instelling in om te beginnen met verdienen.</string>
   <string name="play_and_earn_permissions_enable_now_button">Nu inschakelen</string>
   <string name="play_and_earn_permissions_not_now_button">Nu niet</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Machtigingen vergrendeld?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Mogelijk moet je eerst beperkte instellingen toestaan. We laten je zien hoe.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Laat me zien hoe</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Vraag alles</string>
   <string name="gamegenie_overlay_ask_screenshot">Vraag naar wat ik nu zie</string>

--- a/app-games/src/main/res/values-pa-rIN/strings.xml
+++ b/app-games/src/main/res/values-pa-rIN/strings.xml
@@ -422,6 +422,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">We can\'t count your playtime yet. Enable this setting to start earning.</string>
   <string name="play_and_earn_permissions_enable_now_button">Enable Now</string>
   <string name="play_and_earn_permissions_not_now_button">Not Now</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Permissions locked?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">You may need to allow restricted settings first. We\'ll show you how.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Show Me How</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Ask anything</string>
   <string name="gamegenie_overlay_ask_screenshot">Ask about what I\'m seeing now</string>

--- a/app-games/src/main/res/values-pl-rPL/strings.xml
+++ b/app-games/src/main/res/values-pl-rPL/strings.xml
@@ -442,6 +442,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Nie możemy jeszcze policzyć Twojego czasu gry. Włącz to ustawienie, aby zacząć zarabiać.</string>
   <string name="play_and_earn_permissions_enable_now_button">Włącz teraz</string>
   <string name="play_and_earn_permissions_not_now_button">Nie teraz</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Zablokowane uprawnienia?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Może być konieczne najpierw zezwolenie na ograniczone ustawienia. Pokażemy Ci, jak to zrobić.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Pokaż mi jak</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Zapytaj o wszystko</string>
   <string name="gamegenie_overlay_ask_screenshot">Zapytaj o to, co teraz widzę</string>

--- a/app-games/src/main/res/values-pt-rBR/strings.xml
+++ b/app-games/src/main/res/values-pt-rBR/strings.xml
@@ -420,6 +420,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Ainda não podemos contabilizar o seu tempo de jogo. Ative esta configuração para começar a ganhar.</string>
   <string name="play_and_earn_permissions_enable_now_button">Ativar agora</string>
   <string name="play_and_earn_permissions_not_now_button">Não agora</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Permissões bloqueadas?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Talvez você precise permitir as configurações restritas primeiro. Vamos mostrar como.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Mostrar como</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Pergunte qualquer coisa</string>
   <string name="gamegenie_overlay_ask_screenshot">Pergunte sobre o que estou vendo agora</string>

--- a/app-games/src/main/res/values-pt-rPT/strings.xml
+++ b/app-games/src/main/res/values-pt-rPT/strings.xml
@@ -420,6 +420,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Ainda não podemos contabilizar o seu tempo de jogo. Ative esta configuração para começar a ganhar.</string>
   <string name="play_and_earn_permissions_enable_now_button">Ativar agora</string>
   <string name="play_and_earn_permissions_not_now_button">Não agora</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Permissões bloqueadas?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Poderá ser necessário permitir primeiro as configurações restritas. Vamos mostrar-lhe como.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Mostrar como</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Pergunte qualquer coisa</string>
   <string name="gamegenie_overlay_ask_screenshot">Pergunte sobre o que estou a ver agora</string>

--- a/app-games/src/main/res/values-ro-rRO/strings.xml
+++ b/app-games/src/main/res/values-ro-rRO/strings.xml
@@ -431,6 +431,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Nu putem încă să îți calculăm timpul de joc. Activează această setare pentru a începe să câștigi.</string>
   <string name="play_and_earn_permissions_enable_now_button">Activați acum</string>
   <string name="play_and_earn_permissions_not_now_button">Nu acum</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Permisiuni blocate?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Poate fi necesar să permiți mai întâi setările restricționate. Îți arătăm cum.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Arată-mi cum</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Întrebați orice</string>
   <string name="gamegenie_overlay_ask_screenshot">Întreabă-mă ce văd acum</string>

--- a/app-games/src/main/res/values-ru-rRU/strings.xml
+++ b/app-games/src/main/res/values-ru-rRU/strings.xml
@@ -442,6 +442,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Мы пока не можем подсчитать ваше игровое время. Включите эту настройку, чтобы начать зарабатывать.</string>
   <string name="play_and_earn_permissions_enable_now_button">Включить сейчас</string>
   <string name="play_and_earn_permissions_not_now_button">Не сейчас</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Разрешения заблокированы?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Возможно, сначала нужно разрешить ограниченные настройки. Мы покажем, как это сделать.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Показать как</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Спросите что угодно</string>
   <string name="gamegenie_overlay_ask_screenshot">Спросите о том, что я вижу сейчас</string>

--- a/app-games/src/main/res/values-sr-rCS/strings.xml
+++ b/app-games/src/main/res/values-sr-rCS/strings.xml
@@ -431,6 +431,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">We can\'t count your playtime yet. Enable this setting to start earning.</string>
   <string name="play_and_earn_permissions_enable_now_button">Enable Now</string>
   <string name="play_and_earn_permissions_not_now_button">Not Now</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Permissions locked?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">You may need to allow restricted settings first. We\'ll show you how.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Show Me How</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Ask anything</string>
   <string name="gamegenie_overlay_ask_screenshot">Ask about what I\'m seeing now</string>

--- a/app-games/src/main/res/values-th-rTH/strings.xml
+++ b/app-games/src/main/res/values-th-rTH/strings.xml
@@ -409,6 +409,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">เรายังไม่สามารถนับเวลาเล่นของคุณได้ เปิดใช้งานการตั้งค่านี้เพื่อเริ่มรับรางวัล</string>
   <string name="play_and_earn_permissions_enable_now_button">เปิดใช้งานตอนนี้</string>
   <string name="play_and_earn_permissions_not_now_button">ไม่ตอนนี้</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">สิทธิ์ถูกล็อกอยู่ใช่ไหม</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">คุณอาจต้องอนุญาตการตั้งค่าที่ถูกจำกัดก่อน เราจะแสดงวิธีให้คุณดู</string>
+  <string name="play_and_earn_permissions_show_me_how_button">แสดงวิธีการ</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">ถามอะไรก็ได้</string>
   <string name="gamegenie_overlay_ask_screenshot">ถามเกี่ยวกับสิ่งที่ฉันกำลังเห็นตอนนี้</string>

--- a/app-games/src/main/res/values-tr-rTR/strings.xml
+++ b/app-games/src/main/res/values-tr-rTR/strings.xml
@@ -420,6 +420,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Henüz oyun sürenizi hesaplayamıyoruz. Kazanmaya başlamak için bu ayarı etkinleştirin.</string>
   <string name="play_and_earn_permissions_enable_now_button">Şimdi Etkinleştir</string>
   <string name="play_and_earn_permissions_not_now_button">Şimdi değil</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">İzinler kilitli mi?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Önce kısıtlı ayarlara izin vermeniz gerekebilir. Size nasıl yapılacağını göstereceğiz.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Nasıl Yapılacağını Göster</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Her şeyi sorabilirsiniz</string>
   <string name="gamegenie_overlay_ask_screenshot">Şu anda gördüklerimi sor</string>

--- a/app-games/src/main/res/values-uk-rUA/strings.xml
+++ b/app-games/src/main/res/values-uk-rUA/strings.xml
@@ -442,6 +442,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Ми ще не можемо підрахувати ваш ігровий час. Увімкніть це налаштування, щоб почати заробляти.</string>
   <string name="play_and_earn_permissions_enable_now_button">Увімкнути зараз</string>
   <string name="play_and_earn_permissions_not_now_button">Не зараз</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Дозволи заблоковано?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Можливо, спочатку потрібно дозволити обмежені налаштування. Ми покажемо, як це зробити.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Показати як</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Запитайте про що завгодно</string>
   <string name="gamegenie_overlay_ask_screenshot">Запитайте про те, що я бачу зараз</string>

--- a/app-games/src/main/res/values-vi-rVN/strings.xml
+++ b/app-games/src/main/res/values-vi-rVN/strings.xml
@@ -409,6 +409,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">Chúng tôi chưa thể tính thời gian chơi của bạn. Bật cài đặt này để bắt đầu kiếm điểm.</string>
   <string name="play_and_earn_permissions_enable_now_button">Bật ngay bây giờ</string>
   <string name="play_and_earn_permissions_not_now_button">Không bây giờ</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Quyền bị khóa?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">Bạn có thể cần cho phép cài đặt bị giới hạn trước. Chúng tôi sẽ chỉ cho bạn cách làm.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Xem cách làm</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Hỏi bất cứ điều gì</string>
   <string name="gamegenie_overlay_ask_screenshot">Hỏi về những gì tôi đang nhìn thấy bây giờ.</string>

--- a/app-games/src/main/res/values-zh-rCN/strings.xml
+++ b/app-games/src/main/res/values-zh-rCN/strings.xml
@@ -409,6 +409,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">我们目前无法统计您的游戏时间。请启用此设置开始累积时长。</string>
   <string name="play_and_earn_permissions_enable_now_button">立即启用</string>
   <string name="play_and_earn_permissions_not_now_button">现在不行</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">权限被锁定？</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">您可能需要先允许受限设置。我们将向您展示操作方法。</string>
+  <string name="play_and_earn_permissions_show_me_how_button">查看操作方法</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">问任何问题</string>
   <string name="gamegenie_overlay_ask_screenshot">问我此刻所见为何</string>

--- a/app-games/src/main/res/values-zh-rTW/strings.xml
+++ b/app-games/src/main/res/values-zh-rTW/strings.xml
@@ -409,6 +409,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">我們目前無法計算您的遊戲時間。請啟用此設定以開始累積時間。</string>
   <string name="play_and_earn_permissions_enable_now_button">立即啟用</string>
   <string name="play_and_earn_permissions_not_now_button">現在不行</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">權限被鎖定？</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">您可能需要先允許受限設定。我們將向您展示操作方式。</string>
+  <string name="play_and_earn_permissions_show_me_how_button">查看操作方式</string>
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">儘管問吧</string>
   <string name="gamegenie_overlay_ask_screenshot">請問我現在看到的是什麼</string>

--- a/app-games/src/main/res/values/strings.xml
+++ b/app-games/src/main/res/values/strings.xml
@@ -483,6 +483,9 @@
   <string name="play_and_earn_permissions_denied_dialog_body">We can\'t count your playtime yet. Enable this setting to start earning.</string>
   <string name="play_and_earn_permissions_enable_now_button">Enable Now</string>
   <string name="play_and_earn_permissions_not_now_button">Not Now</string>
+  <string name="play_and_earn_permissions_locked_dialog_title">Permissions locked?</string>
+  <string name="play_and_earn_permissions_locked_dialog_body">You may need to allow restricted settings first. We\'ll show you how.</string>
+  <string name="play_and_earn_permissions_show_me_how_button">Show Me How</string>
 
   <!-- GameGenie Overlay Menu -->
   <string name="gamegenie_overlay_ask_anything">Ask anything</string>


### PR DESCRIPTION
**What does this PR do?**

   On Android 15+, the Play & Earn permissions screen now opens with only the final permissions section (overlay + app usage data). If the grant attempt fails with both permissions still missing, a new "Permissions locked?" dialog explains the user may need to allow restricted settings first; its "Show Me How" button reveals the previous full layout (1. restricted settings instructions, 2. permissions). Repeat failures from the full layout keep showing the existing "Rewards are paused" retry dialog. Pre-Android-15 behavior is unchanged.

   Why permissions-first: Android only makes the "Allow restricted settings" option available in App Info after the app has attempted to use a restricted permission. The previous flow sent users to App Info first, where the option didn't exist yet, so they couldn't complete the setup.

   Technical decisions: flow state uses `rememberSaveable` so the revealed instructions survive rotation/process death while the user is in system Settings, but still reset on a fresh visit (per-visit design); the OS gate is a shared `requiresRestrictedSettings()` predicate in `PermissionUtils.kt`; the old `PermissionDeniedDialog` was parameterized into `PaEPermissionsDialog` reused by both dialogs; new analytics event `pae_lockeddialog_click_showmehow` on the dialog CTA. The dialog copy is hedged ("may need") because trusted install paths (adb, session-based installers) are exempt from restricted settings and can hit the dialog after simply backing out.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] PlayAndEarnPermissionsScreen.kt
- [ ] PermissionUtils.kt

**How should this be manually tested?**

  Restricted settings only apply to intent-based sideloads — an adb/Gradle install never shows the locked state. On an Android 15 (API 35) device/emulator:
  1. Push the dev debug APK to the device (`adb push <apk> /sdcard/Download/`) and install it **from the Files app** (not adb).
  2. Sign in to Play & Earn and reach the permissions screen: only the permissions section is shown, without step numbers.
  3. Tap the button, land on the locked overlay toggle, press back: the "Permissions locked?" dialog appears.
  4. Tap "Show Me How": the full layout appears (1. restricted settings with Open Settings, 2. permissions).
  5. Allow restricted settings via App Info and grant both permissions: success snackbar and the screen closes.
  6. Regression: on an adb-installed build, granting both permissions directly still works and failures from the full layout show the "Rewards are paused" dialog; pre-15 devices are unchanged.

  Flow on how to test this or QA Tickets related to this use-case: [AND-863](https://aptoide.atlassian.net/browse/AND-863)

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-863](https://aptoide.atlassian.net/browse/AND-863)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AND-863]: https://aptoide.atlassian.net/browse/AND-863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “permissions locked” dialog with a **Show Me How** action to guide users to enable required restricted settings.
  * Updated the Play & Earn permission flow to show distinct messaging for **denied** vs **locked** permissions.
  * Added localized translations for the new dialog content across supported languages.
* **Bug Fixes**
  * Preserved permission dialog UI state across process recreation.
  * Improved restricted-settings guidance display to follow consistent logic on supported Android versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->