### PR TITLE
[AND-866] [AND-867] Fix claimed sign-in reward offers and gate Play & Earn by local country

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/presentation/ApkfyScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/presentation/ApkfyScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
@@ -24,6 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import cm.aptoide.pt.extensions.PreviewDark
 import cm.aptoide.pt.extensions.ScreenData
 import cm.aptoide.pt.feature_apps.data.App
@@ -38,6 +40,8 @@ import com.aptoide.android.aptoidegames.error_views.GenericErrorView
 import com.aptoide.android.aptoidegames.installer.analytics.rememberInstallAnalytics
 import com.aptoide.android.aptoidegames.installer.presentation.AppIconWProgress
 import com.aptoide.android.aptoidegames.mmp.WithUTM
+import com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards.RewardState
+import com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards.SignInRewardViewModel
 import com.aptoide.android.aptoidegames.play_and_earn.rememberShouldShowPlayAndEarn
 import com.aptoide.android.aptoidegames.theme.AGTypography
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
@@ -92,10 +96,19 @@ fun ApkfyScreen(
   val apkfyAnalytics = rememberApkfyAnalytics()
   val installAnalytics = rememberInstallAnalytics()
   val shouldShowPlayAndEarn = rememberShouldShowPlayAndEarn()
+  val signInRewardViewModel = hiltViewModel<SignInRewardViewModel>()
+  val rewardState by signInRewardViewModel.rewardState.collectAsState()
   // installViewStates captures onInstallStarted once (in a remember(downloadUiState) block), so read
-  // the latest flag value through this stable State rather than the value captured at that time.
+  // the latest flag values through these stable States rather than the values captured at that time.
   val showPaE by rememberUpdatedState(shouldShowPlayAndEarn)
+  val hasUnclaimedReward by rememberUpdatedState(rewardState is RewardState.Unclaimed)
   val apkfyData = apkfyState.data
+
+  // Retry a failed startup mission fetch so the Play & Earn reward routing below (and the reward
+  // screens it leads to) see real backend state instead of staying hidden behind Loading.
+  LaunchedEffect(Unit) {
+    signInRewardViewModel.refresh()
+  }
 
   LaunchedEffect(Unit) {
     if (apkfyState is ApkfyUiState.Default) {
@@ -151,9 +164,11 @@ fun ApkfyScreen(
             }*/
 
             // Default APKFY: route Roblox / Free Fire installs into the Play & Earn reward flow.
+            // Skipped for already-claimed users; the reward screens also self-dismiss on Claimed
+            // as the safety net for the mission state resolving after this navigation.
 
             //if (apkfyState is ApkfyUiState.Default && shouldShowPlayAndEarn) {
-            if (showPaE) {
+            if (showPaE && hasUnclaimedReward) {
               when {
                 apkfyData.app.isRoblox() -> navigate(robloxApkfyRewardRoute)
                 apkfyData.app.isFreeFire() -> navigate(freeFireApkfyRewardRoute)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/presentation/FreeFireApkfyRewardScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/presentation/FreeFireApkfyRewardScreen.kt
@@ -49,7 +49,7 @@ fun freeFireApkfyRewardScreen(
   var awaitingSignIn by rememberSaveable { mutableStateOf(false) }
 
   // The reward is only claimed once the user returns from the sign-in flow actually signed in.
-  // After claiming we go back to home, so the success dialog shows there.
+  // Navigation away is owned by the Claimed effect below, once the backend confirms the claim.
   LaunchedEffect(userInfo) {
     val unclaimed = rewardState as? RewardState.Unclaimed
     if (awaitingSignIn && userInfo != null && unclaimed != null) {
@@ -60,8 +60,14 @@ fun freeFireApkfyRewardScreen(
         rewardType = PaERewardType.DIAMONDS,
         units = unclaimed.reward.units,
       )
-      navigateToHome()
     }
+  }
+
+  // A claimed reward means there is no offer to show: leave to home whether the claim just
+  // happened here (the success dialog shows over home) or the user reached an already-claimed
+  // offer (stale back stack entry, apkfy re-entry, or the mission state resolving late).
+  LaunchedEffect(rewardState) {
+    if (rewardState is RewardState.Claimed) navigateToHome()
   }
 
   BackHandler {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/presentation/RobloxApkfyRewardScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/presentation/RobloxApkfyRewardScreen.kt
@@ -49,12 +49,11 @@ fun robloxApkfyRewardScreen(
   var awaitingSignIn by rememberSaveable { mutableStateOf(false) }
 
   // The reward is only claimed once the user returns from the sign-in flow actually signed in.
-  // After claiming we go back to home, so the success dialog shows there.
+  // Navigation away is owned by the Claimed effect below, once the backend confirms the claim.
   LaunchedEffect(userInfo) {
     val unclaimed = rewardState as? RewardState.Unclaimed
     if (awaitingSignIn && userInfo != null && unclaimed != null) {
       awaitingSignIn = false
-      navigateToHome()
       viewModel.claim(unclaimed.reward.copy(paERewardType = PaERewardType.ROBUX))
       paeAnalytics.sendPaERewardClaimed(
         source = PaEAnalytics.SOURCE_APKFY,
@@ -62,6 +61,13 @@ fun robloxApkfyRewardScreen(
         units = unclaimed.reward.units,
       )
     }
+  }
+
+  // A claimed reward means there is no offer to show: leave to home whether the claim just
+  // happened here (the success dialog shows over home) or the user reached an already-claimed
+  // offer (stale back stack entry, apkfy re-entry, or the mission state resolving late).
+  LaunchedEffect(rewardState) {
+    if (rewardState is RewardState.Claimed) navigateToHome()
   }
 
   BackHandler {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/app_open_ads/AppOpenGeoProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/app_open_ads/AppOpenGeoProvider.kt
@@ -1,22 +1,11 @@
 package com.aptoide.android.aptoidegames.app_open_ads
 
 import android.content.Context
-import android.telephony.TelephonyManager
-import java.util.Locale
+import com.aptoide.android.aptoidegames.device_info.DeviceCountryProvider
 
 class AppOpenGeoProvider(private val context: Context) {
 
-  fun getGeo(): String {
-    val telephonyManager = context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
-    return listOf(
-      telephonyManager?.networkCountryIso,
-      telephonyManager?.simCountryIso,
-      context.resources.configuration.locales[0]?.country,
-    )
-      .firstOrNull { !it.isNullOrBlank() }
-      ?.uppercase(Locale.US)
-      ?: UNKNOWN_GEO
-  }
+  fun getGeo(): String = DeviceCountryProvider(context).getCountry() ?: UNKNOWN_GEO
 
   companion object {
     const val UNKNOWN_GEO = "UNKNOWN"

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/device_info/DeviceCountryProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/device_info/DeviceCountryProvider.kt
@@ -1,0 +1,31 @@
+package com.aptoide.android.aptoidegames.device_info
+
+import android.content.Context
+import android.telephony.TelephonyManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Resolves the device's country as an uppercase ISO 3166-1 alpha-2 code, preferring signals that
+ * reflect physical location: the current network country (MCC-based, hard to spoof), then the SIM
+ * country, then the device locale. Returns null when none is available (e.g. a WiFi-only device
+ * with a region-less locale).
+ */
+@Singleton
+class DeviceCountryProvider @Inject constructor(
+  @ApplicationContext private val context: Context,
+) {
+
+  fun getCountry(): String? {
+    val telephonyManager = context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
+    return listOf(
+      telephonyManager?.networkCountryIso,
+      telephonyManager?.simCountryIso,
+      context.resources.configuration.locales[0]?.country,
+    )
+      .firstOrNull { !it.isNullOrBlank() }
+      ?.uppercase(Locale.US)
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/PlayAndEarnManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/PlayAndEarnManager.kt
@@ -15,6 +15,7 @@ import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.feature_flags.domain.FeatureFlags
 import cm.aptoide.pt.wallet.datastore.WalletCoreDataSource
 import com.aptoide.android.aptoidegames.BuildConfig
+import com.aptoide.android.aptoidegames.device_info.DeviceCountryProvider
 import com.aptoide.android.aptoidegames.device_info.DeviceSecurityChecker
 import com.aptoide.android.aptoidegames.play_and_earn.data.PaEPreferencesRepository
 import com.aptoide.android.aptoidegames.play_and_earn.presentation.permissions.hasOverlayPermission
@@ -36,6 +37,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.random.Random
@@ -46,12 +48,23 @@ class PlayAndEarnManager @Inject constructor(
   private val featureFlags: FeatureFlags,
   private val walletCoreDataSource: WalletCoreDataSource,
   private val deviceSecurityChecker: DeviceSecurityChecker,
-  private val paEPreferencesRepository: PaEPreferencesRepository
+  private val paEPreferencesRepository: PaEPreferencesRepository,
+  private val deviceCountryProvider: DeviceCountryProvider,
 ) {
 
   companion object {
     private const val TAG = "PlayAndEarnManager"
     private const val PAE_VISIBILITY_FLAG_KEY = "show_play_and_earn"
+
+    // JSON array of ISO 3166-1 alpha-2 codes, e.g. ["US","CA"]. The visibility flag is already
+    // geo-targeted to the same countries, but Firebase's attribution isn't trusted: the locally
+    // detected country must also match (unknown country -> hidden).
+    private const val PAE_COUNTRIES_FLAG_KEY = "pae_countries"
+
+    // Fallback when the pae_countries flag is missing or unparseable.
+    private val PAE_DEFAULT_ALLOWED_COUNTRIES = setOf(
+      "US", "CA", "FI", "FR", "DE", "IT", "NL", "NO", "PT", "ES", "SE", "GB",
+    )
   }
 
   private val _playAndEarnVisibilityFlow = MutableStateFlow(false)
@@ -93,6 +106,12 @@ class PlayAndEarnManager @Inject constructor(
 
   suspend fun shouldShowPlayAndEarn(): Boolean {
     if (!BuildConfig.DEBUG && deviceSecurityChecker.isCompromisedDevice()) {
+      return false
+    }
+    val allowedCountries = featureFlags.getStringListOrNull(PAE_COUNTRIES_FLAG_KEY)
+      ?.map { it.trim().uppercase(Locale.US) }
+      ?: PAE_DEFAULT_ALLOWED_COUNTRIES
+    if (deviceCountryProvider.getCountry() !in allowedCountries) {
       return false
     }
     return featureFlags.getFlag(PAE_VISIBILITY_FLAG_KEY, false)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/PaERewardType.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/PaERewardType.kt
@@ -6,9 +6,8 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import cm.aptoide.pt.play_and_earn.exchange.domain.RedeemType
 import com.aptoide.android.aptoidegames.R
 
-/** Default reward amount granted by the Play & Earn APKFY / earned-reward flows. */
+/** Display fallback for the reward amount while the FIRST_SIGN_IN mission hasn't resolved. */
 const val PAE_DEFAULT_REWARD_AMOUNT = "$0.50"
-const val PAE_DEFAULT_REWARD_UNITS = 50
 
 private const val ROBLOX_PACKAGE = "com.roblox.client"
 private val FREE_FIRE_PACKAGES = setOf("com.dts.freefireth", "com.dts.freefiremax")

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/SignInRewardCard.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/SignInRewardCard.kt
@@ -27,6 +27,11 @@ fun SignInRewardCard(
   val userInfo = rememberUserInfo()
   var awaitingSignIn by rememberSaveable { mutableStateOf(false) }
 
+  // Retry a failed startup mission fetch, so a Loading state doesn't hide the offer all session.
+  LaunchedEffect(Unit) {
+    viewModel.refresh()
+  }
+
   // After the user returns from the reward sign-in flow signed in, claim automatically so the
   // success dialog shows (mirrors the apkfy reward flow).
   LaunchedEffect(userInfo) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/SignInRewardRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/SignInRewardRepository.kt
@@ -3,12 +3,14 @@ package com.aptoide.android.aptoidegames.play_and_earn.presentation.rewards
 import cm.aptoide.pt.campaigns.data.PaEMissionsRepository
 import cm.aptoide.pt.campaigns.domain.PaEMission
 import cm.aptoide.pt.campaigns.domain.PaEMissionStatus
+import cm.aptoide.pt.play_and_earn.events.data.EventAlreadySubmittedException
 import cm.aptoide.pt.play_and_earn.events.data.EventsRepository
 import cm.aptoide.pt.play_and_earn.events.domain.EventType
 import cm.aptoide.pt.play_and_earn.exchange.domain.GetExchangeRateUseCase
 import com.aptoide.android.aptoidegames.play_and_earn.WalletUnitsRefresher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,8 +29,10 @@ data class PendingPaEReward(
   val units: Int,
 )
 
-/** Backend's view of the user's reward: either unclaimed (with the reward data) or claimed. */
+/** Backend's view of the user's reward: unknown until fetched, unclaimed (with data) or claimed. */
 sealed interface RewardState {
+  /** Mission state not resolved yet (fetch in flight or failed) — offer surfaces stay hidden. */
+  data object Loading : RewardState
   data class Unclaimed(val reward: PendingPaEReward) : RewardState
   data object Claimed : RewardState
 }
@@ -41,32 +45,33 @@ class SignInRewardRepository @Inject constructor(
   private val walletUnitsRefresher: WalletUnitsRefresher,
 ) {
 
-  // Placeholder shown until the backend FIRST_SIGN_IN mission resolves; also the fallback if it fails.
-  private val defaultReward = PendingPaEReward(
-    paERewardType = PaERewardType.ROBUX,
-    rewardAmount = PAE_DEFAULT_REWARD_AMOUNT,
-    units = PAE_DEFAULT_REWARD_UNITS,
-  )
-
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
-  private val _rewardState = MutableStateFlow<RewardState>(RewardState.Unclaimed(defaultReward))
+  private val _rewardState = MutableStateFlow<RewardState>(RewardState.Loading)
   val rewardState: StateFlow<RewardState> = _rewardState.asStateFlow()
 
   private val _claimSuccessEvent = MutableSharedFlow<PendingPaEReward>()
   val claimSuccessEvent: SharedFlow<PendingPaEReward> = _claimSuccessEvent.asSharedFlow()
 
+  private var refreshJob: Job? = null
+
   init {
-    refreshSignInReward()
+    refresh()
   }
 
-  // Fetches the FIRST_SIGN_IN event mission and refines the reward amount (from its units, via the
-  // exchange rate) and claimed state (from its progress). Keeps the default reward on failure.
-  private fun refreshSignInReward() {
-    scope.launch {
+  /**
+   * Fetches the FIRST_SIGN_IN event mission and resolves the reward amount (from its units, via
+   * the exchange rate) and claimed state (from its progress). Failures keep the state [Loading] —
+   * offer surfaces call this again on entry, so a failed startup fetch gets retried. Once resolved
+   * the state is never re-fetched: the missions endpoint doesn't report claimed progress yet, so a
+   * re-fetch could regress an in-session Claimed back to Unclaimed.
+   */
+  fun refresh() {
+    if (_rewardState.value != RewardState.Loading || refreshJob?.isActive == true) return
+    refreshJob = scope.launch {
       val mission = paeMissionsRepository.getEventMissions().getOrNull()
         ?.firstOrNull { it.eventType() == EventType.FIRST_SIGN_IN }
-        ?: return@launch
+        ?: return@launch // stays Loading; retried on the next offer-surface entry
 
       _rewardState.value = if (mission.progress?.status == PaEMissionStatus.COMPLETED) {
         RewardState.Claimed
@@ -95,15 +100,22 @@ class SignInRewardRepository @Inject constructor(
 
   fun claimReward(reward: PendingPaEReward) {
     scope.launch {
-      // Register the sign in reward claim as a Play & Earn event. Optimistic write for now.
+      // Register the sign in reward claim as a Play & Earn event.
       eventsRepository.submitEvent(
         eventType = EventType.FIRST_SIGN_IN,
-      )
-      // Claiming grants units on the backend — refresh the toolbar balance.
-      walletUnitsRefresher.invalidate()
-
-      _rewardState.value = RewardState.Claimed
-      _claimSuccessEvent.emit(reward)
+      ).onSuccess {
+        // Claiming grants units on the backend — refresh the toolbar balance.
+        walletUnitsRefresher.invalidate()
+        _rewardState.value = RewardState.Claimed
+        _claimSuccessEvent.emit(reward)
+      }.onFailure { error ->
+        // 409: the backend already granted this reward (stale local state) — sync to Claimed so
+        // every offer surface hides, but without the success dialog. Any other failure keeps the
+        // state Unclaimed so the offer remains claimable (retry).
+        if (error is EventAlreadySubmittedException) {
+          _rewardState.value = RewardState.Claimed
+        }
+      }
     }
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/SignInRewardViewModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/rewards/SignInRewardViewModel.kt
@@ -23,6 +23,11 @@ class SignInRewardViewModel @Inject constructor(
     signInRewardRepository.claimReward(reward)
   }
 
+  /** Retries the mission fetch if the reward state is still unresolved (no-op otherwise). */
+  fun refresh() {
+    signInRewardRepository.refresh()
+  }
+
   /** Runs [log] only the first time the card for [rewardType] is shown this session. */
   fun onRewardCardShown(rewardType: PaERewardType, log: () -> Unit) {
     if (shownLogged.add(rewardType)) log()


### PR DESCRIPTION
**What does this PR do?**

Two Play & Earn fixes, one commit each:

[AND-866] Users who had already claimed the first sign-in reward could still see and interact with the offer (games feed card, apkfy reward screens) even though the backend would reject the claim. The reward state now starts as `Loading` (offer surfaces hidden until the FIRST_SIGN_IN mission fetch resolves, with retry on offer-surface entry), the apkfy reward screens self-dismiss to home whenever the state resolves to `Claimed` (and `ApkfyScreen` skips routing claimed users into them), and `claimReward()` is no longer optimistic: the success dialog only shows when the events call succeeds, a 409 silently syncs the state to `Claimed`, and other failures keep the offer claimable for retry.

Note: for a claimed guest the missions endpoint currently returns `progress.status: null` while the events endpoint returns 409 for the same guest_id, so at load time the client still cannot know the reward was claimed — being raised with the backend team. The 409 handling self-heals the session on the first collect tap.

[AND-867] Firebase geo-targeting of `show_play_and_earn` is not trusted on its own. `shouldShowPlayAndEarn()` now also requires the locally detected country (network country → SIM country → locale, via the new `DeviceCountryProvider`) to be in the allowed list, read from the `pae_countries` remote config value (JSON array of ISO 3166-1 alpha-2 codes) with a hardcoded fallback (US, CA, FI, FR, DE, IT, NL, NO, PT, ES, SE, GB) when the key is missing or unparseable. Unknown country hides the feature (fail-closed).

**Database changed?**

No

**Where should the reviewer start?**

- [ ] SignInRewardRepository.kt (Loading state + result-driven claim)
- [ ] RobloxApkfyRewardScreen.kt / FreeFireApkfyRewardScreen.kt (state-driven dismissal)
- [ ] PlayAndEarnManager.kt (country gate)
- [ ] DeviceCountryProvider.kt

**How should this be manually tested?**

AND-866: on a fresh guest, claim the reward via the games feed card or the apkfy flow → success dialog over home, all offer surfaces disappear. On an already-claimed guest, tap collect → no dialog, offers disappear (409 path). On app open the card only appears after the missions fetch resolves.

AND-867: with `pae_countries` set in remote config, P&E surfaces only show when the device country (network/SIM/locale) is in the list; empty array hides everywhere; deleting the key falls back to the hardcoded list.

**What are the relevant tickets?**

[AND-866](https://aptoide.atlassian.net/browse/AND-866), [AND-867](https://aptoide.atlassian.net/browse/AND-867)

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AND-866]: https://aptoide.atlassian.net/browse/AND-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-867]: https://aptoide.atlassian.net/browse/AND-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Play & Earn rewards now reflect the latest sign-in reward status.
  * Added country-based eligibility checks for Play & Earn availability.
  * Reward offers retry loading when initial mission data is unavailable.

* **Bug Fixes**
  * Improved reward claiming accuracy by preventing false success states.
  * Automatically returns users home after a reward is successfully claimed.
  * Handles previously completed rewards consistently across navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->