### PR TITLE
[AND-869] Stack the P&E uninstall button below the play button

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/PaEInstallView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/presentation/components/PaEInstallView.kt
@@ -179,19 +179,19 @@ private fun PaEInstallViewContent(
     )
 
     is DownloadUiState.Outdated -> if (showUninstall) {
-      Row(
+      Column(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
       ) {
-        SecondaryOutlinedButton(
-          title = stringResource(string.uninstall_button),
-          onClick = state.uninstall,
-          modifier = Modifier.weight(1f),
-        )
         PaELargeCoinButton(
           title = installViewState.actionLabel ?: "",
           onClick = state.update,
-          modifier = Modifier.weight(1f),
+          modifier = Modifier.fillMaxWidth(),
+        )
+        SecondaryOutlinedButton(
+          title = stringResource(string.uninstall_button),
+          onClick = state.uninstall,
+          modifier = Modifier.fillMaxWidth(),
         )
       }
     } else {
@@ -258,20 +258,20 @@ private fun PaEInstallViewContent(
     )
 
     is DownloadUiState.Installed -> if (showUninstall) {
-      Row(
+      Column(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
       ) {
-        SecondaryOutlinedButton(
-          title = stringResource(string.uninstall_button),
-          onClick = state.uninstall,
-          modifier = Modifier.weight(1f),
-        )
         PaEPlayButton(
           onClick = state.open,
           navigate = navigate,
           rewardAmount = rewardAmount,
-          modifier = Modifier.weight(1f),
+          modifier = Modifier.fillMaxWidth(),
+        )
+        SecondaryOutlinedButton(
+          title = stringResource(string.uninstall_button),
+          onClick = state.uninstall,
+          modifier = Modifier.fillMaxWidth(),
         )
       }
     } else {


### PR DESCRIPTION
Follow-up to #2576: at half width the installed-state "Play & Earn up to $X" label gets clipped (maxLines=1, no ellipsis in PaELargeCoinButton). The Installed and Outdated states of PaEInstallView now stack vertically — primary action full-width on top, Uninstall full-width below — instead of sharing a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)