### PR TITLE
Bump targetSdk to 36 + handle enforced edge-to-edge

### DIFF
--- a/app-games/src/aptoideGames/java/com/aptoide/android/aptoidegames/theme/Theme.kt
+++ b/app-games/src/aptoideGames/java/com/aptoide/android/aptoidegames/theme/Theme.kt
@@ -71,8 +71,10 @@ private fun SetupStatusBarColor(
       ?.window
       ?.run {
         statusBarColor = backgroundColor.toArgb()
-        WindowCompat.getInsetsController(this, decorView)
-          .isAppearanceLightStatusBars = !darkTheme
+        WindowCompat.getInsetsController(this, decorView).run {
+          isAppearanceLightStatusBars = !darkTheme
+          isAppearanceLightNavigationBars = !darkTheme
+        }
       }
   }
 }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideGamesBottomSheet.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/AptoideGamesBottomSheet.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
@@ -68,10 +69,12 @@ fun AptoideGamesBottomSheet(
     sheetBackgroundColor = Palette.Black,
     sheetElevation = 0.dp,
     sheetContent = {
-      bottomSheetContent?.Draw(
-        dismiss = onCloseBottomSheetClick,
-        navigate = navigate,
-      )
+      Box(modifier = Modifier.navigationBarsPadding()) {
+        bottomSheetContent?.Draw(
+          dismiss = onCloseBottomSheetClick,
+          navigate = navigate,
+        )
+      }
     },
     content = {
       content {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/UrlActivity.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/UrlActivity.kt
@@ -7,9 +7,14 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.aptoide.android.aptoidegames.home.AppThemeViewModel
 import com.aptoide.android.aptoidegames.theme.AptoideTheme
@@ -31,8 +36,15 @@ class UrlActivity : AppCompatActivity() {
         Scaffold(
           topBar = { SimpleAppGamesToolbar() }
         ) {
-          url?.let {
-            UrlView(url = it)
+          Box(
+            modifier = Modifier
+              .statusBarsPadding()
+              .navigationBarsPadding()
+              .imePadding()
+          ) {
+            url?.let {
+              UrlView(url = it)
+            }
           }
         }
       }

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/bottom_bar/AppGamesBottomBar.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material.BottomNavigationItem
@@ -76,7 +77,11 @@ fun AppGamesBottomBar(navController: NavController) {
   val selection =
     selectionIndex(items = filteredBottomNavigationItems, navController = navController)
   if (selection >= 0) {
-    Box(modifier = Modifier.fillMaxWidth()) {
+    Box(
+      modifier = Modifier
+        .fillMaxWidth()
+        .navigationBarsPadding()
+    ) {
       AppGamesBottomNavigation(backgroundColor = Color.Transparent) {
         filteredBottomNavigationItems.forEachIndexed { index, item ->
           val isSelected = selection == index

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/home/MainView.kt
@@ -3,7 +3,11 @@ package com.aptoide.android.aptoidegames.home
 import android.annotation.SuppressLint
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Snackbar
 import androidx.compose.material.SnackbarHost
@@ -99,6 +103,12 @@ private val routesWithoutTopBar = listOf(
   freeFireApkfyRewardRoute,
 )
 
+// Routes that intentionally draw behind the status bar (they handle the inset themselves)
+private val fullBleedRoutes = listOf(
+  robloxApkfyRewardRoute,
+  freeFireApkfyRewardRoute,
+)
+
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @Composable
 fun MainView(navController: NavHostController) {
@@ -112,6 +122,7 @@ fun MainView(navController: NavHostController) {
     { navController.popBackStack(navController.graph.startDestinationId, false) }
 
   var showTopBar by remember { mutableStateOf(true) }
+  var padStatusBar by remember { mutableStateOf(false) }
   val (promoCodeApp, clearPromoCode) = rememberPromoCodeApp()
 
   val currentRoute =
@@ -120,6 +131,7 @@ fun MainView(navController: NavHostController) {
   LaunchedEffect(currentRoute.value?.destination?.route) {
     val route = currentRoute.value?.destination?.route
     showTopBar = route == null || routesWithoutTopBar.none(route::contains)
+    padStatusBar = !showTopBar && route != null && fullBleedRoutes.none(route::contains)
   }
 
   AptoideTheme {
@@ -173,7 +185,14 @@ fun MainView(navController: NavHostController) {
 
           ClaimedRewardDialog(navigate = navController::navigateTo)
 
-          Box(modifier = Modifier.padding(padding)) {
+          Box(
+            modifier = Modifier
+              .padding(padding)
+              .consumeWindowInsets(padding)
+              .then(if (padStatusBar) Modifier.statusBarsPadding() else Modifier)
+              .navigationBarsPadding()
+              .imePadding()
+          ) {
             NavigationGraph(
               navController,
               showSnack = {

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/support/SupportScreen.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/support/SupportScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
@@ -71,6 +72,8 @@ fun SupportView(
         .fillMaxSize()
         .wrapContentSize(Alignment.TopCenter)
         .background(Palette.Black)
+        .statusBarsPadding()
+        .imePadding()
     ) {
       if (isKeyboardOpen == Keyboard.Closed) {
         AppGamesTopBar(navigateBack = { navigateBack() }, title = title)

--- a/app-games/src/main/java/com/aptoide/android/aptoidegames/toolbar/AppGamesToolBar.kt
+++ b/app-games/src/main/java/com/aptoide/android/aptoidegames/toolbar/AppGamesToolBar.kt
@@ -3,6 +3,7 @@ package com.aptoide.android.aptoidegames.toolbar
 import android.Manifest
 import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Icon
@@ -99,6 +101,9 @@ private fun AppGamesToolBar(
   val userInfo = rememberUserInfo()
 
   TopAppBar(
+    modifier = Modifier
+      .background(Palette.Black)
+      .statusBarsPadding(),
     backgroundColor = Palette.Black,
     elevation = Dp(0f),
     content = {
@@ -167,6 +172,9 @@ private fun AppGamesToolBar(
 @Composable
 fun SimpleAppGamesToolbar() {
   TopAppBar(
+    modifier = Modifier
+      .background(Palette.Black)
+      .statusBarsPadding(),
     backgroundColor = Palette.Black,
     elevation = Dp(0f),
   ) {

--- a/app-games/src/vanilla/java/com/aptoide/android/aptoidegames/theme/Theme.kt
+++ b/app-games/src/vanilla/java/com/aptoide/android/aptoidegames/theme/Theme.kt
@@ -90,8 +90,10 @@ private fun SetupStatusBarColor(
       ?.window
       ?.run {
         statusBarColor = backgroundColor.toArgb()
-        WindowCompat.getInsetsController(this, decorView)
-          .isAppearanceLightStatusBars = !darkTheme
+        WindowCompat.getInsetsController(this, decorView).run {
+          isAppearanceLightStatusBars = !darkTheme
+          isAppearanceLightNavigationBars = !darkTheme
+        }
       }
   }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,9 @@ android {
     versionCode = 10000
     versionName = "10.0.0.0-alpha01"
 
+    // Frozen legacy module: pinned to 35, not validated for the target 36 edge-to-edge enforcement
+    targetSdk = 35
+
     buildConfigField("String", "MARKET_NAME", "\"apps\"")
     buildConfigField("String", "STORE_DOMAIN", "\"https://ws75.aptoide.com/api/7.20221201/\"")
     buildConfigField("String", "SEARCH_BUZZ_DOMAIN", "\"https://buzz.aptoide.com:10002\"")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 compileSdk = "36"
 minSdk = "26"
-targetSdk = "35"
+targetSdk = "36"
 
 #core
 kotlin = "2.3.20"


### PR DESCRIPTION
## Why

Google Play rejected the 1.21.1 (672) US submission: *"Your app currently targets API level 35 and must target at least API level 36."*

## What

**Commit 1 — SDK bump** (`gradle/libs.versions.toml`): `targetSdk` 35 → 36. compileSdk is already 36 and AGP 9.0.1 supports it, so no tooling changes. The frozen legacy `:app` module is pinned at 35 (it is not validated for target-36 behavior changes).

**Commit 2 — edge-to-edge** : at targetSdk 36 the `windowOptOutEdgeToEdgeEnforcement` theme attribute (the only thing keeping the UI laid out today) is **ignored** on Android 15+. This commit adds minimal inset handling for visual parity — all added Compose inset modifiers resolve to zero on Android ≤ 14, so pre-15 rendering is untouched:

- `statusBarsPadding` on both toolbars (background extended behind the status bar)
- `navigationBarsPadding` on the bottom bar, bottom-sheet content, and MainView content box (covers all routes without a bottom bar)
- conditional `statusBarsPadding` for top-bar-less routes, excluding the Roblox/Free Fire reward screens which intentionally draw full-bleed and already pad internally
- `imePadding` on the NavHost / SupportScreen / UrlActivity, replacing `adjustResize` which no longer resizes under enforcement
- `isAppearanceLightNavigationBars` in both brand `Theme.kt` files so nav-bar icons stay legible over the transparent nav bar in vanilla light theme

## Verification

- `:app-games:assembleAptoideGamesGplayDevDebug` + `:app-games:assembleVanillaDirectDevDebug` green; both APKs show `targetSdkVersion 36` (aapt)
- `:app:compileDevDebugKotlin` green; merged manifest shows `targetSdkVersion 35`
- `:app-games` unit tests pass for both flavors (repo-wide `test` fails only on 3 pre-existing tasks: the vendored youtube-player submodule tests, legacy `:app` Hilt javac, and the `:test` module's own missing JUnit launcher — all verified failing identically on the clean dev-v10 baseline)
- **Android 16 (API 36) emulator, both brands**: AG home / search with keyboard / app details top+scrolled bottom / settings / Send-feedback keyboard flow, and vanilla home in **light and dark** — toolbars below the status bar, bottom bar above the nav bar, IME padding working, nav-bar icon contrast correct in vanilla light. Verified with gesture nav **and** 3-button nav.
- **Android 12 device**: pixel-identical to today (inset modifiers no-op below 15).

Not exercised on-device: apkfy/Roblox reward screens (need the install-referrer flow) — they are excluded from the new padding and keep their existing internal `statusBarsPadding`, so their full-bleed header is unchanged by design.

## After merge

Merge `dev-v10` into `release-ag_1.21.1_play` and cut a new Jenkins build (version code > 672) for Play resubmission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout handling around status bars, navigation bars, and the on-screen keyboard across game screens, bottom sheets, toolbars, support, and URL views.
  * Prevented content from being obscured by system navigation areas.
  * Updated status and navigation bar icon appearance to match the selected theme.

* **Compatibility**
  * Updated the application target to Android SDK 36 while keeping the legacy application target pinned to SDK 35.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->