### PR TITLE
Migrate aptoideGamesDev to the device API backend

### DIFF
--- a/app-games/build.gradle.kts
+++ b/app-games/build.gradle.kts
@@ -168,6 +168,14 @@ android {
         "STORE_ENV_DOMAIN",
         "\"https://ws75-devel.aptoide.com/api/7.20240701/\""
       )
+      // New backend (device API) — dev cutover, aptoideGamesDev only. See the
+      // migration plan / contracts (device.openapi.json). Prod stays on v7, so
+      // this field is intentionally dev-only.
+      buildConfigField(
+        type = "String",
+        name = "DEVICE_API_DOMAIN",
+        value = "\"https://api.dev.aptoide.com/\""
+      )
       buildConfigField(
         type = "String",
         name = "API_CHAIN_CATAPPULT_HOST",
@@ -282,6 +290,7 @@ dependencies {
   implementation(projects.downloadView)
   implementation(projects.aptoideInstaller)
   implementation(projects.aptoideNetwork)
+  implementation(projects.deviceApi)
   implementation(projects.featureCampaigns)
   implementation(projects.environmentInfo)
   implementation(projects.exceptionHandler)

--- a/app-games/src/aptoideGamesDev/java/com/aptoide/android/aptoidegames/deviceapi/di/DeviceApiBindsModule.kt
+++ b/app-games/src/aptoideGamesDev/java/com/aptoide/android/aptoidegames/deviceapi/di/DeviceApiBindsModule.kt
@@ -1,0 +1,74 @@
+package com.aptoide.android.aptoidegames.deviceapi.di
+
+import cm.aptoide.pt.aptoide_network.di.StoreName
+import cm.aptoide.pt.device_api.di.DeviceApiRetrofit
+import cm.aptoide.pt.device_api.di.DeviceApiVariant
+import cm.aptoide.pt.device_api.network.DeviceProfileProvider
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiAppRepository
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiAppsListRepository
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiAppsService
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiReviewsRepository
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiSplitsRepository
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceHomeAppsCache
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/**
+ * Fill-bindings for the device-API repositories — **aptoideGamesDev only**.
+ * Providing these concrete types makes the feature modules' `Optional<DeviceApi…>`
+ * present, so their `@Provides` select the device impl over v7. Absent in every
+ * other variant ⇒ those keep v7.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object DeviceApiBindsModule {
+
+  @Provides
+  @Singleton
+  fun provideDeviceApiAppRepository(
+    @DeviceApiRetrofit retrofit: Retrofit,
+    @StoreName storeName: String,
+    deviceProfileProvider: DeviceProfileProvider,
+  ): DeviceApiAppRepository = DeviceApiAppRepository(
+    service = retrofit.create(DeviceApiAppsService::class.java),
+    storeName = storeName,
+    deviceProfileProvider = deviceProfileProvider,
+    scope = CoroutineScope(Dispatchers.IO),
+  )
+
+  @Provides
+  @Singleton
+  fun provideDeviceApiAppsListRepository(
+    @DeviceApiRetrofit retrofit: Retrofit,
+    @StoreName storeName: String,
+    @DeviceApiVariant variant: String,
+    deviceProfileProvider: DeviceProfileProvider,
+    homeAppsCache: DeviceHomeAppsCache,
+  ): DeviceApiAppsListRepository = DeviceApiAppsListRepository(
+    service = retrofit.create(DeviceApiAppsService::class.java),
+    storeName = storeName,
+    variant = variant,
+    deviceProfileProvider = deviceProfileProvider,
+    homeAppsCache = homeAppsCache,
+    scope = CoroutineScope(Dispatchers.IO),
+  )
+
+  @Provides
+  @Singleton
+  fun provideDeviceApiSplitsRepository(): DeviceApiSplitsRepository = DeviceApiSplitsRepository()
+
+  @Provides
+  @Singleton
+  fun provideDeviceApiReviewsRepository(
+    @DeviceApiRetrofit retrofit: Retrofit,
+  ): DeviceApiReviewsRepository = DeviceApiReviewsRepository(
+    service = retrofit.create(DeviceApiReviewsRepository.Service::class.java),
+    scope = CoroutineScope(Dispatchers.IO),
+  )
+}

--- a/app-games/src/aptoideGamesDev/java/com/aptoide/android/aptoidegames/deviceapi/di/DeviceApiCategoriesBindsModule.kt
+++ b/app-games/src/aptoideGamesDev/java/com/aptoide/android/aptoidegames/deviceapi/di/DeviceApiCategoriesBindsModule.kt
@@ -1,0 +1,28 @@
+package com.aptoide.android.aptoidegames.deviceapi.di
+
+import cm.aptoide.pt.device_api.di.DeviceApiRetrofit
+import cm.aptoide.pt.feature_categories.data.deviceapi.DeviceApiCategoriesRepository
+import cm.aptoide.pt.feature_categories.data.deviceapi.DeviceApiCategoriesService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/** Device-API categories fill-binding — aptoideGamesDev only. */
+@Module
+@InstallIn(SingletonComponent::class)
+object DeviceApiCategoriesBindsModule {
+
+  @Provides
+  @Singleton
+  fun provideDeviceApiCategoriesRepository(
+    @DeviceApiRetrofit retrofit: Retrofit,
+  ): DeviceApiCategoriesRepository = DeviceApiCategoriesRepository(
+    service = retrofit.create(DeviceApiCategoriesService::class.java),
+    scope = CoroutineScope(Dispatchers.IO),
+  )
+}

--- a/app-games/src/aptoideGamesDev/java/com/aptoide/android/aptoidegames/deviceapi/di/DeviceApiEditorialBindsModule.kt
+++ b/app-games/src/aptoideGamesDev/java/com/aptoide/android/aptoidegames/deviceapi/di/DeviceApiEditorialBindsModule.kt
@@ -1,0 +1,25 @@
+package com.aptoide.android.aptoidegames.deviceapi.di
+
+import cm.aptoide.pt.device_api.di.DeviceApiRetrofit
+import cm.aptoide.pt.feature_editorial.data.deviceapi.DeviceApiEditorialRepository
+import cm.aptoide.pt.feature_editorial.data.deviceapi.DeviceApiEditorialService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/** Device-API editorial fill-binding — aptoideGamesDev only. */
+@Module
+@InstallIn(SingletonComponent::class)
+object DeviceApiEditorialBindsModule {
+
+  @Provides
+  @Singleton
+  fun provideDeviceApiEditorialRepository(
+    @DeviceApiRetrofit retrofit: Retrofit,
+  ): DeviceApiEditorialRepository = DeviceApiEditorialRepository(
+    service = retrofit.create(DeviceApiEditorialService::class.java),
+  )
+}

--- a/app-games/src/aptoideGamesDev/java/com/aptoide/android/aptoidegames/deviceapi/di/DeviceApiHomeBindsModule.kt
+++ b/app-games/src/aptoideGamesDev/java/com/aptoide/android/aptoidegames/deviceapi/di/DeviceApiHomeBindsModule.kt
@@ -1,0 +1,37 @@
+package com.aptoide.android.aptoidegames.deviceapi.di
+
+import cm.aptoide.pt.aptoide_network.di.StoreName
+import cm.aptoide.pt.device_api.di.DeviceApiRetrofit
+import cm.aptoide.pt.device_api.di.DeviceApiVariant
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceHomeAppsCache
+import cm.aptoide.pt.feature_home.data.deviceapi.DeviceApiWidgetsRepository
+import cm.aptoide.pt.feature_home.data.deviceapi.DeviceApiWidgetsService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/** Device-API home fill-binding — aptoideGamesDev only. */
+@Module
+@InstallIn(SingletonComponent::class)
+object DeviceApiHomeBindsModule {
+
+  @Provides
+  @Singleton
+  fun provideDeviceApiWidgetsRepository(
+    @DeviceApiRetrofit retrofit: Retrofit,
+    @DeviceApiVariant variant: String,
+    @StoreName storeName: String,
+    homeAppsCache: DeviceHomeAppsCache,
+  ): DeviceApiWidgetsRepository = DeviceApiWidgetsRepository(
+    service = retrofit.create(DeviceApiWidgetsService::class.java),
+    variant = variant,
+    storeName = storeName,
+    homeAppsCache = homeAppsCache,
+    scope = CoroutineScope(Dispatchers.IO),
+  )
+}

--- a/app-games/src/aptoideGamesDev/java/com/aptoide/android/aptoidegames/deviceapi/di/DeviceApiNetworkModule.kt
+++ b/app-games/src/aptoideGamesDev/java/com/aptoide/android/aptoidegames/deviceapi/di/DeviceApiNetworkModule.kt
@@ -1,0 +1,117 @@
+package com.aptoide.android.aptoidegames.deviceapi.di
+
+import cm.aptoide.pt.aptoide_network.data.network.AcceptLanguageInterceptor
+import cm.aptoide.pt.aptoide_network.data.network.UserAgentInterceptor
+import cm.aptoide.pt.device_api.di.DeviceApiDomain
+import cm.aptoide.pt.device_api.di.DeviceApiOkHttp
+import cm.aptoide.pt.device_api.di.DeviceApiRetrofit
+import cm.aptoide.pt.device_api.di.DeviceApiVariant
+import cm.aptoide.pt.device_api.json.DiscriminatorAdapterFactory
+import cm.aptoide.pt.feature_home.data.deviceapi.model.AppCollectionSectionResponse
+import cm.aptoide.pt.feature_home.data.deviceapi.model.CategoryGridSectionResponse
+import cm.aptoide.pt.feature_home.data.deviceapi.model.EditorialCardSectionResponse
+import cm.aptoide.pt.feature_home.data.deviceapi.model.FeaturedBannerSectionResponse
+import cm.aptoide.pt.feature_home.data.deviceapi.model.HomeSectionResponse
+import cm.aptoide.pt.feature_home.data.deviceapi.model.TopChartSectionResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.AppEmbedBlockResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.CtaActionBlockResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.EditorialBlockResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.HeadingBlockResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.ImageBlockResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.ParagraphBlockResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.VideoBlockResponse
+import com.aptoide.android.aptoidegames.BuildConfig
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.GsonBuilder
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
+
+/**
+ * Device-API network wiring for the **aptoideGamesDev** variant only. Because it
+ * lives in `src/aptoideGamesDev/`, these providers never compile into
+ * aptoideGamesProd / vanilla / `:app`, so those variants stay on v7 untouched and
+ * never reference `BuildConfig.DEVICE_API_DOMAIN`.
+ *
+ * The client is deliberately slim — none of the v7 `q`/`aab`/`lang`/`vercode`
+ * interceptors. Variant/device-profile/refresh conventions ride per-request as
+ * explicit query params in the Retrofit services (spec-accurate, cache-key-safe),
+ * not as blanket interceptors.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object DeviceApiNetworkModule {
+
+  /** The product variant slug for `?variant=` (guide + device.openapi.json: `aptoide-games`). */
+  @Provides
+  @DeviceApiVariant
+  fun provideDeviceApiVariant(): String = "aptoide-games"
+
+  @Provides
+  @DeviceApiDomain
+  fun provideDeviceApiDomain(): String = BuildConfig.DEVICE_API_DOMAIN
+
+  @Provides
+  @Singleton
+  @DeviceApiOkHttp
+  fun provideDeviceApiOkHttp(
+    userAgentInterceptor: UserAgentInterceptor,
+    acceptLanguageInterceptor: AcceptLanguageInterceptor,
+  ): OkHttpClient = OkHttpClient.Builder()
+    .addInterceptor(userAgentInterceptor)
+    .addInterceptor(acceptLanguageInterceptor)
+    .addInterceptor(HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BASIC })
+    .build()
+
+  @Provides
+  @Singleton
+  @DeviceApiRetrofit
+  fun provideDeviceApiRetrofit(
+    @DeviceApiOkHttp okHttpClient: OkHttpClient,
+    @DeviceApiDomain domain: String,
+  ): Retrofit {
+    // Device API is snake_case; DTOs are camelCase → let Gson bridge the naming so
+    // DTOs stay idiomatic. Discriminated-union adapters are registered per surface.
+    val gson = GsonBuilder()
+      .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+      .registerTypeAdapterFactory(
+        DiscriminatorAdapterFactory(
+          baseType = HomeSectionResponse::class.java,
+          discriminator = "type",
+          subtypes = mapOf(
+            "featured_banner" to FeaturedBannerSectionResponse::class.java,
+            "app_collection" to AppCollectionSectionResponse::class.java,
+            "top_chart" to TopChartSectionResponse::class.java,
+            "category_grid" to CategoryGridSectionResponse::class.java,
+            "editorial_card" to EditorialCardSectionResponse::class.java,
+          ),
+        )
+      )
+      .registerTypeAdapterFactory(
+        DiscriminatorAdapterFactory(
+          baseType = EditorialBlockResponse::class.java,
+          discriminator = "kind",
+          subtypes = mapOf(
+            "heading" to HeadingBlockResponse::class.java,
+            "paragraph" to ParagraphBlockResponse::class.java,
+            "image" to ImageBlockResponse::class.java,
+            "app_embed" to AppEmbedBlockResponse::class.java,
+            "video" to VideoBlockResponse::class.java,
+            "cta_action" to CtaActionBlockResponse::class.java,
+          ),
+        )
+      )
+      .create()
+    return Retrofit.Builder()
+      .client(okHttpClient)
+      .baseUrl(domain)
+      .addConverterFactory(GsonConverterFactory.create(gson))
+      .build()
+  }
+}

--- a/app-games/src/aptoideGamesDev/java/com/aptoide/android/aptoidegames/deviceapi/di/DeviceApiSearchBindsModule.kt
+++ b/app-games/src/aptoideGamesDev/java/com/aptoide/android/aptoidegames/deviceapi/di/DeviceApiSearchBindsModule.kt
@@ -1,0 +1,39 @@
+package com.aptoide.android.aptoidegames.deviceapi.di
+
+import cm.aptoide.pt.aptoide_network.di.StoreName
+import cm.aptoide.pt.device_api.di.DeviceApiRetrofit
+import cm.aptoide.pt.device_api.di.DeviceApiVariant
+import cm.aptoide.pt.device_api.network.DeviceProfileProvider
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiAppsService
+import cm.aptoide.pt.feature_search.data.database.SearchHistoryRepository
+import cm.aptoide.pt.feature_search.data.deviceapi.DeviceApiSearchRepository
+import cm.aptoide.pt.feature_search.data.deviceapi.DeviceApiSuggestService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+/** Device-API search fill-binding — aptoideGamesDev only. */
+@Module
+@InstallIn(SingletonComponent::class)
+object DeviceApiSearchBindsModule {
+
+  @Provides
+  @Singleton
+  fun provideDeviceApiSearchRepository(
+    @DeviceApiRetrofit retrofit: Retrofit,
+    searchHistoryRepository: SearchHistoryRepository,
+    @StoreName storeName: String,
+    @DeviceApiVariant variant: String,
+    deviceProfileProvider: DeviceProfileProvider,
+  ): DeviceApiSearchRepository = DeviceApiSearchRepository(
+    appsService = retrofit.create(DeviceApiAppsService::class.java),
+    suggestService = retrofit.create(DeviceApiSuggestService::class.java),
+    searchHistoryRepository = searchHistoryRepository,
+    storeName = storeName,
+    variant = variant,
+    deviceProfileProvider = deviceProfileProvider,
+  )
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppReviews.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppReviews.kt
@@ -1,0 +1,121 @@
+package com.aptoide.android.aptoidegames.appview
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import cm.aptoide.pt.extensions.runPreviewable
+import cm.aptoide.pt.feature_apps.data.ReviewsRepository
+import cm.aptoide.pt.feature_apps.domain.Review
+import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.theme.AGTypography
+import com.aptoide.android.aptoidegames.theme.Palette
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Read-only reviews list for the app-view Reviews tab. Anonymous, device-API only
+ * (`GET /apps/{package}/reviews`); renders nothing when there are no reviews (v7
+ * variants use [cm.aptoide.pt.feature_apps.data.EmptyReviewsRepository], and the
+ * tab itself is hidden when empty).
+ */
+@Composable
+fun AppReviewsSection(packageName: String) {
+  val reviews = rememberReviews(packageName)
+  if (reviews.isEmpty()) return
+
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 16.dp, vertical = 16.dp),
+    verticalArrangement = Arrangement.spacedBy(16.dp),
+  ) {
+    reviews.take(20).forEach { ReviewRow(it) }
+  }
+}
+
+@Composable
+private fun ReviewRow(review: Review) {
+  Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Row {
+      Text(
+        text = review.authorName?.takeIf { it.isNotBlank() }
+          ?: stringResource(R.string.appview_reviews_anonymous),
+        style = AGTypography.BodyBold,
+        color = Palette.White,
+      )
+      review.rating?.let {
+        Spacer(Modifier.width(8.dp))
+        Text(text = "★ $it", style = AGTypography.Body, color = Palette.Primary)
+      }
+    }
+    review.title?.takeIf { it.isNotBlank() }?.let {
+      Text(text = it, style = AGTypography.BodyBold, color = Palette.GreyLight)
+    }
+    Text(
+      text = review.body,
+      style = AGTypography.Body,
+      color = Palette.GreyLight,
+      maxLines = 6,
+      overflow = TextOverflow.Ellipsis,
+    )
+  }
+}
+
+@Composable
+internal fun rememberReviews(packageName: String): List<Review> = runPreviewable(
+  preview = { emptyList() },
+  real = {
+    val injectionsProvider = hiltViewModel<ReviewsInjectionsProvider>()
+    val vm: ReviewsViewModel = viewModel(
+      key = "reviews/$packageName",
+      factory = object : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+          @Suppress("UNCHECKED_CAST")
+          return ReviewsViewModel(packageName, injectionsProvider.reviewsRepository) as T
+        }
+      },
+    )
+    val reviews by vm.reviews.collectAsState()
+    reviews
+  },
+)
+
+@HiltViewModel
+class ReviewsInjectionsProvider @Inject constructor(
+  val reviewsRepository: ReviewsRepository,
+) : ViewModel()
+
+class ReviewsViewModel(
+  packageName: String,
+  reviewsRepository: ReviewsRepository,
+) : ViewModel() {
+  private val _reviews = MutableStateFlow<List<Review>>(emptyList())
+  val reviews: StateFlow<List<Review>> = _reviews.asStateFlow()
+
+  init {
+    viewModelScope.launch {
+      _reviews.value = runCatching { reviewsRepository.getReviews(packageName) }.getOrDefault(emptyList())
+    }
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -80,6 +80,7 @@ import cm.aptoide.pt.feature_apps.domain.AppSource.Companion.appendIfRequired
 import cm.aptoide.pt.feature_apps.domain.Rating
 import cm.aptoide.pt.feature_apps.presentation.AppUiState
 import cm.aptoide.pt.feature_apps.presentation.rememberApp
+import cm.aptoide.pt.feature_apps.presentation.similarApps
 import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
 import cm.aptoide.pt.play_and_earn.exchange.presentation.rememberExchangeRate
 import com.aptoide.android.aptoidegames.APP_LINK_HOST
@@ -113,6 +114,7 @@ import com.aptoide.android.aptoidegames.editorial.relatedEditorialsCardViewModel
 import com.aptoide.android.aptoidegames.editorial.rememberRelatedEditorials
 import com.aptoide.android.aptoidegames.error_views.GenericErrorView
 import com.aptoide.android.aptoidegames.error_views.NoConnectionView
+import com.aptoide.android.aptoidegames.feature_apps.presentation.SimpleAppsGrid
 import com.aptoide.android.aptoidegames.feature_apps.presentation.SmallEmptyView
 import com.aptoide.android.aptoidegames.feature_apps.presentation.buildSeeMoreBonusRoute
 import com.aptoide.android.aptoidegames.feature_apps.presentation.rememberBonusBundle
@@ -139,6 +141,7 @@ import com.aptoide.android.aptoidegames.videos.presentation.AppViewYoutubePlayer
 
 private val tabsList = listOf(
   AppViewTab.DETAILS,
+  AppViewTab.REVIEWS,
   AppViewTab.REWARDS,
   AppViewTab.RELATED,
   AppViewTab.INFO,
@@ -284,7 +287,11 @@ fun AppViewScreen(
     rememberIsPackageInPaE(packageName = it)
   } ?: false
 
-  val tabsList by remember(relatedEditorialsUiState, isPackageInPaE) {
+  val hasReviews = (uiState as? AppUiState.Idle)?.app?.packageName?.let {
+    rememberReviews(packageName = it).isNotEmpty()
+  } ?: false
+
+  val tabsList by remember(relatedEditorialsUiState, isPackageInPaE, hasReviews) {
     derivedStateOf {
       tabsList
         .let {
@@ -300,6 +307,9 @@ fun AppViewScreen(
           } else {
             it.filter { it != AppViewTab.REWARDS }
           }
+        }
+        .let {
+          if (hasReviews) it else it.filter { tab -> tab != AppViewTab.REVIEWS }
         }
     }
   }
@@ -638,7 +648,9 @@ fun ViewPagerContent(
   navigate: (String) -> Unit,
 ) {
   when (selectedTab) {
-    AppViewTab.DETAILS -> DetailsView(app = app)
+    AppViewTab.DETAILS -> DetailsView(app = app, navigate = navigate)
+
+    AppViewTab.REVIEWS -> AppReviewsSection(packageName = app.packageName)
 
     AppViewTab.REWARDS -> AppRewardsView(packageName = app.packageName)
 
@@ -655,9 +667,9 @@ fun ViewPagerContent(
 }
 
 @Composable
-fun DetailsView(app: App) {
+fun DetailsView(app: App, navigate: (String) -> Unit) {
   Column(
-    modifier = Modifier.padding(top = 16.dp)
+    modifier = Modifier.padding(top = 16.dp, bottom = 32.dp)
   ) {
     app.screenshots?.let { ScreenshotsList(it) }
     app.news?.let {
@@ -665,13 +677,18 @@ fun DetailsView(app: App) {
     }
 
     app.description?.let {
-      Text(
-        text = it,
-        modifier = Modifier.padding(top = 16.dp, bottom = 32.dp, start = 16.dp, end = 16.dp),
-        style = AGTypography.ArticleText,
-        color = Palette.White
-      )
+      CollapsibleDescription(description = it)
     }
+
+    TrustPanel(trust = app.trust)
+
+    val (similarState, _) = similarApps(source = app.packageName)
+    SimpleAppsGrid(
+      title = stringResource(R.string.appview_similar_title),
+      tag = "similar-${app.packageName}",
+      uiState = similarState,
+      navigate = navigate,
+    )
   }
 }
 
@@ -1179,7 +1196,7 @@ fun AppViewScreenPreview() {
 @Composable
 fun DetailsViewPreview() {
   AptoideTheme {
-    DetailsView(app = randomApp)
+    DetailsView(app = randomApp, navigate = {})
   }
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewTabRow.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewTabRow.kt
@@ -100,6 +100,7 @@ private data class TabPositionInfo(
 fun AppViewTab.getTabName(): String = stringResource(
   when (this) {
     AppViewTab.DETAILS -> R.string.appview_details_tab_title
+    AppViewTab.REVIEWS -> R.string.appview_reviews_tab_title
     AppViewTab.REWARDS -> R.string.appview_rewards_tab_title
     AppViewTab.RELATED -> R.string.appview_related_tab_title
     AppViewTab.INFO -> R.string.appview_info_tab_title
@@ -108,6 +109,7 @@ fun AppViewTab.getTabName(): String = stringResource(
 
 enum class AppViewTab {
   DETAILS,
+  REVIEWS,
   REWARDS,
   RELATED,
   INFO

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/CollapsibleDescription.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/CollapsibleDescription.kt
@@ -1,0 +1,63 @@
+package com.aptoide.android.aptoidegames.appview
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.theme.AGTypography
+import com.aptoide.android.aptoidegames.theme.Palette
+
+private const val COLLAPSED_MAX_LINES = 5
+
+/**
+ * App-view description that collapses to [COLLAPSED_MAX_LINES] with a Read more /
+ * Show less toggle, so the sections below the description stay reachable. The toggle
+ * only appears when the text actually overflows when collapsed.
+ */
+@Composable
+fun CollapsibleDescription(description: String) {
+  var expanded by rememberSaveable(description) { mutableStateOf(false) }
+  var hasOverflow by remember(description) { mutableStateOf(false) }
+
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(top = 16.dp, bottom = 32.dp, start = 16.dp, end = 16.dp),
+  ) {
+    Text(
+      text = description,
+      style = AGTypography.ArticleText,
+      color = Palette.White,
+      maxLines = if (expanded) Int.MAX_VALUE else COLLAPSED_MAX_LINES,
+      overflow = TextOverflow.Ellipsis,
+      onTextLayout = { result ->
+        if (!expanded) hasOverflow = result.hasVisualOverflow
+      },
+    )
+    if (expanded || hasOverflow) {
+      Text(
+        text = stringResource(
+          if (expanded) R.string.appview_description_show_less
+          else R.string.appview_description_read_more
+        ),
+        style = AGTypography.BodyBold,
+        color = Palette.Primary,
+        modifier = Modifier
+          .padding(top = 8.dp)
+          .clickable { expanded = !expanded },
+      )
+    }
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/TrustPanel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/TrustPanel.kt
@@ -1,0 +1,105 @@
+package com.aptoide.android.aptoidegames.appview
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import cm.aptoide.pt.feature_apps.domain.Trust
+import com.aptoide.android.aptoidegames.R
+import com.aptoide.android.aptoidegames.theme.AGTypography
+import com.aptoide.android.aptoidegames.theme.Palette
+
+/**
+ * The transparency / trust panel — the product's "transparency inversion". Renders
+ * the device-API trust signals (scan verdict, provenance, signer consistency).
+ * Shown only when [Trust] is present, i.e. the aptoideGamesDev device path; on the
+ * v7 path `app.trust` is null and nothing renders.
+ */
+@Composable
+fun TrustPanel(trust: Trust?) {
+  if (trust == null) return
+
+  // Palette is a @Composable accessor, so colors are resolved here, not in helpers.
+  val rows = mutableListOf<Pair<Color, String>>()
+  trust.scanVerdict?.let { v ->
+    val color = when (v.lowercase()) {
+      "trusted" -> Palette.Primary
+      "critical" -> Palette.Error
+      else -> Palette.GreyLight
+    }
+    rows.add(color to stringResource(scanLabelRes(v)))
+  }
+  trust.provenance?.let { p ->
+    provenanceLabelRes(p)?.let { res -> rows.add(Palette.GreyLight to stringResource(res)) }
+  }
+  trust.signerConsistency?.let { c ->
+    val color = if (c.lowercase() == "different_signer") Palette.Error else Palette.Primary
+    signerLabelRes(c)?.let { res -> rows.add(color to stringResource(res)) }
+  }
+  if (rows.isEmpty()) return
+
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 16.dp, vertical = 16.dp)
+      .clip(RoundedCornerShape(12.dp))
+      .background(Palette.GreyDark)
+      .padding(16.dp),
+    verticalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    Text(
+      text = stringResource(R.string.appview_trust_title),
+      style = AGTypography.BodyBold,
+      color = Palette.White,
+    )
+    rows.forEach { (color, label) ->
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        Spacer(
+          modifier = Modifier
+            .size(10.dp)
+            .clip(RoundedCornerShape(5.dp))
+            .background(color),
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(text = label, style = AGTypography.Body, color = Palette.GreyLight)
+      }
+    }
+  }
+}
+
+@StringRes
+private fun scanLabelRes(verdict: String): Int = when (verdict.lowercase()) {
+  "trusted" -> R.string.appview_trust_scan_trusted
+  "warning" -> R.string.appview_trust_scan_warning
+  "critical" -> R.string.appview_trust_scan_critical
+  else -> R.string.appview_trust_scan_unknown
+}
+
+@StringRes
+private fun provenanceLabelRes(provenance: String): Int? = when (provenance.lowercase()) {
+  "developer_upload" -> R.string.appview_trust_provenance_developer
+  "mirrored" -> R.string.appview_trust_provenance_mirrored
+  else -> null
+}
+
+@StringRes
+private fun signerLabelRes(consistency: String): Int? = when (consistency.lowercase()) {
+  "consistent" -> R.string.appview_trust_signer_consistent
+  "different_signer" -> R.string.appview_trust_signer_different
+  else -> null
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_apps/presentation/AppGridView.kt
@@ -33,6 +33,7 @@ import cm.aptoide.pt.feature_apps.presentation.previewAppsListIdleState
 import cm.aptoide.pt.feature_apps.presentation.rememberAppsByTag
 import cm.aptoide.pt.feature_campaigns.toAptoideMMPCampaign
 import cm.aptoide.pt.feature_home.domain.Bundle
+import cm.aptoide.pt.feature_home.domain.Type
 import cm.aptoide.pt.feature_home.domain.randomBundle
 import com.aptoide.android.aptoidegames.analytics.presentation.AnalyticsContext
 import com.aptoide.android.aptoidegames.analytics.presentation.SwipeListener
@@ -64,6 +65,30 @@ fun AppsGridBundle(
     uiState = uiState,
     navigate = navigate,
     spaceBy = spaceBy,
+  )
+}
+
+/**
+ * A titled apps grid from a caller-supplied [uiState] (not tied to a home bundle
+ * tag). Used for the app-view "Similar games" section. Renders nothing when the
+ * list is empty/errored; no "See all" (no bundle actions).
+ */
+@Composable
+fun SimpleAppsGrid(
+  title: String,
+  tag: String,
+  uiState: AppsListUiState,
+  navigate: (String) -> Unit,
+) {
+  RealAppsGridBundle(
+    bundle = Bundle(
+      title = title,
+      actions = emptyList(),
+      type = Type.APP_GRID,
+      tag = tag,
+    ),
+    uiState = uiState,
+    navigate = navigate,
   )
 }
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieFeatureProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/gamegenie/presentation/GameGenieFeatureProvider.kt
@@ -11,6 +11,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import cm.aptoide.pt.extensions.runPreviewable
 import cm.aptoide.pt.feature_flags.domain.FeatureFlags
+import com.aptoide.android.aptoidegames.BuildConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -49,6 +50,8 @@ fun rememberSearchGameGenie(): Boolean = runPreviewable(
         state = vm.featureFlags.getFlag("search_game_genie", false)
       }
     }
-    state
+    // Dev builds use normal search (device-API backed), never GameGenie search,
+    // regardless of the remote flag.
+    state && !BuildConfig.APPLICATION_ID.endsWith(".dev")
   }
 )

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/search/presentation/SearchScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/search/presentation/SearchScreen.kt
@@ -137,7 +137,9 @@ fun searchScreen() = ScreenData.withAnalytics(
 
   var searchValue by rememberSaveable { mutableStateOf("") }
   val shouldRedirectSearchToGameGenie =
-    rememberGameGenieVisibility() && BuildConfig.FLAVOR_brand != "vanilla"
+    rememberGameGenieVisibility() && BuildConfig.FLAVOR_brand != "vanilla" &&
+      // Dev uses normal (device-API) search results, never GameGenie redirect.
+      !BuildConfig.APPLICATION_ID.endsWith(".dev")
   var searchMeta by rememberSaveable(
     saver = Saver(
       save = { it.value?.toString() ?: "null" },

--- a/app-games/src/main/res/values/strings.xml
+++ b/app-games/src/main/res/values/strings.xml
@@ -527,4 +527,19 @@
   <string name="play_and_earn_more_games_more">More games. More %1$s.</string>
   <string name="play_and_earn_rewards_install_play_title">Install Games. Play your favourite.</string>
   <string name="play_and_earn_earn_amount_badge">Earn %1$s</string>
+  <string name="appview_trust_title">Transparency</string>
+  <string name="appview_trust_scan_trusted">Passed our security scan</string>
+  <string name="appview_trust_scan_warning">Security warning from our scan</string>
+  <string name="appview_trust_scan_critical">Security risk detected</string>
+  <string name="appview_trust_scan_unknown">Not yet scanned</string>
+  <string name="appview_trust_provenance_developer">Uploaded by the developer</string>
+  <string name="appview_trust_provenance_mirrored">Mirrored from another source</string>
+  <string name="appview_trust_signer_consistent">Signed consistently across versions</string>
+  <string name="appview_trust_signer_different">Signing certificate changed</string>
+  <string name="appview_reviews_title">Reviews</string>
+  <string name="appview_reviews_tab_title" comment="reviews">Reviews</string>
+  <string name="appview_reviews_anonymous">Anonymous</string>
+  <string name="appview_similar_title">Similar games</string>
+  <string name="appview_description_read_more">Read more</string>
+  <string name="appview_description_show_less">Show less</string>
 </resources>

--- a/device-api/build.gradle.kts
+++ b/device-api/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.android.module)
+  alias(libs.plugins.hilt)
+}
+
+android {
+  namespace = "cm.aptoide.pt.device_api"
+}
+
+dependencies {
+  implementation(projects.extension)
+  implementation(projects.environmentInfo)
+
+  api(libs.retrofit)
+  api(libs.okhttp)
+  api(libs.retrofit.gson.converter)
+  api(libs.logging.interceptor)
+}

--- a/device-api/src/main/java/cm/aptoide/pt/device_api/di/DeviceApiQualifiers.kt
+++ b/device-api/src/main/java/cm/aptoide/pt/device_api/di/DeviceApiQualifiers.kt
@@ -1,0 +1,26 @@
+package cm.aptoide.pt.device_api.di
+
+import javax.inject.Qualifier
+
+/** OkHttp client for the new device API (no v7 q/aab/lang/vercode interceptors). */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DeviceApiOkHttp
+
+/**
+ * Retrofit bound to the host root `api.dev.aptoide.com/`. Device routes use
+ * `android/v1/…` paths, editorial uses `editorials…` — same host, one Retrofit.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DeviceApiRetrofit
+
+/** Base URL (host root) for the device/editorial API (`BuildConfig.DEVICE_API_DOMAIN`). */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DeviceApiDomain
+
+/** The product variant slug sent as `?variant=` on cache-varying reads (e.g. `aptoide-games`). */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DeviceApiVariant

--- a/device-api/src/main/java/cm/aptoide/pt/device_api/error/DeviceApiException.kt
+++ b/device-api/src/main/java/cm/aptoide/pt/device_api/error/DeviceApiException.kt
@@ -1,0 +1,26 @@
+package cm.aptoide.pt.device_api.error
+
+/**
+ * Typed device-API failures mapped from RFC 9457 problem+json. The three that
+ * carry product meaning on app routes (guide §3): 410 removed, 451 country,
+ * 404 not-in-variant. Everything else surfaces as [Generic].
+ */
+sealed class DeviceApiException(
+  val statusCode: Int,
+  message: String?,
+  cause: Throwable? = null,
+) : Exception(message, cause) {
+
+  /** 410 — removed by serving policy. [reason] is public and MUST be shown. */
+  class Removed(val reason: String?) : DeviceApiException(410, reason)
+
+  /** 451 — unavailable in the requesting country. */
+  class CountryUnavailable(reason: String?) : DeviceApiException(451, reason)
+
+  /** 404 — not present in this variant/catalog (or unknown package). */
+  class NotInVariant(reason: String?) : DeviceApiException(404, reason)
+
+  /** Any other non-2xx (422/5xx/transport). */
+  class Generic(statusCode: Int, message: String?, cause: Throwable? = null) :
+    DeviceApiException(statusCode, message, cause)
+}

--- a/device-api/src/main/java/cm/aptoide/pt/device_api/error/Problem.kt
+++ b/device-api/src/main/java/cm/aptoide/pt/device_api/error/Problem.kt
@@ -1,0 +1,18 @@
+package cm.aptoide.pt.device_api.error
+
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
+
+/**
+ * RFC 9457 `application/problem+json` body returned on every non-2xx from the
+ * device/editorial APIs. `detail` carries the public, user-showable reason on a
+ * 410 (removed by serving policy).
+ */
+@Keep
+data class Problem(
+  val type: String? = null,
+  val title: String? = null,
+  val status: Int? = null,
+  @SerializedName("detail") val detail: String? = null,
+  val instance: String? = null,
+)

--- a/device-api/src/main/java/cm/aptoide/pt/device_api/error/ProblemMapper.kt
+++ b/device-api/src/main/java/cm/aptoide/pt/device_api/error/ProblemMapper.kt
@@ -1,0 +1,38 @@
+package cm.aptoide.pt.device_api.error
+
+import com.google.gson.Gson
+import retrofit2.HttpException
+
+/**
+ * Translates a Retrofit [HttpException] into a typed [DeviceApiException] by
+ * parsing the RFC 9457 problem+json body. Repositories wrap their device-API
+ * calls in [deviceApiCall] so callers only ever see typed failures.
+ */
+object ProblemMapper {
+
+  private val gson = Gson()
+
+  fun map(e: HttpException): DeviceApiException {
+    val reason = parseReason(e)
+    return when (e.code()) {
+      410 -> DeviceApiException.Removed(reason)
+      451 -> DeviceApiException.CountryUnavailable(reason)
+      404 -> DeviceApiException.NotInVariant(reason)
+      else -> DeviceApiException.Generic(e.code(), reason ?: e.message(), e)
+    }
+  }
+
+  private fun parseReason(e: HttpException): String? = runCatching {
+    e.response()?.errorBody()?.string()?.takeIf { it.isNotBlank() }
+      ?.let { gson.fromJson(it, Problem::class.java) }
+      ?.let { it.detail ?: it.title }
+  }.getOrNull()
+}
+
+/** Runs a device-API call, mapping [HttpException] to a typed [DeviceApiException]. */
+suspend fun <T> deviceApiCall(block: suspend () -> T): T =
+  try {
+    block()
+  } catch (e: HttpException) {
+    throw ProblemMapper.map(e)
+  }

--- a/device-api/src/main/java/cm/aptoide/pt/device_api/json/DiscriminatorAdapterFactory.kt
+++ b/device-api/src/main/java/cm/aptoide/pt/device_api/json/DiscriminatorAdapterFactory.kt
@@ -1,0 +1,58 @@
+package cm.aptoide.pt.device_api.json
+
+import com.google.gson.Gson
+import com.google.gson.JsonElement
+import com.google.gson.TypeAdapter
+import com.google.gson.TypeAdapterFactory
+import com.google.gson.reflect.TypeToken
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+
+/**
+ * Gson factory for a discriminated `oneOf` union (OpenAPI discriminator). Reads
+ * the [discriminator] field (`type`/`kind`) and dispatches to the mapped subtype.
+ *
+ * **Unknown discriminator values deserialize to `null`** — new section/card/block
+ * kinds are an additive contract change and the client MUST ignore what it does
+ * not recognize (D-007). Callers `filterNotNull()` the resulting list.
+ */
+class DiscriminatorAdapterFactory<T : Any>(
+  private val baseType: Class<T>,
+  private val discriminator: String,
+  private val subtypes: Map<String, Class<out T>>,
+) : TypeAdapterFactory {
+
+  override fun <R : Any?> create(gson: Gson, type: TypeToken<R>): TypeAdapter<R>? {
+    if (type.rawType != baseType) return null
+
+    val elementAdapter = gson.getAdapter(JsonElement::class.java)
+    val labelToDelegate: Map<String, TypeAdapter<out T>> =
+      subtypes.mapValues { (_, cls) -> gson.getDelegateAdapter(this, TypeToken.get(cls)) }
+    val classToLabel: Map<Class<out T>, String> =
+      subtypes.entries.associate { (label, cls) -> cls to label }
+
+    @Suppress("UNCHECKED_CAST")
+    return object : TypeAdapter<R>() {
+      override fun write(out: JsonWriter, value: R) {
+        if (value == null) {
+          out.nullValue()
+          return
+        }
+        val cls = value.javaClass as Class<out T>
+        val label = classToLabel[cls]
+        val delegate = (labelToDelegate[label]
+          ?: gson.getDelegateAdapter(this@DiscriminatorAdapterFactory, TypeToken.get(cls)))
+          as TypeAdapter<T>
+        elementAdapter.write(out, delegate.toJsonTree(value as T))
+      }
+
+      override fun read(reader: JsonReader): R? {
+        val element = elementAdapter.read(reader)
+        if (element == null || !element.isJsonObject) return null
+        val label = element.asJsonObject.get(discriminator)?.asString ?: return null
+        val delegate = labelToDelegate[label] ?: return null // unknown kind -> ignore
+        return delegate.fromJsonTree(element) as R
+      }
+    }
+  }
+}

--- a/device-api/src/main/java/cm/aptoide/pt/device_api/network/DeviceProfile.kt
+++ b/device-api/src/main/java/cm/aptoide/pt/device_api/network/DeviceProfile.kt
@@ -1,0 +1,36 @@
+package cm.aptoide.pt.device_api.network
+
+import cm.aptoide.pt.environment_info.DeviceInfo
+import javax.inject.Inject
+
+/**
+ * The requesting device's capabilities, sent as clean query params
+ * (`sdk`/`abi`/`tv`/`density`) on search/listings/detail/releases/related, and as
+ * a `device` object in the `POST /apps/updates` body. Everything fails OPEN
+ * server-side — a missing field never hides results. Replaces v7's base64 `q=`
+ * blob entirely (guide §"Device profile", D-050).
+ */
+data class DeviceProfile(
+  val sdk: Int,
+  /** Full `Build.SUPPORTED_ABIS`, in order, comma-separated, lowercase. */
+  val abi: String,
+  val tv: Boolean,
+  /** Bucketed density DPI (nearest standard bucket) — see [DeviceProfileProvider]. */
+  val density: Int,
+)
+
+/** Builds a [DeviceProfile] from the shared [DeviceInfo] (`:environment-info`). */
+class DeviceProfileProvider @Inject constructor(
+  private val deviceInfo: DeviceInfo,
+) {
+  fun get(): DeviceProfile = DeviceProfile(
+    sdk = deviceInfo.getSdk(),
+    abi = deviceInfo.getSupportedABIs(),
+    tv = deviceInfo.hasLeanback() == "1",
+    // Bucketed (getDensityDpi), NOT the raw densityDpi (getScreenDensity): the
+    // device API's detail/releases resolution 404s on non-bucket values like 560
+    // (a Pixel 7 Pro's raw dpi). Bucketing 560→640 resolves. Backend should
+    // fail-open on density — see .context/contract-friction.md.
+    density = deviceInfo.getDensityDpi(),
+  )
+}

--- a/device-api/src/main/java/cm/aptoide/pt/device_api/paging/Page.kt
+++ b/device-api/src/main/java/cm/aptoide/pt/device_api/paging/Page.kt
@@ -1,0 +1,21 @@
+package cm.aptoide.pt.device_api.paging
+
+/**
+ * One page of a cursor-paginated device-API list. [nextCursor] is the opaque
+ * server token for the following page (null ⇒ last page). Cursors are minted by
+ * the server — never parse or fabricate them; a foreign/expired cursor is a 4xx,
+ * restart from page one.
+ */
+data class Page<T>(
+  val items: List<T>,
+  val nextCursor: String?,
+) {
+  val hasMore: Boolean get() = nextCursor != null
+
+  fun <R> map(transform: (T) -> R): Page<R> = Page(items.map(transform), nextCursor)
+
+  companion object {
+    /** A terminal single page (used by the v7 default impls that don't paginate). */
+    fun <T> terminal(items: List<T>): Page<T> = Page(items, nextCursor = null)
+  }
+}

--- a/feature-home/build.gradle.kts
+++ b/feature-home/build.gradle.kts
@@ -11,6 +11,7 @@ android {
 
 dependencies {
   implementation(projects.aptoideNetwork)
+  implementation(projects.deviceApi)
   implementation(projects.featureApps)
   implementation(projects.featureEditorial)
   implementation(projects.featureReactions)

--- a/feature-home/src/main/java/cm/aptoide/pt/feature_home/data/deviceapi/DeviceApiWidgetsRepository.kt
+++ b/feature-home/src/main/java/cm/aptoide/pt/feature_home/data/deviceapi/DeviceApiWidgetsRepository.kt
@@ -1,0 +1,94 @@
+package cm.aptoide.pt.feature_home.data.deviceapi
+
+import cm.aptoide.pt.device_api.error.deviceApiCall
+import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceHomeAppsCache
+import cm.aptoide.pt.feature_apps.data.deviceapi.toApp
+import cm.aptoide.pt.feature_home.data.WidgetsRepository
+import cm.aptoide.pt.feature_home.data.deviceapi.model.AppCollectionSectionResponse
+import cm.aptoide.pt.feature_home.data.deviceapi.model.FeaturedBannerSectionResponse
+import cm.aptoide.pt.feature_home.data.deviceapi.model.HomeSectionResponse
+import cm.aptoide.pt.feature_home.data.deviceapi.model.TopChartSectionResponse
+import cm.aptoide.pt.feature_home.domain.Widget
+import cm.aptoide.pt.feature_home.domain.WidgetLayout
+import cm.aptoide.pt.feature_home.domain.WidgetType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.withContext
+
+/**
+ * Device-API home (`GET /home`, catalog-only). Maps the typed sections onto the
+ * client's `Widget`/`Bundle` renderers and stashes each section's inline apps in
+ * [DeviceHomeAppsCache] (the lazy fetch-by-tag renderer reads them back).
+ *
+ * Catalog-only per the migration decision: monetization/engagement sections that
+ * `/home` doesn't carry are absent (see .context/contract-friction.md). Unknown
+ * section kinds are already dropped to null by the Gson discriminator factory;
+ * category_grid / editorial_card are skipped here (their own screens cover them).
+ */
+class DeviceApiWidgetsRepository(
+  private val service: DeviceApiWidgetsService,
+  private val variant: String,
+  private val storeName: String,
+  private val homeAppsCache: DeviceHomeAppsCache,
+  private val scope: CoroutineScope,
+) : WidgetsRepository {
+
+  override suspend fun getStoreWidgets(context: String?, bypassCache: Boolean): List<Widget> =
+    withContext(scope.coroutineContext) {
+      deviceApiCall { service.getHome(variant, refresh = if (bypassCache) 1 else null) }
+        .sections.orEmpty()
+        .filterNotNull()
+        .mapIndexedNotNull { index, section -> section.toWidget(index) }
+    }
+
+  private fun HomeSectionResponse.toWidget(index: Int): Widget? = when (this) {
+    is FeaturedBannerSectionResponse -> appsWidget(
+      index = index,
+      title = tagline.orEmpty(),
+      layout = WidgetLayout.CAROUSEL_LARGE,
+      graphic = imageUrl,
+      apps = listOfNotNull(app?.toApp(storeName)),
+    )
+
+    is AppCollectionSectionResponse -> appsWidget(
+      index = index,
+      title = title.orEmpty(),
+      layout = WidgetLayout.CAROUSEL,
+      graphic = null,
+      apps = apps.orEmpty().map { it.toApp(storeName) },
+    )
+
+    is TopChartSectionResponse -> appsWidget(
+      index = index,
+      title = title.orEmpty(),
+      layout = WidgetLayout.GRID,
+      graphic = null,
+      apps = apps.orEmpty().map { it.toApp(storeName) },
+    )
+
+    else -> null // category_grid / editorial_card: covered by their own screens
+  }
+
+  private fun appsWidget(
+    index: Int,
+    title: String,
+    layout: WidgetLayout,
+    graphic: String?,
+    apps: List<App>,
+  ): Widget {
+    val key = DeviceHomeAppsCache.KEY_PREFIX + index
+    homeAppsCache.put(key, apps)
+    return Widget(
+      title = title,
+      type = WidgetType.APPS_GROUP,
+      layout = layout,
+      view = key,
+      tag = key,
+      action = emptyList(),
+      icon = null,
+      graphic = graphic,
+      background = null,
+      url = null,
+    )
+  }
+}

--- a/feature-home/src/main/java/cm/aptoide/pt/feature_home/data/deviceapi/DeviceApiWidgetsService.kt
+++ b/feature-home/src/main/java/cm/aptoide/pt/feature_home/data/deviceapi/DeviceApiWidgetsService.kt
@@ -1,0 +1,14 @@
+package cm.aptoide.pt.feature_home.data.deviceapi
+
+import cm.aptoide.pt.feature_home.data.deviceapi.model.HomeResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface DeviceApiWidgetsService {
+
+  @GET("android/v1/home")
+  suspend fun getHome(
+    @Query("variant") variant: String,
+    @Query("refresh") refresh: Int? = null,
+  ): HomeResponse
+}

--- a/feature-home/src/main/java/cm/aptoide/pt/feature_home/data/deviceapi/model/HomeModels.kt
+++ b/feature-home/src/main/java/cm/aptoide/pt/feature_home/data/deviceapi/model/HomeModels.kt
@@ -1,0 +1,58 @@
+package cm.aptoide.pt.feature_home.data.deviceapi.model
+
+import androidx.annotation.Keep
+import cm.aptoide.pt.feature_apps.data.deviceapi.model.AppSummaryResponse
+
+/**
+ * `GET /android/v1/home` — typed, client-rendered sections (`device.openapi.json`,
+ * D-007). Sections are a discriminated union on `type`; unknown kinds deserialize
+ * to null (via DiscriminatorAdapterFactory) and are filtered. camelCase fields bind
+ * snake_case via the device Retrofit's Gson naming policy.
+ */
+@Keep
+data class HomeResponse(
+  val variant: String? = null,
+  val sections: List<HomeSectionResponse?>? = null,
+)
+
+sealed interface HomeSectionResponse
+
+@Keep
+data class FeaturedBannerSectionResponse(
+  val app: AppSummaryResponse? = null,
+  val tagline: String? = null,
+  val imageUrl: String? = null,
+) : HomeSectionResponse
+
+@Keep
+data class AppCollectionSectionResponse(
+  val title: String? = null,
+  val apps: List<AppSummaryResponse>? = null,
+) : HomeSectionResponse
+
+@Keep
+data class TopChartSectionResponse(
+  val title: String? = null,
+  val apps: List<AppSummaryResponse>? = null,
+) : HomeSectionResponse
+
+@Keep
+data class CategoryGridSectionResponse(
+  val title: String? = null,
+  val categories: List<HomeCategoryResponse>? = null,
+) : HomeSectionResponse
+
+@Keep
+data class EditorialCardSectionResponse(
+  val slug: String? = null,
+  val title: String? = null,
+  val coverImageUrl: String? = null,
+) : HomeSectionResponse
+
+@Keep
+data class HomeCategoryResponse(
+  val slug: String? = null,
+  val title: String? = null,
+  val parent: String? = null,
+  val appCount: Int? = null,
+)

--- a/feature-home/src/main/java/cm/aptoide/pt/feature_home/di/OptionalHomeBackendModule.kt
+++ b/feature-home/src/main/java/cm/aptoide/pt/feature_home/di/OptionalHomeBackendModule.kt
@@ -1,0 +1,15 @@
+package cm.aptoide.pt.feature_home.di
+
+import cm.aptoide.pt.feature_home.data.deviceapi.DeviceApiWidgetsRepository
+import dagger.BindsOptionalOf
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+/** Present only in aptoideGamesDev ⇒ device-API home; empty elsewhere ⇒ v7. */
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface OptionalHomeBackendModule {
+  @BindsOptionalOf
+  fun optionalDeviceWidgetsRepository(): DeviceApiWidgetsRepository
+}

--- a/feature-home/src/main/java/cm/aptoide/pt/feature_home/di/RepositoryModule.kt
+++ b/feature-home/src/main/java/cm/aptoide/pt/feature_home/di/RepositoryModule.kt
@@ -4,6 +4,7 @@ import cm.aptoide.pt.aptoide_network.di.RetrofitV7
 import cm.aptoide.pt.aptoide_network.di.StoreName
 import cm.aptoide.pt.feature_home.data.AptoideWidgetsRepository
 import cm.aptoide.pt.feature_home.data.WidgetsRepository
+import cm.aptoide.pt.feature_home.data.deviceapi.DeviceApiWidgetsRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -11,6 +12,7 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import retrofit2.Retrofit
+import java.util.Optional
 import javax.inject.Qualifier
 import javax.inject.Singleton
 
@@ -24,12 +26,17 @@ internal object RepositoryModule {
     @RetrofitV7 retrofitV7: Retrofit,
     @StoreName storeName: String,
     @WidgetsUrl widgetsUrl: String,
-  ): WidgetsRepository = AptoideWidgetsRepository(
-    widgetsRemoteDataSource = retrofitV7.create(AptoideWidgetsRepository.Retrofit::class.java),
-    storeName = storeName,
-    widgetsUrl = widgetsUrl,
-    scope = CoroutineScope(Dispatchers.IO)
-  )
+    deviceApi: Optional<DeviceApiWidgetsRepository>,
+  ): WidgetsRepository = if (deviceApi.isPresent) {
+    deviceApi.get()
+  } else {
+    AptoideWidgetsRepository(
+      widgetsRemoteDataSource = retrofitV7.create(AptoideWidgetsRepository.Retrofit::class.java),
+      storeName = storeName,
+      widgetsUrl = widgetsUrl,
+      scope = CoroutineScope(Dispatchers.IO)
+    )
+  }
 }
 
 @Qualifier

--- a/feature_apps/build.gradle.kts
+++ b/feature_apps/build.gradle.kts
@@ -11,6 +11,7 @@ android {
 
 dependencies {
   implementation(projects.aptoideNetwork)
+  implementation(projects.deviceApi)
   implementation(projects.extension)
   api(projects.featureCampaigns)
 }

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/App.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/App.kt
@@ -5,6 +5,7 @@ import cm.aptoide.pt.extensions.getRandomString
 import cm.aptoide.pt.feature_apps.domain.AppSource
 import cm.aptoide.pt.feature_apps.domain.Rating
 import cm.aptoide.pt.feature_apps.domain.Store
+import cm.aptoide.pt.feature_apps.domain.Trust
 import cm.aptoide.pt.feature_apps.domain.Votes
 import cm.aptoide.pt.feature_campaigns.CampaignImpl
 import java.time.LocalDate
@@ -49,6 +50,7 @@ data class App(
   val campaigns: CampaignImpl? = null,
   val hasMeta: Boolean = false,
   val signature: String?,
+  val trust: Trust? = null,
 ) : AppSource {
   val appSize: Long by lazy {
     file.size + (obb?.size ?: 0) + (aab?.size ?: 0)

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/ReviewsRepository.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/ReviewsRepository.kt
@@ -1,0 +1,16 @@
+package cm.aptoide.pt.feature_apps.data
+
+import cm.aptoide.pt.feature_apps.domain.Review
+
+/**
+ * Read-only reviews list for an app. Backed by the device API in aptoideGamesDev;
+ * elsewhere there is no reviews source, so [EmptyReviewsRepository] returns empty.
+ */
+interface ReviewsRepository {
+  suspend fun getReviews(packageName: String): List<Review>
+}
+
+/** No-op used on non-device variants (v7 has no reviews-list surface). */
+class EmptyReviewsRepository : ReviewsRepository {
+  override suspend fun getReviews(packageName: String): List<Review> = emptyList()
+}

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/DeviceApiAppRepository.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/DeviceApiAppRepository.kt
@@ -1,0 +1,38 @@
+package cm.aptoide.pt.feature_apps.data.deviceapi
+
+import cm.aptoide.pt.device_api.error.deviceApiCall
+import cm.aptoide.pt.device_api.network.DeviceProfileProvider
+import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_apps.data.AppRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.withContext
+
+/**
+ * Device-API app-detail repository (aptoideGamesDev only). Distinct type from the
+ * v7 [cm.aptoide.pt.feature_apps.data.AptoideAppRepository] so the `@BindsOptionalOf`
+ * switch selects it without a duplicate binding.
+ */
+class DeviceApiAppRepository(
+  private val service: DeviceApiAppsService,
+  private val storeName: String,
+  private val deviceProfileProvider: DeviceProfileProvider,
+  private val scope: CoroutineScope,
+) : AppRepository {
+
+  override suspend fun getApp(packageName: String): App = withContext(scope.coroutineContext) {
+    val p = deviceProfileProvider.get()
+    deviceApiCall { service.getApp(packageName, p.sdk, p.abi, p.tv, p.density) }.toApp(storeName)
+  }
+
+  override suspend fun getAppMeta(source: String): App {
+    // The common deep-link case carries `package_name=…`. Opaque ad/campaign source
+    // tokens have no device-API resolution (leftover — see .context/leftover-inventory.md).
+    val packageName = extractPackageName(source)
+      ?: throw IllegalStateException("Unsupported device-API source: $source")
+    return getApp(packageName)
+  }
+}
+
+/** Pulls a package name out of a v7-style source string (`package_name=X/…`). */
+internal fun extractPackageName(source: String): String? =
+  Regex("package_name=([^/&]+)").find(source)?.groupValues?.getOrNull(1)

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/DeviceApiAppsListRepository.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/DeviceApiAppsListRepository.kt
@@ -1,0 +1,122 @@
+package cm.aptoide.pt.feature_apps.data.deviceapi
+
+import cm.aptoide.pt.device_api.error.deviceApiCall
+import cm.aptoide.pt.device_api.network.DeviceProfileProvider
+import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_apps.data.AppsListRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.withContext
+
+/**
+ * Device-API listing repository (aptoideGamesDev only) — See-All / sorted /
+ * trending / category / related / versions. The current UIs are single-shot, so
+ * these return the first cursor page (parity with v7, which also returns a fixed
+ * list). Leftover interface methods with no device-API route stay best-effort:
+ * store/group listing → empty (device home doesn't use it); batch-by-packages →
+ * per-package detail (no batch endpoint yet — see leftover inventory).
+ */
+class DeviceApiAppsListRepository(
+  private val service: DeviceApiAppsService,
+  private val storeName: String,
+  private val variant: String,
+  private val deviceProfileProvider: DeviceProfileProvider,
+  private val homeAppsCache: DeviceHomeAppsCache,
+  private val scope: CoroutineScope,
+) : AppsListRepository {
+
+  override suspend fun getAppsList(url: String, bypassCache: Boolean): List<App> =
+    withContext(scope.coroutineContext) {
+      // Home sections carry their apps inline via /home — served from the bridge cache.
+      if (DeviceHomeAppsCache.isHomeKey(url)) {
+        return@withContext homeAppsCache.get(url).orEmpty()
+      }
+      val (sort, category) = parseListUrl(url)
+      fetchBrowse(sort = sort, category = category, refresh = bypassCache)
+    }
+
+  // v7 store/group widget listing — no device-API equivalent; device home is /home.
+  override suspend fun getAppsList(storeId: Long, groupId: Long, bypassCache: Boolean): List<App> =
+    emptyList()
+
+  override suspend fun getRecommended(path: String): List<App> = withContext(scope.coroutineContext) {
+    val pkg = extractPackageName(path) ?: return@withContext emptyList()
+    val p = deviceProfileProvider.get()
+    deviceApiCall { service.getRelated(pkg, sdk = p.sdk, abi = p.abi, tv = p.tv, density = p.density) }
+      .items.orEmpty().map { it.toApp(storeName) }
+  }
+
+  override suspend fun getCategoryAppsList(categoryName: String): List<App> =
+    withContext(scope.coroutineContext) {
+      fetchBrowse(category = categoryName, sort = "downloads", refresh = false)
+    }
+
+  override suspend fun getAppVersions(packageName: String): List<App> =
+    withContext(scope.coroutineContext) {
+      val p = deviceProfileProvider.get()
+      val base = deviceApiCall { service.getApp(packageName, p.sdk, p.abi, p.tv, p.density) }
+        .toApp(storeName)
+      deviceApiCall {
+        service.getReleases(packageName, sdk = p.sdk, abi = p.abi, tv = p.tv, density = p.density)
+      }.items.orEmpty().mapNotNull { it.release?.toVersionApp(base, it.trust) }
+    }
+
+  // Leftover: batch app summaries by package list (My Games hydration). No batch
+  // device endpoint yet — fan out to per-package detail in parallel.
+  override suspend fun getAppsList(packageNames: String): List<App> =
+    withContext(scope.coroutineContext) {
+      val p = deviceProfileProvider.get()
+      packageNames.split(",").mapNotNull { it.trim().takeIf(String::isNotEmpty) }
+        .map { pkg ->
+          async {
+            runCatching {
+              deviceApiCall { service.getApp(pkg, p.sdk, p.abi, p.tv, p.density) }.toApp(storeName)
+            }.getOrNull()
+          }
+        }
+        .awaitAll()
+        .filterNotNull()
+    }
+
+  override suspend fun getSortedAppsList(sort: String, limit: Int): List<App> =
+    withContext(scope.coroutineContext) {
+      fetchBrowse(sort = mapSort(sort), limit = limit, refresh = false)
+    }
+
+  private suspend fun fetchBrowse(
+    q: String? = null,
+    category: String? = null,
+    sort: String? = null,
+    limit: Int? = null,
+    refresh: Boolean,
+  ): List<App> {
+    val p = deviceProfileProvider.get()
+    return deviceApiCall {
+      service.searchOrBrowse(
+        q = q, category = category, sort = sort, cursor = null, limit = limit,
+        variant = variant, sdk = p.sdk, abi = p.abi, tv = p.tv, density = p.density,
+        refresh = if (refresh) 1 else null,
+      )
+    }.items.orEmpty().map { it.toApp(storeName) }
+  }
+
+  private fun parseListUrl(url: String): Pair<String?, String?> {
+    val sort = Regex("[?&]sort=([^&/]+)").find(url)?.groupValues?.getOrNull(1)
+    val category = Regex("[?&]category=([^&/]+)").find(url)?.groupValues?.getOrNull(1)
+      ?: Regex("group_name=([^&/]+)").find(url)?.groupValues?.getOrNull(1)
+    return sort?.let(::mapSort) to category
+  }
+}
+
+/** Maps v7 sort tokens (`trending60d`, `pdownloads`, `updated`, …) to the new `ListingSort`. */
+internal fun mapSort(v7Sort: String): String = when {
+  v7Sort.contains("trending", ignoreCase = true) -> "trending"
+  v7Sort.contains("download", ignoreCase = true) -> "downloads"
+  v7Sort.contains("alpha", ignoreCase = true) -> "alpha"
+  v7Sort.contains("latest", ignoreCase = true) ||
+    v7Sort.contains("updated", ignoreCase = true) ||
+    v7Sort.contains("added", ignoreCase = true) ||
+    v7Sort.contains("new", ignoreCase = true) -> "latest"
+  else -> "downloads"
+}

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/DeviceApiAppsService.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/DeviceApiAppsService.kt
@@ -1,0 +1,62 @@
+package cm.aptoide.pt.feature_apps.data.deviceapi
+
+import cm.aptoide.pt.feature_apps.data.deviceapi.model.AppResponse
+import cm.aptoide.pt.feature_apps.data.deviceapi.model.AppSummaryPageResponse
+import cm.aptoide.pt.feature_apps.data.deviceapi.model.RelatedAppsResponse
+import cm.aptoide.pt.feature_apps.data.deviceapi.model.ReleaseHistoryResponse
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * Device-API app routes (`device.openapi.json`). Device-profile params ride as
+ * clean query params (never v7's `q=` blob); `variant` only where the spec
+ * carries it (search/browse). Null query args are omitted by Retrofit — fail-open.
+ */
+interface DeviceApiAppsService {
+
+  @GET("android/v1/apps/{package_name}")
+  suspend fun getApp(
+    @Path("package_name") packageName: String,
+    @Query("sdk") sdk: Int?,
+    @Query("abi") abi: String?,
+    @Query("tv") tv: Boolean?,
+    @Query("density") density: Int?,
+  ): AppResponse
+
+  @GET("android/v1/apps")
+  suspend fun searchOrBrowse(
+    @Query("q") q: String? = null,
+    @Query("category") category: String? = null,
+    @Query("sort") sort: String? = null,
+    @Query("cursor") cursor: String? = null,
+    @Query("limit") limit: Int? = null,
+    @Query("variant") variant: String,
+    @Query("sdk") sdk: Int? = null,
+    @Query("abi") abi: String? = null,
+    @Query("tv") tv: Boolean? = null,
+    @Query("density") density: Int? = null,
+    @Query("refresh") refresh: Int? = null,
+  ): AppSummaryPageResponse
+
+  @GET("android/v1/apps/{package_name}/related")
+  suspend fun getRelated(
+    @Path("package_name") packageName: String,
+    @Query("limit") limit: Int? = null,
+    @Query("sdk") sdk: Int?,
+    @Query("abi") abi: String?,
+    @Query("tv") tv: Boolean?,
+    @Query("density") density: Int?,
+  ): RelatedAppsResponse
+
+  @GET("android/v1/apps/{package_name}/releases")
+  suspend fun getReleases(
+    @Path("package_name") packageName: String,
+    @Query("cursor") cursor: String? = null,
+    @Query("limit") limit: Int? = null,
+    @Query("sdk") sdk: Int?,
+    @Query("abi") abi: String?,
+    @Query("tv") tv: Boolean?,
+    @Query("density") density: Int?,
+  ): ReleaseHistoryResponse
+}

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/DeviceApiMappers.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/DeviceApiMappers.kt
@@ -1,0 +1,174 @@
+package cm.aptoide.pt.feature_apps.data.deviceapi
+
+import cm.aptoide.pt.aptoide_network.data.network.model.Screenshot
+import cm.aptoide.pt.feature_apps.data.Aab
+import cm.aptoide.pt.feature_apps.data.App
+import cm.aptoide.pt.feature_apps.data.File
+import cm.aptoide.pt.feature_apps.data.Obb
+import cm.aptoide.pt.feature_apps.data.Split
+import cm.aptoide.pt.feature_apps.data.deviceapi.model.AppResponse
+import cm.aptoide.pt.feature_apps.data.deviceapi.model.AppSummaryResponse
+import cm.aptoide.pt.feature_apps.data.deviceapi.model.ArtifactResponse
+import cm.aptoide.pt.feature_apps.data.deviceapi.model.RatingResponse
+import cm.aptoide.pt.feature_apps.data.deviceapi.model.ReleaseResponse
+import cm.aptoide.pt.feature_apps.data.deviceapi.model.TrustResponse
+import cm.aptoide.pt.feature_apps.domain.Rating
+import cm.aptoide.pt.feature_apps.domain.Store
+import cm.aptoide.pt.feature_apps.domain.Trust
+import cm.aptoide.pt.feature_apps.domain.Votes
+
+/**
+ * Device-API → domain `App` mapping (aptoideGamesDev path). Maps the new contract
+ * cleanly and synthesizes the handful of v7-only fields the domain model still
+ * carries (`appId`=0 so `asSource()` uses the package; `store` placeholder;
+ * `isAppCoins`=false — billing stays on v7; `malware`/`signature` null, superseded
+ * by the structured `trust`). See `.context/contract-friction.md`.
+ */
+
+/** Full app detail. `hasMeta` stays false here — `AppMetaUseCase` flips it, as on v7. */
+fun AppResponse.toApp(storeName: String): App {
+  val artifacts = release?.artifacts.orEmpty()
+  val apk = artifacts.firstOrNull { it.kind == "apk" }
+  return App(
+    appId = 0L,
+    name = name.orEmpty(),
+    packageName = packageName.orEmpty(),
+    md5 = apk?.md5.orEmpty(),
+    icon = iconUrl.orEmpty(),
+    malware = null,
+    rating = rating.toRating(),
+    pRating = rating.toRating(),
+    downloads = downloads ?: 0,
+    // The UI renders pDownloads. Use the source `downloads` (total across sources,
+    // e.g. 10M) for a meaningful + card-consistent number, NOT `aptoide_downloads`
+    // (Aptoide's own metric, ~1 on dev until the nightly rollup — APT-94). Which
+    // number to surface is a product choice; revisit if we want the Aptoide-only count.
+    pDownloads = downloads ?: 0,
+    versionName = release?.versionName.orEmpty(),
+    versionCode = release?.versionCode ?: 0,
+    featureGraphic = featureGraphicUrl.orEmpty(),
+    isAppCoins = false,
+    screenshots = screenshots?.mapNotNull { it.toScreenshot() },
+    description = description,
+    news = null,
+    videos = videos?.mapNotNull { it.url } ?: emptyList(),
+    store = deviceStore(storeName),
+    releaseDate = release?.releasedAt,
+    modifiedDate = release?.releasedAt.orEmpty(),
+    releaseUpdateDate = release?.releasedAt,
+    updateDate = release?.releasedAt,
+    website = null,
+    email = null,
+    privacyPolicy = null,
+    permissions = null,
+    file = apk.toFile(),
+    aab = artifacts.toAab(),
+    obb = artifacts.toObb(),
+    bdsFlags = null,
+    developerName = publisherName,
+    signature = null,
+    trust = trust.toTrust(),
+  )
+}
+
+/** Thin summary (cards/lists). Tapping through re-fetches full detail via `getApp`. */
+fun AppSummaryResponse.toApp(storeName: String): App = App(
+  appId = 0L,
+  name = name.orEmpty(),
+  packageName = packageName.orEmpty(),
+  md5 = "",
+  icon = iconUrl.orEmpty(),
+  malware = null,
+  rating = rating.toRating(),
+  pRating = rating.toRating(),
+  downloads = downloads ?: 0,
+  // UI shows pDownloads; summaries have no aptoide_downloads → use source downloads.
+  pDownloads = downloads ?: 0,
+  versionName = "",
+  versionCode = 0,
+  featureGraphic = featureGraphicUrl.orEmpty(),
+  isAppCoins = false,
+  screenshots = emptyList(),
+  description = null,
+  news = null,
+  videos = emptyList(),
+  store = deviceStore(storeName),
+  releaseDate = null,
+  modifiedDate = "",
+  updateDate = null,
+  website = null,
+  email = null,
+  privacyPolicy = null,
+  permissions = null,
+  file = File(md5 = "", size = 0, path = "", path_alt = ""),
+  aab = null,
+  obb = null,
+  bdsFlags = null,
+  developerName = null,
+  signature = null,
+  trust = null,
+)
+
+/** A per-version [App] from a release-history entry, merged with base app identity. */
+fun ReleaseResponse.toVersionApp(base: App, trust: TrustResponse?): App {
+  val artifacts = artifacts.orEmpty()
+  val apk = artifacts.firstOrNull { it.kind == "apk" }
+  return base.copy(
+    md5 = apk?.md5.orEmpty(),
+    versionName = versionName.orEmpty(),
+    versionCode = versionCode ?: 0,
+    releaseDate = releasedAt,
+    modifiedDate = releasedAt.orEmpty(),
+    updateDate = releasedAt,
+    releaseUpdateDate = releasedAt,
+    file = apk.toFile(),
+    aab = artifacts.toAab(),
+    obb = artifacts.toObb(),
+    trust = trust.toTrust(),
+  )
+}
+
+private fun deviceStore(storeName: String) =
+  Store(storeName = storeName, icon = "", apps = null, subscribers = null, downloads = null)
+
+private fun RatingResponse?.toRating(): Rating = Rating(
+  avgRating = this?.average ?: 0.0,
+  totalVotes = this?.count ?: 0,
+  votes = this?.distribution?.mapNotNull { b ->
+    b.stars?.let { Votes(value = it, count = b.count ?: 0) }
+  },
+)
+
+private fun TrustResponse?.toTrust(): Trust? = this?.let {
+  Trust(
+    scanVerdict = it.scanVerdict,
+    signerSha256 = it.signerSha256,
+    signerConsistency = it.signerConsistency,
+    provenance = it.provenance,
+  )
+}
+
+private fun cm.aptoide.pt.feature_apps.data.deviceapi.model.ScreenshotResponse.toScreenshot(): Screenshot? =
+  url?.let { Screenshot(url = it, height = height ?: 0, width = width ?: 0) }
+
+private fun ArtifactResponse?.toFile(): File = File(
+  md5 = this?.md5.orEmpty(),
+  size = this?.sizeBytes ?: 0,
+  path = this?.url.orEmpty(),
+  path_alt = "",
+)
+
+private fun List<ArtifactResponse>.toAab(): Aab? {
+  val splits = filter { it.kind == "split" }
+  if (splits.isEmpty()) return null
+  return Aab(
+    requiredSplitTypes = emptyList(),
+    baseSplits = splits.map { Split(type = it.filename ?: "split", file = it.toFile()) },
+  )
+}
+
+private fun List<ArtifactResponse>.toObb(): Obb? {
+  val main = firstOrNull { it.kind == "obb_main" } ?: return null
+  val patch = firstOrNull { it.kind == "obb_patch" }
+  return Obb(main = main.toFile(), patch = patch?.let { it.toFile() })
+}

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/DeviceApiReviewsRepository.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/DeviceApiReviewsRepository.kt
@@ -1,0 +1,67 @@
+package cm.aptoide.pt.feature_apps.data.deviceapi
+
+import androidx.annotation.Keep
+import cm.aptoide.pt.device_api.error.deviceApiCall
+import cm.aptoide.pt.feature_apps.data.ReviewsRepository
+import cm.aptoide.pt.feature_apps.domain.Review
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.withContext
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * Device-API reviews (aptoideGamesDev only). `GET /apps/{package}/reviews` — merged
+ * corpus, newest first. Single-shot first page (UI has no load-more).
+ */
+class DeviceApiReviewsRepository(
+  private val service: Service,
+  private val scope: CoroutineScope,
+) : ReviewsRepository {
+
+  override suspend fun getReviews(packageName: String): List<Review> =
+    withContext(scope.coroutineContext) {
+      deviceApiCall { service.getReviews(packageName) }.items.orEmpty().mapNotNull { it.toReview() }
+    }
+
+  private fun ReviewResponse.toReview(): Review? {
+    val id = id ?: return null
+    return Review(
+      id = id,
+      authorName = authorName,
+      authorAvatarUrl = authorAvatarUrl,
+      rating = rating,
+      title = title,
+      body = body.orEmpty(),
+      createdAt = createdAt,
+      helpfulVotes = helpfulVotes ?: 0,
+    )
+  }
+
+  interface Service {
+    @GET("android/v1/apps/{package_name}/reviews")
+    suspend fun getReviews(
+      @Path("package_name") packageName: String,
+      @Query("cursor") cursor: String? = null,
+      @Query("limit") limit: Int? = null,
+    ): ReviewsResponse
+  }
+}
+
+@Keep
+data class ReviewsResponse(
+  val items: List<ReviewResponse>? = null,
+  val nextCursor: String? = null,
+)
+
+@Keep
+data class ReviewResponse(
+  val id: String? = null,
+  val authorName: String? = null,
+  val authorAvatarUrl: String? = null,
+  val rating: Int? = null,
+  val title: String? = null,
+  val body: String? = null,
+  val createdAt: String? = null,
+  val helpfulVotes: Int? = null,
+)

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/DeviceApiSplitsRepository.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/DeviceApiSplitsRepository.kt
@@ -1,0 +1,15 @@
+package cm.aptoide.pt.feature_apps.data.deviceapi
+
+import cm.aptoide.pt.feature_apps.data.SplitsRepository
+import cm.aptoide.pt.feature_apps.data.model.DynamicSplitJSON
+
+/**
+ * Device-API splits (aptoideGamesDev only). The device app-detail response already
+ * embeds the device-resolved required splits (in `aab.baseSplits`), and there is no
+ * device `getDynamicSplits`-by-md5 endpoint. So this returns empty rather than
+ * calling v7 `app/getDynamicSplits` with a device md5 v7 can't resolve — which
+ * otherwise threw and broke the app-view for every AAB app (leftover: getDynamicSplits).
+ */
+class DeviceApiSplitsRepository : SplitsRepository {
+  override suspend fun getAppsDynamicSplits(md5: String): List<DynamicSplitJSON> = emptyList()
+}

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/DeviceHomeAppsCache.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/DeviceHomeAppsCache.kt
@@ -1,0 +1,30 @@
+package cm.aptoide.pt.feature_apps.data.deviceapi
+
+import cm.aptoide.pt.feature_apps.data.App
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Bridges the device `/home` inline-apps model onto the client's lazy
+ * fetch-by-`view`-URL bundle renderer. `DeviceApiWidgetsRepository` stashes each
+ * home section's apps here under a synthetic `device-home:` key it also sets as the
+ * widget's `view`; `DeviceApiAppsListRepository.getAppsList(view)` reads them back.
+ * aptoideGamesDev only.
+ */
+@Singleton
+class DeviceHomeAppsCache @Inject constructor() {
+
+  private val sections = ConcurrentHashMap<String, List<App>>()
+
+  fun put(key: String, apps: List<App>) {
+    sections[key] = apps
+  }
+
+  fun get(key: String): List<App>? = sections[key]
+
+  companion object {
+    const val KEY_PREFIX = "device-home:"
+    fun isHomeKey(url: String) = url.startsWith(KEY_PREFIX)
+  }
+}

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/model/DeviceApiModels.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/deviceapi/model/DeviceApiModels.kt
@@ -1,0 +1,127 @@
+package cm.aptoide.pt.feature_apps.data.deviceapi.model
+
+import androidx.annotation.Keep
+
+/**
+ * DTOs for the new device API (`api.dev.aptoide.com/android/v1`), matching
+ * `device.openapi.json`. Fields are camelCase; the device Retrofit's Gson uses
+ * LOWER_CASE_WITH_UNDERSCORES so `packageName` binds `package_name`, etc.
+ * Shared across surfaces that return apps (home/search/listings/related/detail).
+ */
+
+@Keep
+data class AppSummaryResponse(
+  val packageName: String? = null,
+  val name: String? = null,
+  val iconUrl: String? = null,
+  val featureGraphicUrl: String? = null,
+  val downloads: Int? = null,
+  val rating: RatingResponse? = null,
+)
+
+@Keep
+data class AppResponse(
+  val packageName: String? = null,
+  val name: String? = null,
+  val iconUrl: String? = null,
+  val publisherName: String? = null,
+  val summary: String? = null,
+  val description: String? = null,
+  val downloads: Int? = null,
+  val aptoideDownloads: Int? = null,
+  val rating: RatingResponse? = null,
+  val screenshots: List<ScreenshotResponse>? = null,
+  val videos: List<VideoResponse>? = null,
+  val featureGraphicUrl: String? = null,
+  val ageRating: AgeRatingResponse? = null,
+  val release: ReleaseResponse? = null,
+  val trust: TrustResponse? = null,
+)
+
+@Keep
+data class RatingResponse(
+  val average: Double? = null,
+  val count: Long? = null,
+  val distribution: List<RatingBucketResponse>? = null,
+)
+
+@Keep
+data class RatingBucketResponse(
+  val stars: Int? = null,
+  val count: Int? = null,
+)
+
+@Keep
+data class ScreenshotResponse(
+  val url: String? = null,
+  val width: Int? = null,
+  val height: Int? = null,
+)
+
+@Keep
+data class VideoResponse(
+  val url: String? = null,
+  val thumbnailUrl: String? = null,
+  val kind: String? = null,
+)
+
+@Keep
+data class AgeRatingResponse(
+  val rating: Int? = null,
+  val label: String? = null,
+  val code: String? = null,
+)
+
+@Keep
+data class ReleaseResponse(
+  val versionName: String? = null,
+  val versionCode: Int? = null,
+  val minSdk: Int? = null,
+  val sizeBytes: Long? = null,
+  val releasedAt: String? = null,
+  val artifacts: List<ArtifactResponse>? = null,
+)
+
+@Keep
+data class ArtifactResponse(
+  /** apk | split | obb_main | obb_patch */
+  val kind: String? = null,
+  val url: String? = null,
+  val sizeBytes: Long? = null,
+  val md5: String? = null,
+  val filename: String? = null,
+)
+
+@Keep
+data class TrustResponse(
+  val scanVerdict: String? = null,
+  val signerSha256: String? = null,
+  val signerConsistency: String? = null,
+  val provenance: String? = null,
+)
+
+/** `GET /apps` (search/listing) and `GET /apps/{package}/reviews` share this cursored envelope. */
+@Keep
+data class AppSummaryPageResponse(
+  val items: List<AppSummaryResponse>? = null,
+  val nextCursor: String? = null,
+)
+
+/** `GET /apps/{package}/related` — unpaginated carousel. */
+@Keep
+data class RelatedAppsResponse(
+  val items: List<AppSummaryResponse>? = null,
+)
+
+/** `GET /apps/{package}/releases` — newest-first, cursored version history. */
+@Keep
+data class ReleaseHistoryResponse(
+  val items: List<ReleaseHistoryItemResponse>? = null,
+  val nextCursor: String? = null,
+)
+
+@Keep
+data class ReleaseHistoryItemResponse(
+  val release: ReleaseResponse? = null,
+  val trust: TrustResponse? = null,
+)

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/di/OptionalBackendModule.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/di/OptionalBackendModule.kt
@@ -1,0 +1,32 @@
+package cm.aptoide.pt.feature_apps.di
+
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiAppRepository
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiAppsListRepository
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiReviewsRepository
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiSplitsRepository
+import dagger.BindsOptionalOf
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+/**
+ * Optional device-API repositories. The concrete impls are provided ONLY in the
+ * `aptoideGamesDev` source set, so `Optional<…>` is present there (→ device API)
+ * and empty everywhere else (→ v7 default). This is the dev-only backend switch —
+ * see [RepositoryModule].
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface OptionalBackendModule {
+  @BindsOptionalOf
+  fun optionalDeviceAppRepository(): DeviceApiAppRepository
+
+  @BindsOptionalOf
+  fun optionalDeviceAppsListRepository(): DeviceApiAppsListRepository
+
+  @BindsOptionalOf
+  fun optionalDeviceSplitsRepository(): DeviceApiSplitsRepository
+
+  @BindsOptionalOf
+  fun optionalDeviceReviewsRepository(): DeviceApiReviewsRepository
+}

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/di/RepositoryModule.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/di/RepositoryModule.kt
@@ -12,6 +12,12 @@ import cm.aptoide.pt.feature_apps.data.AptoideAppsListMapper
 import cm.aptoide.pt.feature_apps.data.AptoideAppsListRepository
 import cm.aptoide.pt.feature_apps.data.SplitsRepository
 import cm.aptoide.pt.feature_apps.data.SplitsRepositoryImpl
+import cm.aptoide.pt.feature_apps.data.EmptyReviewsRepository
+import cm.aptoide.pt.feature_apps.data.ReviewsRepository
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiAppRepository
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiAppsListRepository
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiReviewsRepository
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiSplitsRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -19,6 +25,7 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import retrofit2.Retrofit
+import java.util.Optional
 import javax.inject.Singleton
 
 @Module
@@ -39,12 +46,17 @@ internal object RepositoryModule {
     @RetrofitV7 retrofitV7: Retrofit,
     @StoreName storeName: String,
     appMapper: AppMapper,
-  ): AppRepository = AptoideAppRepository(
-    appsRemoteDataSource = retrofitV7.create(AptoideAppRepository.Retrofit::class.java),
-    storeName = storeName,
-    mapper = appMapper,
-    scope = CoroutineScope(Dispatchers.IO)
-  )
+    deviceApi: Optional<DeviceApiAppRepository>,
+  ): AppRepository = if (deviceApi.isPresent) {
+    deviceApi.get()
+  } else {
+    AptoideAppRepository(
+      appsRemoteDataSource = retrofitV7.create(AptoideAppRepository.Retrofit::class.java),
+      storeName = storeName,
+      mapper = appMapper,
+      scope = CoroutineScope(Dispatchers.IO)
+    )
+  }
 
   @Provides
   @Singleton
@@ -52,19 +64,35 @@ internal object RepositoryModule {
     @RetrofitV7 retrofitV7: Retrofit,
     @StoreName storeName: String,
     appsListMapper: AppsListMapper,
-  ): AppsListRepository = AptoideAppsListRepository(
-    appsRemoteDataSource = retrofitV7.create(AptoideAppsListRepository.Retrofit::class.java),
-    storeName = storeName,
-    mapper = appsListMapper,
-    scope = CoroutineScope(Dispatchers.IO)
-  )
+    deviceApi: Optional<DeviceApiAppsListRepository>,
+  ): AppsListRepository = if (deviceApi.isPresent) {
+    deviceApi.get()
+  } else {
+    AptoideAppsListRepository(
+      appsRemoteDataSource = retrofitV7.create(AptoideAppsListRepository.Retrofit::class.java),
+      storeName = storeName,
+      mapper = appsListMapper,
+      scope = CoroutineScope(Dispatchers.IO)
+    )
+  }
+
+  @Provides
+  @Singleton
+  fun providesReviewsRepository(
+    deviceApi: Optional<DeviceApiReviewsRepository>,
+  ): ReviewsRepository = if (deviceApi.isPresent) deviceApi.get() else EmptyReviewsRepository()
 
   @Provides
   @Singleton
   fun providesSplitsRepository(
     @RetrofitV7 retrofitV7: Retrofit,
-  ): SplitsRepository = SplitsRepositoryImpl(
-    appsRemoteDataSource = retrofitV7.create(SplitsRepositoryImpl.Retrofit::class.java),
-    scope = CoroutineScope(Dispatchers.IO)
-  )
+    deviceApi: Optional<DeviceApiSplitsRepository>,
+  ): SplitsRepository = if (deviceApi.isPresent) {
+    deviceApi.get()
+  } else {
+    SplitsRepositoryImpl(
+      appsRemoteDataSource = retrofitV7.create(SplitsRepositoryImpl.Retrofit::class.java),
+      scope = CoroutineScope(Dispatchers.IO)
+    )
+  }
 }

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/Review.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/Review.kt
@@ -1,0 +1,16 @@
+package cm.aptoide.pt.feature_apps.domain
+
+/**
+ * A user review (device API `GET /apps/{package}/reviews`, merged corpus). Read-only,
+ * anonymous. Only populated on the aptoideGamesDev device path.
+ */
+data class Review(
+  val id: String,
+  val authorName: String?,
+  val authorAvatarUrl: String?,
+  val rating: Int?,
+  val title: String?,
+  val body: String,
+  val createdAt: String?,
+  val helpfulVotes: Int,
+)

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/Trust.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/Trust.kt
@@ -1,0 +1,16 @@
+package cm.aptoide.pt.feature_apps.domain
+
+/**
+ * Transparency / trust signals surfaced on app detail — the product's
+ * "transparency inversion" (device.openapi.json `TrustResponse`). Populated only
+ * on the device-API (aptoideGamesDev) path; null on the v7 path.
+ */
+data class Trust(
+  /** trusted | unknown | warning | critical */
+  val scanVerdict: String?,
+  val signerSha256: String?,
+  /** consistent | different_signer | unknown */
+  val signerConsistency: String?,
+  /** developer_upload | mirrored | unknown */
+  val provenance: String?,
+)

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/ViewModelProvider.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/presentation/ViewModelProvider.kt
@@ -18,6 +18,7 @@ import cm.aptoide.pt.feature_apps.domain.AppsBySortUseCase
 import cm.aptoide.pt.feature_apps.domain.AppsByTagUseCase
 import cm.aptoide.pt.feature_apps.domain.CategoryAppsUseCase
 import cm.aptoide.pt.feature_apps.domain.ESkillsAppsUseCase
+import cm.aptoide.pt.feature_apps.domain.SimilarAppsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.reflect.KFunction0
@@ -30,7 +31,30 @@ class InjectionsProvider @Inject constructor(
   val eSkillsAppsUseCase: ESkillsAppsUseCase,
   val categoryAppsUseCase: CategoryAppsUseCase,
   val appsBySortUseCase: AppsBySortUseCase,
+  val similarAppsUseCase: SimilarAppsUseCase,
 ) : ViewModel()
+
+@Composable
+fun similarApps(source: String): Pair<AppsListUiState, () -> Unit> = runPreviewable(
+  preview = { AppsListUiState.Idle(List((3..8).random()) { randomApp }) to {} },
+  real = {
+    val injectionsProvider = hiltViewModel<InjectionsProvider>()
+    val vm: AppsListViewModel = viewModel(
+      key = "similarApps/$source",
+      factory = object : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+          @Suppress("UNCHECKED_CAST")
+          return AppsListViewModel(
+            source = source,
+            appsListUseCase = injectionsProvider.similarAppsUseCase,
+          ) as T
+        }
+      }
+    )
+    val uiState by vm.uiState.collectAsState()
+    uiState to vm::reload
+  }
+)
 
 @Composable
 fun rememberApp(source: String): Pair<AppUiState, () -> Unit> = runPreviewable(

--- a/feature_categories/build.gradle.kts
+++ b/feature_categories/build.gradle.kts
@@ -11,5 +11,6 @@ android {
 
 dependencies {
   implementation(projects.aptoideNetwork)
+  implementation(projects.deviceApi)
   implementation(projects.extension)
 }

--- a/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/data/deviceapi/DeviceApiCategoriesRepository.kt
+++ b/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/data/deviceapi/DeviceApiCategoriesRepository.kt
@@ -1,0 +1,41 @@
+package cm.aptoide.pt.feature_categories.data.deviceapi
+
+import cm.aptoide.pt.device_api.error.deviceApiCall
+import cm.aptoide.pt.feature_categories.data.CategoriesRepository
+import cm.aptoide.pt.feature_categories.domain.AppCategory
+import cm.aptoide.pt.feature_categories.domain.Category
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.withContext
+
+/**
+ * Device-API categories (aptoideGamesDev only). `GET /categories` for the list;
+ * the slug is the domain `name` used to browse (`/apps?category=`). `getAppsCategories`
+ * (installed→category classification) has no device endpoint (leftover) → empty.
+ */
+class DeviceApiCategoriesRepository(
+  private val service: DeviceApiCategoriesService,
+  private val scope: CoroutineScope,
+) : CategoriesRepository {
+
+  override suspend fun getCategoriesList(url: String): List<Category> = fetchCategories()
+
+  override suspend fun getGlobalCategoriesList(url: String): List<Category> = fetchCategories()
+
+  override suspend fun getAppsCategories(packageNames: List<String>): List<AppCategory> = emptyList()
+
+  private suspend fun fetchCategories(): List<Category> = withContext(scope.coroutineContext) {
+    deviceApiCall { service.getCategories() }.categories.orEmpty().mapNotNull { it.toCategory() }
+  }
+
+  private fun CategoryResponse.toCategory(): Category? {
+    val name = slug ?: return null
+    return Category(
+      id = name.hashCode().toLong(),
+      name = name,
+      title = title ?: name,
+      icon = null,
+      graphic = null,
+      background = null,
+    )
+  }
+}

--- a/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/data/deviceapi/DeviceApiCategoriesService.kt
+++ b/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/data/deviceapi/DeviceApiCategoriesService.kt
@@ -1,0 +1,22 @@
+package cm.aptoide.pt.feature_categories.data.deviceapi
+
+import androidx.annotation.Keep
+import retrofit2.http.GET
+
+/** `GET /android/v1/categories` — browseable categories (device.openapi.json). */
+interface DeviceApiCategoriesService {
+
+  @GET("android/v1/categories")
+  suspend fun getCategories(): CategoriesResponse
+}
+
+@Keep
+data class CategoriesResponse(val categories: List<CategoryResponse>? = null)
+
+@Keep
+data class CategoryResponse(
+  val slug: String? = null,
+  val title: String? = null,
+  val parent: String? = null,
+  val appCount: Int? = null,
+)

--- a/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/di/OptionalCategoriesBackendModule.kt
+++ b/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/di/OptionalCategoriesBackendModule.kt
@@ -1,0 +1,15 @@
+package cm.aptoide.pt.feature_categories.di
+
+import cm.aptoide.pt.feature_categories.data.deviceapi.DeviceApiCategoriesRepository
+import dagger.BindsOptionalOf
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+/** Present only in aptoideGamesDev ⇒ device-API categories; empty elsewhere ⇒ v7. */
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface OptionalCategoriesBackendModule {
+  @BindsOptionalOf
+  fun optionalDeviceCategoriesRepository(): DeviceApiCategoriesRepository
+}

--- a/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/di/RepositoryModule.kt
+++ b/feature_categories/src/main/java/cm/aptoide/pt/feature_categories/di/RepositoryModule.kt
@@ -7,11 +7,13 @@ import cm.aptoide.pt.feature_categories.analytics.AptoideAnalyticsInfoProvider
 import cm.aptoide.pt.feature_categories.analytics.AptoideFirebaseInfoProvider
 import cm.aptoide.pt.feature_categories.data.AptoideCategoriesRepository
 import cm.aptoide.pt.feature_categories.data.CategoriesRepository
+import cm.aptoide.pt.feature_categories.data.deviceapi.DeviceApiCategoriesRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import java.util.Optional
 import javax.inject.Singleton
 
 @Module
@@ -25,9 +27,12 @@ internal object RepositoryModule {
     @RetrofitCategoriesApps retrofitCategoriesApps: Retrofit,
     @StoreName storeName: String,
     analyticsInfoProvider: AptoideAnalyticsInfoProvider,
-    messagingInfoProvider: AptoideFirebaseInfoProvider
-  ): CategoriesRepository {
-    return AptoideCategoriesRepository(
+    messagingInfoProvider: AptoideFirebaseInfoProvider,
+    deviceApi: Optional<DeviceApiCategoriesRepository>,
+  ): CategoriesRepository = if (deviceApi.isPresent) {
+    deviceApi.get()
+  } else {
+    AptoideCategoriesRepository(
       categoriesRemoteDataSourceGet = retrofitV7.create(AptoideCategoriesRepository.RetrofitGet::class.java),
       categoriesRemoteDataSourcePost = retrofitCategoriesApps.create(AptoideCategoriesRepository.RetrofitPost::class.java),
       storeName = storeName,

--- a/feature_editorial/build.gradle.kts
+++ b/feature_editorial/build.gradle.kts
@@ -11,6 +11,7 @@ android {
 
 dependencies {
   implementation(projects.aptoideNetwork)
+  implementation(projects.deviceApi)
   implementation(projects.featureApps)
   implementation(projects.extension)
 }

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/deviceapi/DeviceApiEditorialRepository.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/deviceapi/DeviceApiEditorialRepository.kt
@@ -1,0 +1,164 @@
+package cm.aptoide.pt.feature_editorial.data.deviceapi
+
+import cm.aptoide.pt.device_api.error.deviceApiCall
+import cm.aptoide.pt.feature_apps.data.emptyApp
+import cm.aptoide.pt.feature_editorial.data.EditorialRepository
+import cm.aptoide.pt.feature_editorial.data.model.Media
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.AppEmbedBlockResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.CtaActionBlockResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.EditorialBlockResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.EditorialListItemResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.EditorialResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.HeadingBlockResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.ImageBlockResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.ParagraphBlockResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.VideoBlockResponse
+import cm.aptoide.pt.feature_editorial.domain.Action
+import cm.aptoide.pt.feature_editorial.domain.Article
+import cm.aptoide.pt.feature_editorial.domain.ArticleMeta
+import cm.aptoide.pt.feature_editorial.domain.ArticleType
+import cm.aptoide.pt.feature_editorial.domain.Paragraph
+import cm.aptoide.pt.feature_editorial.domain.RELATED_ARTICLE_CACHE_ID_PREFIX
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/**
+ * Device-API editorial (aptoideGamesDev only). `GET /editorials` for lists,
+ * `GET /editorials/{slug}` for detail. Slugs replace v7 card URLs; [getArticle]
+ * extracts the slug from whatever url/source string the caller passes. `getRelatedArticlesMeta`
+ * (→ `?app=`) fills the app-view Related tab. Comments are deferred.
+ */
+class DeviceApiEditorialRepository(
+  private val service: DeviceApiEditorialService,
+) : EditorialRepository {
+
+  override suspend fun getLatestArticle(): List<ArticleMeta> =
+    deviceApiCall { service.listEditorials(limit = 1) }.items.orEmpty().map { it.toArticleMeta() }
+
+  override suspend fun getArticle(editorialUrl: String): Article =
+    deviceApiCall { service.getEditorial(extractSlug(editorialUrl)) }.toArticle()
+
+  override suspend fun getArticlesMeta(
+    editorialWidgetUrl: String,
+    subtype: String?,
+  ): List<ArticleMeta> = deviceApiCall {
+    service.listEditorials(subtype = subtype?.let(::toDeviceSubtype), limit = 25)
+  }.items.orEmpty().map { it.toArticleMeta() }
+
+  override suspend fun getRelatedArticlesMeta(packageName: String): List<ArticleMeta> =
+    deviceApiCall { service.listEditorials(app = packageName, limit = 10) }
+      .items.orEmpty().map { it.toArticleMeta() }
+}
+
+/**
+ * Pulls the slug out of whatever identifier the caller passes: a v7-style card url
+ * (`card/get/{slug}/store_name=…`), a `key={slug}` wrapper (`id=…`, seen from the
+ * article route / urls cache), a cached slug, or a raw slug.
+ */
+internal fun extractSlug(editorialUrl: String): String {
+  var raw = editorialUrl.trim()
+  raw = when {
+    "card/get/" in raw -> raw.substringAfter("card/get/")
+    "card/" in raw -> raw.substringAfter("card/")
+    "editorials/" in raw -> raw.substringAfter("editorials/")
+    else -> raw
+  }
+  raw = raw.substringBefore("/store_name").substringBefore("/").trim()
+  // strip a leading `key=` wrapper, e.g. "id=game-of-the-week-roblox"; a plain slug
+  // has no '=', so substringAfterLast returns it unchanged.
+  return raw.substringAfterLast("=").trim()
+}
+
+private fun EditorialListItemResponse.toArticleMeta() = ArticleMeta(
+  id = slug.orEmpty(),
+  title = title.orEmpty(),
+  url = slug.orEmpty(),
+  caption = summary.orEmpty(),
+  summary = summary.orEmpty(),
+  image = coverImageUrl.orEmpty(),
+  subtype = toArticleType(subtype),
+  date = formatEditorialDate(publishedAt),
+  views = viewCount?.toLong() ?: 0L,
+)
+
+private fun EditorialResponse.toArticle() = Article(
+  id = slug.orEmpty(),
+  title = title.orEmpty(),
+  caption = summary.orEmpty(),
+  subtype = toArticleType(subtype),
+  image = coverImageUrl.orEmpty(),
+  date = formatEditorialDate(publishedAt),
+  views = viewCount?.toLong() ?: 0L,
+  relatedTag = RELATED_ARTICLE_CACHE_ID_PREFIX + slug.orEmpty(),
+  content = blocks.orEmpty().filterNotNull().map { it.toParagraph() },
+)
+
+private fun EditorialBlockResponse.toParagraph(): Paragraph = when (this) {
+  is HeadingBlockResponse ->
+    Paragraph(title = text, message = null, action = null, media = emptyList(), app = null)
+
+  is ParagraphBlockResponse ->
+    Paragraph(title = null, message = text, action = null, media = emptyList(), app = null)
+
+  is ImageBlockResponse -> Paragraph(
+    title = null, message = null, action = null,
+    media = listOf(Media(type = "image", description = alt, image = url, url = null)),
+    app = null,
+  )
+
+  is VideoBlockResponse -> Paragraph(
+    title = null, message = null, action = null,
+    media = listOf(Media(type = "video", description = null, image = null, url = url)),
+    app = null,
+  )
+
+  is CtaActionBlockResponse -> Paragraph(
+    title = null, message = null,
+    action = Action(title = label.orEmpty(), url = url.orEmpty()),
+    media = emptyList(), app = null,
+  )
+
+  is AppEmbedBlockResponse -> Paragraph(
+    title = null, message = summary, action = null, media = emptyList(),
+    app = emptyApp.copy(
+      packageName = packageName.orEmpty(),
+      name = name.orEmpty(),
+      icon = iconUrl.orEmpty(),
+      description = summary,
+    ),
+  )
+}
+
+private val EDITORIAL_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+/**
+ * Converts the device's ISO-8601 `published_at` (e.g. `2026-06-29T11:58:55.294386Z`)
+ * to the `yyyy-MM-dd HH:mm:ss` format the client's `TextFormatter`/`DateUtils` parse.
+ * Falls back to now on any parse failure — must never return an unparseable string
+ * (the date renderer throws on a bad format).
+ */
+private fun formatEditorialDate(isoDate: String?): String {
+  val instant = isoDate?.let { runCatching { Instant.parse(it) }.getOrNull() } ?: Instant.now()
+  return LocalDateTime.ofInstant(instant, ZoneId.systemDefault()).format(EDITORIAL_DATE_FORMAT)
+}
+
+private fun toArticleType(subtype: String?): ArticleType = when (subtype?.lowercase()) {
+  "app_of_the_week" -> ArticleType.APP_OF_THE_WEEK
+  "game_of_the_week" -> ArticleType.GAME_OF_THE_WEEK
+  "collection" -> ArticleType.COLLECTION
+  "news" -> ArticleType.NEWS
+  "new_app" -> ArticleType.NEW_APP
+  else -> ArticleType.OTHER
+}
+
+/** Maps a caller subtype (device or v7 enum-name) to a device subtype, or null if unknown. */
+private fun toDeviceSubtype(subtype: String): String? = when (subtype.lowercase()) {
+  "app_of_the_week" -> "app_of_the_week"
+  "game_of_the_week" -> "game_of_the_week"
+  "collection" -> "collection"
+  "news" -> "news"
+  "new_app" -> "new_app"
+  else -> null
+}

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/deviceapi/DeviceApiEditorialService.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/deviceapi/DeviceApiEditorialService.kt
@@ -1,0 +1,23 @@
+package cm.aptoide.pt.feature_editorial.data.deviceapi
+
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.EditorialListResponse
+import cm.aptoide.pt.feature_editorial.data.deviceapi.model.EditorialResponse
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/** Editorial API (`editorial.openapi.json`), same host as the device API. */
+interface DeviceApiEditorialService {
+
+  @GET("editorials")
+  suspend fun listEditorials(
+    @Query("locale") locale: String? = null,
+    @Query("app") app: String? = null,
+    @Query("subtype") subtype: String? = null,
+    @Query("cursor") cursor: String? = null,
+    @Query("limit") limit: Int? = null,
+  ): EditorialListResponse
+
+  @GET("editorials/{slug}")
+  suspend fun getEditorial(@Path("slug") slug: String): EditorialResponse
+}

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/deviceapi/model/EditorialModels.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/data/deviceapi/model/EditorialModels.kt
@@ -1,0 +1,65 @@
+package cm.aptoide.pt.feature_editorial.data.deviceapi.model
+
+import androidx.annotation.Keep
+
+/**
+ * DTOs for the editorial API (`api.dev.aptoide.com/editorials`), matching
+ * `editorial.openapi.json`. Blocks are a discriminated union on `kind`; unknown
+ * kinds deserialize to null (via DiscriminatorAdapterFactory) and are filtered.
+ */
+
+@Keep
+data class EditorialListResponse(
+  val items: List<EditorialListItemResponse>? = null,
+  val nextCursor: String? = null,
+)
+
+@Keep
+data class EditorialListItemResponse(
+  val slug: String? = null,
+  val locale: String? = null,
+  val subtype: String? = null,
+  val title: String? = null,
+  val summary: String? = null,
+  val coverImageUrl: String? = null,
+  val publishedAt: String? = null,
+  val viewCount: Int? = null,
+)
+
+@Keep
+data class EditorialResponse(
+  val slug: String? = null,
+  val locale: String? = null,
+  val subtype: String? = null,
+  val title: String? = null,
+  val summary: String? = null,
+  val coverImageUrl: String? = null,
+  val blocks: List<EditorialBlockResponse?>? = null,
+  val publishedAt: String? = null,
+  val viewCount: Int? = null,
+)
+
+sealed interface EditorialBlockResponse
+
+@Keep
+data class HeadingBlockResponse(val text: String? = null, val level: Int? = null) : EditorialBlockResponse
+
+@Keep
+data class ParagraphBlockResponse(val text: String? = null) : EditorialBlockResponse
+
+@Keep
+data class ImageBlockResponse(val url: String? = null, val alt: String? = null) : EditorialBlockResponse
+
+@Keep
+data class AppEmbedBlockResponse(
+  val packageName: String? = null,
+  val name: String? = null,
+  val iconUrl: String? = null,
+  val summary: String? = null,
+) : EditorialBlockResponse
+
+@Keep
+data class VideoBlockResponse(val url: String? = null) : EditorialBlockResponse
+
+@Keep
+data class CtaActionBlockResponse(val label: String? = null, val url: String? = null) : EditorialBlockResponse

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/di/OptionalEditorialBackendModule.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/di/OptionalEditorialBackendModule.kt
@@ -1,0 +1,15 @@
+package cm.aptoide.pt.feature_editorial.di
+
+import cm.aptoide.pt.feature_editorial.data.deviceapi.DeviceApiEditorialRepository
+import dagger.BindsOptionalOf
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+/** Present only in aptoideGamesDev ⇒ device-API editorial; empty elsewhere ⇒ v7. */
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface OptionalEditorialBackendModule {
+  @BindsOptionalOf
+  fun optionalDeviceEditorialRepository(): DeviceApiEditorialRepository
+}

--- a/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/di/RepositoryModule.kt
+++ b/feature_editorial/src/main/java/cm/aptoide/pt/feature_editorial/di/RepositoryModule.kt
@@ -5,11 +5,13 @@ import cm.aptoide.pt.aptoide_network.di.StoreName
 import cm.aptoide.pt.feature_apps.data.AppMapper
 import cm.aptoide.pt.feature_editorial.data.AptoideEditorialRepository
 import cm.aptoide.pt.feature_editorial.data.EditorialRepository
+import cm.aptoide.pt.feature_editorial.data.deviceapi.DeviceApiEditorialRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import java.util.Optional
 import javax.inject.Qualifier
 import javax.inject.Singleton
 
@@ -23,11 +25,16 @@ internal object RepositoryModule {
     mapper: AppMapper,
     @RetrofitV7ActionItem retrofit: Retrofit,
     @StoreName storeName: String,
-  ): EditorialRepository = AptoideEditorialRepository(
-    mapper = mapper,
-    editorialRemoteDataSource = retrofit.create(AptoideEditorialRepository.Retrofit::class.java),
-    storeName = storeName
-  )
+    deviceApi: Optional<DeviceApiEditorialRepository>,
+  ): EditorialRepository = if (deviceApi.isPresent) {
+    deviceApi.get()
+  } else {
+    AptoideEditorialRepository(
+      mapper = mapper,
+      editorialRemoteDataSource = retrofit.create(AptoideEditorialRepository.Retrofit::class.java),
+      storeName = storeName
+    )
+  }
 }
 
 @Qualifier

--- a/feature_search/build.gradle.kts
+++ b/feature_search/build.gradle.kts
@@ -17,6 +17,7 @@ android {
 dependencies {
   implementation(projects.featureAppview)
   implementation(projects.aptoideNetwork)
+  implementation(projects.deviceApi)
   implementation(projects.featureApps)
   implementation(projects.extension)
 

--- a/feature_search/src/main/java/cm/aptoide/pt/feature_search/data/deviceapi/DeviceApiSearchRepository.kt
+++ b/feature_search/src/main/java/cm/aptoide/pt/feature_search/data/deviceapi/DeviceApiSearchRepository.kt
@@ -1,0 +1,75 @@
+package cm.aptoide.pt.feature_search.data.deviceapi
+
+import cm.aptoide.pt.device_api.error.deviceApiCall
+import cm.aptoide.pt.device_api.network.DeviceProfileProvider
+import cm.aptoide.pt.feature_apps.data.deviceapi.DeviceApiAppsService
+import cm.aptoide.pt.feature_apps.data.deviceapi.toApp
+import cm.aptoide.pt.feature_search.data.database.SearchHistoryRepository
+import cm.aptoide.pt.feature_search.data.database.model.SearchHistoryEntity
+import cm.aptoide.pt.feature_search.domain.repository.SearchRepository
+import cm.aptoide.pt.feature_search.domain.repository.SearchRepository.AutoCompleteResult
+import cm.aptoide.pt.feature_search.domain.repository.SearchRepository.PopularAppSearchResult
+import cm.aptoide.pt.feature_search.domain.repository.SearchRepository.SearchAppResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+/**
+ * Device-API search (aptoideGamesDev only). Results via `GET /apps?q=` + device
+ * params; autocomplete via `GET /search/suggest` (degrades to empty). Local search
+ * history reuses the same Room DAO as v7. `getTopSearchedApps` (popular-search) has
+ * no device endpoint (leftover) → empty.
+ */
+class DeviceApiSearchRepository(
+  private val appsService: DeviceApiAppsService,
+  private val suggestService: DeviceApiSuggestService,
+  private val searchHistoryRepository: SearchHistoryRepository,
+  private val storeName: String,
+  private val variant: String,
+  private val deviceProfileProvider: DeviceProfileProvider,
+) : SearchRepository {
+
+  override fun searchApp(keyword: String): Flow<SearchAppResult> = flow {
+    val p = deviceProfileProvider.get()
+    runCatching {
+      deviceApiCall {
+        appsService.searchOrBrowse(
+          q = keyword, variant = variant,
+          sdk = p.sdk, abi = p.abi, tv = p.tv, density = p.density,
+        )
+      }.items.orEmpty().map { it.toApp(storeName) }
+    }.fold(
+      onSuccess = { emit(SearchAppResult.Success(it)) },
+      onFailure = { emit(SearchAppResult.Error(it)) },
+    )
+  }.flowOn(Dispatchers.IO)
+
+  override fun getAutoCompleteSuggestions(keyword: String): Flow<AutoCompleteResult> = flow {
+    val terms = runCatching {
+      deviceApiCall { suggestService.suggest(q = keyword) }.suggestions.orEmpty().mapNotNull { it.term }
+    }.getOrDefault(emptyList()) // suggest never surfaces an error state
+    emit(AutoCompleteResult.Success(terms))
+  }.flowOn(Dispatchers.IO)
+
+  override fun getTopSearchedApps(): Flow<PopularAppSearchResult> = flow {
+    emit(PopularAppSearchResult.Success(emptyList()))
+  }
+
+  override fun getSearchHistory(): Flow<List<String>> =
+    searchHistoryRepository.getSearchHistory().map { list -> list.map { it.appName } }
+
+  override suspend fun addAppToSearchHistory(appName: String) {
+    withContext(Dispatchers.IO) {
+      searchHistoryRepository.addAppToSearchHistory(SearchHistoryEntity(appName))
+    }
+  }
+
+  override suspend fun removeAppFromSearchHistory(appName: String) {
+    withContext(Dispatchers.IO) {
+      searchHistoryRepository.removeAppFromSearchHistory(appName)
+    }
+  }
+}

--- a/feature_search/src/main/java/cm/aptoide/pt/feature_search/data/deviceapi/DeviceApiSuggestService.kt
+++ b/feature_search/src/main/java/cm/aptoide/pt/feature_search/data/deviceapi/DeviceApiSuggestService.kt
@@ -1,0 +1,21 @@
+package cm.aptoide.pt.feature_search.data.deviceapi
+
+import androidx.annotation.Keep
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+/** `GET /android/v1/search/suggest` — typo-tolerant autocomplete (degrades to empty). */
+interface DeviceApiSuggestService {
+
+  @GET("android/v1/search/suggest")
+  suspend fun suggest(
+    @Query("q") q: String,
+    @Query("limit") limit: Int? = null,
+  ): SuggestResponse
+}
+
+@Keep
+data class SuggestResponse(val suggestions: List<SuggestionResponse>? = null)
+
+@Keep
+data class SuggestionResponse(val term: String? = null)

--- a/feature_search/src/main/java/cm/aptoide/pt/feature_search/di/OptionalSearchBackendModule.kt
+++ b/feature_search/src/main/java/cm/aptoide/pt/feature_search/di/OptionalSearchBackendModule.kt
@@ -1,0 +1,15 @@
+package cm.aptoide.pt.feature_search.di
+
+import cm.aptoide.pt.feature_search.data.deviceapi.DeviceApiSearchRepository
+import dagger.BindsOptionalOf
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+/** Present only in aptoideGamesDev ⇒ device-API search; empty elsewhere ⇒ v7. */
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface OptionalSearchBackendModule {
+  @BindsOptionalOf
+  fun optionalDeviceSearchRepository(): DeviceApiSearchRepository
+}

--- a/feature_search/src/main/java/cm/aptoide/pt/feature_search/di/RepositoryModule.kt
+++ b/feature_search/src/main/java/cm/aptoide/pt/feature_search/di/RepositoryModule.kt
@@ -8,6 +8,7 @@ import cm.aptoide.pt.feature_search.data.AptoideSearchRepository
 import cm.aptoide.pt.feature_search.data.AutoCompleteSuggestionsRepository
 import cm.aptoide.pt.feature_search.data.database.SearchHistoryDatabase
 import cm.aptoide.pt.feature_search.data.database.SearchHistoryRepository
+import cm.aptoide.pt.feature_search.data.deviceapi.DeviceApiSearchRepository
 import cm.aptoide.pt.feature_search.data.network.RemoteSearchRepository
 import cm.aptoide.pt.feature_search.data.network.service.SearchRetrofitService
 import cm.aptoide.pt.feature_search.domain.repository.SearchRepository
@@ -18,6 +19,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import java.util.Optional
 import javax.inject.Singleton
 
 @Module
@@ -31,8 +33,11 @@ object RepositoryModule {
     searchHistoryRepository: SearchHistoryRepository,
     remoteSearchRepository: RemoteSearchRepository,
     autoCompleteSuggestionsRepository: AutoCompleteSuggestionsRepository,
-  ): SearchRepository {
-    return AptoideSearchRepository(
+    deviceApi: Optional<DeviceApiSearchRepository>,
+  ): SearchRepository = if (deviceApi.isPresent) {
+    deviceApi.get()
+  } else {
+    AptoideSearchRepository(
       mapper = mapper,
       searchHistoryRepository = searchHistoryRepository,
       remoteSearchRepository = remoteSearchRepository,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,6 +32,7 @@ include(
   ":feature-home",
   ":feature_updates",
   ":aptoide-network",
+  ":device-api",
   ":feature_appview",
   ":feature_report_app",
   ":feature-flags",


### PR DESCRIPTION
Adds a new `:device-api` module (typed RFC 9457 errors, device-profile params, and a discriminated-union Gson factory) and device-API repository implementations for home, apps/detail, listings, search, categories, editorial, and a new reviews source. These are selected through a dev-only `@BindsOptionalOf` switch whose concrete providers live only in `src/aptoideGamesDev/`, so only the aptoideGamesDev variant hits the device API while prod, vanilla, and `:app` stay on v7 untouched. The app-view also gains a Reviews tab, a transparency Trust panel, a collapsible description, and a Similar games grid, and GameGenie search is bypassed on `.dev` builds. Note that the app-view UI additions live in shared `src/main`, so the collapsible description and Similar games grid render on all `:app-games` flavors, not just dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Device API support for app details, search, categories, home content, editorial content, reviews, related apps, and app versions.
  * Added reviews, similar apps, trust and security information to app details.
  * Added expandable app descriptions and localized labels.
  * Development builds now use standard search results instead of GameGenie.
* **Bug Fixes**
  * Improved handling of unavailable content, unsupported sections, empty results, and API errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->