### PR TITLE
Fix legacy :app compilation and JUnit Platform launcher on dev-v10

### DIFF
--- a/app/src/main/java/cm/aptoide/pt/appview/DownloadView.kt
+++ b/app/src/main/java/cm/aptoide/pt/appview/DownloadView.kt
@@ -283,6 +283,8 @@ fun DownloadState(
 
     is DownloadUiState.Migrate -> InstallButton(uiState.migrate)
 
+    is DownloadUiState.MigrateAlias -> InstallButton(uiState.migrateAlias)
+
     is DownloadUiState.Waiting -> IndeterminateDownloadView(
       label = "Downloading",
       labelColor = tintColor,

--- a/app/src/main/java/cm/aptoide/pt/updates/FakeUpdatesNotificationProvider.kt
+++ b/app/src/main/java/cm/aptoide/pt/updates/FakeUpdatesNotificationProvider.kt
@@ -1,5 +1,9 @@
 package cm.aptoide.pt.updates
 
+import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_updates.presentation.UpdatesNotificationProvider
 
-class FakeUpdatesNotificationProvider : UpdatesNotificationProvider
+class FakeUpdatesNotificationProvider : UpdatesNotificationProvider {
+  override suspend fun showVIPUpdateNotification(app: App) = Unit
+  override suspend fun showSuccessAutoUpdatedGameNotification(app: App) = Unit
+}

--- a/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/textformatter/DateUtils.kt
+++ b/aptoide-ui/src/main/java/cm/aptoide/pt/aptoide_ui/textformatter/DateUtils.kt
@@ -1,0 +1,116 @@
+package cm.aptoide.pt.aptoide_ui.textformatter
+
+import android.content.Context
+import android.text.format.DateUtils
+import cm.aptoide.pt.aptoide_ui.R
+import java.util.Calendar
+
+class DateUtils private constructor() : DateUtils() {
+  companion object {
+    private const val millisInADay = (1000 * 60 * 60 * 24).toLong()
+
+    /**
+     * Checks if the given date is yesterday.
+     *
+     * @param date - Date to check.
+     * @return TRUE if the date is yesterday, FALSE otherwise.
+     */
+    private fun isYesterday(date: Long): Boolean {
+      val currentDate = Calendar.getInstance()
+      currentDate.timeInMillis = date
+      val yesterdayDate = Calendar.getInstance()
+      yesterdayDate.add(Calendar.DATE, -1)
+      return (yesterdayDate[Calendar.YEAR] == currentDate[Calendar.YEAR]
+        && yesterdayDate[Calendar.DAY_OF_YEAR] == currentDate[Calendar.DAY_OF_YEAR])
+    }
+
+    /**
+     * Displays a user-friendly date difference string
+     *
+     * @param timeDate Timestamp to format as date difference from now
+     * @return Friendly-formatted date diff string
+     */
+    fun getTimeDiffPublishedString(context: Context, timeDate: String): String {
+      val timeDateAsMilliseconds = TextFormatter.parseDateToLong(timeDate)
+      val startDateTime = Calendar.getInstance()
+      val endDateTime = Calendar.getInstance()
+      endDateTime.timeInMillis = timeDateAsMilliseconds
+      val milliseconds1 = startDateTime.timeInMillis
+      val milliseconds2 = endDateTime.timeInMillis
+      val diff = milliseconds1 - milliseconds2
+      val hours = diff / (60 * 60 * 1000)
+      var minutes = diff / (60 * 1000)
+      minutes -= 60 * hours
+      val isToday = isToday(timeDateAsMilliseconds)
+      val isYesterday = isYesterday(timeDateAsMilliseconds)
+      return if (hours in 1..11) {
+        context.resources.getQuantityString(R.plurals.published_hours, hours.toInt(), hours)
+      } else if (hours <= 0) {
+        if (minutes > 0)
+          context.resources.getQuantityString(R.plurals.published_minutes, minutes.toInt(), minutes)
+        else
+          context.getString(R.string.published_just_now)
+      } else if (isToday) {
+        context.getString(R.string.published_today)
+      } else if (isYesterday) {
+        context.getString(R.string.published_yesterday)
+      } else if (startDateTime.timeInMillis - timeDateAsMilliseconds < millisInADay * 6) {
+        val dayOfWeek = when (endDateTime[Calendar.DAY_OF_WEEK]) {
+          Calendar.MONDAY -> R.string.published_on_monday
+          Calendar.TUESDAY -> R.string.published_on_tuesday
+          Calendar.WEDNESDAY -> R.string.published_on_wednesday
+          Calendar.THURSDAY -> R.string.published_on_thursday
+          Calendar.FRIDAY -> R.string.published_on_friday
+          Calendar.SATURDAY -> R.string.published_on_saturday
+          else -> R.string.published_on_sunday
+        }
+        context.getString(dayOfWeek)
+      } else {
+        context.getString(
+          R.string.date_published_on,
+          TextFormatter.formatDateToSystemLocale(context, timeDate)
+        )
+      }
+    }
+
+    fun getTimeDiffString(context: Context, timeDate: String): String {
+      val timeDateAsMilliseconds = TextFormatter.parseDateToLong(timeDate)
+      val startDateTime = Calendar.getInstance()
+      val endDateTime = Calendar.getInstance()
+      endDateTime.timeInMillis = timeDateAsMilliseconds
+      val milliseconds1 = startDateTime.timeInMillis
+      val milliseconds2 = endDateTime.timeInMillis
+      val diff = milliseconds1 - milliseconds2
+      val hours = diff / (60 * 60 * 1000)
+      var minutes = diff / (60 * 1000)
+      minutes -= 60 * hours
+      val isToday = isToday(timeDateAsMilliseconds)
+      val isYesterday = isYesterday(timeDateAsMilliseconds)
+      return if (hours in 1..11) {
+        "${hours} hours ago"
+      } else if (hours <= 0) {
+        if (minutes > 0)
+          "${minutes} minutes ago"
+        else
+          "Just now"
+      } else if (isToday) {
+        "Today"
+      } else if (isYesterday) {
+        "Yesterday"
+      } else if (startDateTime.timeInMillis - timeDateAsMilliseconds < millisInADay * 6) {
+        val dayOfWeek = when (endDateTime[Calendar.DAY_OF_WEEK]) {
+          Calendar.MONDAY -> "Monday"
+          Calendar.TUESDAY -> "Tuesday"
+          Calendar.WEDNESDAY -> "Wednesday"
+          Calendar.THURSDAY -> "Thursday"
+          Calendar.FRIDAY -> "Friday"
+          Calendar.SATURDAY -> "Saturday"
+          else -> "Sunday"
+        }
+        dayOfWeek
+      } else {
+        TextFormatter.formatDateToSystemLocale(context, timeDate)
+      }
+    }
+  }
+}

--- a/build-logic/convention/src/main/kotlin/plugin/TestsPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/plugin/TestsPlugin.kt
@@ -17,6 +17,9 @@ class TestsPlugin : Plugin<Project> {
       plugins.apply(libs.findPlugin("junit5").get().get().pluginId)
       dependencies.apply {
         add("testRuntimeOnly", libs.findLibrary("junit-jupiter-engine").get())
+        // Gradle no longer puts the launcher on the test runtime classpath implicitly;
+        // without it every test task fails with "Failed to load JUnit Platform"
+        add("testRuntimeOnly", libs.findLibrary("junit-platform-launcher").get())
         add("testImplementation", project.project(":test"))
       }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -129,6 +129,7 @@ junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.re
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }
 junit-jupiter-vantage = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit5" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit5" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 #root / build-logic


### PR DESCRIPTION
**What does this PR do?**

Fixes the two pre-existing breakages that make AptoideCI fail on every PR against dev-v10:

1. **Legacy `:app` no longer compiled** (this is what the "(Vanilla) - Android Vanilla Github Hook PR Test" job dies on):
   - Restores `aptoide-ui`'s `DateUtils` — [AND-603] moved the class into `:app-games` but left the `published_*` strings/plurals in `aptoide-ui`, breaking `OtherVersionsView`'s import in `:app` (which cannot depend on `:app-games`). Restoring the file fixes the module with zero call-site changes; app-games keeps its own copy in a different package.
   - Adds the missing `MigrateAlias` branch to `DownloadView`'s `DownloadUiState` handling.
   - Implements the two `UpdatesNotificationProvider` methods added after `FakeUpdatesNotificationProvider` was written.
2. **Every module's unit-test task failed with "Failed to load JUnit Platform"**: Gradle 9 no longer puts the JUnit Platform launcher on the test runtime classpath implicitly. Added `junit-platform-launcher` as `testRuntimeOnly` in the `tests` convention plugin (one change, fixes all modules).

**Database changed?**

No

**Where should the reviewer start?**

- [ ] build-logic/convention/src/main/kotlin/plugin/TestsPlugin.kt
- [ ] aptoide-ui/.../textformatter/DateUtils.kt (verbatim restore of the pre-AND-603 file)
- [ ] app/.../appview/DownloadView.kt
- [ ] app/.../updates/FakeUpdatesNotificationProvider.kt

**How should this be manually tested?**

- `./gradlew :app:compileDevDebugKotlin` — was failing with 5 errors, now BUILD SUCCESSFUL
- `./gradlew :app-games:testAptoideGamesGplayDevDebugUnitTest` — was crashing before running any test, now executes and passes
- `./gradlew :app-games:compileVanillaDirectDevDebugKotlin :app-games:compileAptoideGamesGplayDevDebugKotlin` — both flavors unaffected
- AptoideCI on this PR should turn green — that's the real end-to-end test

**What are the relevant tickets?**

None — CI housekeeping surfaced while preparing the 1.21.1 Play release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AND-603]: https://aptoide.atlassian.net/browse/AND-603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for migrating aliases directly from the download view.
  * Added friendly relative date formatting, including localized “just now,” today, yesterday, weekday, and full-date formats.

* **Tests**
  * Improved test runtime support for JUnit Platform-based tests.

* **Chores**
  * Updated the fake update notification provider to support current notification interface requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->