### PR TITLE
[AND-874] Force Pixel Blast to download from Aptoide's APK pool

### DIFF
--- a/app-games/src/main/res/xml/remote_config_defaults.xml
+++ b/app-games/src/main/res/xml/remote_config_defaults.xml
@@ -24,4 +24,8 @@
     <key>appopen_load_timeout_ms</key>
     <value>3000</value>
   </entry>
+  <entry>
+    <key>pixelblast_app</key>
+    <value>{"url":"https://pool.apk.aptoide.com/apk/com-agedstudio-pixelblast-games-100106-361791163269ae9adab7c1f2208641b1.apk","md5":"361791163269ae9adab7c1f2208641b1","size":135588859}</value>
+  </entry>
 </defaultsMap>

--- a/feature_apps/build.gradle.kts
+++ b/feature_apps/build.gradle.kts
@@ -12,5 +12,6 @@ android {
 dependencies {
   implementation(projects.aptoideNetwork)
   implementation(projects.extension)
+  implementation(projects.featureFlags)
   api(projects.featureCampaigns)
 }

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/App.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/App.kt
@@ -295,3 +295,5 @@ fun App.isInCatappult(): Boolean? {
 fun App.isAab(): Boolean = aab != null && aab.baseSplits.isNotEmpty()
 
 fun App.hasObb(): Boolean = (aab == null || aab.baseSplits.isEmpty()) && obb != null
+
+fun App.isPixelBlast(): Boolean = packageName == "com.agedstudio.pixelblast.games"

--- a/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
+++ b/feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
@@ -3,8 +3,10 @@ package cm.aptoide.pt.feature_apps.domain
 import cm.aptoide.pt.feature_apps.data.App
 import cm.aptoide.pt.feature_apps.data.AppRepository
 import cm.aptoide.pt.feature_apps.data.SplitsRepository
+import cm.aptoide.pt.feature_apps.data.isPixelBlast
 import cm.aptoide.pt.feature_apps.data.model.DynamicSplitJSON
 import cm.aptoide.pt.feature_apps.data.toDomainModel
+import cm.aptoide.pt.feature_flags.domain.FeatureFlags
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -12,21 +14,51 @@ import javax.inject.Singleton
 class AppMetaUseCase @Inject constructor(
   private val appRepository: AppRepository,
   private val splitsRepository: SplitsRepository,
+  private val featureFlags: FeatureFlags,
 ) {
   suspend fun getMetaInfo(source: String): App {
-    return appRepository.getAppMeta(source = source.filterMetaSource())
-      .copy(hasMeta = true)
-      .run {
-        aab
-          ?.let {
-            val dSplits = splitsRepository.getAppsDynamicSplits(md5)
-            it.copy(dynamicSplits = dSplits.map(DynamicSplitJSON::toDomainModel))
-          }
-          ?.let { copy(aab = it) }
-          ?: this
-      }
+    val app = appRepository.getAppMeta(source = source.filterMetaSource()).copy(hasMeta = true)
+    if (app.isPixelBlast()) return app.withPixelBlastApkOverride()
+
+    return app.run {
+      aab
+        ?.let {
+          val dSplits = splitsRepository.getAppsDynamicSplits(md5)
+          it.copy(dynamicSplits = dSplits.map(DynamicSplitJSON::toDomainModel))
+        }
+        ?.let { copy(aab = it) }
+        ?: this
+    }
+  }
+
+  private suspend fun App.withPixelBlastApkOverride(): App {
+    val override = featureFlags.getObject(PIXEL_BLAST_APP_FLAG, PixelBlastAppOverride::class.java)
+      ?.takeIf { it.url.isNotBlank() && it.md5.isNotBlank() && it.size > 0 }
+      ?: return this
+
+    // The pool APK is a single self-contained build (no split delivery), unlike the
+    // backend-reported aab/obb splits, which belong to a different, differently-signed
+    // build. Mixing the two in one install session causes an INSTALL_FAILED_INVALID_APK
+    // "signatures are inconsistent" failure, so both must be dropped here. size must also
+    // be overridden: it feeds the pre-download free-space check and the metered-data size
+    // warning, both computed from File.size before any bytes are actually downloaded.
+    return copy(
+      file = file.copy(path = override.url, path_alt = override.url, md5 = override.md5, size = override.size),
+      aab = null,
+      obb = null,
+    )
+  }
+
+  private companion object {
+    const val PIXEL_BLAST_APP_FLAG = "pixelblast_app"
   }
 }
+
+private data class PixelBlastAppOverride(
+  val url: String,
+  val md5: String,
+  val size: Long,
+)
 
 fun String.filterMetaSource(): String {
   if (this.contains("getMeta")) {


### PR DESCRIPTION
**What does this PR do?**

   Pixel Blast (`com.agedstudio.pixelblast.games`, a Play & Earn sponsored app) was found to be installed by real users through Aptoide as the wrong binary: the backend's `getApp`/`getMeta` `url-provider` response points at a Google-Play-originated build that is missing the Adjust `DefaultTracker` config the partner requires for install attribution. This was confirmed by reverse-engineering repeated real installs (via the actual Aptoide app, US VPN) and comparing them byte-for-byte against the correct build the partner provided directly.

   As a quick fix, the correct APK has been uploaded to Aptoide's own CDN pool. This PR makes `AppMetaUseCase.getMetaInfo()` override Pixel Blast's `file.path`/`path_alt`/`md5` with that pool URL + its MD5, read from a Firebase Remote Config flag (`pixelblast_app`, a `{"url", "md5"}` JSON object) so it can be updated without a new app release, falling back to a hardcoded known-good value if the flag is missing/blank/unparseable.

   Technical decision: the URL and MD5 are read from a single JSON-object flag rather than two separate flags, because the install pipeline (`DownloaderRepository`) verifies the downloaded file's MD5 and fails the install on any mismatch — two independent flags risked someone updating one and forgetting the other, silently breaking installs again.

   The backend-reported `aab`/`obb` splits are also dropped for Pixel Blast: the pool APK is a single self-contained build (no split delivery), and mixing it with the original app's split files (signed under a different pipeline) caused an `INSTALL_FAILED_INVALID_APK` "signatures are inconsistent" failure during testing.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] feature_apps/src/main/java/cm/aptoide/pt/feature_apps/domain/AppMetaUseCase.kt
- [ ] feature_apps/src/main/java/cm/aptoide/pt/feature_apps/data/App.kt
- [ ] feature_apps/build.gradle.kts
- [ ] app-games/src/main/res/xml/remote_config_defaults.xml

**How should this be manually tested?**

  1. Add a Firebase Remote Config parameter `pixelblast_app` (JSON type) with value `{"url":"https://pool.apk.aptoide.com/apk/com-agedstudio-pixelblast-games-100106-361791163269ae9adab7c1f2208641b1.apk","md5":"361791163269ae9adab7c1f2208641b1"}` (already done in Firebase console for this rollout).
  2. Install `app-games` (aptoideGames or vanilla brand, gplay or direct distribution, prod mode — the Pixel Blast P&E campaign only exists in prod) on a device.
  3. Find Pixel Blast in the app and tap Install.
  4. Verify the resulting installed package is a single `base.apk` (no split files) via `adb shell pm path com.agedstudio.pixelblast.games`.
  5. Pull it (`adb pull`) and confirm its MD5 is `361791163269ae9adab7c1f2208641b1`.
  6. Confirm the app launches successfully.

  Verified end-to-end on a real device (Pixel 7, gplay/prod/debug build) as part of this PR's development — matched hash, single APK, app launches.

**What are the relevant tickets?**

  Tickets related to this pull-request: [AND-874](https://aptoide.atlassian.net/browse/AND-874)



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass


[AND-874]: https://aptoide.atlassian.net/browse/AND-874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for distributing Pixel Blast through a remotely configured APK download.
  - Valid download configuration requires both an APK URL and MD5 checksum.
- **Improvements**
  - When valid configuration is available, Pixel Blast uses the configured APK instead of AAB or OBB files.
  - Without valid configuration, Pixel Blast retains its original download files and metadata.
  - Other apps continue receiving their existing dynamic download content and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->