### PR TITLE
[AND-856] Send MMP attribution install event on app launch

### DIFF
--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideApplication.kt
@@ -26,6 +26,7 @@ import coil.util.DebugLogger
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
 import com.aptoide.android.aptoidegames.app_open_ads.AppOpenAdInitializer
+import com.aptoide.android.aptoidegames.attribution.domain.AttributionManager
 import com.aptoide.android.aptoidegames.device_info.DeviceSecurityChecker
 import com.aptoide.android.aptoidegames.device_info.analytics.DeviceInfoAnalytics
 import com.aptoide.android.aptoidegames.feature_companion_apps_notification.CompanionAppsManager
@@ -131,6 +132,9 @@ class AptoideApplication : Application(), ImageLoaderFactory, Provider {
   @Inject
   lateinit var deviceInfoAnalytics: DeviceInfoAnalytics
 
+  @Inject
+  lateinit var attributionManager: AttributionManager
+
   override fun onCreate() {
     FirebaseApp.initializeApp(this)
     super.onCreate()
@@ -148,11 +152,20 @@ class AptoideApplication : Application(), ImageLoaderFactory, Provider {
     }
     AptoideMMPCampaign.init(BuildConfig.OEMID)
     MMPLinkerCampaign.init(BuildConfig.OEMID)
+    initAttribution()
     initCompanionAppsManager()
     initCompanionGamesCachePreloader()
     initTrendingAppsRecommendationManager()
     initInstalledPackagesSyncManager()
     sendDeviceSecurityAnalytics()
+  }
+
+  private fun initAttribution() {
+    if (applicationContext.isObbMoverProcess()) return
+    CoroutineScope(Dispatchers.IO).launch {
+      runCatching { attributionManager.resolve() }
+        .onFailure { Timber.e(it, "Failed to resolve attribution.") }
+    }
   }
 
   private fun initInstalledPackagesSyncManager() {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/PackageManagerExtensions.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/PackageManagerExtensions.kt
@@ -1,0 +1,18 @@
+package com.aptoide.android.aptoidegames
+
+import android.content.pm.PackageManager
+import android.os.Build
+
+/**
+ * Returns the package name of the installer that installed [packageName], handling the
+ * getInstallSourceInfo (API 30+) vs deprecated getInstallerPackageName split. Returns null when the
+ * installer is unknown or the package cannot be resolved.
+ */
+fun PackageManager.getInstallerPackageNameCompat(packageName: String): String? = runCatching {
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+    getInstallSourceInfo(packageName).installingPackageName
+  } else {
+    @Suppress("DEPRECATION")
+    getInstallerPackageName(packageName)
+  }
+}.getOrNull()

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyAnalytics.kt
@@ -1,22 +1,15 @@
 package com.aptoide.android.aptoidegames.apkfy.analytics
 
-import android.content.Context
-import cm.aptoide.pt.feature_apkfy.domain.ApkfyModel
 import com.aptoide.android.aptoidegames.analytics.BIAnalytics
 import com.aptoide.android.aptoidegames.analytics.GenericAnalytics
 import com.aptoide.android.aptoidegames.analytics.UserProperty
 import com.aptoide.android.aptoidegames.analytics.mapOfNonNull
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class ApkfyAnalytics @Inject constructor(
   private val genericAnalytics: GenericAnalytics,
   private val biAnalytics: BIAnalytics,
-  @ApplicationContext private val context: Context,
 ) {
-
-  fun setGuestUIDUserProperty(guestUid: String) =
-    biAnalytics.setUserProperties(UserProperty("aptoide_mmp_guest_id", guestUid))
 
   fun sendApkfySuccessEvent(
     data: String,
@@ -73,60 +66,7 @@ class ApkfyAnalytics @Inject constructor(
   fun sendExp83OpenRobloxClick() =
     genericAnalytics.logEvent("exp83_open_roblox_click", params = emptyMap())
 
-  fun setApkfyUTMProperties(apkfyModel: ApkfyModel) {
-    apkfyModel.run {
-      if (hasUTMs()) {
-        biAnalytics.setUTMProperties(
-          utmSource = utmSource,
-          utmMedium = utmMedium,
-          utmCampaign = utmCampaign,
-          utmTerm = utmTerm,
-          utmContent = utmContent,
-          utmOemId = oemId,
-          utmPackageName = packageName ?: APKFY_BUT_NO_APP
-        )
-      } else if (hasApkfy()) {
-        if (packageName == context.packageName) {
-          biAnalytics.setUTMProperties(
-            utmSource = UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
-            utmMedium = UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
-            utmCampaign = UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
-            utmTerm = UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
-            utmContent = UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
-            utmOemId = oemId ?: UTM_PROPERTY_DIRECT_WITHOUT_UTMS,
-            utmPackageName = packageName
-          )
-        } else {
-          biAnalytics.setUTMProperties(
-            utmSource = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-            utmMedium = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-            utmCampaign = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-            utmTerm = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-            utmContent = UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-            utmOemId = oemId ?: UTM_PROPERTY_APKFY_WITHOUT_UTMS,
-            utmPackageName = packageName
-          )
-        }
-      } else {
-        biAnalytics.setUTMProperties(
-          utmSource = UTM_PROPERTY_NO_APKFY,
-          utmMedium = UTM_PROPERTY_NO_APKFY,
-          utmCampaign = UTM_PROPERTY_NO_APKFY,
-          utmTerm = UTM_PROPERTY_NO_APKFY,
-          utmContent = UTM_PROPERTY_NO_APKFY,
-          utmOemId = UTM_PROPERTY_NO_APKFY,
-          utmPackageName = UTM_PROPERTY_NO_APKFY
-        )
-      }
-    }
-  }
-
   companion object {
-    private const val UTM_PROPERTY_NO_APKFY = "NO_APKFY"
-    private const val UTM_PROPERTY_APKFY_WITHOUT_UTMS = "APKFY_BUT_NO_UTM"
-    private const val APKFY_BUT_NO_APP = "APKFY_BUT_NO_APP"
-    private const val UTM_PROPERTY_DIRECT_WITHOUT_UTMS = "DIRECT_BUT_NO_UTM"
-
     private const val P_STATUS = "status"
     private const val P_DATA = "data"
     private const val P_ERROR_MESSAGE = "error_message"

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyManagerProbe.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/analytics/ApkfyManagerProbe.kt
@@ -2,8 +2,6 @@ package com.aptoide.android.aptoidegames.apkfy.analytics
 
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyManager
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyModel
-import cm.aptoide.pt.feature_campaigns.AptoideMMPCampaign
-import com.aptoide.android.aptoidegames.LocalIdsRepository
 import com.aptoide.android.aptoidegames.apkfy.ApkfySessionPreferences
 import com.google.gson.Gson
 import kotlinx.coroutines.delay
@@ -14,12 +12,10 @@ import retrofit2.HttpException
 class ApkfyManagerProbe(
   private val apkfyManager: ApkfyManager,
   private val apkfyAnalytics: ApkfyAnalytics,
-  private val idsRepository: LocalIdsRepository,
   private val apkfySessionPreferences: ApkfySessionPreferences,
 ) : ApkfyManager {
 
   companion object {
-    const val GUEST_UID_KEY = "GUEST_UID"
     private const val MAX_APKFY_ATTEMPTS = 3
     private const val APKFY_RETRY_DELAY_MS = 5000L
   }
@@ -43,13 +39,6 @@ class ApkfyManagerProbe(
         // Apkfy call repeated at most 3 times, to make sure there is no apkfy app associated.
         try {
           apkfyModel = apkfyManager.getApkfy()
-            ?.also(apkfyAnalytics::setApkfyUTMProperties)
-            ?.also { idsRepository.saveId(GUEST_UID_KEY, it.guestUid) }
-            ?.also { apkfyAnalytics.setGuestUIDUserProperty(it.guestUid) }
-            .also {
-              // TODO: improve this logic
-              AptoideMMPCampaign.guestUID = it?.guestUid ?: idsRepository.getId(GUEST_UID_KEY)
-            }
             ?.also {
               apkfyAnalytics.sendApkfySuccessEvent(
                 data = Gson().toJson(it),
@@ -86,10 +75,6 @@ class ApkfyManagerProbe(
 
       return apkfyModel
     } else {
-      idsRepository.getId(GUEST_UID_KEY).let {
-        apkfyAnalytics.setGuestUIDUserProperty(it)
-        AptoideMMPCampaign.guestUID = it
-      }
       return null
     }
   }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/di/RepositoryModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/di/RepositoryModule.kt
@@ -3,7 +3,6 @@ package com.aptoide.android.aptoidegames.apkfy.di
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyFilter
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyManager
 import cm.aptoide.pt.feature_apkfy.domain.ApkfyManagerImpl
-import com.aptoide.android.aptoidegames.LocalIdsRepository
 import com.aptoide.android.aptoidegames.apkfy.AGApkfyFilter
 import com.aptoide.android.aptoidegames.apkfy.ApkfySessionPreferences
 import com.aptoide.android.aptoidegames.apkfy.DownloadPermissionStateProbe
@@ -25,13 +24,11 @@ internal object RepositoryModule {
   fun provideApkfyManager(
     apkfyManager: ApkfyManagerImpl,
     apkfyAnalytics: ApkfyAnalytics,
-    idsRepository: LocalIdsRepository,
     apkfySessionPreferences: ApkfySessionPreferences,
   ): ApkfyManager =
     ApkfyManagerProbe(
       apkfyManager = apkfyManager,
       apkfyAnalytics = apkfyAnalytics,
-      idsRepository = idsRepository,
       apkfySessionPreferences = apkfySessionPreferences,
     )
 

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/presentation/AnalyticsProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/apkfy/presentation/AnalyticsProvider.kt
@@ -1,7 +1,6 @@
 package com.aptoide.android.aptoidegames.apkfy.presentation
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import cm.aptoide.pt.extensions.runPreviewable
@@ -24,8 +23,7 @@ fun rememberApkfyAnalytics(): ApkfyAnalytics = runPreviewable(
   preview = {
     ApkfyAnalytics(
       GenericAnalytics(object : AnalyticsSender {}),
-      BIAnalytics(object : AnalyticsSender {}),
-      LocalContext.current.applicationContext
+      BIAnalytics(object : AnalyticsSender {})
     )
   },
   real = {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/AttributionSessionPreferences.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/AttributionSessionPreferences.kt
@@ -1,0 +1,29 @@
+package com.aptoide.android.aptoidegames.attribution
+
+import android.content.Context
+import androidx.core.content.edit
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AttributionSessionPreferences @Inject constructor(
+  @ApplicationContext context: Context,
+) {
+
+  private val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+  fun hasResolvedAttribution(): Boolean =
+    preferences.getBoolean(KEY_HAS_RESOLVED_ATTRIBUTION, false)
+
+  fun markAttributionResolved() {
+    preferences.edit {
+      putBoolean(KEY_HAS_RESOLVED_ATTRIBUTION, true)
+    }
+  }
+
+  private companion object {
+    const val PREFERENCES_NAME = "attribution_session"
+    const val KEY_HAS_RESOLVED_ATTRIBUTION = "has_resolved_attribution"
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/analytics/AttributionAnalytics.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/analytics/AttributionAnalytics.kt
@@ -1,0 +1,86 @@
+package com.aptoide.android.aptoidegames.attribution.analytics
+
+import com.aptoide.android.aptoidegames.analytics.BIAnalytics
+import com.aptoide.android.aptoidegames.analytics.UserProperty
+import com.aptoide.android.aptoidegames.analytics.mapOfNonNull
+import com.aptoide.android.aptoidegames.attribution.domain.AttributionModel
+import javax.inject.Inject
+
+class AttributionAnalytics @Inject constructor(
+  private val biAnalytics: BIAnalytics,
+) {
+
+  fun setGuestUIDUserProperty(guestUid: String) =
+    biAnalytics.setUserProperties(UserProperty("aptoide_mmp_guest_id", guestUid))
+
+  fun setAttributionUTMProperties(model: AttributionModel) {
+    model.run {
+      if (hasUTMs()) {
+        biAnalytics.setUTMProperties(
+          utmSource = utmSource,
+          utmMedium = utmMedium,
+          utmCampaign = utmCampaign,
+          utmTerm = utmTerm,
+          utmContent = utmContent,
+          utmOemId = oemId,
+          utmPackageName = packageName ?: NO_APKFY,
+        )
+      } else {
+        biAnalytics.setUTMProperties(
+          utmSource = NO_APKFY,
+          utmMedium = NO_APKFY,
+          utmCampaign = NO_APKFY,
+          utmTerm = NO_APKFY,
+          utmContent = NO_APKFY,
+          utmOemId = oemId ?: NO_APKFY,
+          utmPackageName = packageName ?: NO_APKFY,
+        )
+      }
+    }
+  }
+
+  fun sendAttributionSuccessEvent(
+    data: String,
+    isRetry: Boolean,
+    callNumber: Int,
+  ) = biAnalytics.logEvent(
+    name = EVENT_NAME,
+    mapOfNonNull(
+      P_STATUS to "success",
+      P_DATA to data,
+      P_RETRY to isRetry,
+      P_CALL_NUMBER to callNumber,
+    )
+  )
+
+  fun sendAttributionFailEvent(
+    errorMessage: String?,
+    errorType: String?,
+    errorCode: Int? = null,
+    isRetry: Boolean,
+    callNumber: Int,
+  ) = biAnalytics.logEvent(
+    name = EVENT_NAME,
+    mapOfNonNull(
+      P_STATUS to "fail",
+      P_ERROR_MESSAGE to errorMessage,
+      P_ERROR_TYPE to errorType,
+      P_ERROR_HTTP_CODE to errorCode,
+      P_RETRY to isRetry,
+      P_CALL_NUMBER to callNumber,
+    )
+  )
+
+  companion object {
+    private const val NO_APKFY = "NO_APKFY"
+    private const val EVENT_NAME = "aptoide_mmp_attribution"
+
+    private const val P_STATUS = "status"
+    private const val P_DATA = "data"
+    private const val P_ERROR_MESSAGE = "error_message"
+    private const val P_ERROR_TYPE = "error_type"
+    private const val P_ERROR_HTTP_CODE = "error_http_code"
+    private const val P_RETRY = "retry"
+    private const val P_CALL_NUMBER = "call_number"
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/data/AptoideAttributionRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/data/AptoideAttributionRepository.kt
@@ -1,0 +1,48 @@
+package com.aptoide.android.aptoidegames.attribution.data
+
+import com.aptoide.android.aptoidegames.attribution.domain.AttributionModel
+import com.aptoide.android.aptoidegames.attribution.domain.AttributionRepository
+import retrofit2.http.GET
+import retrofit2.http.Query
+import javax.inject.Inject
+
+internal class AptoideAttributionRepository @Inject constructor(
+  private val mmpRemoteDataSource: Service,
+) : AttributionRepository {
+
+  override suspend fun getAttribution(
+    packageName: String,
+    guestUid: String?,
+    timestamp: Long,
+    vercode: Long,
+    installerPackageName: String?,
+  ): AttributionModel = mmpRemoteDataSource.getAttribution(
+    packageName = packageName,
+    guestUid = guestUid,
+    timestamp = timestamp,
+    vercode = vercode,
+    installerPackageName = installerPackageName,
+  ).toDomainModel()
+
+  interface Service {
+    @GET("attribution")
+    suspend fun getAttribution(
+      @Query("package_name") packageName: String,
+      @Query("guest_uid") guestUid: String?,
+      @Query("timestamp") timestamp: Long,
+      @Query("vercode") vercode: Long,
+      @Query("installer_package_name") installerPackageName: String?,
+    ): AttributionJSON
+  }
+}
+
+fun AttributionJSON.toDomainModel(): AttributionModel = AttributionModel(
+  packageName = packageName,
+  oemId = oemId,
+  guestUid = guestUid.orEmpty(),
+  utmSource = utmSource,
+  utmMedium = utmMedium,
+  utmCampaign = utmCampaign,
+  utmTerm = utmTerm,
+  utmContent = utmContent,
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/data/AttributionJSON.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/data/AttributionJSON.kt
@@ -1,0 +1,17 @@
+package com.aptoide.android.aptoidegames.attribution.data
+
+import androidx.annotation.Keep
+import com.google.gson.annotations.SerializedName
+
+@Keep
+data class AttributionJSON(
+  @SerializedName("package_name") val packageName: String? = null,
+  @SerializedName("oemid") val oemId: String? = null,
+  // Gson bypasses Kotlin null-safety, so an explicit JSON null still lands here as null.
+  @SerializedName("guest_uid") val guestUid: String? = null,
+  @SerializedName("utm_source") val utmSource: String? = null,
+  @SerializedName("utm_medium") val utmMedium: String? = null,
+  @SerializedName("utm_campaign") val utmCampaign: String? = null,
+  @SerializedName("utm_term") val utmTerm: String? = null,
+  @SerializedName("utm_content") val utmContent: String? = null,
+)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/di/AttributionModule.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/di/AttributionModule.kt
@@ -1,0 +1,29 @@
+package com.aptoide.android.aptoidegames.attribution.di
+
+import cm.aptoide.pt.feature_apkfy.di.RetrofitMMP
+import com.aptoide.android.aptoidegames.attribution.data.AptoideAttributionRepository
+import com.aptoide.android.aptoidegames.attribution.domain.AttributionManager
+import com.aptoide.android.aptoidegames.attribution.domain.AttributionManagerImpl
+import com.aptoide.android.aptoidegames.attribution.domain.AttributionRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object AttributionModule {
+
+  @Provides
+  @Singleton
+  fun provideAttributionRepository(@RetrofitMMP retrofitMMP: Retrofit): AttributionRepository =
+    AptoideAttributionRepository(
+      mmpRemoteDataSource = retrofitMMP.create(AptoideAttributionRepository.Service::class.java)
+    )
+
+  @Provides
+  @Singleton
+  fun provideAttributionManager(impl: AttributionManagerImpl): AttributionManager = impl
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/domain/AttributionManager.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/domain/AttributionManager.kt
@@ -1,0 +1,138 @@
+package com.aptoide.android.aptoidegames.attribution.domain
+
+import android.content.Context
+import cm.aptoide.pt.feature_campaigns.AptoideMMPCampaign
+import com.aptoide.android.aptoidegames.BuildConfig
+import com.aptoide.android.aptoidegames.LocalIdsRepository
+import com.aptoide.android.aptoidegames.attribution.AttributionSessionPreferences
+import com.aptoide.android.aptoidegames.attribution.analytics.AttributionAnalytics
+import com.aptoide.android.aptoidegames.getInstallerPackageNameCompat
+import com.google.gson.Gson
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import retrofit2.HttpException
+import java.security.SecureRandom
+import javax.inject.Inject
+import javax.inject.Singleton
+
+interface AttributionManager {
+  /**
+   * Sends the MMP attribution install event, starting the first time the app is opened, retrying
+   * with exponential backoff for the first minute and then once every minute until it succeeds.
+   * On success it becomes the source of truth for guest_uid, the UTM values and the oemid, and the
+   * event is never sent again. On subsequent opens it only re-hydrates the in-memory guest_uid
+   * used by campaign events.
+   */
+  suspend fun resolve()
+
+  companion object {
+    const val GUEST_UID_KEY = "GUEST_UID"
+  }
+}
+
+@Singleton
+class AttributionManagerImpl @Inject constructor(
+  @ApplicationContext private val context: Context,
+  private val attributionRepository: AttributionRepository,
+  private val idsRepository: LocalIdsRepository,
+  private val attributionAnalytics: AttributionAnalytics,
+  private val attributionSessionPreferences: AttributionSessionPreferences,
+) : AttributionManager {
+
+  private val mutex = Mutex()
+
+  override suspend fun resolve(): Unit = mutex.withLock {
+    if (attributionSessionPreferences.hasResolvedAttribution()) {
+      rehydrateGuestUid()
+      return@withLock
+    }
+
+    // Captured once so that retries keep the timestamp of the first attempt.
+    val timestamp = System.currentTimeMillis()
+    // Until attribution succeeds, a locally generated guest_uid is stored and used everywhere
+    // (campaign events, RTB, and the attribution request itself). The successful response's
+    // guest_uid then replaces it as the definitive identity.
+    val existingGuestUid = idsRepository.getId(AttributionManager.GUEST_UID_KEY).ifEmpty {
+      generateLocalGuestUid().also {
+        idsRepository.saveId(AttributionManager.GUEST_UID_KEY, it)
+      }
+    }
+    attributionAnalytics.setGuestUIDUserProperty(existingGuestUid)
+    AptoideMMPCampaign.guestUID = existingGuestUid
+    var delayMs = INITIAL_RETRY_DELAY_MS
+    var attempt = 0
+    var isRetry = false
+
+    while (true) {
+      try {
+        val model = attributionRepository.getAttribution(
+          packageName = context.packageName,
+          guestUid = existingGuestUid,
+          timestamp = timestamp,
+          vercode = BuildConfig.VERSION_CODE.toLong(),
+          installerPackageName = context.packageManager
+            .getInstallerPackageNameCompat(context.packageName),
+        )
+        applyAttribution(model)
+        attributionAnalytics.sendAttributionSuccessEvent(
+          data = Gson().toJson(model),
+          isRetry = isRetry,
+          callNumber = attempt,
+        )
+        // Only success resolves the attribution: the event is sent successfully at most once.
+        attributionSessionPreferences.markAttributionResolved()
+        break
+      } catch (e: Throwable) {
+        attributionAnalytics.sendAttributionFailEvent(
+          errorMessage = e.message,
+          errorType = e::class.simpleName,
+          errorCode = (e as? HttpException)?.code(),
+          isRetry = isRetry,
+          callNumber = attempt,
+        )
+        isRetry = true
+      }
+
+      attempt++
+      val backoffRemaining = BACKOFF_WINDOW_MS - (System.currentTimeMillis() - timestamp)
+      if (backoffRemaining > 0) {
+        delay(delayMs.coerceAtMost(backoffRemaining))
+        delayMs = delayMs * 2
+      } else {
+        // Backoff window exhausted: keep retrying at a steady pace until it succeeds.
+        delay(STEADY_RETRY_DELAY_MS)
+      }
+    }
+  }
+
+  private suspend fun applyAttribution(model: AttributionModel) {
+    // An empty guest_uid in the response must not overwrite the locally generated one: it would
+    // become the permanent identity and break every flow that waits for a non-empty guest_uid.
+    model.guestUid.takeIf { it.isNotEmpty() }?.let { guestUid ->
+      idsRepository.saveId(AttributionManager.GUEST_UID_KEY, guestUid)
+      attributionAnalytics.setGuestUIDUserProperty(guestUid)
+      AptoideMMPCampaign.guestUID = guestUid
+    }
+    attributionAnalytics.setAttributionUTMProperties(model)
+    model.oemId?.takeIf { it.isNotEmpty() }?.let { AptoideMMPCampaign.oemid = it }
+  }
+
+  private suspend fun rehydrateGuestUid() {
+    val guestUid = idsRepository.getId(AttributionManager.GUEST_UID_KEY)
+    attributionAnalytics.setGuestUIDUserProperty(guestUid)
+    AptoideMMPCampaign.guestUID = guestUid
+  }
+
+  // Same shape as the server-issued guest_uid: 40 lowercase hex chars.
+  private fun generateLocalGuestUid(): String = ByteArray(20)
+    .also { SecureRandom().nextBytes(it) }
+    .joinToString("") { "%02x".format(it) }
+
+  companion object {
+    private const val BACKOFF_WINDOW_MS = 60_000L
+    private const val INITIAL_RETRY_DELAY_MS = 1_000L
+    private const val STEADY_RETRY_DELAY_MS = 60_000L
+  }
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/domain/AttributionModel.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/domain/AttributionModel.kt
@@ -1,0 +1,19 @@
+package com.aptoide.android.aptoidegames.attribution.domain
+
+import androidx.annotation.Keep
+
+@Keep
+data class AttributionModel(
+  val packageName: String?,
+  val oemId: String?,
+  val guestUid: String,
+  val utmSource: String?,
+  val utmMedium: String?,
+  val utmCampaign: String?,
+  val utmTerm: String?,
+  val utmContent: String?,
+) {
+  fun hasUTMs() =
+    utmSource != null || utmMedium != null || utmCampaign != null ||
+      utmTerm != null || utmContent != null
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/domain/AttributionRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/attribution/domain/AttributionRepository.kt
@@ -1,0 +1,11 @@
+package com.aptoide.android.aptoidegames.attribution.domain
+
+interface AttributionRepository {
+  suspend fun getAttribution(
+    packageName: String,
+    guestUid: String?,
+    timestamp: Long,
+    vercode: Long,
+    installerPackageName: String?,
+  ): AttributionModel
+}

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/AptoideInstalledPackagesRTBRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/AptoideInstalledPackagesRTBRepository.kt
@@ -4,7 +4,7 @@ import cm.aptoide.pt.extensions.ifNormalAppOrGame
 import cm.aptoide.pt.feature_flags.domain.FeatureFlags
 import cm.aptoide.pt.install_manager.InstallManager
 import com.aptoide.android.aptoidegames.LocalIdsRepository
-import com.aptoide.android.aptoidegames.apkfy.analytics.ApkfyManagerProbe
+import com.aptoide.android.aptoidegames.attribution.domain.AttributionManager
 import kotlinx.coroutines.flow.first
 
 class AptoideInstalledPackagesRTBRepository(
@@ -15,7 +15,7 @@ class AptoideInstalledPackagesRTBRepository(
 ) : InstalledPackagesRTBRepository {
 
   override suspend fun syncInstalledPackages() {
-    val guestUid = aptoideIdsRepository.observeId(ApkfyManagerProbe.GUEST_UID_KEY)
+    val guestUid = aptoideIdsRepository.observeId(AttributionManager.GUEST_UID_KEY)
       .first { it.isNotEmpty() }
 
     val limit = featureFlags

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/AptoideRTBRepository.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/feature_rtb/repository/AptoideRTBRepository.kt
@@ -9,7 +9,7 @@ import cm.aptoide.pt.feature_campaigns.CampaignRepository
 import cm.aptoide.pt.feature_campaigns.CampaignTuple
 import com.aptoide.android.aptoidegames.BuildConfig
 import com.aptoide.android.aptoidegames.LocalIdsRepository
-import com.aptoide.android.aptoidegames.apkfy.analytics.ApkfyManagerProbe
+import com.aptoide.android.aptoidegames.attribution.domain.AttributionManager
 import com.aptoide.android.aptoidegames.feature_rtb.data.RTBApp
 import com.aptoide.android.aptoidegames.network.repository.AdvertisingIdsRepository
 import kotlinx.coroutines.CoroutineScope
@@ -34,7 +34,7 @@ class AptoideRTBRepository @Inject constructor(
         return@withContext it
       }
 
-      val guestUid = aptoideIdsRepository.observeId(ApkfyManagerProbe.GUEST_UID_KEY)
+      val guestUid = aptoideIdsRepository.observeId(AttributionManager.GUEST_UID_KEY)
         .first { it.isNotEmpty() }
 
       val result = rtbApi.getApps(

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/PlayAndEarnIdProvider.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/play_and_earn/PlayAndEarnIdProvider.kt
@@ -1,7 +1,7 @@
 package com.aptoide.android.aptoidegames.play_and_earn
 
 import com.aptoide.android.aptoidegames.LocalIdsRepository
-import com.aptoide.android.aptoidegames.apkfy.analytics.ApkfyManagerProbe
+import com.aptoide.android.aptoidegames.attribution.domain.AttributionManager
 import com.aptoide.android.aptoidegames.firebase.FirebaseInfoProvider
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -17,7 +17,7 @@ class PlayAndEarnIdProvider @Inject constructor(
 ) {
 
   suspend fun getId(): String {
-    val guestId = localIdsRepository.getId(ApkfyManagerProbe.GUEST_UID_KEY)
+    val guestId = localIdsRepository.getId(AttributionManager.GUEST_UID_KEY)
     return guestId.ifBlank { firebaseInfoProvider.getFirebaseToken().orEmpty() }
   }
 }


### PR DESCRIPTION
**What does this PR do?**

Adds a new MMP attribution install flow that calls `GET /attribution` once, on the first app open. The response becomes the single source of truth for `guest_uid`, the UTM user properties and the `oemid`.

- Before the first call a local 40-char lowercase-hex `guest_uid` (`SecureRandom`) is generated, stored under the existing `"GUEST_UID"` ids key, published to analytics + `AptoideMMPCampaign`, and sent on the request — until the server's `guest_uid` replaces it as the definitive identity.
- The call retries with exponential backoff for the first minute and then every minute until it succeeds; only a successful response permanently resolves it, so the event is sent successfully at most once.
- `apkfy` keeps its UI/deeplink flow intact but **no longer writes** `guest_uid` / UTM / `oemid` — those are now owned by attribution. RTB and Play & Earn `guest_uid` lookups are repointed to `AttributionManager.GUEST_UID_KEY`.

Technical notes: an empty `guest_uid` in the response never overwrites the local one (that would brick flows waiting on a non-empty guest_uid, e.g. RTB's `observeId(...).first { it.isNotEmpty() }`); `AttributionJSON.guestUid` is nullable because Gson bypasses Kotlin null-safety and a literal JSON `null` would otherwise violate a non-null field. This ports the code-reviewed App Arena implementation of the same ticket, adapted to app-games (apkfy is kept and only its writes are stripped, rather than removed).

**Database changed?**

No

**Where should the reviewer start?**

- [ ] app-games/.../attribution/domain/AttributionManager.kt
- [ ] app-games/.../attribution/analytics/AttributionAnalytics.kt
- [ ] app-games/.../attribution/data/AptoideAttributionRepository.kt
- [ ] app-games/.../attribution/data/AttributionJSON.kt
- [ ] app-games/.../attribution/di/AttributionModule.kt
- [ ] app-games/.../AptoideApplication.kt (initAttribution trigger)
- [ ] app-games/.../apkfy/analytics/ApkfyManagerProbe.kt (writes removed, UI kept)
- [ ] app-games/.../apkfy/analytics/ApkfyAnalytics.kt (guest_uid/UTM setters removed)
- [ ] app-games/.../feature_rtb/repository/AptoideRTBRepository.kt & AptoideInstalledPackagesRTBRepository.kt
- [ ] app-games/.../play_and_earn/PlayAndEarnIdProvider.kt

**How should this be manually tested?**

On a fresh install of `:app-games` (verify both brand flavors — `aptoideGames` and `vanilla`):
1. Open the app for the first time and confirm `GET /attribution` fires once, with `package_name`, `guest_uid` (the locally generated 40-hex), `timestamp`, `vercode`, `installer_package_name`.
2. Confirm the response's `guest_uid` / UTM / `oemid` are persisted and picked up by RTB / Play & Earn / campaign events.
3. Relaunch the app and confirm `/attribution` is **not** called again.

**What are the relevant tickets?**

Tickets related to this pull-request: [AND-856](https://aptoide.atlassian.net/browse/AND-856)

**What are the relevant PRs?**

Ports the code-reviewed App Arena implementation of the same ticket (app-arena-android @ `3f045ca`).



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-856]: https://aptoide.atlassian.net/browse/AND-856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added install attribution support, including campaign and UTM data collection.
  * Added persistent attribution status and guest ID handling.
  * Added attribution success, failure, and retry analytics.
  * Added installer source detection across supported Android versions.

* **Updates**
  * Updated audience measurement and rewards features to use the new attribution guest ID.
  * Improved attribution reliability with asynchronous processing and automatic retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->