### PR TITLE
[AND-869] Show uninstall button on the App View for Play & Earn apps

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/appview/AppViewScreen.kt
@@ -467,7 +467,8 @@ fun AppViewContent(
           modifier = Modifier.padding(top = 24.dp, start = 16.dp, end = 16.dp),
           app = app,
           rewardAmount = rewardAmount,
-          navigate = navigate
+          navigate = navigate,
+          showUninstall = true,
         )
       } else {
         val autoOpenUTMMedium = if (autoOpenBillingEligible) {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/PaEInstallView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/PaEInstallView.kt
@@ -25,9 +25,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.stateDescription
@@ -45,6 +47,7 @@ import java.math.BigDecimal
 import com.aptoide.android.aptoidegames.R.string
 import com.aptoide.android.aptoidegames.design_system.PrimaryButton
 import com.aptoide.android.aptoidegames.design_system.PrimarySmallButton
+import com.aptoide.android.aptoidegames.design_system.SecondaryOutlinedButton
 import com.aptoide.android.aptoidegames.design_system.SecondarySmallOutlinedButton
 import com.aptoide.android.aptoidegames.drawables.icons.getError
 import com.aptoide.android.aptoidegames.installer.presentation.InstallViewState
@@ -91,17 +94,20 @@ fun PaEInstallView(
   onInstallStarted: () -> Unit = {},
   onCancel: () -> Unit = {},
   navigate: ((String) -> Unit)? = null,
+  showUninstall: Boolean = false,
 ) {
   val installViewState = installViewStates(
     app = app,
     onInstallStarted = onInstallStarted,
     onCancel = onCancel
   )
+  val uninstallLabel = stringResource(string.uninstall_button)
 
   PaEInstallViewContent(
     installViewState = installViewState,
     navigate = navigate,
     rewardAmount = rewardAmount,
+    showUninstall = showUninstall,
     modifier = modifier.clearAndSetSemantics {
       installViewState.actionLabel?.let {
         onClick(label = it) {
@@ -115,6 +121,20 @@ fun PaEInstallView(
             else -> null
           }?.invoke()
           true
+        }
+      }
+      if (showUninstall) {
+        when (val uiState = installViewState.uiState) {
+          is DownloadUiState.Outdated -> uiState.uninstall
+          is DownloadUiState.Installed -> uiState.uninstall
+          else -> null
+        }?.let { uninstall ->
+          customActions = listOf(
+            CustomAccessibilityAction(label = uninstallLabel) {
+              uninstall()
+              true
+            }
+          )
         }
       }
       this.contentDescription = installViewState.contentDescription
@@ -132,6 +152,7 @@ private fun PaEInstallViewContent(
   rewardAmount: BigDecimal? = null,
   verticalSpacing: Dp = 8.dp,
   horizontalSpacing: Dp = 24.dp,
+  showUninstall: Boolean = false,
 ) = Box(
   modifier = modifier
     .fillMaxWidth()
@@ -157,11 +178,29 @@ private fun PaEInstallViewContent(
       modifier = Modifier.fillMaxWidth(),
     )
 
-    is DownloadUiState.Outdated -> PaELargeCoinButton(
-      title = installViewState.actionLabel ?: "",
-      onClick = state.update,
-      modifier = Modifier.fillMaxWidth(),
-    )
+    is DownloadUiState.Outdated -> if (showUninstall) {
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        SecondaryOutlinedButton(
+          title = stringResource(string.uninstall_button),
+          onClick = state.uninstall,
+          modifier = Modifier.weight(1f),
+        )
+        PaELargeCoinButton(
+          title = installViewState.actionLabel ?: "",
+          onClick = state.update,
+          modifier = Modifier.weight(1f),
+        )
+      }
+    } else {
+      PaELargeCoinButton(
+        title = installViewState.actionLabel ?: "",
+        onClick = state.update,
+        modifier = Modifier.fillMaxWidth(),
+      )
+    }
 
     is DownloadUiState.Waiting -> PaEProgressView(
       title = installViewState.stateDescription,
@@ -218,12 +257,31 @@ private fun PaEInstallViewContent(
       horizontalSpacing = horizontalSpacing,
     )
 
-    is DownloadUiState.Installed -> PaEPlayButton(
-      onClick = state.open,
-      navigate = navigate,
-      rewardAmount = rewardAmount,
-      modifier = Modifier.fillMaxWidth(),
-    )
+    is DownloadUiState.Installed -> if (showUninstall) {
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        SecondaryOutlinedButton(
+          title = stringResource(string.uninstall_button),
+          onClick = state.uninstall,
+          modifier = Modifier.weight(1f),
+        )
+        PaEPlayButton(
+          onClick = state.open,
+          navigate = navigate,
+          rewardAmount = rewardAmount,
+          modifier = Modifier.weight(1f),
+        )
+      }
+    } else {
+      PaEPlayButton(
+        onClick = state.open,
+        navigate = navigate,
+        rewardAmount = rewardAmount,
+        modifier = Modifier.fillMaxWidth(),
+      )
+    }
 
     is DownloadUiState.Error -> Row(
       modifier = Modifier


### PR DESCRIPTION
The uninstall button added to the App View in #2575 only covered regular apps; gamified apps render `PaEInstallView`, which kept the single full-width button. This applies the same treatment there: an opt-in `showUninstall` flag, an outlined Uninstall button next to Play (Installed) and Update (Outdated), and the matching custom accessibility action since the view uses `clearAndSetSemantics`. The App View's gamified branch opts in, keeping parity with the regular `InstallView` call site. Both `vanillaDirectDevDebug` and `aptoideGamesGplayDevDebug` build and install cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)